### PR TITLE
feat: NATS JetStream queue framework with producer, consumer, and DLQ

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -4,8 +4,7 @@ Create the ASGI application by calling ``create_app()``.  The factory:
   - reads Settings from the environment
   - configures structured logging
   - initialises OpenTelemetry
-  - registers a lifespan handler that logs placeholder connection setup
-    for Postgres and NATS (real connections wired in Wave 2)
+  - connects to NATS JetStream and ensures streams are provisioned
   - mounts the Prometheus metrics ASGI app at /metrics
   - adds TracingMiddleware
   - registers all route groups
@@ -21,6 +20,7 @@ import structlog
 from fastapi import FastAPI
 from omniscience_core.config import Settings
 from omniscience_core.logging import configure_logging
+from omniscience_core.queue import NatsConnection, ensure_streams
 from omniscience_core.telemetry import init_telemetry
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from starlette.requests import Request
@@ -46,7 +46,7 @@ def _redact_url(url: str) -> str:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Application lifespan: startup tasks → yield → shutdown tasks."""
+    """Application lifespan: startup tasks -> yield -> shutdown tasks."""
     settings: Settings = app.state.settings
 
     configure_logging(settings.log_level)
@@ -63,15 +63,18 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # TODO(wave-2, issue-#2): Replace with real asyncpg pool / SQLAlchemy engine.
     log.info("postgres_connect_placeholder", url=_redact_url(settings.database_url))
 
-    # --- Placeholder: NATS JetStream connection (Wave 2, issue #3) ---
-    # TODO(wave-2, issue-#3): Replace with real nats-py connection + stream setup.
-    log.info("nats_connect_placeholder", url=_redact_url(settings.nats_url))
+    # --- NATS JetStream connection ---
+    nats_conn = NatsConnection()
+    await nats_conn.connect(settings)
+    await ensure_streams(nats_conn.jetstream)
+    app.state.nats = nats_conn
 
     yield
 
     # --- Shutdown ---
     log.info("shutdown", app=settings.app_name)
-    # TODO(wave-2): Close Postgres pool and NATS connection here.
+    # TODO(wave-2): Close Postgres pool here.
+    await nats_conn.disconnect()
 
 
 async def _metrics_endpoint(request: Request) -> Response:
@@ -108,7 +111,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
     app.state.settings = resolved
 
-    # Metrics endpoint — mounted before middleware so scrapes don't hit TracingMiddleware
+    # Metrics endpoint - mounted before middleware so scrapes don't hit TracingMiddleware
     app.add_route("/metrics", _metrics_endpoint, include_in_schema=False)
 
     # Middleware (applied in reverse registration order by Starlette)

--- a/apps/server/src/omniscience_server/routes/health.py
+++ b/apps/server/src/omniscience_server/routes/health.py
@@ -1,12 +1,11 @@
 """Health check endpoint.
 
 Returns a structured JSON payload describing the liveness of each
-infrastructure dependency.  Placeholder check functions return ``healthy``
-until real connections are wired in Wave 2.
+infrastructure dependency.
 
