### PR TITLE
feat: API token auth with argon2 hashing and scope-based authorization

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -27,7 +27,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from omniscience_server.middleware import TracingMiddleware
-from omniscience_server.routes import health_router
+from omniscience_server.routes import health_router, tokens_router
 
 log = structlog.get_logger(__name__)
 
@@ -119,5 +119,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     # Routers
     app.include_router(health_router)
+    app.include_router(tokens_router)
 
     return app

--- a/apps/server/src/omniscience_server/routes/__init__.py
+++ b/apps/server/src/omniscience_server/routes/__init__.py
@@ -1,5 +1,6 @@
 """Route package — each module registers one logical group of endpoints."""
 
 from omniscience_server.routes.health import router as health_router
+from omniscience_server.routes.tokens import router as tokens_router
 
-__all__ = ["health_router"]
+__all__ = ["health_router", "tokens_router"]

--- a/apps/server/src/omniscience_server/routes/tokens.py
+++ b/apps/server/src/omniscience_server/routes/tokens.py
@@ -1,0 +1,136 @@
+"""Token management endpoints.
+
+Provides CRUD operations for API tokens.  These routes are intentionally
+unprotected on POST (bootstrap use-case — minting the very first admin token).
+List and Delete require an active admin-scoped session in future waves; for
+the current wave they are available to any authenticated caller (or
+unauthenticated during bootstrap) to keep the implementation self-contained.
+
+POST  /api/v1/tokens        — create a new token (returns plaintext once)
+GET   /api/v1/tokens        — list all active tokens (no secrets exposed)
+DELETE /api/v1/tokens/{id}  — deactivate a token by id
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request
+from omniscience_core.auth.audit import audit_token_created, audit_token_deleted
+from omniscience_core.auth.tokens import (
+    delete_api_token,
+    generate_token,
+    hash_token,
+)
+from omniscience_core.db.models import ApiToken
+from omniscience_core.db.schemas import ApiTokenRead
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/tokens", tags=["tokens"])
+
+
+class TokenCreateRequest(BaseModel):
+    """Payload for minting a new API token."""
+
+    name: str
+    scopes: list[str]
+    expires_at: datetime | None = None
+
+
+class TokenCreateResponse(BaseModel):
+    """Response after minting — includes the one-time plaintext secret."""
+
+    token: ApiTokenRead
+    secret: str  # shown exactly once; cannot be recovered
+
+
+def _get_db_factory(request: Request) -> Any:
+    """Pull the session factory off app.state, raise 503 if not configured."""
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if factory is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+    return factory
+
+
+def _get_env(request: Request) -> str:
+    """Return the deployment environment string from app settings."""
+    settings = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        return str(settings.environment)
+    return "development"
+
+
+@router.post("", response_model=TokenCreateResponse, status_code=201)
+async def create_token(
+    payload: TokenCreateRequest,
+    request: Request,
+) -> TokenCreateResponse:
+    """Mint a new API token.
+
+    The plaintext secret is returned exactly once in the response body.
+    It is not stored and cannot be recovered again.
+    """
+    factory = _get_db_factory(request)
+    env = _get_env(request)
+
+    plaintext, prefix = generate_token(env)
+    hashed = hash_token(plaintext)
+
+    db: AsyncSession
+    async with factory() as db:
+        token_obj = ApiToken(
+            name=payload.name,
+            hashed_token=hashed,
+            token_prefix=prefix,
+            scopes=payload.scopes,
+            expires_at=payload.expires_at,
+        )
+        db.add(token_obj)
+        await db.flush()
+        await db.refresh(token_obj)
+        await db.commit()
+
+        read_model = ApiTokenRead.model_validate(token_obj)
+
+    audit_token_created(prefix, payload.scopes)
+    log.info("token_created_via_api", token_prefix=prefix, name=payload.name)
+
+    return TokenCreateResponse(token=read_model, secret=plaintext)
+
+
+@router.get("", response_model=list[ApiTokenRead])
+async def list_tokens(request: Request) -> list[ApiTokenRead]:
+    """List all active API tokens (secrets never exposed)."""
+    factory = _get_db_factory(request)
+
+    db: AsyncSession
+    async with factory() as db:
+        result = await db.execute(select(ApiToken).where(ApiToken.is_active.is_(True)))
+        tokens = result.scalars().all()
+        return [ApiTokenRead.model_validate(t) for t in tokens]
+
+
+@router.delete("/{token_id}", status_code=204)
+async def delete_token(token_id: uuid.UUID, request: Request) -> None:
+    """Deactivate an API token by id."""
+    factory = _get_db_factory(request)
+
+    db: AsyncSession
+    async with factory() as db:
+        token_obj = await db.get(ApiToken, token_id)
+        if token_obj is None:
+            raise HTTPException(status_code=404, detail="Token not found")
+
+        prefix: str = token_obj.token_prefix
+        await delete_api_token(db, token_id)
+        await db.commit()
+
+    audit_token_deleted(prefix)
+    log.info("token_deleted_via_api", token_prefix=prefix)

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "alembic>=1.13.0",
     "pgvector>=0.3.0",
     "nats-py>=2.7.0",
+    "argon2-cffi>=23.1.0",
 ]
 
 [build-system]

--- a/packages/core/src/omniscience_core/auth/__init__.py
+++ b/packages/core/src/omniscience_core/auth/__init__.py
@@ -1,0 +1,28 @@
+"""Auth package: token generation, hashing, scope enforcement, and audit logging."""
+
+from __future__ import annotations
+
+from omniscience_core.auth.audit import audit_token_created, audit_token_deleted
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope, check_scopes
+from omniscience_core.auth.tokens import (
+    create_api_token,
+    delete_api_token,
+    generate_token,
+    hash_token,
+    verify_token,
+)
+
+__all__ = [
+    "Scope",
+    "audit_token_created",
+    "audit_token_deleted",
+    "check_scopes",
+    "create_api_token",
+    "delete_api_token",
+    "generate_token",
+    "get_current_token",
+    "hash_token",
+    "require_scope",
+    "verify_token",
+]

--- a/packages/core/src/omniscience_core/auth/audit.py
+++ b/packages/core/src/omniscience_core/auth/audit.py
@@ -1,0 +1,49 @@
+"""Audit logging for API token lifecycle events."""
+
+from __future__ import annotations
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+def audit_token_created(
+    token_prefix: str,
+    scopes: list[str],
+    actor: str = "system",
+) -> None:
+    """Emit a structured audit log entry for token creation.
+
+    Args:
+        token_prefix: First 8 chars of the token (safe to log).
+        scopes:       Scopes granted to the token.
+        actor:        Identity initiating the action (defaults to "system").
+    """
+    log.info(
+        "audit.token.created",
+        event_type="token_created",
+        token_prefix=token_prefix,
+        scopes=scopes,
+        actor=actor,
+    )
+
+
+def audit_token_deleted(
+    token_prefix: str,
+    actor: str = "system",
+) -> None:
+    """Emit a structured audit log entry for token deletion.
+
+    Args:
+        token_prefix: First 8 chars of the deleted token (safe to log).
+        actor:        Identity initiating the action (defaults to "system").
+    """
+    log.info(
+        "audit.token.deleted",
+        event_type="token_deleted",
+        token_prefix=token_prefix,
+        actor=actor,
+    )
+
+
+__all__ = ["audit_token_created", "audit_token_deleted"]

--- a/packages/core/src/omniscience_core/auth/middleware.py
+++ b/packages/core/src/omniscience_core/auth/middleware.py
@@ -1,0 +1,133 @@
+"""FastAPI dependencies for token-based authentication and scope enforcement."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from omniscience_core.auth.scopes import Scope, check_scopes
+from omniscience_core.auth.tokens import verify_token
+from omniscience_core.db.models import ApiToken
+
+log = structlog.get_logger(__name__)
+
+_bearer = HTTPBearer(auto_error=False)
+# Module-level singleton so FastAPI Depends() calls don't trip ruff B008
+_bearer_dep = Depends(_bearer)
+
+_AUTH_ERROR = HTTPException(
+    status_code=401,
+    detail={"code": "unauthorized", "message": "Token missing or invalid"},
+)
+
+_PREFIX_LEN = 8
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+async def _lookup_token(session: AsyncSession, plaintext: str) -> ApiToken | None:
+    """Find an active, non-expired token whose prefix matches and hash verifies."""
+    if len(plaintext) < _PREFIX_LEN:
+        return None
+    prefix = plaintext[:_PREFIX_LEN]
+
+    result = await session.execute(
+        select(ApiToken).where(
+            ApiToken.token_prefix == prefix,
+            ApiToken.is_active.is_(True),
+        )
+    )
+    candidates = result.scalars().all()
+
+    for candidate in candidates:
+        if not verify_token(plaintext, candidate.hashed_token):
+            continue
+        if candidate.expires_at and candidate.expires_at.replace(tzinfo=UTC) < _utc_now():
+            return None
+        return candidate
+
+    return None
+
+
+async def _update_last_used(session: AsyncSession, token: ApiToken) -> None:
+    """Update last_used_at on the token row (best-effort)."""
+    try:
+        token.last_used_at = _utc_now()
+        await session.flush()
+    except Exception:
+        log.warning("last_used_at_update_failed", token_prefix=token.token_prefix)
+
+
+async def get_current_token(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = _bearer_dep,
+) -> ApiToken:
+    """FastAPI dependency: extract and validate the Bearer token.
+
+    Raises:
+        HTTPException 401 — token missing, invalid, or expired.
+
+    Returns:
+        The authenticated ApiToken ORM instance.
+    """
+    if credentials is None or not credentials.credentials:
+        raise _AUTH_ERROR
+
+    plaintext = credentials.credentials
+
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if factory is None:
+        raise _AUTH_ERROR
+
+    async with factory() as db:
+        token = await _lookup_token(db, plaintext)
+        if token is None:
+            raise _AUTH_ERROR
+
+        await _update_last_used(db, token)
+        await db.commit()
+
+        return token
+
+
+# Module-level singleton for use inside require_scope closure
+_current_token_dep: Any = Depends(get_current_token)
+
+
+def require_scope(
+    *scopes: Scope,
+) -> Callable[[ApiToken], Coroutine[Any, Any, ApiToken]]:
+    """Return a FastAPI dependency that enforces one or more scopes.
+
+    Usage::
+
+        @router.get("/sources", dependencies=[Depends(require_scope(Scope.sources_read))])
+        async def list_sources() -> ...: ...
+
+    Raises:
+        HTTPException 403 — token lacks required scope.
+    """
+    required = set(scopes)
+
+    async def _check(token: ApiToken = _current_token_dep) -> ApiToken:
+        granted = {Scope(s) for s in token.scopes if s in Scope.__members__.values()}
+        if not check_scopes(required, granted):
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "forbidden", "message": "Insufficient token scopes"},
+            )
+        return token
+
+    return _check
+
+
+__all__ = ["get_current_token", "require_scope"]

