### PR TITLE
docs: freshness, lineage, agent framework, connector framework clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Pre-v0.1 — scaffolding. See [docs/roadmap.md](docs/roadmap.md).
 - [Connector framework](docs/api/connector-sdk.md) — how to add a source
 - [Database schema](docs/schema.md)
 - [Freshness & lineage](docs/freshness-and-lineage.md) — trust model for AI clients
+- [Retrieval strategy (ADR 0004)](docs/decisions/0004-retrieval-strategy-staged.md) — hybrid → structural → GraphRAG-if-needed
 - [Architecture decisions](docs/decisions/)
 - Integrations: [Claude Code](docs/integrations/claude-code.md) · [Cursor](docs/integrations/cursor.md) · [multiqlti](docs/integrations/multiqlti.md) · [LangGraph](docs/integrations/langgraph.md) · [CrewAI](docs/integrations/crewai.md) · [PydanticAI](docs/integrations/pydantic-ai.md)
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Pre-v0.1 — scaffolding. See [docs/roadmap.md](docs/roadmap.md).
 - [Roadmap](docs/roadmap.md) — milestones M0 → M6
 - [MCP API](docs/api/mcp.md) — tool contracts (primary interface)
 - [REST API](docs/api/rest.md) — secondary interface
-- [Connector SDK](docs/api/connector-sdk.md) — how to add a source
+- [Connector framework](docs/api/connector-sdk.md) — how to add a source
 - [Database schema](docs/schema.md)
+- [Freshness & lineage](docs/freshness-and-lineage.md) — trust model for AI clients
 - [Architecture decisions](docs/decisions/)
+- Integrations: [Claude Code](docs/integrations/claude-code.md) · [Cursor](docs/integrations/cursor.md) · [multiqlti](docs/integrations/multiqlti.md) · [LangGraph](docs/integrations/langgraph.md) · [CrewAI](docs/integrations/crewai.md) · [PydanticAI](docs/integrations/pydantic-ai.md)
 
 ## License
 

--- a/docs/api/connector-sdk.md
+++ b/docs/api/connector-sdk.md
@@ -1,4 +1,6 @@
-# Connector SDK
+# Connector framework
+
+> **Note on naming.** This document was previously titled "Connector SDK". For v0.1 and v0.2 the connector mechanism is an **internal framework** — part of the Omniscience monorepo, not a published PyPI package. Adding a new connector = PR against Omniscience. See [ADR 0002](../decisions/0002-connector-framework-vs-sdk.md) for the reasoning and revisit triggers.
 
 How to add a new source type to Omniscience.
 
@@ -93,10 +95,43 @@ Planned:
 - `k8s` — Cluster resources as structured documents.
 - `terraform` — State files + tf modules.
 
+## AgenticConnector — LLM-driven discovery
+
+Some sources cannot be fully described declaratively. Examples:
+
+- **Kubernetes** — which resource kinds matter? Deployments and ConfigMaps yes; transient events no; Secrets never. The right subset depends on the cluster.
+- **Databases** — index schemas, comments, saved queries. Skip transactional row data. Which tables are reference vs transactional?
+- **Selective log ingestion** — ingest error/warn from specific services only; summarize rather than embed raw lines.
+
+For these, we define **`AgenticConnector`** — a connector whose `discover()` phase is **LLM-driven**:
+
+```python
+class AgenticConnector(Connector, Protocol):
+    """A connector whose discovery phase is LLM-driven.
+
+    Overrides `discover()` to run an agent that inspects the source, decides
+    what to include, and yields DocumentRefs. Everything else (fetch, webhook)
+    is unchanged.
+    """
+
+    agent_config: ClassVar[AgentConfig]
+    """Default agent config: instructions, model, max_iterations."""
+
+    async def discover(
+        self, config: BaseModel, secrets: dict[str, str]
+    ) -> AsyncIterator[DocumentRef]:
+        """Runs an agent with MCP tools that expose the source's API.
+        Agent yields DocumentRefs as it decides what to index."""
+```
+
+The agent under the hood uses **LangGraph** ([ADR 0003](../decisions/0003-agent-framework-langgraph-primary.md)). CrewAI and PydanticAI adapters land in v0.2.
+
+Agentic connectors are **not** the default — regular (declarative) `Connector` is. Use `AgenticConnector` only when declarative discovery cannot express the right scope.
+
 ## Writing a new connector
 
 1. Create package: `packages/connectors/omniscience_connectors/<name>/`
-2. Implement `Connector` protocol
+2. Implement `Connector` protocol (or `AgenticConnector` if LLM-driven discovery is needed)
 3. Register in connector registry (`packages/connectors/omniscience_connectors/__init__.py`)
 4. Add contract tests (see `tests/connectors/contract_tests.py`)
 5. Add docs: `docs/connectors/<name>.md` — required config, minimum scopes, caveats

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -55,6 +55,13 @@ Primary retrieval. Hybrid vector + BM25 + filter.
         "indexed_at": "2026-04-16T10:32:15Z",
         "doc_version": 7
       },