-Wave 2 references:
-  - Postgres connection: issue #2 (database layer)
-  - NATS connection: issue #3 (NATS JetStream integration)
+Wave 2 status:
+  - Postgres connection: placeholder (issue #2, database layer)
+  - NATS connection: real ping via NatsConnection.is_connected (issue #3)
 """
 
 from __future__ import annotations
@@ -15,6 +14,7 @@ from typing import Literal
 
 import structlog
 from fastapi import APIRouter, Request
+from omniscience_core.queue import NatsConnection
 from starlette.responses import JSONResponse
 
 log = structlog.get_logger(__name__)
@@ -32,12 +32,18 @@ async def _check_postgres() -> CheckStatus:
     return "unchecked"
 
 
-async def _check_nats() -> CheckStatus:
-    """Verify NATS JetStream connectivity.
+async def _check_nats(nats_conn: NatsConnection | None) -> CheckStatus:
+    """Verify NATS JetStream connectivity via the live connection object.
 
-    TODO(wave-2, issue-#3): Replace with a real nats-py connection check.
+    Returns:
+        ``"healthy"`` when the connection is open and confirmed connected.
+        ``"unhealthy"`` when a connection object exists but is disconnected.
+        ``"unchecked"`` when the connection has not been initialised yet
+        (e.g. during testing without a real NATS server).
     """
-    return "unchecked"
+    if nats_conn is None:
+        return "unchecked"
+    return "healthy" if nats_conn.is_connected else "unhealthy"
 
 
 def _aggregate_status(checks: dict[str, CheckStatus]) -> CheckStatus:
@@ -57,9 +63,11 @@ async def health(request: Request) -> JSONResponse:
     Returns HTTP 503 when status is unhealthy, 200 otherwise.
     """
     settings = request.app.state.settings
+    nats_conn: NatsConnection | None = getattr(request.app.state, "nats", None)
+
     checks: dict[str, CheckStatus] = {
         "postgres": await _check_postgres(),
-        "nats": await _check_nats(),
+        "nats": await _check_nats(nats_conn),
     }
     overall = _aggregate_status(checks)
     log.info("health_check", status=overall, checks=checks)

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -12,6 +12,11 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.25.0",
     "opentelemetry-instrumentation-fastapi>=0.46b0",
     "prometheus-client>=0.20.0",
+    "sqlalchemy[asyncio]>=2.0.30",
+    "asyncpg>=0.29.0",
+    "alembic>=1.13.0",
+    "pgvector>=0.3.0",
+    "nats-py>=2.7.0",
 ]
 
 [build-system]

--- a/packages/core/src/omniscience_core/queue/__init__.py
+++ b/packages/core/src/omniscience_core/queue/__init__.py
@@ -1,0 +1,28 @@
+"""NATS JetStream queue framework for Omniscience.
+
+Public surface:
+
+    - :class:`NatsConnection` — lifecycle wrapper (connect / disconnect).
+    - :func:`ensure_streams` — idempotent JetStream stream setup.
+    - :class:`QueueProducer` — publish Pydantic models to a subject.
+    - :class:`QueueConsumer` — async-iterator consumer with DLQ support.
+    - :class:`Message` — typed wrapper around a consumed message.
+    - :class:`DLQMessage` — schema for Dead Letter Queue entries.
+"""
+
+from __future__ import annotations
+
+from omniscience_core.queue.connection import NatsConnection
+from omniscience_core.queue.consumer import QueueConsumer
+from omniscience_core.queue.messages import DLQMessage, Message
+from omniscience_core.queue.producer import QueueProducer
+from omniscience_core.queue.streams import ensure_streams
+
+__all__ = [
+    "DLQMessage",
+    "Message",
+    "NatsConnection",
+    "QueueConsumer",
+    "QueueProducer",
+    "ensure_streams",
+]

--- a/packages/core/src/omniscience_core/queue/connection.py
+++ b/packages/core/src/omniscience_core/queue/connection.py
@@ -1,0 +1,138 @@
+"""NATS JetStream connection management.
+
+``NatsConnection`` wraps the nats-py client and provides a clean lifecycle
+(connect / disconnect) with structured logging and auto-reconnect callbacks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import nats
+import nats.js
+import structlog
+from nats.aio.client import Client as NatsClient
+
+from omniscience_core.config import Settings
+
+log = structlog.get_logger(__name__)
+
+
+def _make_error_cb(url: str) -> Any:
+    """Return an async error callback that logs unexpected NATS errors."""
+
+    async def _error_cb(exc: Exception) -> None:
+        log.error("nats_error", url=url, error=str(exc))
+
+    return _error_cb
+
+
+def _make_reconnected_cb(url: str) -> Any:
+    """Return an async callback that logs successful reconnection."""
+
+    async def _reconnected_cb() -> None:
+        log.info("nats_reconnected", url=url)
+
+    return _reconnected_cb
+
+
+def _make_disconnected_cb(url: str) -> Any:
+    """Return an async callback that logs disconnection events."""
+
+    async def _disconnected_cb() -> None:
+        log.warning("nats_disconnected", url=url)
+
+    return _disconnected_cb
+
+
+def _make_closed_cb(url: str) -> Any:
+    """Return an async callback that logs when the client connection closes."""
+
+    async def _closed_cb() -> None:
+        log.info("nats_closed", url=url)
+
+    return _closed_cb
+
+
+class NatsConnection:
+    """Lifecycle wrapper for a nats-py client with JetStream enabled.
+
+    Usage::
+
+        conn = NatsConnection()
+        await conn.connect(settings)
+        js = conn.jetstream
+        # ... use js ...
+        await conn.disconnect()
+    """
+
+    def __init__(self) -> None:
+        self._client: NatsClient | None = None
+        self._js: nats.js.JetStreamContext | None = None
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def client(self) -> NatsClient:
+        """The underlying nats-py client.  Raises if not connected."""
+        if self._client is None:
+            raise RuntimeError("NatsConnection is not connected. Call connect() first.")
+        return self._client
+
+    @property
+    def jetstream(self) -> nats.js.JetStreamContext:
+        """The JetStream context.  Raises if not connected."""
+        if self._js is None:
+            raise RuntimeError("NatsConnection is not connected. Call connect() first.")
+        return self._js
+
+    @property
+    def is_connected(self) -> bool:
+        """Return True when the underlying client is currently connected."""
+        return self._client is not None and self._client.is_connected
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self, settings: Settings) -> None:
+        """Open the NATS connection and enable JetStream.
+
+        Idempotent — calling connect() on an already-connected instance is a no-op.
+        """
+        if self._client is not None and self._client.is_connected:
+            log.debug("nats_already_connected", url=settings.nats_url)
+            return
+
+        url = settings.nats_url
+        log.info("nats_connecting", url=url)
+
+        self._client = await nats.connect(
+            servers=url,
+            error_cb=_make_error_cb(url),
+            reconnected_cb=_make_reconnected_cb(url),
+            disconnected_cb=_make_disconnected_cb(url),
+            closed_cb=_make_closed_cb(url),
+            # Retry indefinitely with back-off — the server may be starting up.
+            max_reconnect_attempts=-1,
+        )
+        self._js = self._client.jetstream()
+        log.info("nats_connected", url=url)
+
+    async def disconnect(self) -> None:
+        """Drain in-flight messages and close the NATS connection gracefully."""
+        if self._client is None:
+            return
+
+        url = self._client.connected_url.netloc if self._client.connected_url else "unknown"
+        log.info("nats_disconnecting", url=url)
+        try:
+            await self._client.drain()
+        except Exception as exc:
+            log.warning("nats_drain_error", url=url, error=str(exc))
+        finally:
+            self._client = None
+            self._js = None
+            log.info("nats_disconnected_clean", url=url)

--- a/packages/core/src/omniscience_core/queue/consumer.py
+++ b/packages/core/src/omniscience_core/queue/consumer.py
@@ -1,0 +1,223 @@
+"""NATS JetStream message consumer.
+
+``QueueConsumer`` is an async-iterator-based consumer that:
+
+- Delivers typed ``Message[T]`` objects to the caller.
+- Forwards messages that have exceeded ``max_deliver`` to the DLQ.
+- Records Prometheus metrics for consumed, DLQ-routed, and processing duration.
+- Drains in-flight processing on graceful shutdown.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from typing import TypeVar
+
+import nats.errors
+import nats.js
+import nats.js.api
+import structlog
+from nats.aio.msg import Msg
+from pydantic import BaseModel
+
+from omniscience_core.queue.messages import DLQMessage, Message
+from omniscience_core.queue.metrics import (
+    QUEUE_CONSUMED_TOTAL,
+    QUEUE_DLQ_TOTAL,
+    QUEUE_PROCESSING_DURATION_SECONDS,
+)
+from omniscience_core.queue.producer import QueueProducer
+
+log = structlog.get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+_DEFAULT_ACK_WAIT_SECONDS = 30
+_DEFAULT_MAX_DELIVER = 5
+_DEFAULT_FETCH_BATCH = 10
+
+
+class QueueConsumer[T: BaseModel]:
+    """Async iterator that yields typed ``Message[T]`` objects from a NATS consumer.
+
+    Callers are responsible for calling ``message.ack()``, ``message.nak()``,
+    or ``message.term()`` on each yielded message.
+
+    When a raw NATS message has been delivered more times than *max_deliver*,
+    the consumer publishes it to the Dead Letter Queue and terms it at the
+    broker rather than yielding it to the caller.
+
+    Args:
+        js: Active JetStream context.
+        stream: Name of the stream to consume.
+        subject: Filter subject, e.g. ``"ingest.changes.git"``.
+        durable: Durable consumer name (enables resumable subscriptions).
+        payload_type: Pydantic model class used to deserialise message bodies.
+        dlq_subject: Subject to publish DLQ messages to.
+        max_deliver: Max redelivery attempts before DLQ routing.
+        ack_wait: Seconds the broker waits for an ack before redelivering.
+        fetch_batch: Number of messages to pull from NATS per request.
+    """
+
+    def __init__(
+        self,
+        *,
+        js: nats.js.JetStreamContext,
+        stream: str,
+        subject: str,
+        durable: str,
+        payload_type: type[T],
+        dlq_subject: str,
+        max_deliver: int = _DEFAULT_MAX_DELIVER,
+        ack_wait: int = _DEFAULT_ACK_WAIT_SECONDS,
+        fetch_batch: int = _DEFAULT_FETCH_BATCH,
+    ) -> None:
+        self._js = js
+        self._stream = stream
+        self._subject = subject
+        self._durable = durable
+        self._payload_type = payload_type
+        self._dlq_subject = dlq_subject
+        self._max_deliver = max_deliver
+        self._ack_wait = ack_wait
+        self._fetch_batch = fetch_batch
+        self._dlq_producer = QueueProducer(js)
+        self._running = True
+
+    # ------------------------------------------------------------------
+    # Async iterator protocol
+    # ------------------------------------------------------------------
+
+    def __aiter__(self) -> AsyncIterator[Message[T]]:
+        return self._iter()
+
+    async def _iter(self) -> AsyncIterator[Message[T]]:
+        """Pull messages in batches and yield typed wrappers.
+
+        The loop runs at least one fetch cycle before checking ``_running``.
+        This ensures that calling ``stop()`` from inside the ``async for``
+        body causes the iterator to drain the current batch and then exit,
+        rather than preventing the first batch from being fetched at all.
+        """
+        consumer_config = nats.js.api.ConsumerConfig(
+            durable_name=self._durable,
+            max_deliver=self._max_deliver,
+            ack_wait=self._ack_wait,
+        )
+        psub = await self._js.pull_subscribe(
+            subject=self._subject,
+            durable=self._durable,
+            stream=self._stream,
+            config=consumer_config,
+        )
+
+        while True:
+            try:
+                raw_msgs = await psub.fetch(self._fetch_batch, timeout=5)
+            except nats.errors.TimeoutError:
+                if not self._running:
+                    return
+                continue
+            except Exception as exc:
+                log.error("consumer_fetch_error", stream=self._stream, error=str(exc))
+                if not self._running:
+                    return
+                continue
+
+            for raw in raw_msgs:
+                msg = await self._process_raw(raw)
+                if msg is not None:
+                    yield msg
+
+            if not self._running:
+                return
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _process_raw(self, raw: Msg) -> Message[T] | None:
+        """Decode a raw NATS message, routing to DLQ if max deliveries exceeded."""
+        start = time.monotonic()
+        attempt = _get_num_delivered(raw)
+
+        if attempt >= self._max_deliver:
+            await self._route_to_dlq(raw, attempt)
+            QUEUE_CONSUMED_TOTAL.labels(subject=self._subject, status="dlq").inc()
+            elapsed = time.monotonic() - start
+            QUEUE_PROCESSING_DURATION_SECONDS.labels(subject=self._subject).observe(elapsed)
+            return None
+
+        try:
+            payload = self._payload_type.model_validate_json(raw.data)
+        except Exception as exc:
+            log.warning(
+                "consumer_decode_error",
+                subject=self._subject,
+                error=str(exc),
+            )
+            await raw.nak()
+            QUEUE_CONSUMED_TOTAL.labels(subject=self._subject, status="decode_error").inc()
+            return None
+
+        msg: Message[T] = Message(
+            payload=payload,
+            subject=raw.subject,
+            metadata=dict(raw.headers or {}),
+            ack=raw.ack,
+            nak=raw.nak,
+            term=raw.term,
+        )
+
+        elapsed = time.monotonic() - start
+        QUEUE_PROCESSING_DURATION_SECONDS.labels(subject=self._subject).observe(elapsed)
+        QUEUE_CONSUMED_TOTAL.labels(subject=self._subject, status="delivered").inc()
+        return msg
+
+    async def _route_to_dlq(self, raw: Msg, attempt_count: int) -> None:
+        """Publish a DLQ entry and term the original message at the broker."""
+        dlq_msg = DLQMessage(
+            original_subject=raw.subject,
+            original_payload=raw.data.decode(errors="replace"),
+            error=f"Exceeded max_deliver={self._max_deliver}",
+            attempt_count=attempt_count,
+        )
+        try:
+            await self._dlq_producer.publish(self._dlq_subject, dlq_msg)
+            QUEUE_DLQ_TOTAL.labels(subject=self._subject).inc()
+            log.warning(
+                "consumer_dlq_routed",
+                subject=self._subject,
+                dlq_subject=self._dlq_subject,
+                attempt_count=attempt_count,
+            )
+        except Exception as exc:
+            log.error("consumer_dlq_publish_error", error=str(exc))
+        finally:
+            await raw.term()
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    def stop(self) -> None:
+        """Signal the iterator to stop after the current batch completes.
+
+        The current fetch and processing cycle will finish before the iterator
+        exits.  Calling ``stop()`` from inside the ``async for`` body is the
+        recommended pattern for test helpers and one-shot consumers.
+        """
+        self._running = False
+        log.info("consumer_stopping", stream=self._stream, subject=self._subject)
+
+
+def _get_num_delivered(raw: Msg) -> int:
+    """Extract delivery count from message metadata; return 1 if unavailable."""
+    try:
+        meta = raw.metadata  # sync property on nats.aio.msg.Msg
+        if meta is not None and hasattr(meta, "num_delivered"):
+            return int(meta.num_delivered)
+    except Exception as exc:
+        log.debug("consumer_metadata_unavailable", error=str(exc))
+    return 1

--- a/packages/core/src/omniscience_core/queue/messages.py
+++ b/packages/core/src/omniscience_core/queue/messages.py
@@ -1,0 +1,86 @@
+"""Message wrappers for NATS JetStream messages.
+
+``Message[T]`` is the standard typed wrapper for consumed messages.
+``DLQMessage`` carries the context of a message forwarded to the Dead Letter Queue.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, Field
+
+T = TypeVar("T", bound=BaseModel)
+
+# ---------------------------------------------------------------------------
+# Ack callbacks
+# ---------------------------------------------------------------------------
+
+AckCallback = Callable[[], Coroutine[Any, Any, None]]
+
+
+# ---------------------------------------------------------------------------
+# Generic message wrapper
+# ---------------------------------------------------------------------------
+
+
+class Message[T: BaseModel]:
+    """Typed wrapper around a raw NATS JetStream message.
+
+    Callers should use :meth:`ack`, :meth:`nak`, or :meth:`term` to signal
+    the broker rather than calling the underlying nats-py message directly.
+    """
+
+    __slots__ = ("_ack", "_nak", "_term", "metadata", "payload", "subject")
+
+    def __init__(
+        self,
+        *,
+        payload: T,
+        subject: str,
+        metadata: dict[str, str],
+        ack: AckCallback,
+        nak: AckCallback,
+        term: AckCallback,
+    ) -> None:
+        self.payload = payload
+        self.subject = subject
+        self.metadata = metadata
+        self._ack = ack
+        self._nak = nak
+        self._term = term
+
+    async def ack(self) -> None:
+        """Acknowledge successful processing."""
+        await self._ack()
+
+    async def nak(self) -> None:
+        """Negative-acknowledge — triggers redelivery according to consumer config."""
+        await self._nak()
+
+    async def term(self) -> None:
+        """Terminate — drop the message without redelivery (no DLQ routing from broker side)."""
+        await self._term()
+
+    def __repr__(self) -> str:
+        return f"Message(subject={self.subject!r}, payload={self.payload!r})"
+
+
+# ---------------------------------------------------------------------------
+# Dead Letter Queue message
+# ---------------------------------------------------------------------------
+
+
+class DLQMessage(BaseModel):
+    """Schema for a message published to the Dead Letter Queue stream."""
+
+    original_subject: str = Field(description="Subject the failed message was consumed from.")
+    original_payload: str = Field(description="JSON-encoded original message payload.")
+    error: str = Field(description="Human-readable description of the terminal failure.")
+    attempt_count: int = Field(description="Number of delivery attempts before DLQ routing.")
+    failed_at: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.now(datetime.UTC),
+        description="UTC timestamp when the message was forwarded to the DLQ.",
+    )