--- a/packages/core/src/omniscience_core/auth/scopes.py
+++ b/packages/core/src/omniscience_core/auth/scopes.py
@@ -1,0 +1,43 @@
+"""Scope definitions and authorization checking for Omniscience API tokens."""
+
+from __future__ import annotations
+
+import enum
+
+
+class Scope(enum.StrEnum):
+    """Valid permission scopes for API tokens."""
+
+    search = "search"
+    sources_read = "sources:read"
+    sources_write = "sources:write"
+    admin = "admin"
+
+
+# admin scope implies all other scopes
+SCOPE_HIERARCHY: dict[Scope, set[Scope]] = {
+    Scope.admin: {Scope.search, Scope.sources_read, Scope.sources_write, Scope.admin},
+    Scope.sources_write: {Scope.sources_write},
+    Scope.sources_read: {Scope.sources_read},
+    Scope.search: {Scope.search},
+}
+
+
+def _expand_scopes(granted: set[Scope]) -> set[Scope]:
+    """Expand granted scopes by applying hierarchy rules."""
+    expanded: set[Scope] = set()
+    for scope in granted:
+        expanded.update(SCOPE_HIERARCHY.get(scope, {scope}))
+    return expanded
+
+
+def check_scopes(required: set[Scope], granted: set[Scope]) -> bool:
+    """Return True if granted scopes satisfy all required scopes.
+
+    Applies the scope hierarchy (admin implies all others).
+    """
+    effective = _expand_scopes(granted)
+    return required.issubset(effective)
+
+
+__all__ = ["SCOPE_HIERARCHY", "Scope", "check_scopes"]

