### PR TITLE
feat: connector SDK with protocol, registry, and contract tests

### DIFF
--- a/packages/connectors/pyproject.toml
+++ b/packages/connectors/pyproject.toml
@@ -5,6 +5,7 @@ description = "Source connector framework and built-in connectors for Omniscienc
 requires-python = ">=3.12"
 dependencies = [
     "omniscience-core",
+    "pydantic>=2.7.0",
 ]
 
 [tool.uv.sources]

--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -1,5 +1,45 @@
-"""Source connector framework — placeholder for Wave 2 (issues #2/#5).
+"""omniscience-connectors — Source connector framework for Omniscience.
 
-Built-in connectors (git, fs) and the connector SDK will be implemented here.
-See docs/api/connector-sdk.md for the planned interface.
+Public surface
+--------------
+Data types::
+
+    from omniscience_connectors import DocumentRef, FetchedDocument
+    from omniscience_connectors import WebhookHandler, WebhookPayload
+
+Protocols::
+
+    from omniscience_connectors import Connector
+
+Registry::
+
+    from omniscience_connectors import ConnectorRegistry, get_connector
+
+Built-in connectors (``git``, ``fs``) will be registered here in subsequent
+issues.  Third-party connectors call :func:`get_connector` after registering
+against the shared registry.
 """
+
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+    WebhookPayload,
+)
+from omniscience_connectors.registry import (
+    ConnectorRegistry,
+    NotFoundError,
+    get_connector,
+)
+
+__all__ = [
+    "Connector",
+    "ConnectorRegistry",
+    "DocumentRef",
+    "FetchedDocument",
+    "NotFoundError",
+    "WebhookHandler",
+    "WebhookPayload",
+    "get_connector",
+]

--- a/packages/connectors/src/omniscience_connectors/base.py
+++ b/packages/connectors/src/omniscience_connectors/base.py
@@ -1,0 +1,227 @@
+"""Connector protocol and data types for the Omniscience source connector framework.
+
+Every source connector must implement the ``Connector`` protocol.  The framework
+is intentionally small: connectors own discovery and fetching; parsing, chunking,
+and embedding happen downstream in the ingestion pipeline.
+
+Design constraints (see docs/api/connector-sdk.md):
+- Connectors never receive secrets in ``config``; secrets arrive via a separate
+  ``secrets: dict[str, str]`` argument resolved at runtime.
+- Connectors must not log raw secret values.
+- Parsing/chunking happens downstream, NOT in connectors.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "Connector",
+    "DocumentRef",
+    "FetchedDocument",
+    "WebhookHandler",
+    "WebhookPayload",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data transfer objects
+# ---------------------------------------------------------------------------
+
+
+class DocumentRef(BaseModel):
+    """Reference to a document in a source.
+
+    Passed from ``discover()`` to the ingestion pipeline; the pipeline then
+    calls ``fetch()`` with this ref to retrieve the actual content.
+    """
+
+    external_id: str
+    """Source-native identifier — stable across syncs (e.g. git blob SHA, Confluence page ID)."""
+
+    uri: str
+    """Human-readable address for the document (URL, file path, …)."""
+
+    updated_at: datetime | None = None
+    """Last-modified timestamp as reported by the source.  May be ``None`` when
+    the source does not expose modification timestamps."""
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Arbitrary source-specific metadata (labels, mime-hint, author, …).
+    Must not contain secrets."""
+
+
+class FetchedDocument(BaseModel):
+    """Full document content fetched from a source.
+
+    Raw bytes + MIME type.  Parsing is left to the downstream pipeline.
+    """
+
+    ref: DocumentRef
+    """The reference that triggered this fetch."""
+
+    content_bytes: bytes
+    """Raw document bytes.  Encoding is source-specific; the MIME type provides a hint."""
+
+    content_type: str
+    """IANA MIME type (e.g. ``"text/markdown"``, ``"text/plain"``, ``"application/json"``)."""
+
+
+class WebhookPayload(BaseModel):
+    """Parsed webhook payload produced by :class:`WebhookHandler`.
+
+    After signature verification and parsing, the connector returns the
+    affected document refs so the ingestion pipeline can trigger a targeted
+    partial sync.
+    """
+
+    source_name: str
+    """Logical name of the source that sent the webhook."""
+
+    affected_refs: list[DocumentRef]
+    """Documents reported as changed by this webhook event."""
+
+    raw_headers: dict[str, str]
+    """Original HTTP headers forwarded by the webhook receiver (lower-cased keys)."""
+
+
+# ---------------------------------------------------------------------------
+# Protocols
+# ---------------------------------------------------------------------------
+
+
+class WebhookHandler:
+    """Handler for push-style source updates.
+
+    Connectors that support webhooks return an instance of this class from
+    :meth:`Connector.webhook_handler`.  Callers MUST call
+    :meth:`verify_signature` before :meth:`parse_payload`.
+    """
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        """Return ``True`` if the request is authentic, ``False`` otherwise.
+
+        Implementations should use a constant-time comparison to prevent
+        timing attacks.  Must not raise on invalid inputs — return ``False``
+        instead.
+        """
+        raise NotImplementedError
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        """Parse the raw request body into a :class:`WebhookPayload`.
+
+        Should only be called after :meth:`verify_signature` returns ``True``.
+        Raises :class:`ValueError` if the payload cannot be parsed.
+        """
+        raise NotImplementedError
+
+
+class Connector:
+    """Base class every source connector must implement.
+
+    Connectors are **stateless** with respect to configuration — all
+    configuration is passed explicitly at call-time so a single class
+    instance can serve multiple source records.
+
+    Class variables
+    ---------------
+    connector_type:
+        Short, unique string key used in the registry (e.g. ``"git"``).
+        Exposed as ``type`` via a property for backwards compatibility with
+        the spec.
+    config_schema:
+        Pydantic model class that validates the public, persisted config block
+        for this connector type.  Never include secrets here.
+    """
+
+    # ``type`` conflicts with the Python 3.12 soft keyword in class bodies when
+    # used inside ClassVar[type[...]] annotations — mypy misinterprets the
+    # inner ``type`` as a forward reference to this attribute.  We store the
+    # connector's type string under ``connector_type`` and expose it as
+    # ``type`` via a class property to satisfy the interface and the registry.
+    connector_type: ClassVar[str]
+    config_schema: ClassVar[builtins.type[BaseModel]]
+
+    @classmethod
+    def get_connector_type(cls) -> str:
+        """Return the connector type string (alias for ``connector_type``)."""
+        return cls.connector_type
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Dry-run connectivity and permission check.
+
+        Should attempt the cheapest possible authenticated request to verify
+        that the configuration and secrets are correct.  Raises on failure —
+        callers treat any exception as a validation error.
+
+        Args:
+            config: Validated public configuration (never contains secrets).
+            secrets: Runtime-resolved secret values keyed by name.  Must not
+                be logged or stored.
+        """
+        raise NotImplementedError
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield every document currently present in the source.
+
+        For large sources this may be a long-running stream.  The pipeline
+        controls back-pressure — connectors should not buffer the full list
+        in memory.
+
+        Args:
+            config: Validated public configuration.
+            secrets: Runtime-resolved secret values.
+
+        Yields:
+            :class:`DocumentRef` objects for each discovered document.
+        """
+        raise NotImplementedError
+        # Make this a valid async generator at the type level.
+        yield  # pragma: no cover  # type: ignore[misc]
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Return content + metadata for one document.
+
+        Args:
+            config: Validated public configuration.
+            secrets: Runtime-resolved secret values.
+            ref: The reference returned by :meth:`discover` (or from a webhook).
+
+        Returns:
+            :class:`FetchedDocument` with raw bytes and MIME type.
+        """
+        raise NotImplementedError
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        """Return a handler if this connector supports push-style updates.
+
+        Returns:
+            A :class:`WebhookHandler` instance, or ``None`` for pull-only connectors.
+        """
+        return None