--- a/packages/core/src/omniscience_core/queue/metrics.py
+++ b/packages/core/src/omniscience_core/queue/metrics.py
@@ -1,0 +1,42 @@
+"""Prometheus metrics for the NATS JetStream queue subsystem.
+
+All metric names are prefixed with ``omniscience_queue_`` to avoid
+collisions with the HTTP metrics defined in ``telemetry/metrics.py``.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+# ---------------------------------------------------------------------------
+# Publish metrics
+# ---------------------------------------------------------------------------
+
+QUEUE_PUBLISHED_TOTAL: Counter = Counter(
+    name="omniscience_queue_published_total",
+    documentation="Total number of messages successfully published to NATS JetStream.",
+    labelnames=["subject"],
+)
+
+# ---------------------------------------------------------------------------
+# Consume metrics
+# ---------------------------------------------------------------------------
+
+QUEUE_CONSUMED_TOTAL: Counter = Counter(
+    name="omniscience_queue_consumed_total",
+    documentation="Total number of messages consumed from NATS JetStream.",
+    labelnames=["subject", "status"],
+)
+
+QUEUE_DLQ_TOTAL: Counter = Counter(
+    name="omniscience_queue_dlq_total",
+    documentation="Total number of messages forwarded to the Dead Letter Queue.",
+    labelnames=["subject"],
+)
+
+QUEUE_PROCESSING_DURATION_SECONDS: Histogram = Histogram(
+    name="omniscience_queue_processing_duration_seconds",
+    documentation="Time spent processing a single NATS JetStream message.",
+    labelnames=["subject"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)

--- a/packages/core/src/omniscience_core/queue/producer.py
+++ b/packages/core/src/omniscience_core/queue/producer.py
@@ -1,0 +1,54 @@
+"""NATS JetStream message producer.
+
+``QueueProducer`` validates a Pydantic model, serialises it to JSON, and
+publishes it to NATS JetStream with a synchronous acknowledgement.
+"""
+
+from __future__ import annotations
+
+import nats.js
+import structlog
+from pydantic import BaseModel
+
+from omniscience_core.queue.metrics import QUEUE_PUBLISHED_TOTAL
+
+log = structlog.get_logger(__name__)
+
+
+class QueueProducer:
+    """Publishes Pydantic-validated payloads to NATS JetStream.
+
+    Args:
+        js: An active JetStream context obtained from a connected NATS client.
+    """
+
+    def __init__(self, js: nats.js.JetStreamContext) -> None:
+        self._js = js
+
+    async def publish(self, subject: str, payload: BaseModel) -> None:
+        """Validate, serialise, and publish *payload* to *subject*.
+
+        Pydantic validates the model before serialisation so malformed objects
+        never reach the wire.  After a successful publish the
+        ``omniscience_queue_published_total`` counter is incremented.
+
+        Args:
+            subject: NATS subject string, e.g. ``"ingest.changes.git"``.
+            payload: A Pydantic model instance to publish.
+
+        Raises:
+            pydantic.ValidationError: If *payload* fails Pydantic validation.
+            nats.js.errors.PublishAckNotReceived: If JetStream acknowledgement
+                is not received within the timeout.
+        """
+        # model_validate ensures the object satisfies its own schema — fast
+        # path when the caller has already constructed a valid model, but
+        # catches issues with subclasses that bypass __init__.
+        payload.model_validate(payload.model_dump())
+
+        data = payload.model_dump_json().encode()
+
+        await self._js.publish(subject=subject, payload=data)
+
+        QUEUE_PUBLISHED_TOTAL.labels(subject=subject).inc()
+        log.debug("queue_published", subject=subject, payload_type=type(payload).__name__)

--- a/packages/core/src/omniscience_core/queue/streams.py
+++ b/packages/core/src/omniscience_core/queue/streams.py
@@ -1,0 +1,74 @@
+"""JetStream stream definitions and idempotent setup.
+
+Call ``ensure_streams(js)`` once at application startup.  The function
+creates each stream if it does not already exist; if it does exist the call
+is a no-op (idempotent via ``find_or_create`` semantics from nats-py).
+"""
+
+from __future__ import annotations
+
+import nats.js
+import nats.js.api
+import structlog
+from nats.js.errors import BadRequestError
+
+log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SEVEN_DAYS_NS: int = 7 * 24 * 60 * 60 * 10**9  # nanoseconds
+
+INGEST_CHANGES_STREAM = "INGEST_CHANGES"
+INGEST_DLQ_STREAM = "INGEST_DLQ"
+
+_STREAM_CONFIGS: list[nats.js.api.StreamConfig] = [
+    nats.js.api.StreamConfig(
+        name=INGEST_CHANGES_STREAM,
+        subjects=["ingest.changes.*"],
+        retention=nats.js.api.RetentionPolicy.LIMITS,
+        max_age=_SEVEN_DAYS_NS,
+        storage=nats.js.api.StorageType.FILE,
+        num_replicas=1,
+    ),
+    nats.js.api.StreamConfig(
+        name=INGEST_DLQ_STREAM,
+        subjects=["ingest.dlq.*"],
+        retention=nats.js.api.RetentionPolicy.LIMITS,
+        max_age=_SEVEN_DAYS_NS,
+        storage=nats.js.api.StorageType.FILE,
+        num_replicas=1,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def ensure_streams(js: nats.js.JetStreamContext) -> None:
+    """Idempotently create all required JetStream streams.
+
+    If a stream already exists this function leaves it unchanged and logs a
+    debug message.  This makes the function safe to call on every startup.
+
+    Args:
+        js: An active JetStream context obtained from a connected NATS client.
+    """
+    for cfg in _STREAM_CONFIGS:
+        await _ensure_stream(js, cfg)
+
+
+async def _ensure_stream(
+    js: nats.js.JetStreamContext,
+    cfg: nats.js.api.StreamConfig,
+) -> None:
+    """Create a single stream, or skip if it already exists."""
+    try:
+        await js.add_stream(config=cfg)
+        log.info("nats_stream_created", stream=cfg.name, subjects=cfg.subjects)
+    except BadRequestError:
+        # Stream already exists — this is expected on restart.
+        log.debug("nats_stream_exists", stream=cfg.name)

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,662 @@
+"""Tests for the NATS JetStream queue framework.
+
+All tests mock the nats-py client — no real NATS server is required.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import nats.errors
+import nats.js.api
+import pytest
+from omniscience_core.queue.consumer import QueueConsumer
+from omniscience_core.queue.messages import DLQMessage, Message
+from omniscience_core.queue.metrics import (
+    QUEUE_CONSUMED_TOTAL,
+    QUEUE_DLQ_TOTAL,
+    QUEUE_PROCESSING_DURATION_SECONDS,
+    QUEUE_PUBLISHED_TOTAL,
+)
+from omniscience_core.queue.producer import QueueProducer
+from omniscience_core.queue.streams import (
+    INGEST_CHANGES_STREAM,
+    INGEST_DLQ_STREAM,
+    ensure_streams,
+)
+from pydantic import BaseModel, ValidationError
+
+# ---------------------------------------------------------------------------
+# Shared fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+class _SamplePayload(BaseModel):
+    source_id: str
+    doc_id: str
+    version: int = 1
+
+
+def _make_js_mock() -> MagicMock:
+    """Return a MagicMock configured to behave like a JetStreamContext."""
+    js = MagicMock()
+    js.publish = AsyncMock()
+    js.add_stream = AsyncMock()
+    return js
+
+
+def _make_raw_msg(
+    subject: str = "ingest.changes.git",
+    data: bytes = b'{"source_id":"s1","doc_id":"d1","version":1}',
+    num_delivered: int = 1,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    """Build a mock NATS Msg object.
+
+    The ``metadata`` property on nats.aio.msg.Msg is a regular sync property,
+    so we set it as a direct attribute on the MagicMock instance.
+    """
+    msg = MagicMock()
+    msg.subject = subject
+    msg.data = data
+    msg.headers = headers or {}
+    msg.ack = AsyncMock()
+    msg.nak = AsyncMock()
+    msg.term = AsyncMock()
+
+    meta = MagicMock()
+    meta.num_delivered = num_delivered
+    # Direct attribute wins over auto-spec property in MagicMock
+    msg.metadata = meta
+    return msg
+
+
+def _make_consumer(
+    *,
+    subject: str = "ingest.changes.git",
+    max_deliver: int = 5,
+    durable: str = "test-consumer",
+) -> tuple[QueueConsumer[_SamplePayload], MagicMock]:
+    """Build a QueueConsumer with a mocked pull subscription."""
+    js = _make_js_mock()
+    psub = MagicMock()
+    psub.fetch = AsyncMock()
+    js.pull_subscribe = AsyncMock(return_value=psub)
+
+    consumer: QueueConsumer[_SamplePayload] = QueueConsumer(
+        js=js,
+        stream=INGEST_CHANGES_STREAM,
+        subject=subject,
+        durable=durable,
+        payload_type=_SamplePayload,
+        dlq_subject="ingest.dlq.git",
+        max_deliver=max_deliver,
+    )
+    return consumer, psub
+
+
+async def _drain_consumer(
+    consumer: QueueConsumer[_SamplePayload],
+    psub: MagicMock,
+    messages: list[MagicMock],
+) -> list[Message[_SamplePayload]]:
+    """Drive the consumer through *messages* then stop it.
+
+    Sets psub.fetch to return *messages* first, then raise TimeoutError so the
+    consumer stops naturally when we call consumer.stop() inside the loop.
+    """
+    psub.fetch = AsyncMock(side_effect=[messages, nats.errors.TimeoutError()])
+    collected: list[Message[_SamplePayload]] = []
+    async for msg in consumer:
+        collected.append(msg)
+        consumer.stop()  # stop after collecting all yielded messages
+    return collected
+
+
+# ---------------------------------------------------------------------------
+# QueueProducer tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueueProducer:
+    @pytest.mark.asyncio
+    async def test_publish_calls_js_publish(self) -> None:
+        """publish() should call js.publish with the correct subject and JSON bytes."""
+        js = _make_js_mock()
+        producer = QueueProducer(js)
+        payload = _SamplePayload(source_id="s1", doc_id="d1")
+
+        await producer.publish("ingest.changes.git", payload)
+
+        js.publish.assert_awaited_once()
+        call_kwargs = js.publish.call_args.kwargs
+        assert call_kwargs["subject"] == "ingest.changes.git"
+        assert b"s1" in call_kwargs["payload"]
+
+    @pytest.mark.asyncio
+    async def test_publish_serialises_all_fields(self) -> None:
+        """Payload JSON must contain all model fields."""
+        js = _make_js_mock()
+        producer = QueueProducer(js)
+        payload = _SamplePayload(source_id="src", doc_id="doc42", version=7)
+
+        await producer.publish("ingest.changes.fs", payload)
+
+        data: bytes = js.publish.call_args.kwargs["payload"]
+        decoded = data.decode()
+        assert "src" in decoded
+        assert "doc42" in decoded
+        assert "7" in decoded
+
+    @pytest.mark.asyncio
+    async def test_publish_increments_metric(self) -> None:
+        """publish() should increment the published counter for the subject."""
+        js = _make_js_mock()
+        producer = QueueProducer(js)
+        subject = "ingest.changes.unique_subject_metric_test"
+
+        before = _get_counter_value(QUEUE_PUBLISHED_TOTAL, {"subject": subject})
+        await producer.publish(subject, _SamplePayload(source_id="x", doc_id="y"))
+        after = _get_counter_value(QUEUE_PUBLISHED_TOTAL, {"subject": subject})
+
+        assert after - before == 1.0
+
+    @pytest.mark.asyncio
+    async def test_publish_raises_on_invalid_type(self) -> None:
+        """publish() must raise when given a non-BaseModel object."""
+        js = _make_js_mock()
+        producer = QueueProducer(js)
+
+        with pytest.raises((TypeError, AttributeError, ValidationError)):
+            await producer.publish("ingest.changes.git", "not-a-model")  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_publish_propagates_nats_error(self) -> None:
+        """Errors from js.publish() must propagate to the caller."""
+        js = _make_js_mock()
+        js.publish = AsyncMock(side_effect=RuntimeError("nats down"))
+        producer = QueueProducer(js)
+
+        with pytest.raises(RuntimeError, match="nats down"):
+            await producer.publish(
+                "ingest.changes.git", _SamplePayload(source_id="a", doc_id="b")
+            )
+
+
+# ---------------------------------------------------------------------------
+# Message and DLQMessage tests
+# ---------------------------------------------------------------------------
+
+
+class TestMessage:
+    def _make_message(self) -> Message[_SamplePayload]:
+        ack = AsyncMock()
+        nak = AsyncMock()
+        term = AsyncMock()
+        payload = _SamplePayload(source_id="s1", doc_id="d1")
+        return Message(
+            payload=payload,
+            subject="ingest.changes.git",
+            metadata={"header-x": "val"},
+            ack=ack,
+            nak=nak,
+            term=term,
+        )
+
+    def test_message_stores_payload(self) -> None:
+        msg = self._make_message()
+        assert msg.payload.source_id == "s1"
+
+    def test_message_stores_subject(self) -> None:
+        msg = self._make_message()
+        assert msg.subject == "ingest.changes.git"
+
+    def test_message_stores_metadata(self) -> None:
+        msg = self._make_message()
+        assert msg.metadata["header-x"] == "val"
+
+    @pytest.mark.asyncio
+    async def test_message_ack_calls_callback(self) -> None:
+        msg = self._make_message()
+        await msg.ack()
+        msg._ack.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_message_nak_calls_callback(self) -> None:
+        msg = self._make_message()
+        await msg.nak()
+        msg._nak.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_message_term_calls_callback(self) -> None:
+        msg = self._make_message()
+        await msg.term()
+        msg._term.assert_awaited_once()
+
+    def test_message_repr(self) -> None:
+        msg = self._make_message()
+        r = repr(msg)
+        assert "ingest.changes.git" in r
+
+
+class TestDLQMessage:
+    def test_dlq_message_required_fields(self) -> None:
+        msg = DLQMessage(
+            original_subject="ingest.changes.git",
+            original_payload='{"x":1}',
+            error="exceeded retries",
+            attempt_count=5,
+        )
+        assert msg.original_subject == "ingest.changes.git"
+        assert msg.attempt_count == 5
+        assert msg.error == "exceeded retries"
+
+    def test_dlq_message_failed_at_defaults_to_utc(self) -> None:
+        msg = DLQMessage(
+            original_subject="s",
+            original_payload="{}",
+            error="err",
+            attempt_count=1,
+        )
+        assert msg.failed_at.tzinfo is not None
+        assert msg.failed_at.tzinfo == datetime.UTC
+
+    def test_dlq_message_serialises_to_json(self) -> None:
+        msg = DLQMessage(
+            original_subject="ingest.dlq.git",
+            original_payload='{"a":1}',
+            error="bad data",
+            attempt_count=3,
+        )
+        json_str = msg.model_dump_json()
+        assert "ingest.dlq.git" in json_str
+        assert "bad data" in json_str
+
+    def test_dlq_message_roundtrip(self) -> None:
+        original = DLQMessage(
+            original_subject="sub",
+            original_payload="{}",
+            error="e",
+            attempt_count=2,
+        )
+        restored = DLQMessage.model_validate_json(original.model_dump_json())
+        assert restored.original_subject == original.original_subject
+        assert restored.attempt_count == original.attempt_count
+
+
+# ---------------------------------------------------------------------------
+# Stream creation tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStreams:
+    @pytest.mark.asyncio
+    async def test_creates_both_streams(self) -> None:
+        """ensure_streams() must call add_stream for each defined stream."""
+        js = _make_js_mock()
+        await ensure_streams(js)
+
+        assert js.add_stream.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stream_names_correct(self) -> None:
+        """Stream configs must reference the expected stream names."""
+        js = _make_js_mock()
+        await ensure_streams(js)
+
+        stream_names = {call.kwargs["config"].name for call in js.add_stream.call_args_list}
+        assert INGEST_CHANGES_STREAM in stream_names
+        assert INGEST_DLQ_STREAM in stream_names
+
+    @pytest.mark.asyncio
+    async def test_stream_subjects_correct(self) -> None:
+        """Each stream config must have the correct subject filter."""
+        js = _make_js_mock()
+        await ensure_streams(js)
+
+        subjects_by_name: dict[str, list[str]] = {}
+        for call in js.add_stream.call_args_list:
+            cfg = call.kwargs["config"]
+            subjects_by_name[cfg.name] = cfg.subjects
+
+        assert subjects_by_name[INGEST_CHANGES_STREAM] == ["ingest.changes.*"]
+        assert subjects_by_name[INGEST_DLQ_STREAM] == ["ingest.dlq.*"]
+
+    @pytest.mark.asyncio
+    async def test_idempotent_on_bad_request_error(self) -> None:
+        """ensure_streams() must silently handle stream-already-exists errors."""
+        from nats.js.errors import BadRequestError
+
+        js = _make_js_mock()
+        js.add_stream = AsyncMock(side_effect=BadRequestError())
+
+        # Should not raise
+        await ensure_streams(js)
+
+    @pytest.mark.asyncio
+    async def test_stream_max_age_seven_days(self) -> None:
+        """Both streams must have a 7-day max_age in nanoseconds."""
+        seven_days_ns = 7 * 24 * 60 * 60 * 10**9
+        js = _make_js_mock()
+        await ensure_streams(js)
+
+        for call in js.add_stream.call_args_list:
+            cfg = call.kwargs["config"]
+            assert cfg.max_age == seven_days_ns
+
+    @pytest.mark.asyncio
+    async def test_storage_type_is_file(self) -> None:
+        """Both streams must use FILE storage."""
+        js = _make_js_mock()
+        await ensure_streams(js)
+
+        for call in js.add_stream.call_args_list:
+            cfg = call.kwargs["config"]
+            assert cfg.storage == nats.js.api.StorageType.FILE
+
+
+# ---------------------------------------------------------------------------
+# QueueConsumer tests
+# ---------------------------------------------------------------------------
+
+
+class TestQueueConsumerMessages:
+    @pytest.mark.asyncio
+    async def test_yields_typed_message(self) -> None:
+        """Consumer must yield Message[T] with correctly typed payload."""
+        consumer, psub = _make_consumer()
+        raw = _make_raw_msg(num_delivered=1)
+
+        messages = await _drain_consumer(consumer, psub, [raw])
+
+        assert len(messages) == 1
+        assert messages[0].payload.source_id == "s1"
+        assert messages[0].subject == "ingest.changes.git"
+
+    @pytest.mark.asyncio
+    async def test_routes_to_dlq_on_max_deliver(self) -> None:
+        """Messages at or beyond max_deliver must be routed to the DLQ."""
+        consumer, psub = _make_consumer(max_deliver=3)
+        raw = _make_raw_msg(num_delivered=3)  # exactly at the limit
+        psub.fetch = AsyncMock(side_effect=[[raw], nats.errors.TimeoutError()])
+
+        with patch.object(consumer._dlq_producer, "publish", new_callable=AsyncMock) as mock_pub:
+            consumer.stop()  # stop after first batch — no yielded messages expected
+            async for _ in consumer:
+                pass
+
+        mock_pub.assert_awaited_once()
+        dlq_call = mock_pub.call_args
+        assert dlq_call.args[0] == "ingest.dlq.git"
+        dlq_msg: DLQMessage = dlq_call.args[1]
+        assert dlq_msg.original_subject == "ingest.changes.git"
+        assert dlq_msg.attempt_count == 3
+
+    @pytest.mark.asyncio
+    async def test_terms_message_after_dlq_routing(self) -> None:
+        """After routing to DLQ, the raw message must be term()ed."""
+        consumer, psub = _make_consumer(max_deliver=3)
+        raw = _make_raw_msg(num_delivered=3)
+        psub.fetch = AsyncMock(side_effect=[[raw], nats.errors.TimeoutError()])
+
+        with patch.object(consumer._dlq_producer, "publish", new_callable=AsyncMock):
+            consumer.stop()
+            async for _ in consumer:
+                pass
+
+        raw.term.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_naks_on_decode_error(self) -> None:
+        """Messages with invalid JSON must be nak()ed."""
+        consumer, psub = _make_consumer()
+        raw = _make_raw_msg(data=b"not-json", num_delivered=1)
+        psub.fetch = AsyncMock(side_effect=[[raw], nats.errors.TimeoutError()])
+
+        consumer.stop()
+        async for _ in consumer:
+            pass
+
+        raw.nak.assert_awaited_once()
+
+    def test_stop_sets_running_false(self) -> None:
+        """stop() must mark the consumer as not running."""
+        consumer, _ = _make_consumer()
+        assert consumer._running is True
+        consumer.stop()
+        assert consumer._running is False
+
+    @pytest.mark.asyncio
+    async def test_continues_on_timeout(self) -> None:
+        """Consumer must not crash on fetch timeout — it loops and retries."""
+        consumer, psub = _make_consumer()
+        raw = _make_raw_msg(num_delivered=1)
+        # First fetch times out, second returns a message
+        psub.fetch = AsyncMock(
+            side_effect=[nats.errors.TimeoutError(), [raw], nats.errors.TimeoutError()]
+        )
+
+        messages: list[Message[_SamplePayload]] = []
+        async for msg in consumer:
+            messages.append(msg)
+            consumer.stop()
+            break
+
+        assert len(messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_does_not_yield_dlq_messages(self) -> None:
+        """Messages routed to DLQ must NOT be yielded to the caller."""
+        consumer, psub = _make_consumer(max_deliver=2)
+        raw = _make_raw_msg(num_delivered=2)
+        psub.fetch = AsyncMock(side_effect=[[raw], nats.errors.TimeoutError()])
+
+        with patch.object(consumer._dlq_producer, "publish", new_callable=AsyncMock):
+            consumer.stop()
+            yielded = [msg async for msg in consumer]
+
+        assert len(yielded) == 0
+
+
+# ---------------------------------------------------------------------------
+# Metrics increment tests
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsIncrements:
+    @pytest.mark.asyncio
+    async def test_published_counter_increments(self) -> None:
+        js = _make_js_mock()
+        producer = QueueProducer(js)
+        subject = "ingest.changes.metrics_inc_test"
+
+        before = _get_counter_value(QUEUE_PUBLISHED_TOTAL, {"subject": subject})
+        await producer.publish(subject, _SamplePayload(source_id="a", doc_id="b"))
+        after = _get_counter_value(QUEUE_PUBLISHED_TOTAL, {"subject": subject})
+
+        assert after - before == 1.0
+
+    @pytest.mark.asyncio
+    async def test_dlq_counter_increments(self) -> None:
+        """DLQ counter must increment when a message is routed to the DLQ."""
+        subject = "ingest.changes.dlq_metric_test_2"
+        consumer, psub = _make_consumer(subject=subject, max_deliver=3, durable="dlq-durable-2")
+        raw = _make_raw_msg(subject=subject, num_delivered=3)
+        psub.fetch = AsyncMock(side_effect=[[raw], nats.errors.TimeoutError()])
+
+        before = _get_counter_value(QUEUE_DLQ_TOTAL, {"subject": subject})
+
+        with patch.object(consumer._dlq_producer, "publish", new_callable=AsyncMock):
+            consumer.stop()
+            async for _ in consumer:
+                pass
+
+        after = _get_counter_value(QUEUE_DLQ_TOTAL, {"subject": subject})
+        assert after - before == 1.0
+
+    @pytest.mark.asyncio
+    async def test_consumed_counter_increments_on_delivered(self) -> None:
+        """Consumed counter must increment with status=delivered for normal messages."""
+        subject = "ingest.changes.consumed_metric_test_2"
+        consumer, psub = _make_consumer(
+            subject=subject, durable="consumed-durable-2"
+        )
+        raw = _make_raw_msg(subject=subject, num_delivered=1)
+
+        before = _get_counter_value(
+            QUEUE_CONSUMED_TOTAL, {"subject": subject, "status": "delivered"}
+        )
+        await _drain_consumer(consumer, psub, [raw])
+        after = _get_counter_value(
+            QUEUE_CONSUMED_TOTAL, {"subject": subject, "status": "delivered"}
+        )
+        assert after - before == 1.0
+
+    def test_processing_duration_histogram_exists(self) -> None:
+        """The processing duration histogram must be importable and named correctly."""
+        assert QUEUE_PROCESSING_DURATION_SECONDS._name == (
+            "omniscience_queue_processing_duration_seconds"
+        )
+
+
+# ---------------------------------------------------------------------------
+# NatsConnection tests
+# ---------------------------------------------------------------------------
+
+
+class TestNatsConnection:
+    @pytest.mark.asyncio
+    async def test_connect_sets_is_connected(self) -> None:
+        """After connect(), is_connected must be True."""
+        from omniscience_core.config import Settings
+        from omniscience_core.queue.connection import NatsConnection
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.jetstream = MagicMock(return_value=MagicMock())
+
+        with patch(
+            "omniscience_core.queue.connection.nats.connect", new_callable=AsyncMock
+        ) as mock_connect:
+            mock_connect.return_value = mock_client
+
+            conn = NatsConnection()
+            settings = Settings(nats_url="nats://localhost:4222")
+            await conn.connect(settings)
+
+            assert conn.is_connected is True
+            mock_connect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_idempotent(self) -> None:
+        """Calling connect() twice must not open a second connection."""
+        from omniscience_core.config import Settings
+        from omniscience_core.queue.connection import NatsConnection
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.jetstream = MagicMock(return_value=MagicMock())
+
+        with patch(
+            "omniscience_core.queue.connection.nats.connect", new_callable=AsyncMock
+        ) as mock_connect:
+            mock_connect.return_value = mock_client
+
+            conn = NatsConnection()
+            settings = Settings(nats_url="nats://localhost:4222")
+            await conn.connect(settings)
+            await conn.connect(settings)
+
+            mock_connect.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_drains_client(self) -> None:
+        """disconnect() must call drain() on the client."""
+        from omniscience_core.config import Settings
+        from omniscience_core.queue.connection import NatsConnection
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.drain = AsyncMock()
+        mock_client.connected_url = MagicMock()
+        mock_client.connected_url.netloc = "localhost:4222"
+        mock_client.jetstream = MagicMock(return_value=MagicMock())
+
+        with patch(
+            "omniscience_core.queue.connection.nats.connect", new_callable=AsyncMock
+        ) as mock_connect:
+            mock_connect.return_value = mock_client
+
+            conn = NatsConnection()
+            settings = Settings(nats_url="nats://localhost:4222")
+            await conn.connect(settings)
+            await conn.disconnect()
+
+            mock_client.drain.assert_awaited_once()
+
+    def test_client_raises_when_not_connected(self) -> None:
+        """Accessing .client before connect() must raise RuntimeError."""
+        from omniscience_core.queue.connection import NatsConnection
+
+        conn = NatsConnection()
+        with pytest.raises(RuntimeError, match="not connected"):
+            _ = conn.client
+
+    def test_jetstream_raises_when_not_connected(self) -> None:
+        """Accessing .jetstream before connect() must raise RuntimeError."""
+        from omniscience_core.queue.connection import NatsConnection
+
+        conn = NatsConnection()
+        with pytest.raises(RuntimeError, match="not connected"):
+            _ = conn.jetstream
+
+
+# ---------------------------------------------------------------------------
+# Health check integration
+# ---------------------------------------------------------------------------
+
+
+class TestHealthNatsCheck:
+    @pytest.mark.asyncio
+    async def test_check_nats_healthy_when_connected(self) -> None:
+        from omniscience_core.queue.connection import NatsConnection
+        from omniscience_server.routes.health import _check_nats
+
+        conn = MagicMock(spec=NatsConnection)
+        conn.is_connected = True
+
+        result = await _check_nats(conn)
+        assert result == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_check_nats_unhealthy_when_disconnected(self) -> None:
+        from omniscience_core.queue.connection import NatsConnection
+        from omniscience_server.routes.health import _check_nats
+
+        conn = MagicMock(spec=NatsConnection)
+        conn.is_connected = False
+
+        result = await _check_nats(conn)
+        assert result == "unhealthy"
+
+    @pytest.mark.asyncio
+    async def test_check_nats_unchecked_when_none(self) -> None:
+        from omniscience_server.routes.health import _check_nats
+
+        result = await _check_nats(None)
+        assert result == "unchecked"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_counter_value(counter: Any, labels: dict[str, str]) -> float:
+    """Read the current value of a prometheus_client Counter for given labels."""
+    try:
+        return counter.labels(**labels)._value.get()  # type: ignore[no-any-return]
+    except Exception:
+        return 0.0

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -180,9 +180,7 @@ class TestQueueProducer:
         producer = QueueProducer(js)
 
         with pytest.raises(RuntimeError, match="nats down"):
-            await producer.publish(
-                "ingest.changes.git", _SamplePayload(source_id="a", doc_id="b")
-            )
+            await producer.publish("ingest.changes.git", _SamplePayload(source_id="a", doc_id="b"))
 
 
 # ---------------------------------------------------------------------------
@@ -500,9 +498,7 @@ class TestMetricsIncrements:
     async def test_consumed_counter_increments_on_delivered(self) -> None:
         """Consumed counter must increment with status=delivered for normal messages."""
         subject = "ingest.changes.consumed_metric_test_2"
-        consumer, psub = _make_consumer(
-            subject=subject, durable="consumed-durable-2"
-        )
+        consumer, psub = _make_consumer(subject=subject, durable="consumed-durable-2")
         raw = _make_raw_msg(subject=subject, num_delivered=1)
 
         before = _get_counter_value(

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,20 @@ members = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -58,6 +72,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]
@@ -422,6 +476,53 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
+    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
+    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
+    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -664,6 +765,81 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -741,12 +917,82 @@ wheels = [
 ]
 
 [[package]]
+name = "nats-py"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f8/b956c4621ba88748ed707c52e69f95b7a50c8914e750edca59a5bef84a76/nats_py-2.14.0.tar.gz", hash = "sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed", size = 120751, upload-time = "2026-02-23T22:44:58.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl", hash = "sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d", size = 82259, upload-time = "2026-02-23T22:45:00.152Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
 ]
 
 [[package]]
@@ -809,25 +1055,35 @@ name = "omniscience-core"
 version = "0.1.0"
 source = { editable = "packages/core" }
 dependencies = [
+    { name = "alembic" },
+    { name = "asyncpg" },
+    { name = "nats-py" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-sdk" },
+    { name = "pgvector" },
     { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.13.0" },
+    { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "nats-py", specifier = ">=2.7.0" },
     { name = "opentelemetry-api", specifier = ">=1.25.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.25.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.46b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.25.0" },
+    { name = "pgvector", specifier = ">=0.3.0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.30" },
     { name = "structlog", specifier = ">=24.2.0" },
 ]
 
@@ -1079,6 +1335,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
 ]
 
 [[package]]
@@ -1544,6 +1812,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `NatsConnection` wrapper with auto-reconnect, structured logging, graceful drain
- Idempotent stream creation: `INGEST_CHANGES` + `INGEST_DLQ` (7-day retention, file storage)
- `QueueProducer` with Pydantic validation + publish with ack
- Generic `QueueConsumer[T]` async iterator with typed message deserialization
- DLQ routing: failures after N retries → `ingest.dlq.*` with error context
- Real NATS health check wired into `/health` endpoint
- Prometheus metrics: published, consumed, DLQ, processing duration

## Key design decisions

- Generic `Message[T]` wrapper preserves type safety through the pipeline
- Consumer uses `while True` loop so `stop()` from inside `async for` drains cleanly
- DLQ publishes structured `DLQMessage` (original subject, payload, error, attempt count)
- Health check returns `"unchecked"` when NATS connection not initialized (backward compatible)

## Test plan

- [ ] 41 unit tests passing (producer, consumer, DLQ, streams, connection, health)
- [ ] `mypy --strict` clean
- [ ] `ruff check` + `ruff format` clean

Closes #3