--- a/packages/core/src/omniscience_core/auth/tokens.py
+++ b/packages/core/src/omniscience_core/auth/tokens.py
@@ -1,0 +1,134 @@
+"""API token generation, hashing, and database lifecycle management."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import datetime
+
+import structlog
+from argon2 import PasswordHasher
+from argon2.exceptions import VerificationError, VerifyMismatchError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from omniscience_core.db.models import ApiToken
+from omniscience_core.db.schemas import ApiTokenCreate, ApiTokenRead
+
+log = structlog.get_logger(__name__)
+
+_ph = PasswordHasher()
+
+# Token format: sk_{env}_{uuid}_{random32}
+# prefix = first 8 chars of the full token string
+_PREFIX_LEN = 8
+_RANDOM_BYTES = 24  # produces ~32 url-safe base64 chars
+
+
+def generate_token(env: str) -> tuple[str, str]:
+    """Generate a new plaintext API token.
+
+    Args:
+        env: Deployment environment (e.g. "development", "staging", "production").
+
+    Returns:
+        A (plaintext, prefix) tuple where prefix is the first 8 characters
+        of the token — safe to store and display in logs.
+    """
+    env_tag = env[:3].lower()
+    token_id = uuid.uuid4().hex
+    random_part = secrets.token_urlsafe(_RANDOM_BYTES)
+    plaintext = f"sk_{env_tag}_{token_id}_{random_part}"
+    prefix = plaintext[:_PREFIX_LEN]
+    return plaintext, prefix
+
+
+def hash_token(plaintext: str) -> str:
+    """Return the argon2 hash of *plaintext*.
+
+    The plaintext is never stored or logged — only the hash is persisted.
+    """
+    return _ph.hash(plaintext)
+
+
+def verify_token(plaintext: str, hashed: str) -> bool:
+    """Return True if *plaintext* matches *hashed*.
+
+    Uses argon2's constant-time comparison; logs nothing about the plaintext.
+    Returns False on any verification failure (mismatch or corrupted hash).
+    """
+    try:
+        return _ph.verify(hashed, plaintext)
+    except (VerifyMismatchError, VerificationError):
+        return False
+
+
+async def create_api_token(
+    session: AsyncSession,
+    name: str,
+    scopes: list[str],
+    expires_at: datetime | None = None,
+) -> tuple[ApiTokenRead, str]:
+    """Create a new API token, persist it, and return the read model + plaintext.
+
+    The plaintext token is returned exactly once — it cannot be recovered from
+    the stored hash.  The caller MUST surface it to the user immediately.
+
+    Args:
+        session:    Active async SQLAlchemy session.
+        name:       Human-readable label for this token.
+        scopes:     List of scope strings (e.g. ["search", "sources:read"]).
+        expires_at: Optional expiry datetime (UTC).
+
+    Returns:
+        (ApiTokenRead, plaintext) — read model for the new token and the
+        one-time plaintext secret.
+    """
+    env = "development"
+    plaintext, prefix = generate_token(env)
+    hashed = hash_token(plaintext)
+
+    create_schema = ApiTokenCreate(
+        name=name,
+        hashed_token=hashed,
+        token_prefix=prefix,
+        scopes=scopes,
+        expires_at=expires_at,
+    )
+
+    token_obj = ApiToken(
+        name=create_schema.name,
+        hashed_token=create_schema.hashed_token,
+        token_prefix=create_schema.token_prefix,
+        scopes=create_schema.scopes,
+        expires_at=create_schema.expires_at,
+    )
+    session.add(token_obj)
+    await session.flush()
+    await session.refresh(token_obj)
+
+    read_model = ApiTokenRead.model_validate(token_obj)
+    log.info("token_created", token_prefix=prefix, name=name, scopes=scopes)
+    return read_model, plaintext
+
+
+async def delete_api_token(session: AsyncSession, token_id: uuid.UUID) -> None:
+    """Soft-delete a token by marking it inactive and flushing.
+
+    Args:
+        session:  Active async SQLAlchemy session.
+        token_id: UUID of the token to deactivate.
+    """
+    token_obj = await session.get(ApiToken, token_id)
+    if token_obj is not None:
+        token_obj.is_active = False
+        await session.flush()
+        log.info("token_deleted", token_prefix=token_obj.token_prefix)
+
+
+__all__ = [
+    "create_api_token",
+    "delete_api_token",
+    "generate_token",
+    "hash_token",
+    "verify_token",
+]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,498 @@
+"""Tests for the auth package: tokens, scopes, middleware, audit logging."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.audit import audit_token_created, audit_token_deleted
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope, check_scopes
+from omniscience_core.auth.tokens import (
+    create_api_token,
+    delete_api_token,
+    generate_token,
+    hash_token,
+    verify_token,
+)
+from omniscience_core.db.models import ApiToken
+from omniscience_core.db.schemas import ApiTokenRead
+
+# Module-level Depends singletons — avoids ruff B008 (no function calls in defaults)
+_current_token_dep = Depends(get_current_token)
+_scope_search_dep = Depends(require_scope(Scope.search))
+_scope_admin_dep = Depends(require_scope(Scope.admin))
+
+# ---------------------------------------------------------------------------
+# Token generation
+# ---------------------------------------------------------------------------
+
+
+def test_generate_token_format() -> None:
+    """Generated token matches the sk_{env}_{uuid}_{random} pattern."""
+    plaintext, _prefix = generate_token("development")
+    assert re.match(r"^sk_dev_[0-9a-f]{32}_", plaintext), f"Bad format: {plaintext}"
+
+
+def test_generate_token_env_prefix() -> None:
+    """Environment tag uses the first 3 chars of the env argument."""
+    plaintext, _ = generate_token("staging")
+    assert plaintext.startswith("sk_sta_")
+
+
+def test_generate_token_prefix_length() -> None:
+    """Prefix is exactly the first 8 chars of the full token."""
+    plaintext, prefix = generate_token("production")
+    assert prefix == plaintext[:8]
+    assert len(prefix) == 8
+
+
+def test_generate_token_unique() -> None:
+    """Two calls produce different tokens."""
+    t1, _ = generate_token("development")
+    t2, _ = generate_token("development")
+    assert t1 != t2
+
+
+# ---------------------------------------------------------------------------
+# Hash and verify
+# ---------------------------------------------------------------------------
+
+
+def test_hash_token_returns_string() -> None:
+    """hash_token returns a non-empty string."""
+    token, _ = generate_token("development")
+    hashed = hash_token(token)
+    assert isinstance(hashed, str)
+    assert len(hashed) > 20
+
+
+def test_verify_token_correct() -> None:
+    """verify_token returns True for the correct plaintext."""
+    token, _ = generate_token("development")
+    hashed = hash_token(token)
+    assert verify_token(token, hashed) is True
+
+
+def test_verify_token_wrong() -> None:
+    """verify_token returns False for a different plaintext."""
+    token, _ = generate_token("development")
+    hashed = hash_token(token)
+    assert verify_token("wrong_token_value", hashed) is False
+
+
+def test_verify_token_tampered_hash() -> None:
+    """verify_token returns False when the hash is corrupted."""
+    token, _ = generate_token("development")
+    hashed = hash_token(token)
+    tampered = hashed[:-4] + "XXXX"
+    assert verify_token(token, tampered) is False
+
+
+# ---------------------------------------------------------------------------
+# Scope checking
+# ---------------------------------------------------------------------------
+
+
+def test_check_scopes_exact_match() -> None:
+    """A token with exactly the required scope passes."""
+    assert check_scopes({Scope.search}, {Scope.search}) is True
+
+
+def test_check_scopes_admin_implies_all() -> None:
+    """Admin scope satisfies every other scope."""
+    for scope in Scope:
+        assert check_scopes({scope}, {Scope.admin}) is True, f"admin should imply {scope}"
+
+
+def test_check_scopes_insufficient() -> None:
+    """search scope does not grant sources:write."""
+    assert check_scopes({Scope.sources_write}, {Scope.search}) is False
+
+
+def test_check_scopes_sources_write_not_implies_read() -> None:
+    """sources:write does not implicitly grant sources:read."""
+    assert check_scopes({Scope.sources_read}, {Scope.sources_write}) is False
+
+
+def test_check_scopes_empty_required() -> None:
+    """No required scopes always passes."""
+    assert check_scopes(set(), {Scope.search}) is True
+
+
+def test_check_scopes_multiple_granted() -> None:
+    """Multiple granted scopes are all honoured."""
+    assert (
+        check_scopes({Scope.search, Scope.sources_read}, {Scope.search, Scope.sources_read})
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_api_token (mocked session)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_token(
+    prefix: str = "sk_dev_x",
+    scopes: list[str] | None = None,
+) -> ApiToken:
+    """Construct a minimal ApiToken-like mock."""
+    scopes = scopes or ["search"]
+    now = datetime.now(tz=UTC)
+    token: ApiToken = MagicMock(spec=ApiToken)
+    token.id = uuid.uuid4()
+    token.name = "test-token"
+    token.token_prefix = prefix
+    token.scopes = scopes
+    token.created_at = now
+    token.expires_at = None
+    token.last_used_at = None
+    token.is_active = True
+    token.hashed_token = "placeholder"
+    return token
+
+
+@pytest.mark.asyncio
+async def test_create_api_token_persists_to_db() -> None:
+    """create_api_token adds a token to the session and returns (ApiTokenRead, plaintext)."""
+    mock_token = _make_mock_token()
+
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    async def _refresh(obj: Any) -> None:
+        obj.id = mock_token.id
+        obj.name = mock_token.name
+        obj.token_prefix = mock_token.token_prefix
+        obj.scopes = mock_token.scopes
+        obj.created_at = mock_token.created_at
+        obj.expires_at = mock_token.expires_at
+        obj.last_used_at = mock_token.last_used_at
+        obj.is_active = mock_token.is_active
+
+    session.refresh.side_effect = _refresh
+
+    read_model, plaintext = await create_api_token(session, "my-token", ["search"])
+
+    session.add.assert_called_once()
+    session.flush.assert_called_once()
+    session.refresh.assert_called_once()
+
+    assert isinstance(read_model, ApiTokenRead)
+    assert isinstance(plaintext, str)
+    assert plaintext.startswith("sk_")
+
+
+@pytest.mark.asyncio
+async def test_delete_api_token_marks_inactive() -> None:
+    """delete_api_token sets is_active=False and flushes."""
+    token_id = uuid.uuid4()
+    mock_token = _make_mock_token()
+
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=mock_token)
+    session.flush = AsyncMock()
+
+    await delete_api_token(session, token_id)
+
+    assert mock_token.is_active is False
+    session.flush.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_api_token_noop_when_missing() -> None:
+    """delete_api_token is a no-op when token is not found."""
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=None)
+    session.flush = AsyncMock()
+
+    await delete_api_token(session, uuid.uuid4())
+
+    session.flush.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building test apps
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_session(tokens: list[Any]) -> AsyncMock:
+    """Build a reusable fake async session context manager."""
+    fake_session = AsyncMock()
+
+    async def _fake_execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = tokens
+        return result
+
+    fake_session.execute = _fake_execute
+    fake_session.flush = AsyncMock()
+    fake_session.commit = AsyncMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    return fake_session
+
+
+def _make_protected_app(mock_token: Any) -> FastAPI:
+    """Build a minimal FastAPI app with /protected using get_current_token."""
+    app = FastAPI()
+    fake_session = _make_fake_session([mock_token])
+    app.state.db_session_factory = MagicMock(return_value=fake_session)
+
+    @app.get("/protected")
+    async def _protected(token: ApiToken = _current_token_dep) -> dict[str, str]:  # type: ignore[assignment]
+        return {"prefix": token.token_prefix}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Middleware — bearer extraction and validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_middleware_extracts_bearer_token() -> None:
+    """Middleware returns 200 when a valid Bearer token is provided."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+
+    now = datetime.now(tz=UTC)
+    mock_token: ApiToken = MagicMock(spec=ApiToken)
+    mock_token.token_prefix = prefix
+    mock_token.hashed_token = hashed
+    mock_token.scopes = ["search"]
+    mock_token.expires_at = None
+    mock_token.is_active = True
+    mock_token.last_used_at = now
+
+    app = _make_protected_app(mock_token)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/protected", headers={"Authorization": f"Bearer {plaintext}"}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["prefix"] == prefix
+
+
+@pytest.mark.asyncio
+async def test_middleware_rejects_missing_token() -> None:
+    """Middleware returns 401 when no Authorization header is present."""
+    app = FastAPI()
+
+    @app.get("/protected")
+    async def _protected(token: ApiToken = _current_token_dep) -> dict[str, str]:  # type: ignore[assignment]
+        return {"prefix": token.token_prefix}
+
+    # No db_session_factory — 401 before DB is reached
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/protected")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_middleware_rejects_invalid_token() -> None:
+    """Middleware returns 401 when hash verification fails."""
+    _, prefix = generate_token("development")
+    hashed = hash_token("different_token_than_sent")
+
+    mock_token: ApiToken = MagicMock(spec=ApiToken)
+    mock_token.token_prefix = prefix
+    mock_token.hashed_token = hashed
+    mock_token.scopes = ["search"]
+    mock_token.expires_at = None
+    mock_token.is_active = True
+
+    app = _make_protected_app(mock_token)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/protected", headers={"Authorization": "Bearer sk_dev_wrongtoken_abc123"}
+        )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_middleware_rejects_expired_token() -> None:
+    """Middleware returns 401 when the token has passed its expiry datetime."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    expired_at = datetime.now(tz=UTC) - timedelta(hours=1)
+
+    mock_token: ApiToken = MagicMock(spec=ApiToken)
+    mock_token.token_prefix = prefix
+    mock_token.hashed_token = hashed
+    mock_token.scopes = ["search"]
+    mock_token.expires_at = expired_at
+    mock_token.is_active = True
+
+    app = _make_protected_app(mock_token)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/protected", headers={"Authorization": f"Bearer {plaintext}"}
+        )
+
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# require_scope dependency
+# ---------------------------------------------------------------------------
+
+
+def _make_token_with_scopes(scopes: list[str]) -> ApiToken:
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock: ApiToken = MagicMock(spec=ApiToken)
+    mock.token_prefix = prefix
+    mock.hashed_token = hashed
+    mock.scopes = scopes
+    mock.expires_at = None
+    mock.is_active = True
+    mock.last_used_at = None
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_require_scope_allows_matching_scope() -> None:
+    """require_scope passes when the token has the required scope."""
+    token = _make_token_with_scopes(["search"])
+    fake_session = _make_fake_session([token])
+
+    app = FastAPI()
+    app.state.db_session_factory = MagicMock(return_value=fake_session)
+
+    @app.get("/search-only")
+    async def _endpoint(tok: ApiToken = _scope_search_dep) -> dict[str, bool]:  # type: ignore[assignment]
+        return {"ok": True}
+
+    plaintext, _ = generate_token("development")
+    with patch("omniscience_core.auth.middleware.verify_token", return_value=True):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/search-only", headers={"Authorization": f"Bearer {plaintext}"}
+            )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_require_scope_rejects_insufficient_scope() -> None:
+    """require_scope returns 403 when the token lacks the required scope."""
+    token = _make_token_with_scopes(["search"])
+    fake_session = _make_fake_session([token])
+
+    app = FastAPI()
+    app.state.db_session_factory = MagicMock(return_value=fake_session)
+
+    @app.get("/admin-only")
+    async def _endpoint(tok: ApiToken = _scope_admin_dep) -> dict[str, bool]:  # type: ignore[assignment]
+        return {"ok": True}
+
+    plaintext, _ = generate_token("development")
+    with patch("omniscience_core.auth.middleware.verify_token", return_value=True):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/admin-only", headers={"Authorization": f"Bearer {plaintext}"}
+            )
+
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# last_used_at update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_used_at_update_fires() -> None:
+    """get_current_token triggers a last_used_at update on the token."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+
+    mock_token: ApiToken = MagicMock(spec=ApiToken)
+    mock_token.token_prefix = prefix
+    mock_token.hashed_token = hashed
+    mock_token.scopes = ["search"]
+    mock_token.expires_at = None
+    mock_token.is_active = True
+    mock_token.last_used_at = None
+
+    flush_call_count: list[int] = [0]
+    fake_session = AsyncMock()
+
+    async def _fake_execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [mock_token]
+        return result
+
+    async def _fake_flush() -> None:
+        flush_call_count[0] += 1
+
+    fake_session.execute = _fake_execute
+    fake_session.flush = _fake_flush
+    fake_session.commit = AsyncMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+
+    app = FastAPI()
+    app.state.db_session_factory = MagicMock(return_value=fake_session)
+
+    @app.get("/check")
+    async def _endpoint(token: ApiToken = _current_token_dep) -> dict[str, str]:  # type: ignore[assignment]
+        return {"prefix": token.token_prefix}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.get("/check", headers={"Authorization": f"Bearer {plaintext}"})
+
+    # flush was called at least once (last_used_at update)
+    assert flush_call_count[0] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Audit logging
+# ---------------------------------------------------------------------------
+
+
+def test_audit_token_created_logs() -> None:
+    """audit_token_created emits a structured log entry."""
+    with patch("omniscience_core.auth.audit.log") as mock_log:
+        audit_token_created("sk_dev_ab", ["search", "admin"])
+        mock_log.info.assert_called_once()
+        call_kwargs = mock_log.info.call_args
+        assert call_kwargs[0][0] == "audit.token.created"
+        assert call_kwargs[1]["event_type"] == "token_created"
+        assert call_kwargs[1]["token_prefix"] == "sk_dev_ab"
+        assert call_kwargs[1]["scopes"] == ["search", "admin"]
+
+
+def test_audit_token_deleted_logs() -> None:
+    """audit_token_deleted emits a structured log entry."""
+    with patch("omniscience_core.auth.audit.log") as mock_log:
+        audit_token_deleted("sk_dev_ab")
+        mock_log.info.assert_called_once()
+        call_kwargs = mock_log.info.call_args
+        assert call_kwargs[0][0] == "audit.token.deleted"
+        assert call_kwargs[1]["event_type"] == "token_deleted"
+        assert call_kwargs[1]["token_prefix"] == "sk_dev_ab"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -279,9 +279,7 @@ async def test_middleware_extracts_bearer_token() -> None:
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get(
-            "/protected", headers={"Authorization": f"Bearer {plaintext}"}
-        )
+        response = await client.get("/protected", headers={"Authorization": f"Bearer {plaintext}"})
 
     assert response.status_code == 200
     assert response.json()["prefix"] == prefix
@@ -346,9 +344,7 @@ async def test_middleware_rejects_expired_token() -> None:
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get(
-            "/protected", headers={"Authorization": f"Bearer {plaintext}"}
-        )
+        response = await client.get("/protected", headers={"Authorization": f"Bearer {plaintext}"})
 
     assert response.status_code == 401
 


### PR DESCRIPTION
## Summary

- Token generation: `sk_{env}_{uuid}_{random32}` format with argon2 hashing
- Scope system: `search`, `sources:read`, `sources:write`, `admin` with hierarchy (admin implies all)
- FastAPI middleware: `get_current_token` dependency (Bearer extraction, DB lookup, expiry check)
- `require_scope()` dependency factory for route-level authorization
- `last_used_at` updated async on every successful auth
- Audit logging for token create/delete events
- Token management routes: POST/GET/DELETE /api/v1/tokens
- Token plaintext NEVER logged, only prefix

## Test plan

- [ ] 26 new tests pass; all existing tests pass
- [ ] `mypy --strict` clean
- [ ] `ruff` clean
- [ ] Token format, hash/verify, scope hierarchy, middleware 401/403 paths all tested

Closes #12