--- a/packages/connectors/src/omniscience_connectors/registry.py
+++ b/packages/connectors/src/omniscience_connectors/registry.py
@@ -1,0 +1,136 @@
+"""Connector registry — maps connector type strings to connector instances.
+
+Usage::
+
+    from omniscience_connectors.registry import ConnectorRegistry, get_connector
+
+    registry = ConnectorRegistry()
+    registry.register(MyConnector)
+
+    connector = get_connector("my_connector_type")
+
+The module-level :func:`get_connector` convenience function operates on a
+shared :data:`_registry` singleton.  Built-in connectors are registered
+at import time via the package's ``__init__``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Final
+
+from omniscience_connectors.base import Connector
+
+__all__ = [
+    "ConnectorRegistry",
+    "NotFoundError",
+    "get_connector",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class NotFoundError(KeyError):
+    """Raised when a connector type is not registered."""
+
+    def __init__(self, connector_type: str) -> None:
+        self.connector_type = connector_type
+        super().__init__(f"No connector registered for type {connector_type!r}")
+
+
+class ConnectorRegistry:
+    """Registry that maps connector ``connector_type`` strings to connector instances.
+
+    Instances are stored once at registration time (connectors are stateless).
+    """
+
+    def __init__(self) -> None:
+        self._connectors: dict[str, Connector] = {}
+
+    def register(self, connector_cls: type[Connector]) -> None:
+        """Register a connector class by its ``connector_type`` attribute.
+
+        Instantiates the class with no arguments and stores the instance.
+        Re-registering the same type replaces the previous entry and emits a
+        warning.
+
+        Args:
+            connector_cls: A concrete :class:`~omniscience_connectors.base.Connector`
+                subclass with a non-empty ``connector_type`` class variable.
+
+        Raises:
+            ValueError: If the connector class has no ``connector_type`` attribute
+                or if ``connector_type`` is an empty string.
+        """
+        connector_type: str = getattr(connector_cls, "connector_type", "")
+        if not connector_type:
+            raise ValueError(
+                f"Connector class {connector_cls.__name__!r} must define a non-empty "
+                "'type' class variable."
+            )
+
+        if connector_type in self._connectors:
+            logger.warning(
+                "connector.registry.overwrite",
+                extra={"connector_type": connector_type, "class": connector_cls.__name__},
+            )
+
+        instance = connector_cls()
+        self._connectors[connector_type] = instance
+        logger.info(
+            "connector.registry.registered",
+            extra={"connector_type": connector_type, "class": connector_cls.__name__},
+        )
+
+    def get(self, connector_type: str) -> Connector:
+        """Return the registered connector instance for *connector_type*.
+
+        Args:
+            connector_type: The ``connector_type`` string used during registration.
+
+        Returns:
+            The registered :class:`~omniscience_connectors.base.Connector` instance.
+
+        Raises:
+            NotFoundError: If no connector is registered for *connector_type*.
+        """
+        try:
+            connector = self._connectors[connector_type]
+        except KeyError:
+            logger.debug(
+                "connector.registry.not_found",
+                extra={"connector_type": connector_type},
+            )
+            raise NotFoundError(connector_type) from None
+
+        logger.debug(
+            "connector.registry.lookup",
+            extra={"connector_type": connector_type, "class": type(connector).__name__},
+        )
+        return connector
+
+    def registered_types(self) -> list[str]:
+        """Return a sorted list of registered connector type strings."""
+        return sorted(self._connectors.keys())
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_registry: Final[ConnectorRegistry] = ConnectorRegistry()
+
+
+def get_connector(connector_type: str) -> Connector:
+    """Look up *connector_type* in the shared module-level registry.
+
+    Args:
+        connector_type: The connector type string (e.g. ``"git"``).
+
+    Returns:
+        The registered :class:`~omniscience_connectors.base.Connector` instance.
+
+    Raises:
+        NotFoundError: If the type is not registered.
+    """
+    return _registry.get(connector_type)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "httpx>=0.27.0",
     "pre-commit>=3.7.1",
     "omniscience-core",
+    "omniscience-connectors",
     "omniscience-server",
     "omniscience-embeddings",
     "tenacity>=9.1.4",

--- a/tests/connectors/__init__.py
+++ b/tests/connectors/__init__.py
@@ -1,0 +1,6 @@
+"""Contract tests for the Omniscience connector framework.
+
+Any concrete connector test class should inherit from
+:class:`~tests.connectors.contract_tests.ConnectorContractTests` and
+provide the fixtures required by the abstract methods.
+"""

--- a/tests/connectors/contract_tests.py
+++ b/tests/connectors/contract_tests.py
@@ -1,0 +1,201 @@
+"""Abstract contract test suite for Omniscience connectors.
+
+Every connector must pass this suite.  To use it, create a concrete test
+class that:
+
+1. Inherits from :class:`ConnectorContractTests`.
+2. Overrides the three abstract helper methods to return a configured
+   connector, valid config, invalid config, and secrets.
+
+Example::
+
+    class TestMyConnector(ConnectorContractTests):
+        def make_connector(self) -> Connector:
+            return MyConnector()
+
+        def valid_config(self) -> BaseModel:
+            return MyConfig(repo="https://example.com/repo.git")
+
+        def invalid_config(self) -> BaseModel:
+            return MyConfig(repo="")  # empty repo → validate should raise
+
+        def secrets(self) -> dict[str, str]:
+            return {"token": "test-token"}
+
+Run with::
+
+    pytest tests/connectors/contract_tests.py::TestMyConnector
+
+The base class is purposefully *not* collected by pytest (no ``Test``
+prefix, abstract methods would fail on instantiation).
+"""
+
+from __future__ import annotations
+
+import abc
+import hashlib
+
+import pytest
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+)
+from pydantic import BaseModel
+
+
+class ConnectorContractTests(abc.ABC):
+    """Abstract base for connector contract tests.
+
+    Concrete subclasses MUST implement the three abstract methods below.
+    All test methods are async-compatible via pytest-asyncio.
+    """
+
+    # ------------------------------------------------------------------
+    # Abstract fixture helpers — override in concrete test classes
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def make_connector(self) -> Connector:
+        """Return a fully initialised connector under test."""
+
+    @abc.abstractmethod
+    def valid_config(self) -> BaseModel:
+        """Return a valid config that ``validate()`` and ``discover()`` accept."""
+
+    @abc.abstractmethod
+    def invalid_config(self) -> BaseModel:
+        """Return a config that ``validate()`` must reject (raise any exception)."""
+
+    @abc.abstractmethod
+    def secrets(self) -> dict[str, str]:
+        """Return secrets dict used alongside :meth:`valid_config`."""
+
+    # ------------------------------------------------------------------
+    # Contract: validate()
+    # ------------------------------------------------------------------
+
+    async def test_validate_succeeds_with_valid_config(self) -> None:
+        """validate() must not raise when given a valid config + secrets."""
+        connector = self.make_connector()
+        # Should complete without raising
+        await connector.validate(self.valid_config(), self.secrets())
+
+    async def test_validate_raises_with_invalid_config(self) -> None:
+        """validate() must raise for bad config or bad secrets."""
+        connector = self.make_connector()
+        with pytest.raises(Exception):  # noqa: B017 — any exception is a contract pass
+            await connector.validate(self.invalid_config(), self.secrets())
+
+    # ------------------------------------------------------------------
+    # Contract: discover()
+    # ------------------------------------------------------------------
+
+    async def test_discover_yields_at_least_one_ref(self) -> None:
+        """discover() must yield at least one DocumentRef against a fixture source."""
+        connector = self.make_connector()
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(self.valid_config(), self.secrets()):
+            refs.append(ref)
+            break  # We only need one to satisfy the contract
+
+        assert len(refs) >= 1, "discover() must yield at least one DocumentRef"
+        assert isinstance(refs[0], DocumentRef)
+
+    async def test_discover_refs_have_required_fields(self) -> None:
+        """Every yielded DocumentRef must have non-empty external_id and uri."""
+        connector = self.make_connector()
+        async for ref in connector.discover(self.valid_config(), self.secrets()):
+            assert ref.external_id, "DocumentRef.external_id must be non-empty"
+            assert ref.uri, "DocumentRef.uri must be non-empty"
+            break
+
+    # ------------------------------------------------------------------
+    # Contract: fetch()
+    # ------------------------------------------------------------------
+
+    async def test_fetch_returns_fetched_document(self) -> None:
+        """fetch() must return a FetchedDocument with non-empty content_bytes."""
+        connector = self.make_connector()
+
+        # Get a ref from discover() to feed into fetch()
+        ref: DocumentRef | None = None
+        async for discovered_ref in connector.discover(self.valid_config(), self.secrets()):
+            ref = discovered_ref
+            break
+
+        assert ref is not None, "discover() must yield at least one ref for fetch() test"
+
+        result = await connector.fetch(self.valid_config(), self.secrets(), ref)
+
+        assert isinstance(result, FetchedDocument)
+        assert isinstance(result.content_bytes, bytes)
+        assert len(result.content_bytes) > 0, "FetchedDocument.content_bytes must be non-empty"
+        assert result.content_type, "FetchedDocument.content_type must be non-empty"
+        assert result.ref == ref
+
+    async def test_fetch_content_bytes_are_deterministic(self) -> None:
+        """fetch() for the same ref must return the same bytes (deterministic)."""
+        connector = self.make_connector()
+
+        ref: DocumentRef | None = None
+        async for discovered_ref in connector.discover(self.valid_config(), self.secrets()):
+            ref = discovered_ref
+            break
+
+        assert ref is not None
+
+        result1 = await connector.fetch(self.valid_config(), self.secrets(), ref)
+        result2 = await connector.fetch(self.valid_config(), self.secrets(), ref)
+
+        assert (
+            hashlib.sha256(result1.content_bytes).hexdigest()
+            == hashlib.sha256(result2.content_bytes).hexdigest()
+        ), "fetch() must be deterministic for the same ref"
+
+    # ------------------------------------------------------------------
+    # Contract: webhook_handler()
+    # ------------------------------------------------------------------
+
+    def test_webhook_handler_returns_handler_or_none(self) -> None:
+        """webhook_handler() must return a WebhookHandler or None."""
+        connector = self.make_connector()
+        handler = connector.webhook_handler()
+        assert handler is None or isinstance(handler, WebhookHandler), (
+            "webhook_handler() must return WebhookHandler | None"
+        )
+
+    async def test_webhook_handler_rejects_invalid_signature(self) -> None:
+        """If webhook_handler() is not None, it must reject tampered payloads."""
+        connector = self.make_connector()
+        handler = connector.webhook_handler()
+
+        if handler is None:
+            pytest.skip("Connector does not support webhooks")
+
+        result = await handler.verify_signature(
+            payload=b'{"tampered": true}',
+            headers={"x-hub-signature-256": "sha256=badhash"},
+            secret="test-secret",
+        )
+        assert result is False, "verify_signature() must return False for invalid signatures"
+
+    async def test_webhook_handler_accepts_valid_signature(self) -> None:
+        """If webhook_handler() is not None, a correctly-signed payload is accepted.
+
+        Subclasses should override this if the connector has custom signing logic.
+        The base implementation skips the test when no webhook handler is present.
+        """
+        connector = self.make_connector()
+        handler = connector.webhook_handler()
+
+        if handler is None:
+            pytest.skip("Connector does not support webhooks")
+
+        # Subclasses must override with a properly signed payload.
+        # The base just verifies the method doesn't crash.
+        pytest.skip(
+            "Override test_webhook_handler_accepts_valid_signature in your test class "
+            "to provide a properly-signed payload specific to your connector."
+        )

--- a/tests/test_connector_sdk.py
+++ b/tests/test_connector_sdk.py
@@ -1,0 +1,528 @@
+"""Unit tests for the Omniscience connector SDK.
+
+Covers:
+- ConnectorRegistry register / get / unknown-type error
+- DocumentRef / FetchedDocument / WebhookPayload model validation
+- A dummy connector implementing the full protocol
+- Secrets-config separation enforcement
+- Contract test suite running against the mock connector
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any, ClassVar, cast
+
+import pytest
+from omniscience_connectors import (
+    Connector,
+    ConnectorRegistry,
+    DocumentRef,
+    FetchedDocument,
+    NotFoundError,
+    WebhookHandler,
+    WebhookPayload,
+    get_connector,
+)
+from omniscience_connectors.registry import _registry
+from pydantic import BaseModel
+
+from tests.connectors.contract_tests import ConnectorContractTests
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyConfig(BaseModel):
+    """Minimal config for the dummy connector.  No secrets here."""
+
+    path: str = "/fixtures"
+
+
+class _InvalidDummyConfig(BaseModel):
+    """Config that will cause the dummy connector's validate() to raise."""
+
+    path: str = ""
+
+
+class _DummyWebhookHandler(WebhookHandler):
+    """Webhook handler that uses HMAC-SHA256 for signature verification."""
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        sig_header = headers.get("x-hub-signature-256", "")
+        if not sig_header.startswith("sha256="):
+            return False
+        expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+        provided = sig_header[len("sha256=") :]
+        return hmac.compare_digest(expected, provided)
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        return WebhookPayload(
+            source_name="dummy",
+            affected_refs=[
+                DocumentRef(
+                    external_id="abc123",
+                    uri="/fixtures/hello.md",
+                    updated_at=datetime.now(UTC),
+                )
+            ],
+            raw_headers=headers,
+        )
+
+
+class DummyConnector(Connector):
+    """Mock connector implementing the full Connector protocol for testing."""
+
+    connector_type: ClassVar[str] = "dummy"
+    config_schema: ClassVar[type[BaseModel]] = _DummyConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        cfg = cast("_DummyConfig", config)
+        if not isinstance(cfg, _DummyConfig) or not cfg.path:
+            raise ValueError("DummyConnector requires a non-empty path")
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        cfg = cast("_DummyConfig", config)
+        yield DocumentRef(
+            external_id="doc-1",
+            uri=f"{cfg.path}/doc-1.md",
+            updated_at=datetime.now(UTC),
+            metadata={"author": "test"},
+        )
+        yield DocumentRef(
+            external_id="doc-2",
+            uri=f"{cfg.path}/doc-2.md",
+        )
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        content = f"# {ref.external_id}\n\nContent for {ref.uri}".encode()
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=content,
+            content_type="text/markdown",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return _DummyWebhookHandler()
+
+
+class DummyPullOnlyConnector(Connector):
+    """Pull-only connector — webhook_handler returns None."""
+
+    connector_type: ClassVar[str] = "dummy-pull-only"
+    config_schema: ClassVar[type[BaseModel]] = _DummyConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        pass
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        yield DocumentRef(external_id="ref-0", uri="/path/ref-0.txt")
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=b"hello world",
+            content_type="text/plain",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# ConnectorRegistry tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorRegistry:
+    def setup_method(self) -> None:
+        """Use a fresh registry for each test."""
+        self.registry = ConnectorRegistry()
+
+    def test_register_and_get_returns_instance(self) -> None:
+        self.registry.register(DummyConnector)
+        connector = self.registry.get("dummy")
+        assert isinstance(connector, DummyConnector)
+
+    def test_get_unknown_type_raises_not_found_error(self) -> None:
+        with pytest.raises(NotFoundError) as exc_info:
+            self.registry.get("nonexistent")
+        assert exc_info.value.connector_type == "nonexistent"
+        assert "nonexistent" in str(exc_info.value)
+
+    def test_register_multiple_connectors(self) -> None:
+        self.registry.register(DummyConnector)
+        self.registry.register(DummyPullOnlyConnector)
+        assert isinstance(self.registry.get("dummy"), DummyConnector)
+        assert isinstance(self.registry.get("dummy-pull-only"), DummyPullOnlyConnector)
+
+    def test_registered_types_returns_sorted_list(self) -> None:
+        self.registry.register(DummyPullOnlyConnector)
+        self.registry.register(DummyConnector)
+        types = self.registry.registered_types()
+        assert types == sorted(types)
+        assert "dummy" in types
+        assert "dummy-pull-only" in types
+
+    def test_reregister_replaces_previous_entry(self) -> None:
+        self.registry.register(DummyConnector)
+        self.registry.register(DummyConnector)  # Re-register same type
+        # Should not raise; should still work
+        connector = self.registry.get("dummy")
+        assert isinstance(connector, DummyConnector)
+
+    def test_register_raises_for_connector_without_type(self) -> None:
+        class NoTypeConnector(Connector):
+            config_schema: ClassVar[type[BaseModel]] = _DummyConfig
+
+            async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+                pass
+
+            async def discover(
+                self, config: BaseModel, secrets: dict[str, str]
+            ) -> AsyncIterator[DocumentRef]:
+                yield DocumentRef(external_id="x", uri="y")  # pragma: no cover
+
+            async def fetch(
+                self, config: BaseModel, secrets: dict[str, str], ref: DocumentRef
+            ) -> FetchedDocument:
+                return FetchedDocument(  # pragma: no cover
+                    ref=ref, content_bytes=b"", content_type="text/plain"
+                )
+
+        with pytest.raises(ValueError, match="non-empty 'type'"):
+            self.registry.register(NoTypeConnector)
+
+    def test_not_found_error_is_key_error_subclass(self) -> None:
+        """NotFoundError inherits from KeyError for dict-style exception handling."""
+        err = NotFoundError("test-type")
+        assert isinstance(err, KeyError)
+
+    def test_module_level_get_connector_uses_shared_registry(self) -> None:
+        """get_connector() delegates to the module-level singleton registry."""
+        _registry.register(DummyConnector)
+        connector = get_connector("dummy")
+        assert isinstance(connector, DummyConnector)
+
+
+# ---------------------------------------------------------------------------
+# DocumentRef model tests
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentRef:
+    def test_minimal_fields(self) -> None:
+        ref = DocumentRef(external_id="abc", uri="https://example.com/doc")
+        assert ref.external_id == "abc"
+        assert ref.uri == "https://example.com/doc"
+        assert ref.updated_at is None
+        assert ref.metadata == {}
+
+    def test_with_all_fields(self) -> None:
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        ref = DocumentRef(
+            external_id="abc",
+            uri="https://example.com/doc",
+            updated_at=ts,
+            metadata={"author": "alice", "tags": ["infra", "k8s"]},
+        )
+        assert ref.updated_at == ts
+        assert ref.metadata["author"] == "alice"
+
+    def test_metadata_default_is_empty_dict(self) -> None:
+        ref1 = DocumentRef(external_id="a", uri="b")
+        ref2 = DocumentRef(external_id="c", uri="d")
+        # Ensure they are not the same object (mutable default factory)
+        ref1.metadata["key"] = "value"
+        assert "key" not in ref2.metadata
+
+    def test_equality(self) -> None:
+        ref1 = DocumentRef(external_id="x", uri="y")
+        ref2 = DocumentRef(external_id="x", uri="y")
+        assert ref1 == ref2
+
+    def test_json_roundtrip(self) -> None:
+        ref = DocumentRef(
+            external_id="abc",
+            uri="file:///tmp/doc.md",
+            updated_at=datetime(2024, 6, 1, tzinfo=UTC),
+            metadata={"size": 1234},
+        )
+        dumped = ref.model_dump_json()
+        loaded = DocumentRef.model_validate_json(dumped)
+        assert loaded == ref
+
+
+# ---------------------------------------------------------------------------
+# FetchedDocument model tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchedDocument:
+    def test_basic_construction(self) -> None:
+        ref = DocumentRef(external_id="id1", uri="/path/doc.md")
+        doc = FetchedDocument(ref=ref, content_bytes=b"hello", content_type="text/markdown")
+        assert doc.ref == ref
+        assert doc.content_bytes == b"hello"
+        assert doc.content_type == "text/markdown"
+
+    def test_content_bytes_can_be_empty(self) -> None:
+        """Empty byte string is technically valid (e.g. zero-byte files)."""
+        ref = DocumentRef(external_id="empty", uri="/empty.txt")
+        doc = FetchedDocument(ref=ref, content_bytes=b"", content_type="text/plain")
+        assert doc.content_bytes == b""
+
+    def test_binary_content(self) -> None:
+        ref = DocumentRef(external_id="bin", uri="/doc.pdf")
+        data = bytes(range(256))
+        doc = FetchedDocument(ref=ref, content_bytes=data, content_type="application/pdf")
+        assert doc.content_bytes == data
+
+
+# ---------------------------------------------------------------------------
+# WebhookPayload model tests
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookPayload:
+    def test_basic_construction(self) -> None:
+        refs = [DocumentRef(external_id="r1", uri="/a"), DocumentRef(external_id="r2", uri="/b")]
+        payload = WebhookPayload(
+            source_name="github",
+            affected_refs=refs,
+            raw_headers={"x-github-event": "push", "content-type": "application/json"},
+        )
+        assert payload.source_name == "github"
+        assert len(payload.affected_refs) == 2
+        assert payload.raw_headers["x-github-event"] == "push"
+
+    def test_empty_affected_refs_allowed(self) -> None:
+        payload = WebhookPayload(source_name="noop", affected_refs=[], raw_headers={})
+        assert payload.affected_refs == []
+
+    def test_json_roundtrip(self) -> None:
+        payload = WebhookPayload(
+            source_name="gitlab",
+            affected_refs=[DocumentRef(external_id="abc", uri="https://gl.example.com/file.py")],
+            raw_headers={"x-gitlab-token": "redacted"},
+        )
+        restored = WebhookPayload.model_validate_json(payload.model_dump_json())
+        assert restored.source_name == payload.source_name
+        assert len(restored.affected_refs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Secrets-config separation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsConfigSeparation:
+    """Verifies the contract that secrets must never appear in config objects."""
+
+    def test_dummy_config_has_no_secret_fields(self) -> None:
+        """Config model fields must not be named 'secret', 'token', 'password', etc."""
+        sensitive_names = {"secret", "token", "password", "api_key", "key", "credential"}
+        config_fields = set(_DummyConfig.model_fields.keys())
+        overlap = config_fields & sensitive_names
+        assert not overlap, f"Config model must not contain secret fields: {overlap}"
+
+    async def test_secrets_passed_separately_to_validate(self) -> None:
+        """validate() receives config and secrets as distinct arguments."""
+        connector = DummyConnector()
+        config = _DummyConfig(path="/test")
+        secrets: dict[str, str] = {"token": "super-secret-value"}
+        # Should work without error
+        await connector.validate(config, secrets)
+        # Config object must not have the token attribute
+        assert not hasattr(config, "token")
+
+    async def test_secrets_passed_separately_to_fetch(self) -> None:
+        """fetch() must accept secrets as a separate dict, not embedded in config."""
+        connector = DummyConnector()
+        config = _DummyConfig(path="/test")
+        secrets: dict[str, str] = {"token": "test-token"}
+        ref = DocumentRef(external_id="doc-1", uri="/test/doc-1.md")
+        doc = await connector.fetch(config, secrets, ref)
+        assert doc.content_bytes  # fetched successfully without secrets in config
+
+    async def test_connector_config_schema_declared(self) -> None:
+        """config_schema ClassVar must be declared and be a BaseModel subclass."""
+        assert hasattr(DummyConnector, "config_schema")
+        assert issubclass(DummyConnector.config_schema, BaseModel)
+
+
+# ---------------------------------------------------------------------------
+# Dummy connector protocol compliance tests
+# ---------------------------------------------------------------------------
+
+
+class TestDummyConnectorProtocol:
+    async def test_validate_succeeds_with_valid_config(self) -> None:
+        connector = DummyConnector()
+        await connector.validate(_DummyConfig(path="/repo"), {"token": "tok"})
+
+    async def test_validate_fails_with_empty_path(self) -> None:
+        connector = DummyConnector()
+        with pytest.raises(ValueError):
+            await connector.validate(_InvalidDummyConfig(), {})
+
+    async def test_discover_yields_document_refs(self) -> None:
+        connector = DummyConnector()
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(_DummyConfig(), {}):
+            refs.append(ref)
+        assert len(refs) == 2
+        assert all(isinstance(r, DocumentRef) for r in refs)
+
+    async def test_fetch_returns_fetched_document(self) -> None:
+        connector = DummyConnector()
+        ref = DocumentRef(external_id="doc-1", uri="/fixtures/doc-1.md")
+        doc = await connector.fetch(_DummyConfig(), {}, ref)
+        assert isinstance(doc, FetchedDocument)
+        assert b"doc-1" in doc.content_bytes
+        assert doc.content_type == "text/markdown"
+
+    def test_webhook_handler_returns_handler(self) -> None:
+        connector = DummyConnector()
+        handler = connector.webhook_handler()
+        assert isinstance(handler, WebhookHandler)
+
+    def test_pull_only_webhook_handler_returns_none(self) -> None:
+        connector = DummyPullOnlyConnector()
+        assert connector.webhook_handler() is None
+
+    async def test_webhook_verify_rejects_bad_signature(self) -> None:
+        connector = DummyConnector()
+        handler = connector.webhook_handler()
+        assert handler is not None
+        result = await handler.verify_signature(
+            payload=b'{"event":"push"}',
+            headers={"x-hub-signature-256": "sha256=badhash"},
+            secret="test-secret",
+        )
+        assert result is False
+
+    async def test_webhook_verify_accepts_valid_signature(self) -> None:
+        connector = DummyConnector()
+        handler = connector.webhook_handler()
+        assert handler is not None
+
+        payload = b'{"event":"push","repo":"myrepo"}'
+        secret = "my-webhook-secret"
+        mac = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+        headers = {"x-hub-signature-256": f"sha256={mac}"}
+
+        result = await handler.verify_signature(payload=payload, headers=headers, secret=secret)
+        assert result is True
+
+    async def test_webhook_parse_returns_webhook_payload(self) -> None:
+        connector = DummyConnector()
+        handler = connector.webhook_handler()
+        assert handler is not None
+
+        parsed = await handler.parse_payload(
+            payload=b'{"event":"push"}',
+            headers={"content-type": "application/json"},
+        )
+        assert isinstance(parsed, WebhookPayload)
+        assert parsed.source_name == "dummy"
+        assert len(parsed.affected_refs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Contract test suite - runs against the mock connector
+# ---------------------------------------------------------------------------
+
+
+class TestDummyConnectorContract(ConnectorContractTests):
+    """Runs the full connector contract against :class:`DummyConnector`."""
+
+    def make_connector(self) -> Connector:
+        return DummyConnector()
+
+    def valid_config(self) -> BaseModel:
+        return _DummyConfig(path="/fixtures")
+
+    def invalid_config(self) -> BaseModel:
+        return _InvalidDummyConfig()
+
+    def secrets(self) -> dict[str, str]:
+        return {"token": "test-token"}
+
+    async def test_webhook_handler_accepts_valid_signature(self) -> None:
+        """Override: provide a correctly-signed payload for the HMAC handler."""
+        connector = self.make_connector()
+        handler = connector.webhook_handler()
+        assert handler is not None
+
+        payload = b'{"ref":"refs/heads/main"}'
+        secret = "contract-test-secret"
+        mac = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+        result = await handler.verify_signature(
+            payload=payload,
+            headers={"x-hub-signature-256": f"sha256={mac}"},
+            secret=secret,
+        )
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Registry integration - shared module-level registry
+# ---------------------------------------------------------------------------
+
+
+class TestModuleLevelRegistry:
+    def test_get_connector_raises_not_found_for_unregistered_type(self) -> None:
+        with pytest.raises(NotFoundError):
+            get_connector("type-that-definitely-does-not-exist-xyz")
+
+    def test_registered_connector_retrievable_via_module_function(self) -> None:
+        _registry.register(DummyConnector)
+        conn = get_connector("dummy")
+        assert isinstance(conn, DummyConnector)
+
+    def test_registered_types_includes_all_registered(self) -> None:
+        _registry.register(DummyConnector)
+        _registry.register(DummyPullOnlyConnector)
+        types = _registry.registered_types()
+        assert "dummy" in types
+        assert "dummy-pull-only" in types
+
+    def test_document_ref_metadata_isolation(self) -> None:
+        """Ensure mutable default for metadata doesn't bleed between instances."""
+        ref_a: dict[str, Any] = DocumentRef(external_id="a", uri="a").metadata
+        ref_b: dict[str, Any] = DocumentRef(external_id="b", uri="b").metadata
+        ref_a["injected"] = True
+        assert "injected" not in ref_b

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,49 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1007,6 +1050,7 @@ dependencies = [
 dev = [
     { name = "httpx" },
     { name = "mypy" },
+    { name = "omniscience-connectors" },
     { name = "omniscience-core" },
     { name = "omniscience-embeddings" },
     { name = "omniscience-server" },
@@ -1026,6 +1070,7 @@ requires-dist = [{ name = "nats-py", specifier = ">=2.14.0" }]
 dev = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", specifier = ">=1.10.0" },
+    { name = "omniscience-connectors", editable = "packages/connectors" },
     { name = "omniscience-core", editable = "packages/core" },
     { name = "omniscience-embeddings", editable = "packages/embeddings" },
     { name = "omniscience-server", editable = "apps/server" },
@@ -1055,10 +1100,14 @@ version = "0.1.0"
 source = { editable = "packages/connectors" }
 dependencies = [
     { name = "omniscience-core" },
+    { name = "pydantic" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "omniscience-core", editable = "packages/core" }]
+requires-dist = [
+    { name = "omniscience-core", editable = "packages/core" },
+    { name = "pydantic", specifier = ">=2.7.0" },
+]
 
 [[package]]
 name = "omniscience-core"
@@ -1066,6 +1115,7 @@ version = "0.1.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "alembic" },
+    { name = "argon2-cffi" },
     { name = "asyncpg" },
     { name = "nats-py" },
     { name = "opentelemetry-api" },
@@ -1083,6 +1133,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
+    { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "nats-py", specifier = ">=2.7.0" },
     { name = "opentelemetry-api", specifier = ">=1.25.0" },


### PR DESCRIPTION
## Summary

- `Connector` protocol: `validate`, `discover` (async generator), `fetch`, `webhook_handler`
- DTOs: `DocumentRef`, `FetchedDocument`, `WebhookPayload`
- `WebhookHandler` protocol for push-style updates with signature verification
- `ConnectorRegistry` with register/get/registered_types + structured logging
- Abstract `ConnectorContractTests` base class for connector validation
- 45 unit tests including full contract suite against a DummyConnector

## Test plan

- [ ] 45 new tests pass; all existing tests pass
- [ ] `mypy --strict` clean
- [ ] `ruff` clean
- [ ] Contract test suite validates against mock connector

Closes #5