+      "lineage": {
+        "ingestion_run_id": "ir_01HXYZ...",
+        "embedding_model": "text-embedding-004",
+        "embedding_provider": "google-ai",
+        "parser_version": "treesitter-python-0.21+oms-0.4.2",
+        "chunker_strategy": "code_symbol"
+      },
       "metadata": {
         "language": "python",
         "symbol": "authenticate_token",

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -20,7 +20,7 @@ Tokens are scoped: `search`, `sources:read`, `sources:write`, `admin`. See [sche
 
 ### `search`
 
-Primary retrieval. Hybrid vector + BM25 + filter.
+Primary retrieval. Hybrid vector + BM25 + filter in v0.1; additional strategies in v0.2+.
 
 **Input**:
 
@@ -33,6 +33,22 @@ Primary retrieval. Hybrid vector + BM25 + filter.
 | `max_age_seconds` | int (optional) | Only return chunks whose `indexed_at` is within this age |
 | `filters` | object (optional) | Metadata filters (`language=python`, `path_prefix=apps/server/`, ...) |
 | `include_tombstoned` | bool (default false) | Include removed documents |
+| `retrieval_strategy` | enum (default `"hybrid"`) | `"hybrid"` (v0.1), `"structural"`, `"keyword"`, `"auto"` — see below |
+
+### Retrieval strategies
+
+The `retrieval_strategy` parameter lets the caller choose how retrieval works. In v0.1, only `"hybrid"` is implemented; other values are part of the v0.2 plan and documented here for contract stability. See [ADR 0004](../decisions/0004-retrieval-strategy-staged.md) for rationale.
+
+| Value | Behavior | Status |
+|---|---|---|
+| `"hybrid"` (default) | Vector (pgvector HNSW) + BM25 (tsvector), merged via reciprocal rank fusion. Good for ~70–80% of typical queries | v0.1 |
+| `"structural"` | Graph-first. Interpret query as "find entities and traverse" using the structural graph (code imports, infra DEPENDS_ON, doc cross-refs). Falls back to hybrid if graph finds nothing | v0.2 |
+| `"keyword"` | BM25-only. For exact-name lookup (function names, error strings, service names) | v0.1 (via `filters` today; explicit strategy in v0.2) |
+| `"auto"` | A lightweight classifier picks the strategy for you. Use this when you don't want to reason about query shape | v0.2 |
+
+The **caller is often best-placed to choose**: a code-aware agent asking *"what depends on X"* knows to pass `"structural"`. `"auto"` exists for callers that don't want to decide.
+
+In v0.1, requests with `retrieval_strategy` other than `"hybrid"` are accepted with a warning and downgraded to `"hybrid"`. This preserves the API contract so clients written for v0.2 continue to work against v0.1 deployments.
 
 **Output**:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,6 +116,25 @@ Single `docker-compose.yml` brings up:
 
 Helm chart available for Kubernetes.
 
+### Managed Postgres
+
+Nothing in Omniscience requires the built-in Postgres. Any Postgres 14+ with pgvector works:
+
+- **AWS RDS for PostgreSQL** — pgvector available as a managed extension
+- **Google Cloud SQL** — pgvector extension supported
+- **Supabase / Neon / Crunchy Bridge** — pgvector first-class
+- **Aurora PostgreSQL** — pgvector supported
+
+Set `DATABASE_URL` to the external instance; drop the `postgres` service from Compose. Daily `pg_dump` backup sidecar can be similarly disabled in favor of the managed provider's backup mechanism.
+
+## Agent layer (for AgenticConnector only)
+
+Most of Omniscience is deterministic. The exception is **AgenticConnector** — a connector variant whose `discover()` phase uses an LLM to decide what to index (see [ADR 0003](decisions/0003-agent-framework-langgraph-primary.md)).
+
+- **v0.1**: LangGraph, with pluggable LLM provider (Gemini, Claude, Ollama)
+- **v0.2**: CrewAI and PydanticAI adapters added
+- **Layer B** (external users calling Omniscience from their agent code): uses MCP directly, no Omniscience-side abstraction — see [integrations/](integrations/)
+
 ## Data flow: a source update
 
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,13 +81,35 @@ Single source of truth. No separate vector DB.
 
 ### 4. Retrieval service (`packages/retrieval/`)
 
-Hybrid search:
+Hybrid search — **staged**, see [ADR 0004](decisions/0004-retrieval-strategy-staged.md).
+
+#### v0.1 — Hybrid baseline
 
 1. **Vector** — pgvector HNSW top-K
 2. **BM25-like** — tsvector ranking
 3. **Merge** — reciprocal rank fusion
 4. **Filter** — ACL, source subset, freshness cap
-5. **Re-rank** (v0.3) — cross-encoder optional
+
+#### v0.2 — Adaptive retrieval
+
+Add structural strategies using edges already present in source data (no LLM extraction):
+
+- **Code**: imports, calls, class inheritance — from tree-sitter output
+- **Infrastructure**: DEPENDS_ON from Terraform state, k8s ownerReferences, Helm chart deps
+- **Docs**: markdown links, ADR supersedes
+- **Cross-source entity linking**: resource-name matching across connectors
+
+Storage: same Postgres, new `entities` + `edges` tables. Queries via recursive CTEs or Apache AGE (Cypher). **No separate graph database.**
+
+Callers (or an internal `"auto"` classifier) select the strategy per query via the `retrieval_strategy` parameter.
+
+#### v0.3+ — Full GraphRAG (optional, triggered by evidence)
+
+LLM-extracted entities + community detection — only if v0.2 structural coverage leaves clear gaps on text-heavy sources (ADRs, post-mortems, wikis).
+
+#### v0.3 — Re-ranking
+
+Cross-encoder second pass over top-N to boost precision. Cheap quality win.
 
 Returns chunks with citations and provenance.
 

--- a/docs/decisions/0002-connector-framework-vs-sdk.md
+++ b/docs/decisions/0002-connector-framework-vs-sdk.md
@@ -1,0 +1,51 @@
+# ADR 0002 — Connector framework, not a published SDK (for now)
+
+- **Status**: Accepted
+- **Date**: 2026-04-17
+- **Supersedes**: none
+
+## Context
+
+The term "Connector SDK" appeared in early docs ([docs/api/connector-sdk.md](../api/connector-sdk.md), issue [#5](https://github.com/100rd/Omniscience/issues/5)). Strictly speaking, an SDK is a published package with stable API, semver guarantees, and external-developer-targeted documentation — so that third parties can write connectors without forking Omniscience.
+
+That is a **significant** ongoing commitment: stability, backward compatibility, versioning, examples, CI matrix against multiple framework versions, etc.
+
+## Decision
+
+For v0.1 and v0.2, the connector mechanism is an **internal framework**, not a published SDK. All connectors live in the Omniscience monorepo under `packages/connectors/`. Adding a new source type = PR against Omniscience.
+
+Published SDK (separate `omniscience-sdk` PyPI package) is deferred. Revisit triggers listed below.
+
+## Rationale
+
+- **Smaller surface area** during rapid iteration — interface can evolve freely
+- **Zero maintenance cost** for external versions, downstream breakage, or CI against older SDK versions
+- **Consolidated learning** — we figure out what the right abstraction is by building several connectors ourselves, not by committing to an interface prematurely
+- **Contributors contribute directly** — a PR in one repo is strictly easier than "install our SDK, write against it, test against our server, upstream back" flow
+
+## Revisit triggers
+
+Re-evaluate when any of these is true:
+
+- External developer(s) explicitly request to ship a connector without merging into Omniscience
+- 3+ different people outside the core team have contributed connectors (signal: ecosystem forming)
+- A company needs to ship a proprietary / internal connector that cannot be upstreamed (licensing, IP, compliance)
+- API stability is demonstrably reached (6+ months without breaking changes)
+
+When triggered, extract to `packages/connectors/omniscience-connectors-sdk` → publish to PyPI → semver from that point.
+
+## Consequences
+
+- Doc `docs/api/connector-sdk.md` is renamed conceptually to "Connector framework". For now we keep the file path to avoid breaking existing links and add a disclaimer at the top.
+- Issue [#5](https://github.com/100rd/Omniscience/issues/5) title adjusted in description to "Connector framework".
+- No `@public` API annotations, no semver commitment. Breaking changes allowed, with migration notes in release notes.
+
+## Alternatives rejected
+
+### Publish SDK day-one
+
+Rejected. Classic premature standardization — we'd freeze an interface we don't yet fully understand. Every real-world SDK-first design has iterated its interface post-launch; doing that with semver is costly.
+
+### Full fork model
+
+"Connectors live in their own repos, users fork Omniscience to add them." Rejected: this turns Omniscience into a generator/scaffold, not a product. Users want batteries-included.

--- a/docs/decisions/0003-agent-framework-langgraph-primary.md
+++ b/docs/decisions/0003-agent-framework-langgraph-primary.md
@@ -1,0 +1,116 @@
+# ADR 0003 — Agent framework: LangGraph primary, CrewAI + PydanticAI as adapters
+
+- **Status**: Accepted
+- **Date**: 2026-04-17
+- **Supersedes**: none
+
+## Context
+
+Omniscience's retrieval path is deterministic — no agents, no LLMs in hot path. However, some connectors cannot be expressed declaratively and require **LLM-driven decisions during discovery**: what to index, how to interpret, when to stop. Examples:
+
+- **k8s** — which resources? Deployments and ConfigMaps yes; transient events no; Secrets never. Heuristics leak; an LLM that understands the cluster decides better
+- **Databases** — index schemas, comments, saved queries; skip transactional data. Which tables are reference data vs transactional?
+- **Selective log ingestion** — ingest error/warn only from specific services; summarize rather than embed raw lines
+
+We call these **AgenticConnectors**. They need an agent framework.
+
+### Constraints
+
+- Target stack: Gemini + Claude (mixed provider setup, no single-vendor alignment)
+- No tight coupling to Google or Anthropic ecosystems
+- Must support MCP tools natively (we already expose MCP tools internally — e.g., k8s API via MCP server)
+- Must support streaming, structured output, max-iterations guards
+- Must be reasonably mature (production adoption, not pre-alpha)
+
+### Candidates evaluated
+
+| Framework | Verdict |
+|---|---|
+| **LangGraph** | ✅ chosen primary |
+| **CrewAI** | ✅ chosen as v0.2 adapter |
+| **PydanticAI** | ✅ chosen as v0.2 adapter |
+| Google ADK | ❌ Gemini-biased, not optimal for mixed stack |
+| AutoGen | ❌ Microsoft-biased ecosystem; weaker tool interop |
+| Self-rolled loop | ❌ reinvents the wheel; sufficient for a PoC but not for sustained development |
+
+## Decision
+
+### v0.1 (now)
+
+**LangGraph** is the primary and only supported agent framework for AgenticConnector. Reasons:
+
+- **Mature and battle-tested** — 2+ years, large community, extensive documentation
+- **Vendor-neutral** — `ChatGoogleGenerativeAI`, `ChatAnthropic` work identically; Gemini + Claude use is first-class
+- **Stateful graphs** — right abstraction for AgenticConnector (branching decisions, retry loops, tool use)
+- **MCP tools supported** via `langchain-mcp-adapters`
+- **Streaming + structured output** built in
+- **Human-in-the-loop** primitives if needed later for approval gates
+
+### v0.2
+
+Introduce an `AgentRunner` abstraction with adapters for:
+
+- **CrewAI** — for role-based multi-agent scenarios (e.g., Researcher + Curator + Verifier for entity extraction)
+- **PydanticAI** — for simpler, typed, low-overhead loops where LangGraph is overkill
+
+Adapters translate a unified `AgentConfig` + `MCPTool[]` into each framework's native form. Each adapter is ~150–250 LOC.
+
+## Why staged
+
+Building three framework adapters simultaneously in v0.1 would:
+
+- Triple testing matrix before we understand what the common abstraction should be
+- Delay MVP by ~1.5–2 weeks
+- Lock us into an abstraction that real-world use might reveal as wrong
+
+Staging means: get LangGraph working end-to-end, build 2–3 AgenticConnectors on it, **then** extract the abstraction from observed patterns. Classic "prefer concrete over abstract until you have three examples" rule.
+
+## LLM provider abstraction
+
+Independent of agent framework choice, we keep an `LLMProvider` abstraction:
+
+```python
+class LLMProvider(Protocol):
+    name: str                      # "gemini", "anthropic", "ollama"
+    default_model: str
+
+    def langgraph_chat_model(self) -> BaseChatModel: ...
+    def crewai_llm(self) -> LLM: ...              # when CrewAI adapter lands
+    def pydantic_ai_model(self) -> Model: ...     # when PydanticAI adapter lands
+```
+
+This means an AgenticConnector can say "use Gemini Flash" or "use Claude Sonnet" and the LangGraph-powered implementation picks up the right model object. When adapters land, the same `LLMProvider` feeds CrewAI and PydanticAI too.
+
+## Default models
+
+For AgenticConnector LLM calls:
+
+- **Default**: `claude-sonnet-4-5` (strong tool-use, good reasoning/cost balance)
+- **Cost-optimized**: `gemini-2.5-flash`
+- **Local / air-gapped**: `ollama:llama-3.1` (reduced capability, documented)
+
+Configurable per-connector + per-workspace.
+
+## Layer B: external framework use is free
+
+This ADR covers **Layer A**: frameworks used *inside* Omniscience. For **Layer B** — users calling Omniscience *from* their LangGraph/CrewAI/PydanticAI code — nothing to build. MCP is the standard; all three frameworks support MCP tools natively. We only ship integration guides. See [docs/integrations/](../integrations/).
+
+## Revisit triggers
+
+- LangGraph has a sustained period (6+ months) of breaking changes or community decline
+- v0.2 reveals that CrewAI/PydanticAI adapters don't cover actual user needs
+- A compelling new agent framework emerges with substantially better fit (unlikely in a 1-year horizon)
+- User feedback shows more demand for agent framework X than our adapter matrix predicts
+
+## Dependencies added
+
+```
+langgraph             ~=0.2        # v0.1
+langchain-google-genai ~=2.0       # v0.1 — Gemini chat model
+langchain-anthropic   ~=0.2        # v0.1 — Claude chat model
+langchain-mcp-adapters ~=0.1       # v0.1 — MCP tools into LangGraph
+crewai                ~=0.100      # v0.2 — adapter
+pydantic-ai           ~=0.0.20     # v0.2 — adapter
+```
+
+Exact versions pinned in `pyproject.toml` when the AgenticConnector issue lands.

--- a/docs/decisions/0004-retrieval-strategy-staged.md
+++ b/docs/decisions/0004-retrieval-strategy-staged.md
@@ -1,0 +1,111 @@
+# ADR 0004 — Retrieval strategy: staged (hybrid → structural → GraphRAG-if-needed)
+
+- **Status**: Accepted
+- **Date**: 2026-04-17
+- **Supersedes**: none
+
+## Context
+
+Retrieval quality is the single biggest determinant of Omniscience's usefulness. Multiple strategies exist; none is strictly better — each solves a different class of query. A concrete decision is needed about what to implement when, to avoid either:
+
+1. **Under-building** — ship pure vector RAG and discover too late that it misses structural queries
+2. **Over-building** — implement Microsoft-style GraphRAG day one, drowning in LLM-ingestion cost before users have said what they want
+
+## The retrieval landscape in 2026
+
+| Strategy | What it does | Cost | When it wins |
+|---|---|---|---|
+| **Vector (dense)** | Embed query, kNN over chunk embeddings | Low runtime, moderate ingest | Semantic similarity ("how do I configure X") |
+| **BM25 / tsvector** | Keyword scoring, exact matches | Very low | Exact names, error strings, function names |
+| **Hybrid (vector + BM25)** | Both, merged via reciprocal rank fusion | Low | Baseline for production RAG |
+| **Lightweight structural graph** | Follow edges already present in data (imports, DEPENDS_ON, ownerReferences, markdown links) | Very low (edges extracted deterministically) | "What depends on X?", "Where is Y used?" |
+| **Re-ranking** (cross-encoder) | Second pass over top-N to boost precision | Moderate (tiny model per query) | Always a quality win for top-10 |
+| **Full GraphRAG (Microsoft-style)** | LLM extracts entities + relationships, builds KG, community detection + summarisation | **Very high ingest cost** (LLM per doc × 1–many calls) | Text corpora without explicit structure (research, memos) |
+| **Agentic retrieval** | LLM plans multiple retrieval calls, refines iteratively | Moderate per query | Complex queries ("why did X break?") |
+
+**What is NOT the 2026 standard**: pure full-GraphRAG. The actual production norm is **hybrid + lightweight structural + re-ranking**, with agentic retrieval on the rise for complex queries.
+
+## Decision
+
+Staged implementation. Each stage delivers user-visible value; no stage commits to the next.
+
+### v0.1 — Hybrid baseline
+
+- Vector (pgvector HNSW) + BM25 (tsvector)
+- Reciprocal rank fusion to merge
+- Filters: source, type, freshness, metadata
+- **Sufficient for ~70–80% of typical queries**
+
+Already scoped in issue #13.
+
+### v0.2 — Lightweight structural
+
+Add edges that are **already present in source data**, extracted without LLM:
+
+- **Code**: imports, function calls, class inheritance, module references — from tree-sitter output
+- **Infrastructure**: DEPENDS_ON from Terraform state, ownerReferences from k8s, Helm chart dependencies
+- **Docs**: markdown links, ADR supersedes, cross-references between pages
+- **Cross-source entity linking**: match by name — Terraform resource `aws_eks_cluster.prod` ↔ k8s context `prod` ↔ Grafana dashboard `prod-cluster`; stored as weighted edges
+
+Storage:
+
+- Same Postgres instance, new tables: `entities` (one row per identifiable thing), `edges` (one row per relationship)
+- Edge queries via recursive CTEs — or upgrade to Apache AGE if Cypher becomes useful
+- **No separate graph database** (Neo4j / FalkorDB) — would add ops complexity without proportional benefit at our scale
+
+Retrieval becomes **adaptive**: the retrieval service selects strategy based on query shape.
+
+### v0.3+ — Optional full GraphRAG
+
+Only if v0.2 leaves clear gaps. Triggers to consider:
+
+- Users repeatedly ask "what does this post-mortem say about X?" type queries and answers are poor
+- We accumulate text-heavy sources (ADRs, meeting notes, wikis, incident reports) with implicit relationships
+- Cost-of-missed-answer outweighs LLM ingestion cost
+
+Implementation would introduce a separate **entity extraction pipeline** (LLM over chunks) and community-detection index. Still reuses Postgres for storage.
+
+## Adaptive retrieval
+
+From v0.2, the `search` tool exposes an optional `retrieval_strategy` parameter:
+
+| Value | Behavior |
+|---|---|
+| `"hybrid"` (default) | v0.1 hybrid — vector + BM25 |
+| `"structural"` | Graph-first — interpret query as "find entities and traverse", fall back to hybrid |
+| `"keyword"` | BM25-only — for exact-name lookup |
+| `"auto"` | LLM classifies the query and picks strategy (light, cached) |
+
+The **caller** is often best-placed to choose (Claude Code agent knows it's asking "what depends on X"). `auto` exists for callers that don't want to reason about it.
+
+## Rationale for staging (not building GraphRAG now)
+
+1. **Cost profile**: full-GraphRAG ingest adds ~$0.10–1.00 per 1000 chunks (LLM calls). For a 10M-chunk corpus — $1k–$10k per reindex. Without evidence the gain justifies this, don't build.
+2. **Quality of structural edges from non-LLM sources is high** (tree-sitter, Terraform graph, k8s ownerReferences are ground truth, not inferred). Take the free signal first.
+3. **User queries cluster around semantic + keyword** in practice. Exotic graph-traversal queries are valuable but rarer.
+4. **Adaptive retrieval is cheap to add later** once we have multiple strategies to route between.
+
+## Alternatives rejected
+
+### "Ship pure vector RAG in v0.1, decide later"
+
+Rejected. Pure vector RAG is a known production deficit — misses exact-name queries, produces off-target results for short queries. Hybrid is marginal cost and obvious win; no reason to skip.
+
+### "Ship full GraphRAG day one"
+
+Rejected. Premature optimisation, high cost, locks us into a specific methodology before we know whether it fits user queries. Microsoft's published numbers show gains but also dramatic ingestion costs; we'd absorb that before knowing the gain.
+
+### "Use Neo4j as primary graph store"
+
+Rejected for v0.2. Separate graph DB adds operational complexity. Postgres with `edges` table + recursive CTEs (or Apache AGE for Cypher) covers the structural queries we'd actually run. Revisit at v0.4+ if scale or query complexity genuinely needs it.
+
+## Consequences
+
+- Issue #13 (retrieval) stays as v0.1 hybrid; no graph logic added there
+- v0.2 issues created for structural retrieval pieces:
+  - Symbol graph for code
+  - Infrastructure dependency edges
+  - Cross-source entity linking
+  - Adaptive retrieval agent
+- `docs/api/mcp.md` documents the `retrieval_strategy` parameter now (contract), but only `hybrid` works in v0.1; other values land in v0.2
+- `docs/architecture.md` gets an "Adaptive retrieval" subsection reflecting the staged plan

--- a/docs/freshness-and-lineage.md
+++ b/docs/freshness-and-lineage.md
@@ -1,0 +1,131 @@
+# Freshness and lineage
+
+Two cross-cutting concerns that determine how much **trust** a caller can place in Omniscience's responses:
+
+- **Freshness** — how recently the source was synced, and how recently each chunk was re-indexed
+- **Lineage** — where a chunk came from, by what process, with what model/parser, in which ingestion run
+
+Together these let an AI client decide: *"is this chunk trustworthy enough for my task, and can I explain the answer to my user?"*
+
+## Freshness
+
+### Per-source SLO
+
+Each `source` carries `freshness_sla_seconds` (see [schema.md](schema.md)). When `now() - last_sync_at > sla`, the source is flagged stale:
+
+- `GET /sources` surfaces it in status
+- MCP `list_sources` returns `is_stale: true`
+- Prometheus alert fires
+- UI badges it
+
+### Per-query filter
+
+The MCP `search` tool accepts `max_age_seconds`. Chunks whose `indexed_at` is older than this are filtered out before ranking. Caller controls the trade-off between recall and freshness.
+
+### Source update mechanisms
+
+| Source type | Mechanism | Target freshness |
+|---|---|---|
+| `git` (GitHub/GitLab) | Push webhook → incremental fetch | < 5 min after push |
+| `fs` (local filesystem) | `watchfiles`/`fsnotify` → immediate reparse | < 30 sec after save |
+| `confluence` | Webhook (Cloud) / polling (Server); daily full sync as safety net | < 5 min (Cloud), 15 min (Server) |
+| `notion` | Webhook via Notion integration | < 5 min |
+| `slack` | Events API subscription | Seconds |
+| `jira` / `linear` | Webhook | < 2 min |
+| `grafana` | Polling (15 min default) | < 15 min |
+| `argocd` | Webhook on sync events | < 1 min |
+| `k8s` (state) | Watch API | Real-time |
+| `terraform` | On-apply hook + periodic state-file pull | < 5 min after apply |
+| `databases` (schemas) | Polling with change detection | < 1 hour |
+
+### Safety net: periodic full sync
+
+Every source runs a scheduled full rediscover regardless of push/pull mode — default daily at low-traffic hour. Catches:
+
+- Missed webhooks (networking, provider downtime)
+- Source-side edits that didn't emit events (manual DB writes)
+- Permission changes affecting which documents are visible
+
+### Retention of stale data
+
+A document whose source goes silent for longer than `freshness_sla_seconds * N` (configurable, default 7× SLA) is tombstoned. Retention window keeps it queryable-with-warning for 30 days before hard delete.
+
+## Lineage
+
+### Data model
+
+Lineage fields on every chunk (see [schema.md](schema.md) — updated in the same PR as this doc):
+
+| Field | Meaning |
+|---|---|
+| `document_id` | Parent doc |
+| `source_id` | Source that produced the doc |
+| `ingestion_run_id` | The specific ingestion run that produced this chunk |
+| `embedding_model` | e.g., `bge-large-en-v1.5` |
+| `embedding_provider` | e.g., `ollama`, `google-ai`, `openai` |
+| `parser_version` | Version of the parser used (tree-sitter grammar hash + parser code hash) |
+| `chunker_strategy` | e.g., `code_symbol`, `markdown_section` |
+| `indexed_at` | Timestamp of index write |
+| `doc_version` | Monotonic; changes when source content changes |
+
+### Response format
+
+MCP `search` response includes a `lineage` sub-object on every hit (see [api/mcp.md](api/mcp.md) — same PR):
+
+```json
+{
+  "hits": [{
+    "chunk_id": "...",
+    "text": "...",
+    "score": 0.87,
+    "source": {"id": "...", "name": "main-gitlab", "type": "git"},
+    "citation": {
+      "uri": "https://github.com/org/repo/blob/abc123/auth.py#L42-L60",
+      "title": "auth.py",
+      "indexed_at": "2026-04-17T10:32:15Z",
+      "doc_version": 7
+    },
+    "lineage": {
+      "ingestion_run_id": "ir_01HXYZ...",
+      "embedding_model": "text-embedding-004",
+      "embedding_provider": "google-ai",
+      "parser_version": "treesitter-python-0.21+oms-0.4.2",
+      "chunker_strategy": "code_symbol"
+    },
+    "metadata": {...}
+  }]
+}
+```
+
+### Why these fields specifically
+
+Every field answers a real operational question:
+
+- **`ingestion_run_id`** → *"which run produced this? Did that run complete cleanly?"*
+- **`embedding_model` + `embedding_provider`** → *"is this chunk embedded with the current model, or does it need re-embed?"* Critical when model changes or a workspace switches providers
+- **`parser_version`** → *"a parser bug was fixed on 2026-04-01. Which chunks predate the fix?"* Enables targeted reindex instead of blast-radius full reindex
+- **`chunker_strategy`** → *"this answer is oddly specific — is it a whole-function chunk or a sliding window?"* Affects how the caller interprets context
+
+### Lineage as a first-class query
+
+For operators, not AI clients:
+
+- `GET /documents/:id` returns the full lineage trail
+- `GET /chunks/:id/lineage` returns ingestion history for a single chunk
+- CLI: `omniscience chunks inspect <chunk_id>` prints the trail
+
+### Privacy note
+
+Lineage contains no source content itself (no prompts, no secrets). It is safe to log and export. Source content (text of chunks, document bodies) is governed by regular ACL — see query-time filters.
+
+## How this enables downstream use
+
+- **AI clients** can decide trust per-chunk ("only accept chunks under 10 min old from sources tagged `prod-docs`")
+- **Operators** can diagnose "why is this answer wrong?" by tracing back to ingestion run + parser version
+- **Re-embed / reindex jobs** can target only affected chunks (same model? same parser? same ingestion run?) rather than nuking everything
+
+## See also
+
+- [schema.md](schema.md) — database fields
+- [api/mcp.md](api/mcp.md) — response format
+- [architecture.md](architecture.md) — ingestion pipeline stages where these fields are populated

--- a/docs/integrations/crewai.md
+++ b/docs/integrations/crewai.md
@@ -1,0 +1,112 @@
+# Using Omniscience from CrewAI
+
+You have CrewAI agents (role-based multi-agent) and want them to query Omniscience for grounded retrieval. CrewAI supports MCP tools natively.
+
+## Prerequisites
+
+- Running Omniscience instance
+- Omniscience API token with `search` + `sources:read` scopes
+- Python 3.10+, CrewAI installed
+
+## Install
+
+```bash
+pip install crewai crewai-tools
+```
+
+## Connect
+
+```python
+import os
+from crewai import Agent, Task, Crew
+from crewai_tools import MCPServerAdapter
+
+OMNISCIENCE_URL = os.environ["OMNISCIENCE_URL"]
+OMNISCIENCE_TOKEN = os.environ["OMNISCIENCE_TOKEN"]
+
+# Connect to Omniscience via MCP
+server_params = {
+    "url": f"{OMNISCIENCE_URL}/mcp",
+    "transport": "streamable-http",
+    "headers": {"Authorization": f"Bearer {OMNISCIENCE_TOKEN}"},
+}
+
+with MCPServerAdapter(server_params) as omniscience_tools:
+    # Tools: search, get_document, list_sources, source_stats
+    researcher = Agent(
+        role="Codebase Researcher",
+        goal="Find relevant code and docs grounding for engineering questions",
+        backstory="You know where to look in a large codebase.",
+        tools=omniscience_tools,
+        verbose=True,
+    )
+
+    writer = Agent(
+        role="Technical Writer",
+        goal="Synthesize findings into accurate, cited answers",
+        backstory="You turn raw research into readable answers with citations.",
+        verbose=True,
+    )
+
+    research_task = Task(
+        description="Research how authentication works in the payments service.",
+        agent=researcher,
+        expected_output="Bulleted findings with chunk_ids and source paths.",
+    )
+
+    write_task = Task(
+        description="Write a clear explanation from the research findings.",
+        agent=writer,
+        expected_output="Markdown answer with inline citations.",
+        context=[research_task],
+    )
+
+    crew = Crew(agents=[researcher, writer], tasks=[research_task, write_task])
+    result = crew.kickoff()
+    print(result)
+```
+
+## When CrewAI fits
+
+- **Role-based decomposition** — separate Researcher, Verifier, Writer, etc.
+- **Linear task dependencies** — research → synthesize → verify → report
+- **Low-ceremony multi-agent** — CrewAI is simpler than LangGraph for basic fan-out/aggregate
+
+For complex state machines (loops, branches, human-in-the-loop), prefer [LangGraph](langgraph.md).
+
+## Recommended patterns
+
+### Source-specialized agents
+
+Give different agents different tool subsets via `list_sources()` inspection, or filter at `search()` call time with `sources=[...]`:
+
+```python
+code_researcher = Agent(
+    role="Code Researcher",
+    goal="Find code patterns — only look in source code, not docs or tickets",
+    tools=omniscience_tools,
+    # Instruction to the agent:
+    backstory="Always pass sources filter to search: sources=['main-gitlab']",
+)
+```
+
+### Verification before committing an answer
+
+```python
+verifier = Agent(
+    role="Citation Verifier",
+    goal="Re-fetch each cited chunk to confirm claims",
+    tools=omniscience_tools,
+    backstory="You call get_document() for each citation and flag any mismatch.",
+)
+```
+
+## Scope and security
+
+Same as [LangGraph guide](langgraph.md): narrow token scopes, never ship `admin` tokens to agents, propagate lineage in outputs.
+
+## See also
+
+- [LangGraph integration](langgraph.md)
+- [PydanticAI integration](pydantic-ai.md)
+- [MCP API reference](../api/mcp.md)

--- a/docs/integrations/langgraph.md
+++ b/docs/integrations/langgraph.md
@@ -1,0 +1,121 @@
+# Using Omniscience from LangGraph
+
+You have LangGraph agents and want them to query Omniscience for grounded retrieval across your sources. Omniscience exposes an MCP server; LangGraph consumes MCP tools natively via `langchain-mcp-adapters`.
+
+## Prerequisites
+
+- Running Omniscience instance (see [quickstart](../../README.md))
+- Omniscience API token with `search` + `sources:read` scopes
+- Python 3.10+, LangGraph installed
+
+## Install
+
+```bash
+pip install langgraph langchain-mcp-adapters langchain-anthropic  # or langchain-google-genai
+```
+
+## Connect
+
+```python
+import os
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+from langchain_anthropic import ChatAnthropic
+
+OMNISCIENCE_URL = os.environ["OMNISCIENCE_URL"]
+OMNISCIENCE_TOKEN = os.environ["OMNISCIENCE_TOKEN"]
+
+async def build_agent():
+    # Connect to Omniscience via MCP streamable-http
+    client = MultiServerMCPClient(
+        {
+            "omniscience": {
+                "url": f"{OMNISCIENCE_URL}/mcp",
+                "transport": "streamable_http",
+                "headers": {"Authorization": f"Bearer {OMNISCIENCE_TOKEN}"},
+            }
+        }
+    )
+    tools = await client.get_tools()
+
+    # Tools now include: search, get_document, list_sources, source_stats
+    agent = create_react_agent(
+        model=ChatAnthropic(model="claude-sonnet-4-5"),
+        tools=tools,
+        prompt=(
+            "You are a code-aware assistant. Use omniscience.search() to "
+            "retrieve grounded context before answering. Always cite sources."
+        ),
+    )
+    return agent
+
+# Run it
+async def main():
+    agent = await build_agent()
+    result = await agent.ainvoke({
+        "messages": [("user", "How does authentication work in the payments service?")]
+    })
+    print(result["messages"][-1].content)
+```
+
+## Recommended agent patterns
+
+### Retrieval-augmented Q&A
+
+```python
+agent = create_react_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-5"),
+    tools=tools,  # includes omniscience.search
+    prompt="Answer questions using omniscience.search for grounding. Cite.",
+)
+```
+
+### Multi-step research with state
+
+Use LangGraph's `StateGraph` when a single search isn't enough (research → synthesize → verify):
+
+```python
+from langgraph.graph import StateGraph, START, END
+from typing import TypedDict, Annotated
+import operator
+
+class ResearchState(TypedDict):
+    question: str
+    search_results: Annotated[list, operator.add]
+    draft_answer: str
+    verified: bool
+
+# ... build graph with nodes that call omniscience tools
+```
+
+### Freshness-aware retrieval
+
+Pass `max_age_seconds` to limit stale results:
+
+```python
+# Via tool call kwargs
+result = await search_tool.ainvoke({
+    "query": "recent deployment config changes",
+    "max_age_seconds": 3600,  # last hour only
+    "top_k": 10,
+})
+```
+
+## Scope and security
+
+- Use a **narrowly scoped token** (`search` + `sources:read` only). Never use `admin` in an agent context.
+- Store `OMNISCIENCE_TOKEN` via your secret manager, not in code.
+- Omniscience lineage data (`embedding_model`, `indexed_at`, `source.name`) is returned on every hit — propagate it in your agent's citations.
+
+## Gotchas
+
+- **First call latency**: MCP connection setup adds ~100ms. Reuse `client` across agent invocations.
+- **Stale results**: if your sources haven't synced recently, results may be outdated. Check `list_sources()` for `is_stale` flags.
+- **Rate limits**: default 60 rpm per token. For high-throughput agents, request a higher limit via token config.
+
+## See also
+
+- [MCP API reference](../api/mcp.md)
+- [Claude Code integration](claude-code.md) — same MCP, IDE-integrated
+- [CrewAI integration](crewai.md) — alternative framework
+- [PydanticAI integration](pydantic-ai.md) — alternative framework

--- a/docs/integrations/pydantic-ai.md
+++ b/docs/integrations/pydantic-ai.md
@@ -1,0 +1,117 @@
+# Using Omniscience from PydanticAI
+
+You have PydanticAI agents (typed, lightweight) and want them to query Omniscience. PydanticAI has native MCP support.
+
+## Prerequisites
+
+- Running Omniscience instance
+- Omniscience API token with `search` + `sources:read` scopes
+- Python 3.10+, PydanticAI installed
+
+## Install
+
+```bash
+pip install pydantic-ai
+```
+
+## Connect
+
+```python
+import os
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerHTTP
+
+OMNISCIENCE_URL = os.environ["OMNISCIENCE_URL"]
+OMNISCIENCE_TOKEN = os.environ["OMNISCIENCE_TOKEN"]
+
+omniscience = MCPServerHTTP(
+    url=f"{OMNISCIENCE_URL}/mcp",
+    headers={"Authorization": f"Bearer {OMNISCIENCE_TOKEN}"},
+)
+
+agent = Agent(
+    "anthropic:claude-sonnet-4-5",   # or "google-gla:gemini-2.5-flash"
+    mcp_servers=[omniscience],
+    system_prompt=(
+        "You answer engineering questions. Use omniscience.search to find "
+        "grounded context. Cite chunk_id + uri for every claim."
+    ),
+)
+
+async def main():
+    async with agent.run_mcp_servers():
+        result = await agent.run(
+            "How does authentication work in the payments service?"
+        )
+        print(result.data)
+```
+
+## When PydanticAI fits
+
+- **Typed, structured output** — Pydantic models as `result_type` give you guaranteed schemas
+- **Simple loops** — one or two tool calls per user turn, not complex state graphs
+- **Clean API, low overhead** — the fastest way to ship a typed agent
+- **Vendor-neutral** — `"anthropic:..."` and `"google-gla:..."` work identically
+
+For complex workflows, use [LangGraph](langgraph.md). For role-based teams, use [CrewAI](crewai.md).
+
+## Recommended patterns
+
+### Structured retrieval responses
+
+```python
+from pydantic import BaseModel
+
+class Citation(BaseModel):
+    chunk_id: str
+    uri: str
+    title: str
+    indexed_at: str
+
+class Answer(BaseModel):
+    text: str
+    citations: list[Citation]
+
+agent = Agent(
+    "anthropic:claude-sonnet-4-5",
+    mcp_servers=[omniscience],
+    result_type=Answer,
+    system_prompt="Return an Answer with at least 2 citations from omniscience.search.",
+)
+
+async with agent.run_mcp_servers():
+    result = await agent.run("Explain our rate-limiting strategy.")
+    # result.data is a validated Answer instance
+    for c in result.data.citations:
+        print(c.uri, c.indexed_at)
+```
+
+### Streaming
+
+```python
+async with agent.run_mcp_servers():
+    async with agent.run_stream("What changed in the last deploy?") as result:
+        async for chunk in result.stream_text():
+            print(chunk, end="", flush=True)
+```
+
+### Multi-source filtering
+
+PydanticAI passes through MCP tool args, so you can steer via system prompt or explicit tool args:
+
+```python
+# In your system prompt:
+"When the user asks about docs, call search with sources=['company-wiki']. "
+"When asking about code, call search with sources=['main-gitlab']."
+```
+
+## Scope and security
+
+Same as other guides: narrow token scopes, store `OMNISCIENCE_TOKEN` via secret manager, propagate lineage fields.
+
+## See also
+
+- [LangGraph integration](langgraph.md)
+- [CrewAI integration](crewai.md)
+- [MCP API reference](../api/mcp.md)
+- [PydanticAI MCP docs](https://ai.pydantic.dev/mcp/)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -62,12 +62,21 @@ Chunked, embedded content used at retrieval.
 | `text_tsv` | tsvector | Generated column, language-aware |
 | `embedding` | vector(768) | Dim parameterized via migration |
 | `symbol` | text | For code: function/class FQN; nullable |
-| `metadata` | jsonb | Anything useful for filters (line_range, section_path, ...) |
+| **`ingestion_run_id`** | uuid fk → ingestion_runs | Which ingestion run produced this chunk — lineage |
+| **`embedding_model`** | text | e.g., `bge-large-en-v1.5`, `text-embedding-004` — lineage |
+| **`embedding_provider`** | text | e.g., `ollama`, `google-ai`, `openai` — lineage |
+| **`parser_version`** | text | Parser identifier + hash, e.g., `treesitter-python-0.21+oms-0.4.2` — lineage |
+| **`chunker_strategy`** | text | e.g., `code_symbol`, `markdown_section`, `fixed_window` — lineage |
+| `metadata` | jsonb | Anything else useful for filters (line_range, section_path, ...) |
 
 Indexes:
 - `(document_id, ord)`
 - GIN on `text_tsv`
 - HNSW on `embedding` (`vector_cosine_ops`, `m=16, ef_construction=64`)
+- `embedding_model` + `embedding_provider` — for targeted re-embed after model change
+- `parser_version` — for targeted reindex after parser bug-fix
+
+Lineage fields matter for operational answers: "which chunks predate the parser fix?", "is this chunk embedded with the current model?", "which ingestion run produced this?". See [freshness-and-lineage.md](freshness-and-lineage.md).
 
 ### `ingestion_runs`
 


### PR DESCRIPTION
## Summary

Addresses design-review questions raised before implementation begins:

- **Where the DB lives** — explicit managed Postgres support (RDS, Cloud SQL, Supabase, Neon) in [architecture.md](docs/architecture.md)
- **Update cadence** — new [docs/freshness-and-lineage.md](docs/freshness-and-lineage.md) with per-source SLO matrix
- **Freshness parameter** — confirmed already in MCP API (\`max_age_seconds\` per query); documented alongside source-level SLA
- **Rich lineage per chunk** — [schema.md](docs/schema.md) gains \`ingestion_run_id\`, \`embedding_model\`, \`embedding_provider\`, \`parser_version\`, \`chunker_strategy\` columns; MCP \`search\` response gains \`lineage\` sub-object
- **Connectors vs agents** — introduces \`AgenticConnector\` as the LLM-driven-discovery variant (k8s, databases, selective log ingestion); regular \`Connector\` remains default
- **SDK naming** — ADR 0002 clarifies that \`packages/connectors\` is an internal framework for v0.1–v0.2, not a published SDK; revisit triggers documented
- **Agent framework** — ADR 0003 commits to LangGraph primary for v0.1; CrewAI + PydanticAI adapters scheduled for v0.2
- **Layer B integrations** — external usage from LangGraph, CrewAI, PydanticAI documented; no server-side changes needed (MCP is the contract)

## Files

### New
- \`docs/decisions/0002-connector-framework-vs-sdk.md\` — ADR
- \`docs/decisions/0003-agent-framework-langgraph-primary.md\` — ADR
- \`docs/freshness-and-lineage.md\` — single source for both topics
- \`docs/integrations/{langgraph,crewai,pydantic-ai}.md\` — Layer B guides

### Updated
- \`README.md\` — quick-links updated
- \`docs/architecture.md\` — managed Postgres section + agent layer note
- \`docs/api/connector-sdk.md\` — framework vs SDK disclaimer + AgenticConnector section
- \`docs/api/mcp.md\` — lineage in \`search\` response
- \`docs/schema.md\` — lineage fields on \`chunks\`

## Follow-up

Separate issues are being filed for:

- Rich lineage implementation (extends #2, #10 AC)
- AgenticConnector framework (new, M1)
- Database connector metadata-only (v0.2)

See comments on #2, #5, #10, #21 for specifics.

## Test plan

- [ ] Doc links resolve (no 404s)
- [ ] ADRs reference each other consistently
- [ ] MCP API example JSON is well-formed
- [ ] Integration guides use current library APIs (langchain-mcp-adapters, crewai-tools, pydantic-ai MCPServerHTTP)