### PR TITLE
feat: parser framework, tree-sitter code parser, and chunking strategies

### DIFF
--- a/packages/parsers/pyproject.toml
+++ b/packages/parsers/pyproject.toml
@@ -4,7 +4,17 @@ version = "0.1.0"
 description = "Document parsers and chunkers for Omniscience ingestion pipeline"
 requires-python = ">=3.12"
 dependencies = [
+    "markdown-it-py>=3.0.0",
     "omniscience-core",
+    "pydantic>=2.7.0",
+    "python-frontmatter>=1.1.0",
+    "tree-sitter>=0.22.0",
+    "tree-sitter-go>=0.25.0",
+    "tree-sitter-java>=0.23.5",
+    "tree-sitter-javascript>=0.25.0",
+    "tree-sitter-python>=0.25.0",
+    "tree-sitter-rust>=0.24.2",
+    "tree-sitter-typescript>=0.23.2",
 ]
 
 [tool.uv.sources]

--- a/packages/parsers/src/omniscience_parsers/__init__.py
+++ b/packages/parsers/src/omniscience_parsers/__init__.py
@@ -1,5 +1,48 @@
-"""Document parsers and chunkers — placeholder for Wave 2.
+"""Document parsers and chunkers for the Omniscience ingestion pipeline.
 
-Will include tree-sitter (code), markdown-it-py (docs), and
-langchain-text-splitters (chunking strategies).
+Public API
+----------
+Parsers:
+    Parser          — protocol all parsers satisfy
+    ParsedDocument  — structured output of a parser
+    Section         — one structural section within a document
+    ParserDispatch  — selects the best parser by content-type / extension
+    MarkdownParser  — markdown-it-py + frontmatter parser
+    PlainTextParser — fallback single-section parser
+    TreeSitterParser — tree-sitter backed code symbol extractor
+
+Chunkers:
+    Chunker                  — protocol all chunkers satisfy
+    ChunkOutput              — one chunk ready for embedding
+    CodeSymbolChunker        — one chunk per code symbol
+    MarkdownSectionChunker   — one chunk per markdown section
+    FixedWindowChunker       — sliding window for plain text
 """
+
+from omniscience_parsers.base import ParsedDocument, Parser, Section
+from omniscience_parsers.chunking import (
+    Chunker,
+    ChunkOutput,
+    CodeSymbolChunker,
+    FixedWindowChunker,
+    MarkdownSectionChunker,
+)
+from omniscience_parsers.code.treesitter import TreeSitterParser
+from omniscience_parsers.dispatch import ParserDispatch
+from omniscience_parsers.markdown import MarkdownParser
+from omniscience_parsers.plaintext import PlainTextParser
+
+__all__ = [
+    "ChunkOutput",
+    "Chunker",
+    "CodeSymbolChunker",
+    "FixedWindowChunker",
+    "MarkdownParser",
+    "MarkdownSectionChunker",
+    "ParsedDocument",
+    "Parser",
+    "ParserDispatch",
+    "PlainTextParser",
+    "Section",
+    "TreeSitterParser",
+]

--- a/packages/parsers/src/omniscience_parsers/base.py
+++ b/packages/parsers/src/omniscience_parsers/base.py
@@ -1,0 +1,67 @@
+"""Base types for the parser framework.
+
+Every parser returns a :class:`ParsedDocument` composed of :class:`Section`
+objects.  The :class:`Parser` protocol is the contract all parsers satisfy.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+
+class Section(BaseModel):
+    """A structural section of a parsed document."""
+
+    heading_path: list[str]
+    """Heading hierarchy leading to this section, e.g. ["Architecture", "API"]."""
+
+    text: str
+    """Raw text content of the section."""
+
+    line_start: int
+    """1-based line number of the first line of this section."""
+
+    line_end: int
+    """1-based line number of the last line of this section (inclusive)."""
+
+    symbol: str | None = None
+    """Fully-qualified name for code symbols, e.g. ``module.ClassName.method``."""
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Arbitrary key/value metadata (language, fence info, decorator flags, …)."""
+
+
+class ParsedDocument(BaseModel):
+    """Output of a parser — structural representation of a document."""
+
+    title: str | None = None
+    """Document title if available (e.g. first H1 heading or frontmatter key)."""
+
+    sections: list[Section]
+    """Ordered list of sections extracted from the document."""
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Document-level metadata (e.g. frontmatter key/value pairs)."""
+
+    content_type: str
+    """MIME type or well-known type string, e.g. ``text/markdown``."""
+
+    language: str | None = None
+    """Programming language identifier for code documents, e.g. ``python``."""
+
+
+class Parser(Protocol):
+    """Protocol every parser must implement."""
+
+    def can_handle(self, content_type: str, file_extension: str) -> bool:
+        """Return True if this parser handles the given content-type and extension."""
+        ...
+
+    def parse(self, content: bytes, file_path: str = "") -> ParsedDocument:
+        """Parse *content* and return a structured :class:`ParsedDocument`."""
+        ...
+
+
+__all__ = ["ParsedDocument", "Parser", "Section"]

--- a/packages/parsers/src/omniscience_parsers/chunking.py
+++ b/packages/parsers/src/omniscience_parsers/chunking.py
@@ -1,0 +1,263 @@
+"""Chunking strategies for the Omniscience ingestion pipeline.
+
+Each strategy implements the :class:`Chunker` protocol and consumes a
+:class:`~omniscience_parsers.base.ParsedDocument` produced by a parser,
+emitting an ordered list of :class:`ChunkOutput` objects ready for embedding.
+
+Token counting uses ``len(text.split())`` as a word-count approximation.
+This is intentional for v0.1 — replace with ``tiktoken`` in v0.2.
+
+Strategies
+----------
+- :class:`CodeSymbolChunker`   — one chunk per symbol; splits oversized ones.
+- :class:`MarkdownSectionChunker` — one chunk per section with heading context.
+- :class:`FixedWindowChunker`  — sliding window for plain text.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel, Field
+
+from omniscience_parsers.base import ParsedDocument, Section
+
+# ---------------------------------------------------------------------------
+# Output model
+# ---------------------------------------------------------------------------
+
+
+class ChunkOutput(BaseModel):
+    """A single chunk ready for embedding and indexing."""
+
+    ord: int
+    """Sequential position of this chunk within the document (0-based)."""
+
+    text: str
+    """Text content to be embedded."""
+
+    symbol: str | None = None
+    """Fully-qualified symbol name for code chunks."""
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    """Strategy-specific metadata (line_range, heading_path, section_path, …)."""
+
+    line_start: int | None = None
+    line_end: int | None = None
+
+    strategy: str
+    """Identifier for the chunking strategy that produced this chunk."""
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class Chunker(Protocol):
+    """Protocol every chunker must implement."""
+
+    def chunk(self, parsed: ParsedDocument) -> list[ChunkOutput]: ...
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_tokens(text: str) -> int:
+    """Approximate token count via whitespace splitting."""
+    return len(text.split())
+
+
+def _split_text(text: str, max_tokens: int, overlap_tokens: int) -> list[str]:
+    """Split *text* into overlapping windows of at most *max_tokens* words."""
+    words = text.split()
+    if not words:
+        return []
+    chunks: list[str] = []
+    step = max(1, max_tokens - overlap_tokens)
+    start = 0
+    while start < len(words):
+        end = min(start + max_tokens, len(words))
+        chunks.append(" ".join(words[start:end]))
+        if end == len(words):
+            break
+        start += step
+    return chunks
+
+
+def _heading_prefix(heading_path: list[str]) -> str:
+    """Return a breadcrumb prefix string for a heading path, or empty string."""
+    return " > ".join(heading_path) + "\n\n" if heading_path else ""
+
+
+# ---------------------------------------------------------------------------
+# CodeSymbolChunker
+# ---------------------------------------------------------------------------
+
+
+class CodeSymbolChunker:
+    """One chunk per function/class symbol; splits oversized symbols.
+
+    For code documents parsed by
+    :class:`~omniscience_parsers.code.treesitter.TreeSitterParser`.
+    """
+
+    STRATEGY = "code_symbol"
+
+    def __init__(self, max_tokens: int = 512, overlap_tokens: int = 50) -> None:
+        self._max = max_tokens
+        self._overlap = overlap_tokens
+
+    def chunk(self, parsed: ParsedDocument) -> list[ChunkOutput]:
+        outputs: list[ChunkOutput] = []
+        for section in parsed.sections:
+            outputs.extend(self._chunk_section(section, len(outputs)))
+        return outputs
+
+    def _chunk_section(self, section: Section, start_ord: int) -> list[ChunkOutput]:
+        prefix = _heading_prefix(section.heading_path)
+        full_text = prefix + section.text
+        base_meta = {
+            "strategy": self.STRATEGY,
+            "line_range": [section.line_start, section.line_end],
+        }
+
+        if _count_tokens(section.text) <= self._max:
+            return [
+                ChunkOutput(
+                    ord=start_ord,
+                    text=full_text,
+                    symbol=section.symbol,
+                    metadata={**base_meta, **section.metadata},
+                    line_start=section.line_start,
+                    line_end=section.line_end,
+                    strategy=self.STRATEGY,
+                )
+            ]
+
+        # Oversized — split the raw text and prepend heading prefix to each window
+        windows = _split_text(section.text, self._max, self._overlap)
+        results: list[ChunkOutput] = []
+        for i, window in enumerate(windows):
+            results.append(
+                ChunkOutput(
+                    ord=start_ord + i,
+                    text=prefix + window,
+                    symbol=section.symbol,
+                    metadata={**base_meta, "window": i, **section.metadata},
+                    line_start=section.line_start,
+                    line_end=section.line_end,
+                    strategy=self.STRATEGY,
+                )
+            )
+        return results
+
+
+# ---------------------------------------------------------------------------
+# MarkdownSectionChunker
+# ---------------------------------------------------------------------------
+
+
+class MarkdownSectionChunker:
+    """One chunk per markdown section with ancestor heading context prepended.
+
+    For documents parsed by :class:`~omniscience_parsers.markdown.MarkdownParser`.
+    """
+
+    STRATEGY = "markdown_section"
+
+    def __init__(self, max_tokens: int = 512, overlap_tokens: int = 50) -> None:
+        self._max = max_tokens
+        self._overlap = overlap_tokens
+
+    def chunk(self, parsed: ParsedDocument) -> list[ChunkOutput]:
+        outputs: list[ChunkOutput] = []
+        for section in parsed.sections:
+            outputs.extend(self._chunk_section(section, len(outputs)))
+        return outputs
+
+    def _chunk_section(self, section: Section, start_ord: int) -> list[ChunkOutput]:
+        prefix = _heading_prefix(section.heading_path)
+        full_text = prefix + section.text
+        base_meta: dict[str, Any] = {
+            "strategy": self.STRATEGY,
+            "section_path": list(section.heading_path),
+        }
+        if section.line_start:
+            base_meta["line_range"] = [section.line_start, section.line_end]
+
+        if _count_tokens(full_text) <= self._max:
+            return [
+                ChunkOutput(
+                    ord=start_ord,
+                    text=full_text,
+                    symbol=section.symbol,
+                    metadata={**base_meta, **section.metadata},
+                    line_start=section.line_start,
+                    line_end=section.line_end,
+                    strategy=self.STRATEGY,
+                )
+            ]
+
+        # Section too large — split body and prefix heading to each window
+        windows = _split_text(section.text, self._max, self._overlap)
+        results: list[ChunkOutput] = []
+        for i, window in enumerate(windows):
+            results.append(
+                ChunkOutput(
+                    ord=start_ord + i,
+                    text=prefix + window,
+                    symbol=section.symbol,
+                    metadata={**base_meta, "window": i, **section.metadata},
+                    line_start=section.line_start,
+                    line_end=section.line_end,
+                    strategy=self.STRATEGY,
+                )
+            )
+        return results
+
+
+# ---------------------------------------------------------------------------
+# FixedWindowChunker
+# ---------------------------------------------------------------------------
+
+
+class FixedWindowChunker:
+    """Sliding fixed-window chunker for plain text documents.
+
+    Concatenates all section text and slides a window with overlap.
+    """
+
+    STRATEGY = "fixed_window"
+
+    def __init__(self, max_tokens: int = 512, overlap_tokens: int = 128) -> None:
+        self._max = max_tokens
+        self._overlap = overlap_tokens
+
+    def chunk(self, parsed: ParsedDocument) -> list[ChunkOutput]:
+        full_text = "\n\n".join(s.text for s in parsed.sections if s.text.strip())
+        if not full_text.strip():
+            return []
+
+        windows = _split_text(full_text, self._max, self._overlap)
+        return [
+            ChunkOutput(
+                ord=i,
+                text=window,
+                symbol=None,
+                metadata={"strategy": self.STRATEGY, "window": i},
+                strategy=self.STRATEGY,
+            )
+            for i, window in enumerate(windows)
+        ]
+
+
+__all__ = [
+    "ChunkOutput",
+    "Chunker",
+    "CodeSymbolChunker",
+    "FixedWindowChunker",
+    "MarkdownSectionChunker",
+]

--- a/packages/parsers/src/omniscience_parsers/code/__init__.py
+++ b/packages/parsers/src/omniscience_parsers/code/__init__.py
@@ -1,0 +1,5 @@
+"""Code parsers for the Omniscience ingestion pipeline."""
+
+from omniscience_parsers.code.treesitter import TreeSitterParser
+
+__all__ = ["TreeSitterParser"]

--- a/packages/parsers/src/omniscience_parsers/code/treesitter.py
+++ b/packages/parsers/src/omniscience_parsers/code/treesitter.py
@@ -1,0 +1,399 @@
+"""Tree-sitter backed code parser.
+
+Extracts top-level symbols (functions, classes, methods) from source code
+and maps each to a :class:`~omniscience_parsers.base.Section` with an FQN
+``symbol`` and ``line_start``/``line_end`` from the AST node positions.
+
+Supported languages (detected by file extension):
+  Python, TypeScript, JavaScript, Go, Rust, Java
+
+Unsupported extensions fall back to a single plain-text section.
+Syntax errors produce a partial result with a ``parse_error`` warning in
+``ParsedDocument.metadata`` rather than raising.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any
+
+import structlog
+
+from omniscience_parsers.base import ParsedDocument, Section
+
+log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Extension → language name
+# ---------------------------------------------------------------------------
+
+_EXT_TO_LANG: dict[str, str] = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+}
+
+_CODE_CONTENT_TYPES = frozenset(
+    {
+        "text/x-python",
+        "application/typescript",
+        "text/typescript",
+        "application/javascript",
+        "text/javascript",
+        "text/x-go",
+        "text/x-rustsrc",
+        "text/x-java-source",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Per-language symbol node types
+# ---------------------------------------------------------------------------
+
+_SYMBOL_NODE_TYPES: dict[str, list[str]] = {
+    "python": [
+        "function_definition",
+        "class_definition",
+        "decorated_definition",
+    ],
+    "typescript": [
+        "function_declaration",
+        "class_declaration",
+        "export_statement",
+        "lexical_declaration",  # const arrowFn = (x) => ... at top level
+        "method_definition",
+    ],
+    "javascript": [
+        "function_declaration",
+        "class_declaration",
+        "export_statement",
+        "lexical_declaration",  # const arrowFn = (x) => ... at top level
+        "method_definition",
+    ],
+    "go": [
+        "function_declaration",
+        "method_declaration",
+        "type_declaration",
+    ],
+    "rust": [
+        "function_item",
+        "impl_item",
+        "struct_item",
+        "enum_item",
+    ],
+    "java": [
+        "method_declaration",
+        "class_declaration",
+        "interface_declaration",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Language loader — uses importlib to avoid repeated `import X as mod` aliases
+# that trigger mypy's no-redef check.
+# ---------------------------------------------------------------------------
+
+_LANG_MODULE_MAP: dict[str, tuple[str, str]] = {
+    # language → (module_name, attr_to_call)
+    "python": ("tree_sitter_python", "language"),
+    "javascript": ("tree_sitter_javascript", "language"),
+    "go": ("tree_sitter_go", "language"),
+    "rust": ("tree_sitter_rust", "language"),
+    "java": ("tree_sitter_java", "language"),
+    # typescript uses a different attr name
+    "typescript": ("tree_sitter_typescript", "language_typescript"),
+}
+
+
+def _load_language(language: str) -> Any:
+    """Import and return the tree-sitter ``Language`` object for *language*.
+
+    Uses :func:`importlib.import_module` to avoid repeated ``import X as mod``
+    aliases that trigger mypy ``no-redef``.  All packages are untyped so this
+    function returns ``Any``.
+    """
+    entry = _LANG_MODULE_MAP.get(language)
+    if entry is None:
+        raise ValueError(f"Unsupported language: {language}")
+
+    module_name, attr = entry
+    mod = importlib.import_module(module_name)
+    ts_lang_fn = getattr(mod, attr)
+
+    from tree_sitter import Language
+
+    return Language(ts_lang_fn())
+
+
+# ---------------------------------------------------------------------------
+# Name extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_named_child(node: Any, *types: str) -> Any | None:
+    """Return the first named child whose type is in *types*, or None."""
+    for child in node.named_children:
+        if child.type in types:
+            return child
+    return None
+
+
+def _node_text(node: Any, src_bytes: bytes) -> str:
+    return src_bytes[node.start_byte : node.end_byte].decode(errors="replace")
+
+
+def _symbol_name_python(node: Any, src_bytes: bytes) -> str | None:
+    """Extract name from a Python function/class/decorated node."""
+    if node.type == "decorated_definition":
+        inner = _first_named_child(node, "function_definition", "class_definition")
+        if inner is None:
+            return None
+        node = inner
+    name_node = _first_named_child(node, "identifier")
+    return _node_text(name_node, src_bytes) if name_node else None
+
+
+def _symbol_name_ts_js(node: Any, src_bytes: bytes) -> str | None:
+    """Extract name from TypeScript/JavaScript function, class, or export."""
+    if node.type == "export_statement":
+        inner = _first_named_child(
+            node,
+            "function_declaration",
+            "class_declaration",
+            "lexical_declaration",
+        )
+        if inner is None:
+            return None
+        node = inner
+    if node.type == "lexical_declaration":
+        # const arrowFn = (x) => ...  — only named arrow functions
+        declarator = _first_named_child(node, "variable_declarator")
+        if declarator is None:
+            return None
+        arrow = _first_named_child(declarator, "arrow_function")
+        if arrow is None:
+            return None  # not a named arrow function — skip
+        name_node = _first_named_child(declarator, "identifier")
+        return _node_text(name_node, src_bytes) if name_node else None
+    if node.type == "method_definition":
+        name_node = _first_named_child(node, "property_identifier")
+        return _node_text(name_node, src_bytes) if name_node else None
+    # function_declaration, class_declaration
+    name_node = _first_named_child(node, "identifier", "type_identifier")
+    return _node_text(name_node, src_bytes) if name_node else None
+
+
+def _symbol_name_go(node: Any, src_bytes: bytes) -> str | None:
+    """Extract name from a Go function, method, or type declaration."""
+    if node.type == "type_declaration":
+        spec = _first_named_child(node, "type_spec")
+        if spec is None:
+            return None
+        name_node = _first_named_child(spec, "type_identifier")
+        return _node_text(name_node, src_bytes) if name_node else None
+    if node.type == "method_declaration":
+        recv = _first_named_child(node, "parameter_list")
+        method_name_node = _first_named_child(node, "field_identifier")
+        method_name = _node_text(method_name_node, src_bytes) if method_name_node else None
+        if recv and method_name:
+            recv_type = _first_named_child(recv, "parameter_declaration")
+            if recv_type:
+                type_id = _first_named_child(recv_type, "type_identifier")
+                if type_id:
+                    return f"{_node_text(type_id, src_bytes)}.{method_name}"
+        return method_name
+    # function_declaration
+    name_node = _first_named_child(node, "identifier")
+    return _node_text(name_node, src_bytes) if name_node else None
+
+
+def _symbol_name_rust(node: Any, src_bytes: bytes) -> str | None:
+    """Extract name from a Rust fn, impl, struct, or enum."""
+    if node.type == "impl_item":
+        type_id = _first_named_child(node, "type_identifier")
+        return _node_text(type_id, src_bytes) if type_id else None
+    name_node = _first_named_child(node, "identifier", "type_identifier")
+    return _node_text(name_node, src_bytes) if name_node else None
+
+
+def _symbol_name_java(node: Any, src_bytes: bytes) -> str | None:
+    """Extract name from a Java method, class, or interface."""
+    name_node = _first_named_child(node, "identifier")
+    return _node_text(name_node, src_bytes) if name_node else None
+
+
+_NAME_EXTRACTORS = {
+    "python": _symbol_name_python,
+    "typescript": _symbol_name_ts_js,
+    "javascript": _symbol_name_ts_js,
+    "go": _symbol_name_go,
+    "rust": _symbol_name_rust,
+    "java": _symbol_name_java,
+}
+
+# ---------------------------------------------------------------------------
+# Recursive symbol walker
+# ---------------------------------------------------------------------------
+
+
+def _collect_symbols(
+    node: Any,
+    src_bytes: bytes,
+    language: str,
+    module_name: str,
+    parent_name: str | None,
+    target_types: list[str],
+    sections: list[Section],
+    depth: int = 0,
+) -> None:
+    """Recursively walk *node* and collect symbol sections."""
+    if depth > 8:  # guard against pathological nesting
+        return
+
+    if node.type in target_types:
+        extract = _NAME_EXTRACTORS[language]
+        raw_name = extract(node, src_bytes)
+        if raw_name:
+            if parent_name:
+                symbol_parts = [module_name, parent_name, raw_name]
+                heading_path = [module_name, parent_name, raw_name]
+            else:
+                symbol_parts = [module_name, raw_name]
+                heading_path = [module_name, raw_name]
+            symbol = ".".join(symbol_parts)
+            text = _node_text(node, src_bytes)
+            line_start = node.start_point[0] + 1  # tree-sitter rows are 0-based
+            line_end = node.end_point[0] + 1
+            sections.append(
+                Section(
+                    heading_path=heading_path,
+                    text=text,
+                    line_start=line_start,
+                    line_end=line_end,
+                    symbol=symbol,
+                )
+            )
+            # Descend into class/impl bodies to pick up methods
+            is_container = "class" in node.type or "impl" in node.type
+            next_parent = raw_name if is_container else parent_name
+            for child in node.named_children:
+                _collect_symbols(
+                    child,
+                    src_bytes,
+                    language,
+                    module_name,
+                    next_parent,
+                    target_types,
+                    sections,
+                    depth + 1,
+                )
+            return  # children handled above; avoid double-collecting
+
+    for child in node.named_children:
+        _collect_symbols(
+            child,
+            src_bytes,
+            language,
+            module_name,
+            parent_name,
+            target_types,
+            sections,
+            depth + 1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class TreeSitterParser:
+    """Parse source code into symbol-level sections using tree-sitter."""
+
+    def can_handle(self, content_type: str, file_extension: str) -> bool:
+        return content_type in _CODE_CONTENT_TYPES or file_extension.lower() in _EXT_TO_LANG
+
+    def parse(self, content: bytes, file_path: str = "") -> ParsedDocument:
+        ext = os.path.splitext(file_path)[1].lower() if file_path else ""
+        language = _EXT_TO_LANG.get(ext)
+        if language is None:
+            return self._fallback(content, file_path)
+
+        module_name = os.path.splitext(os.path.basename(file_path))[0] or "module"
+        return self._parse_language(content, language, module_name, file_path)
+
+    def _parse_language(
+        self, content: bytes, language: str, module_name: str, file_path: str
+    ) -> ParsedDocument:
+        meta: dict[str, Any] = {}
+        sections: list[Section] = []
+        try:
+            from tree_sitter import Parser as TSParser
+
+            ts_lang = _load_language(language)
+            parser = TSParser(ts_lang)
+            tree = parser.parse(content)
+            if tree.root_node.has_error:
+                meta["parse_warning"] = "Tree-sitter reported syntax errors; result may be partial"
+                log.warning("treesitter_syntax_error", file_path=file_path, language=language)
+            target_types = _SYMBOL_NODE_TYPES.get(language, [])
+            _collect_symbols(
+                tree.root_node,
+                content,
+                language,
+                module_name,
+                None,
+                target_types,
+                sections,
+            )
+        except Exception as exc:
+            log.error(
+                "treesitter_parse_failed",
+                file_path=file_path,
+                language=language,
+                error=str(exc),
+            )
+            meta["parse_error"] = str(exc)
+            return self._fallback(content, file_path, language=language, extra_meta=meta)
+
+        # If nothing was extracted (empty file, only comments, etc.) fall back
+        if not sections:
+            return self._fallback(content, file_path, language=language, extra_meta=meta)
+
+        return ParsedDocument(
+            sections=sections,
+            content_type="text/x-source",
+            language=language,
+            metadata=meta,
+        )
+
+    def _fallback(
+        self,
+        content: bytes,
+        file_path: str,
+        language: str | None = None,
+        extra_meta: dict[str, Any] | None = None,
+    ) -> ParsedDocument:
+        """Return a single-section document when extraction is not possible."""
+        from omniscience_parsers.plaintext import PlainTextParser
+
+        doc = PlainTextParser().parse(content, file_path=file_path)
+        if language or extra_meta:
+            return ParsedDocument(
+                sections=doc.sections,
+                content_type=doc.content_type,
+                language=language,
+                metadata={**(extra_meta or {})},
+            )
+        return doc
+
+
+__all__ = ["TreeSitterParser"]

--- a/packages/parsers/src/omniscience_parsers/dispatch.py
+++ b/packages/parsers/src/omniscience_parsers/dispatch.py
@@ -1,0 +1,51 @@
+"""Parser dispatch — selects the best parser for a given content-type + extension.
+
+Usage::
+
+    dispatch = ParserDispatch([MarkdownParser(), TreeSitterParser(), PlainTextParser()])
+    parser = dispatch.get_parser("text/markdown", ".md")
+    doc = parser.parse(content)
+"""
+
+from __future__ import annotations
+
+from omniscience_parsers.base import ParsedDocument, Parser
+from omniscience_parsers.plaintext import PlainTextParser
+
+
+class ParserDispatch:
+    """Selects a parser from a registry, falling back to :class:`PlainTextParser`.
+
+    Parsers are evaluated in registration order.  The first one that returns
+    ``True`` from :meth:`~Parser.can_handle` wins.  :class:`PlainTextParser`
+    is always appended as the final fallback.
+    """
+
+    def __init__(self, parsers: list[Parser]) -> None:
+        self._parsers: list[Parser] = list(parsers)
+        # Ensure PlainTextParser is last
+        if not any(isinstance(p, PlainTextParser) for p in self._parsers):
+            self._parsers.append(PlainTextParser())
+
+    def get_parser(self, content_type: str, file_extension: str) -> Parser:
+        """Return the first parser that claims the content-type / extension."""
+        for parser in self._parsers:
+            if parser.can_handle(content_type, file_extension):
+                return parser
+        # PlainTextParser.can_handle always returns True so this is unreachable,
+        # but mypy needs a return on all paths.
+        return PlainTextParser()  # pragma: no cover
+
+    def parse(
+        self,
+        content: bytes,
+        content_type: str,
+        file_extension: str,
+        file_path: str = "",
+    ) -> ParsedDocument:
+        """Convenience: pick a parser and parse in one call."""
+        parser = self.get_parser(content_type, file_extension)
+        return parser.parse(content, file_path=file_path)
+
+
+__all__ = ["ParserDispatch"]

--- a/packages/parsers/src/omniscience_parsers/markdown.py
+++ b/packages/parsers/src/omniscience_parsers/markdown.py
@@ -1,0 +1,142 @@
+"""Markdown parser using markdown-it-py + python-frontmatter.
+
+Heading hierarchy is tracked as a stack so that every section carries the
+full path of its ancestor headings.  Code fences are preserved inside the
+section text and their ``info`` string is stored in ``section.metadata``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import frontmatter  # type: ignore[import-untyped]
+import markdown_it
+
+from omniscience_parsers.base import ParsedDocument, Section
+
+_CONTENT_TYPES = frozenset({"text/markdown", "text/x-markdown"})
+_EXTENSIONS = frozenset({".md", ".mdx", ".markdown"})
+
+# Heading tag → nesting depth (h1 = 1, h2 = 2, …)
+_HEADING_DEPTH = {"h1": 1, "h2": 2, "h3": 3, "h4": 4, "h5": 5, "h6": 6}
+
+
+class MarkdownParser:
+    """Parse Markdown documents into hierarchical sections."""
+
+    def __init__(self) -> None:
+        self._md = markdown_it.MarkdownIt()
+
+    def can_handle(self, content_type: str, file_extension: str) -> bool:
+        return content_type in _CONTENT_TYPES or file_extension.lower() in _EXTENSIONS
+
+    def parse(self, content: bytes, file_path: str = "") -> ParsedDocument:
+        raw_text = content.decode(errors="replace")
+        post = frontmatter.loads(raw_text)
+        body: str = post.content
+        fm_meta: dict[str, Any] = dict(post.metadata)
+
+        tokens = self._md.parse(body)
+        sections: list[Section] = []
+        title: str | None = fm_meta.get("title")
+
+        # heading_stack: list of (depth, label) representing the current path
+        heading_stack: list[tuple[int, str]] = []
+        current_lines: list[str] = []
+        current_line_start: int = 1
+        current_meta: dict[str, Any] = {}
+
+        body_lines = body.splitlines(keepends=True)
+
+        def _flush_section(end_line: int) -> None:
+            """Emit a section if there is accumulated content."""
+            text = "".join(current_lines).strip()
+            if not text:
+                return
+            path = [lbl for _, lbl in heading_stack]
+            sections.append(
+                Section(
+                    heading_path=path,
+                    text=text,
+                    line_start=current_line_start,
+                    line_end=end_line,
+                    metadata={**current_meta},
+                )
+            )
+
+        def _body_lines_for(token: markdown_it.token.Token) -> list[str]:
+            """Return body lines that correspond to this token's map."""
+            if token.map is None:
+                return []
+            start, end = token.map
+            return body_lines[start:end]
+
+        i = 0
+        while i < len(tokens):
+            token = tokens[i]
+
+            if token.type == "heading_open":
+                depth = _HEADING_DEPTH.get(token.tag, 1)
+                # Grab the inline content from the next token
+                if i + 1 < len(tokens) and tokens[i + 1].type == "inline":
+                    label = tokens[i + 1].content.strip()
+                else:
+                    label = ""
+
+                # Flush what came before this heading
+                end_line = (token.map[0] if token.map else len(body_lines)) + 1
+                _flush_section(end_line - 1)
+
+                # If first H1 and no frontmatter title, capture it
+                if depth == 1 and title is None:
+                    title = label
+
+                # Trim the heading stack to this depth
+                heading_stack = [(d, lbl) for d, lbl in heading_stack if d < depth]
+                heading_stack.append((depth, label))
+
+                current_lines = []
+                current_meta = {}
+                # Line start is right after the heading line
+                current_line_start = (token.map[1] if token.map else 0) + 1
+
+            elif token.type == "fence":
+                fence_lines = _body_lines_for(token)
+                current_lines.extend(fence_lines)
+                # Store language hint from the fence info
+                info = token.info.strip().split()[0] if token.info.strip() else ""
+                if info:
+                    current_meta.setdefault("fence_languages", [])
+                    langs: list[str] = current_meta["fence_languages"]
+                    langs.append(info)
+
+            elif token.type not in ("heading_close",):
+                tok_lines = _body_lines_for(token)
+                if tok_lines:
+                    current_lines.extend(tok_lines)
+
+            i += 1
+
+        # Flush the last section
+        _flush_section(len(body_lines))
+
+        # If no heading was ever seen, wrap everything in a single section
+        if not sections and body.strip():
+            sections.append(
+                Section(
+                    heading_path=[],
+                    text=body.strip(),
+                    line_start=1,
+                    line_end=len(body_lines) or 1,
+                )
+            )
+
+        return ParsedDocument(
+            title=title,
+            sections=sections,
+            metadata=fm_meta,
+            content_type="text/markdown",
+        )
+
+
+__all__ = ["MarkdownParser"]

--- a/packages/parsers/src/omniscience_parsers/plaintext.py
+++ b/packages/parsers/src/omniscience_parsers/plaintext.py
@@ -1,0 +1,35 @@
+"""Plain-text parser — fallback for any content without a specialised parser."""
+
+from __future__ import annotations
+
+from omniscience_parsers.base import ParsedDocument, Section
+
+
+class PlainTextParser:
+    """Wraps the entire content in a single section.
+
+    Used as the fallback when no other parser claims the content-type or
+    file extension.
+    """
+
+    def can_handle(self, content_type: str, file_extension: str) -> bool:
+        """Accept everything — this parser is the final fallback."""
+        return True
+
+    def parse(self, content: bytes, file_path: str = "") -> ParsedDocument:
+        """Return a :class:`ParsedDocument` with one section spanning the file."""
+        text = content.decode(errors="replace")
+        line_count = len(text.splitlines()) or 1
+        section = Section(
+            heading_path=[],
+            text=text,
+            line_start=1,
+            line_end=line_count,
+        )
+        return ParsedDocument(
+            sections=[section],
+            content_type="text/plain",
+        )
+
+
+__all__ = ["PlainTextParser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ members = [
 [tool.uv.sources]
 omniscience-core       = { workspace = true }
 omniscience-connectors = { workspace = true }
-omniscience-parsers    = { workspace = true }
 omniscience-embeddings = { workspace = true }
 omniscience-index      = { workspace = true }
 omniscience-retrieval  = { workspace = true }
 omniscience-server     = { workspace = true }
 omniscience-cli        = { workspace = true }
+omniscience-parsers = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -40,6 +40,7 @@ dev = [
     "omniscience-index",
     "tenacity>=9.1.4",
     "respx>=0.23.1",
+    "omniscience-parsers",
 ]
 
 [tool.ruff]

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,278 @@
+"""Tests for chunking strategies: CodeSymbolChunker, MarkdownSectionChunker, FixedWindowChunker."""
+
+from __future__ import annotations
+
+from omniscience_parsers import (
+    CodeSymbolChunker,
+    FixedWindowChunker,
+    MarkdownSectionChunker,
+    ParsedDocument,
+    Section,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_doc(sections: list[Section], content_type: str = "text/x-source") -> ParsedDocument:
+    return ParsedDocument(sections=sections, content_type=content_type)
+
+
+def _word_section(
+    words: int,
+    heading_path: list[str] | None = None,
+    symbol: str | None = None,
+    line_start: int = 1,
+    line_end: int = 10,
+) -> Section:
+    text = " ".join(f"word{i}" for i in range(words))
+    return Section(
+        heading_path=heading_path or [],
+        text=text,
+        symbol=symbol,
+        line_start=line_start,
+        line_end=line_end,
+    )
+
+
+def _count_tokens(text: str) -> int:
+    return len(text.split())
+
+
+# ---------------------------------------------------------------------------
+# CodeSymbolChunker
+# ---------------------------------------------------------------------------
+
+
+class TestCodeSymbolChunker:
+    def setup_method(self) -> None:
+        self.chunker = CodeSymbolChunker(max_tokens=512, overlap_tokens=50)
+
+    def test_one_chunk_per_small_symbol(self) -> None:
+        sections = [
+            _word_section(10, ["mod", "func_a"], symbol="mod.func_a"),
+            _word_section(10, ["mod", "func_b"], symbol="mod.func_b"),
+        ]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        assert len(chunks) == 2
+
+    def test_symbol_preserved(self) -> None:
+        sections = [_word_section(5, symbol="mod.MyClass.method")]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        assert chunks[0].symbol == "mod.MyClass.method"
+
+    def test_oversized_symbol_splits(self) -> None:
+        chunker = CodeSymbolChunker(max_tokens=10, overlap_tokens=2)
+        sections = [_word_section(50, ["mod", "big_fn"], symbol="mod.big_fn")]
+        chunks = chunker.chunk(_make_doc(sections))
+        assert len(chunks) > 1
+
+    def test_oversized_split_all_windows_have_symbol(self) -> None:
+        chunker = CodeSymbolChunker(max_tokens=10, overlap_tokens=2)
+        sections = [_word_section(50, symbol="mod.fn")]
+        chunks = chunker.chunk(_make_doc(sections))
+        assert all(c.symbol == "mod.fn" for c in chunks)
+
+    def test_token_budget_respected(self) -> None:
+        chunker = CodeSymbolChunker(max_tokens=20, overlap_tokens=5)
+        sections = [_word_section(100, symbol="mod.fn")]
+        chunks = chunker.chunk(_make_doc(sections))
+        for chunk in chunks:
+            # heading_prefix words + window words ≤ max + some slack for prefix
+            assert _count_tokens(chunk.text) <= 30  # prefix + 20 words max
+
+    def test_ord_is_sequential(self) -> None:
+        sections = [_word_section(5, symbol=f"mod.fn{i}") for i in range(5)]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        ords = [c.ord for c in chunks]
+        assert ords == list(range(len(chunks)))
+
+    def test_strategy_in_metadata(self) -> None:
+        sections = [_word_section(5, symbol="m.f")]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        assert chunks[0].strategy == "code_symbol"
+        assert chunks[0].metadata.get("strategy") == "code_symbol"
+
+    def test_line_range_in_metadata(self) -> None:
+        section = _word_section(5, symbol="m.f", line_start=10, line_end=20)
+        chunks = self.chunker.chunk(_make_doc([section]))
+        assert chunks[0].metadata["line_range"] == [10, 20]
+        assert chunks[0].line_start == 10
+        assert chunks[0].line_end == 20
+
+    def test_heading_path_prepended(self) -> None:
+        section = _word_section(5, heading_path=["module", "MyClass", "method"])
+        chunks = self.chunker.chunk(_make_doc([section]))
+        assert "MyClass" in chunks[0].text
+        assert "method" in chunks[0].text
+
+    def test_empty_document(self) -> None:
+        chunks = self.chunker.chunk(_make_doc([]))
+        assert chunks == []
+
+    def test_window_index_in_metadata_for_splits(self) -> None:
+        chunker = CodeSymbolChunker(max_tokens=5, overlap_tokens=1)
+        sections = [_word_section(30, symbol="mod.fn")]
+        chunks = chunker.chunk(_make_doc(sections))
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            assert chunk.metadata.get("window") == i
+
+
+# ---------------------------------------------------------------------------
+# MarkdownSectionChunker
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownSectionChunker:
+    def setup_method(self) -> None:
+        self.chunker = MarkdownSectionChunker(max_tokens=512, overlap_tokens=50)
+
+    def test_one_chunk_per_section(self) -> None:
+        sections = [
+            _word_section(10, heading_path=["A"]),
+            _word_section(10, heading_path=["B"]),
+        ]
+        chunks = self.chunker.chunk(_make_doc(sections, "text/markdown"))
+        assert len(chunks) == 2
+
+    def test_heading_context_prepended(self) -> None:
+        section = _word_section(5, heading_path=["Architecture", "API"])
+        chunks = self.chunker.chunk(_make_doc([section]))
+        assert "Architecture" in chunks[0].text
+        assert "API" in chunks[0].text
+
+    def test_no_heading_no_prefix(self) -> None:
+        section = _word_section(5, heading_path=[])
+        chunks = self.chunker.chunk(_make_doc([section]))
+        # first token should be the actual content, not a separator
+        assert chunks[0].text.strip().startswith("word0")
+
+    def test_large_section_splits(self) -> None:
+        chunker = MarkdownSectionChunker(max_tokens=10, overlap_tokens=2)
+        sections = [_word_section(80, heading_path=["Big Section"])]
+        chunks = chunker.chunk(_make_doc(sections, "text/markdown"))
+        assert len(chunks) > 1
+
+    def test_split_windows_all_have_heading(self) -> None:
+        chunker = MarkdownSectionChunker(max_tokens=10, overlap_tokens=2)
+        sections = [_word_section(80, heading_path=["Title"])]
+        chunks = chunker.chunk(_make_doc(sections, "text/markdown"))
+        assert all("Title" in c.text for c in chunks)
+
+    def test_ord_sequential(self) -> None:
+        sections = [_word_section(5, heading_path=[f"H{i}"]) for i in range(4)]
+        chunks = self.chunker.chunk(_make_doc(sections, "text/markdown"))
+        assert [c.ord for c in chunks] == list(range(len(chunks)))
+
+    def test_strategy_in_chunk(self) -> None:
+        sections = [_word_section(5, heading_path=["S"])]
+        chunks = self.chunker.chunk(_make_doc(sections, "text/markdown"))
+        assert chunks[0].strategy == "markdown_section"
+        assert chunks[0].metadata.get("strategy") == "markdown_section"
+
+    def test_section_path_in_metadata(self) -> None:
+        path = ["Root", "Child"]
+        sections = [_word_section(5, heading_path=path)]
+        chunks = self.chunker.chunk(_make_doc(sections, "text/markdown"))
+        assert chunks[0].metadata["section_path"] == path
+
+    def test_line_range_in_metadata(self) -> None:
+        section = _word_section(5, heading_path=["S"], line_start=5, line_end=15)
+        chunks = self.chunker.chunk(_make_doc([section]))
+        assert chunks[0].metadata["line_range"] == [5, 15]
+
+    def test_empty_document(self) -> None:
+        chunks = self.chunker.chunk(_make_doc([], "text/markdown"))
+        assert chunks == []
+
+    def test_token_budget_respected_after_split(self) -> None:
+        chunker = MarkdownSectionChunker(max_tokens=15, overlap_tokens=3)
+        sections = [_word_section(200, heading_path=["H"])]
+        chunks = chunker.chunk(_make_doc(sections))
+        # Heading prefix is "H\n\n" = 1 word; each window ≤ 15 words
+        for chunk in chunks:
+            assert _count_tokens(chunk.text) <= 20  # some slack for prefix
+
+
+# ---------------------------------------------------------------------------
+# FixedWindowChunker
+# ---------------------------------------------------------------------------
+
+
+class TestFixedWindowChunker:
+    def setup_method(self) -> None:
+        self.chunker = FixedWindowChunker(max_tokens=10, overlap_tokens=3)
+
+    def test_single_window_for_small_content(self) -> None:
+        sections = [_word_section(5)]
+        chunks = self.chunker.chunk(_make_doc(sections, "text/plain"))
+        assert len(chunks) == 1
+
+    def test_multiple_windows_for_large_content(self) -> None:
+        sections = [_word_section(100)]
+        chunks = self.chunker.chunk(_make_doc(sections, "text/plain"))
+        assert len(chunks) > 1
+
+    def test_window_size_respected(self) -> None:
+        chunker = FixedWindowChunker(max_tokens=5, overlap_tokens=0)
+        sections = [_word_section(20)]
+        chunks = chunker.chunk(_make_doc(sections))
+        for chunk in chunks[:-1]:  # last may be smaller
+            assert _count_tokens(chunk.text) <= 5
+
+    def test_overlap_present(self) -> None:
+        chunker = FixedWindowChunker(max_tokens=5, overlap_tokens=2)
+        sections = [_word_section(20)]
+        chunks = chunker.chunk(_make_doc(sections))
+        if len(chunks) >= 2:
+            words_0 = set(chunks[0].text.split())
+            words_1 = set(chunks[1].text.split())
+            assert len(words_0 & words_1) >= 2  # overlap
+
+    def test_ord_sequential(self) -> None:
+        sections = [_word_section(50)]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        assert [c.ord for c in chunks] == list(range(len(chunks)))
+
+    def test_strategy_field(self) -> None:
+        sections = [_word_section(5)]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        assert all(c.strategy == "fixed_window" for c in chunks)
+        assert all(c.metadata.get("strategy") == "fixed_window" for c in chunks)
+
+    def test_window_index_in_metadata(self) -> None:
+        sections = [_word_section(30)]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        for i, chunk in enumerate(chunks):
+            assert chunk.metadata.get("window") == i
+
+    def test_no_symbol_for_plain_text(self) -> None:
+        sections = [_word_section(5)]
+        chunks = self.chunker.chunk(_make_doc(sections))
+        assert all(c.symbol is None for c in chunks)
+
+    def test_concatenates_multiple_sections(self) -> None:
+        chunker = FixedWindowChunker(max_tokens=100, overlap_tokens=0)
+        sections = [_word_section(5, heading_path=["A"]), _word_section(5, heading_path=["B"])]
+        chunks = chunker.chunk(_make_doc(sections))
+        combined = " ".join(c.text for c in chunks)
+        assert "word0" in combined
+
+    def test_empty_document(self) -> None:
+        chunks = self.chunker.chunk(_make_doc([]))
+        assert chunks == []
+
+    def test_empty_section_text(self) -> None:
+        section = Section(heading_path=[], text="   ", line_start=1, line_end=1)
+        chunks = self.chunker.chunk(_make_doc([section]))
+        assert chunks == []
+
+    def test_large_overlap_relative_to_max(self) -> None:
+        # overlap >= max — should still make progress (step = max(1, max-overlap))
+        chunker = FixedWindowChunker(max_tokens=5, overlap_tokens=5)
+        sections = [_word_section(20)]
+        chunks = chunker.chunk(_make_doc(sections))
+        # Should not infinite loop and should have at least one chunk
+        assert len(chunks) >= 1

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,205 @@
+"""Tests for parser framework: MarkdownParser, PlainTextParser, ParserDispatch."""
+
+from __future__ import annotations
+
+from omniscience_parsers import (
+    MarkdownParser,
+    ParserDispatch,
+    PlainTextParser,
+    TreeSitterParser,
+)
+
+# ---------------------------------------------------------------------------
+# MarkdownParser
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownParser:
+    def setup_method(self) -> None:
+        self.parser = MarkdownParser()
+
+    def test_can_handle_by_content_type(self) -> None:
+        assert self.parser.can_handle("text/markdown", "") is True
+        assert self.parser.can_handle("text/x-markdown", "") is True
+        assert self.parser.can_handle("application/json", "") is False
+
+    def test_can_handle_by_extension(self) -> None:
+        assert self.parser.can_handle("", ".md") is True
+        assert self.parser.can_handle("", ".mdx") is True
+        assert self.parser.can_handle("", ".markdown") is True
+        assert self.parser.can_handle("", ".txt") is False
+
+    def test_heading_hierarchy(self) -> None:
+        content = (
+            b"# Root\n\nRoot text.\n\n## Child\n\nChild text.\n\n### Grandchild\n\nDeep text.\n"
+        )
+        doc = self.parser.parse(content)
+        headings = [s.heading_path for s in doc.sections]
+        # Root section
+        assert ["Root"] in headings
+        # Child section must include parent
+        assert any("Child" in path for path in headings)
+        # Grandchild section must include ancestors
+        assert any("Grandchild" in path for path in headings)
+
+    def test_heading_path_nesting(self) -> None:
+        content = b"# A\n\nText A.\n\n## B\n\nText B.\n"
+        doc = self.parser.parse(content)
+        b_section = next(s for s in doc.sections if "B" in s.heading_path)
+        # Path should include A and B
+        assert "A" in b_section.heading_path
+        assert "B" in b_section.heading_path
+
+    def test_frontmatter_metadata(self) -> None:
+        content = b"---\ntitle: My Doc\nauthor: Alice\n---\n\n# Hello\n\nBody text.\n"
+        doc = self.parser.parse(content)
+        assert doc.metadata.get("author") == "Alice"
+
+    def test_frontmatter_title(self) -> None:
+        content = b"---\ntitle: Frontmatter Title\n---\n\n# H1 Title\n\nBody.\n"
+        doc = self.parser.parse(content)
+        # frontmatter title wins
+        assert doc.title == "Frontmatter Title"
+
+    def test_first_h1_becomes_title_without_frontmatter(self) -> None:
+        content = b"# My Title\n\nSome text.\n"
+        doc = self.parser.parse(content)
+        assert doc.title == "My Title"
+
+    def test_code_fence_preserved(self) -> None:
+        content = b"# Section\n\n```python\nprint('hello')\n```\n\nAfter fence.\n"
+        doc = self.parser.parse(content)
+        # The section text should contain the fence content
+        section_texts = " ".join(s.text for s in doc.sections)
+        assert "print" in section_texts or "python" in section_texts
+
+    def test_code_fence_language_in_metadata(self) -> None:
+        content = b"# Code\n\n```typescript\nconst x = 1;\n```\n"
+        doc = self.parser.parse(content)
+        metas = [s.metadata for s in doc.sections]
+        langs = [m.get("fence_languages", []) for m in metas]
+        flat = [lang for lst in langs for lang in lst]
+        assert "typescript" in flat
+
+    def test_no_heading_single_section(self) -> None:
+        content = b"Just some plain markdown without headings.\n"
+        doc = self.parser.parse(content)
+        assert len(doc.sections) == 1
+        assert doc.sections[0].heading_path == []
+
+    def test_content_type(self) -> None:
+        doc = self.parser.parse(b"# Hello\n")
+        assert doc.content_type == "text/markdown"
+
+    def test_empty_content(self) -> None:
+        doc = self.parser.parse(b"")
+        assert doc.sections == [] or all(s.text.strip() == "" for s in doc.sections)
+
+    def test_sibling_sections_separate(self) -> None:
+        content = b"# A\n\nText A.\n\n# B\n\nText B.\n"
+        doc = self.parser.parse(content)
+        texts = [s.text for s in doc.sections if s.text.strip()]
+        assert any("Text A" in t for t in texts)
+        assert any("Text B" in t for t in texts)
+
+
+# ---------------------------------------------------------------------------
+# PlainTextParser
+# ---------------------------------------------------------------------------
+
+
+class TestPlainTextParser:
+    def setup_method(self) -> None:
+        self.parser = PlainTextParser()
+
+    def test_can_handle_anything(self) -> None:
+        assert self.parser.can_handle("application/octet-stream", ".bin") is True
+        assert self.parser.can_handle("", "") is True
+
+    def test_single_section(self) -> None:
+        content = b"Line one.\nLine two.\nLine three.\n"
+        doc = self.parser.parse(content)
+        assert len(doc.sections) == 1
+        assert "Line one" in doc.sections[0].text
+        assert "Line three" in doc.sections[0].text
+
+    def test_heading_path_is_empty(self) -> None:
+        doc = self.parser.parse(b"Hello world\n")
+        assert doc.sections[0].heading_path == []
+
+    def test_line_range(self) -> None:
+        content = b"A\nB\nC\n"
+        doc = self.parser.parse(content)
+        assert doc.sections[0].line_start == 1
+        assert doc.sections[0].line_end == 3
+
+    def test_content_type(self) -> None:
+        doc = self.parser.parse(b"text")
+        assert doc.content_type == "text/plain"
+
+    def test_empty_content(self) -> None:
+        doc = self.parser.parse(b"")
+        assert len(doc.sections) == 1
+
+    def test_binary_like_content_decodes(self) -> None:
+        # Should not raise on invalid UTF-8
+        content = b"\xff\xfe hello"
+        doc = self.parser.parse(content)
+        assert len(doc.sections) == 1
+
+
+# ---------------------------------------------------------------------------
+# ParserDispatch
+# ---------------------------------------------------------------------------
+
+
+class TestParserDispatch:
+    def setup_method(self) -> None:
+        self.dispatch = ParserDispatch([MarkdownParser(), TreeSitterParser(), PlainTextParser()])
+
+    def test_routes_markdown_by_content_type(self) -> None:
+        parser = self.dispatch.get_parser("text/markdown", "")
+        assert isinstance(parser, MarkdownParser)
+
+    def test_routes_markdown_by_extension(self) -> None:
+        parser = self.dispatch.get_parser("", ".md")
+        assert isinstance(parser, MarkdownParser)
+
+    def test_routes_python_to_treesitter(self) -> None:
+        parser = self.dispatch.get_parser("", ".py")
+        assert isinstance(parser, TreeSitterParser)
+
+    def test_routes_typescript_to_treesitter(self) -> None:
+        parser = self.dispatch.get_parser("", ".ts")
+        assert isinstance(parser, TreeSitterParser)
+
+    def test_fallback_to_plaintext_for_unknown(self) -> None:
+        parser = self.dispatch.get_parser("application/octet-stream", ".xyz")
+        assert isinstance(parser, PlainTextParser)
+
+    def test_fallback_to_plaintext_empty_inputs(self) -> None:
+        parser = self.dispatch.get_parser("", "")
+        assert isinstance(parser, PlainTextParser)
+
+    def test_plaintext_not_duplicated_as_fallback(self) -> None:
+        # When PlainTextParser is already in the list, should not double up
+        dispatch = ParserDispatch([PlainTextParser()])
+        plain_count = sum(1 for p in dispatch._parsers if isinstance(p, PlainTextParser))
+        assert plain_count == 1
+
+    def test_parse_convenience_method_markdown(self) -> None:
+        content = b"# Hello\n\nWorld.\n"
+        doc = self.dispatch.parse(content, "text/markdown", ".md")
+        assert doc.content_type == "text/markdown"
+        assert any(s.text for s in doc.sections)
+
+    def test_parse_convenience_method_unknown(self) -> None:
+        content = b"just text"
+        doc = self.dispatch.parse(content, "unknown/type", ".zzz")
+        assert doc.content_type == "text/plain"
+        assert len(doc.sections) == 1
+
+    def test_no_explicit_plaintext_gets_fallback_added(self) -> None:
+        dispatch = ParserDispatch([MarkdownParser()])
+        # Should auto-append PlainTextParser
+        assert any(isinstance(p, PlainTextParser) for p in dispatch._parsers)

--- a/tests/test_treesitter.py
+++ b/tests/test_treesitter.py
@@ -1,0 +1,229 @@
+"""Tests for TreeSitterParser — code symbol extraction."""
+
+from __future__ import annotations
+
+import pytest
+from omniscience_parsers import TreeSitterParser
+
+
+@pytest.fixture()
+def parser() -> TreeSitterParser:
+    return TreeSitterParser()
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+
+class TestPythonExtraction:
+    def test_function_extracted(self, parser: TreeSitterParser) -> None:
+        src = b"def my_func(x):\n    return x + 1\n"
+        doc = parser.parse(src, "module.py")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("my_func" in sym for sym in symbols)
+
+    def test_function_fqn(self, parser: TreeSitterParser) -> None:
+        src = b"def greet(name):\n    return name\n"
+        doc = parser.parse(src, "utils.py")
+        section = next(s for s in doc.sections if s.symbol and "greet" in s.symbol)
+        assert section.symbol == "utils.greet"
+
+    def test_class_extracted(self, parser: TreeSitterParser) -> None:
+        src = b"class Foo:\n    pass\n"
+        doc = parser.parse(src, "models.py")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("Foo" in sym for sym in symbols)
+
+    def test_method_fqn(self, parser: TreeSitterParser) -> None:
+        src = b"class MyClass:\n    def my_method(self):\n        pass\n"
+        doc = parser.parse(src, "mymod.py")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("MyClass" in sym and "my_method" in sym for sym in symbols)
+
+    def test_decorated_function(self, parser: TreeSitterParser) -> None:
+        src = b"@property\ndef value(self):\n    return self._v\n"
+        doc = parser.parse(src, "mod.py")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("value" in sym for sym in symbols)
+
+    def test_line_numbers_correct(self, parser: TreeSitterParser) -> None:
+        src = b"\ndef foo():\n    pass\n"
+        doc = parser.parse(src, "x.py")
+        section = next(s for s in doc.sections if s.symbol and "foo" in s.symbol)
+        assert section.line_start >= 1
+        assert section.line_end >= section.line_start
+
+    def test_section_text_contains_source(self, parser: TreeSitterParser) -> None:
+        src = b"def add(a, b):\n    return a + b\n"
+        doc = parser.parse(src, "math_utils.py")
+        section = next(s for s in doc.sections if s.symbol and "add" in s.symbol)
+        assert "return a + b" in section.text
+
+    def test_heading_path_includes_module(self, parser: TreeSitterParser) -> None:
+        src = b"def hello():\n    pass\n"
+        doc = parser.parse(src, "greetings.py")
+        section = next(s for s in doc.sections if s.symbol and "hello" in s.symbol)
+        assert "greetings" in section.heading_path
+
+    def test_language_set(self, parser: TreeSitterParser) -> None:
+        src = b"def f(): pass\n"
+        doc = parser.parse(src, "f.py")
+        assert doc.language == "python"
+
+    def test_syntax_error_partial_result(self, parser: TreeSitterParser) -> None:
+        # Valid prefix + syntax error suffix
+        src = b"def valid():\n    pass\n\ndef (:\n    pass\n"
+        doc = parser.parse(src, "broken.py")
+        # Should not raise and should return something
+        assert doc is not None
+        # parse_warning may be set
+        # We either get sections or a warning in metadata — no crash is sufficient
+        assert len(doc.sections) >= 0  # at minimum doesn't crash
+
+
+# ---------------------------------------------------------------------------
+# TypeScript
+# ---------------------------------------------------------------------------
+
+
+class TestTypeScriptExtraction:
+    def test_function_extracted(self, parser: TreeSitterParser) -> None:
+        src = b"function greet(name: string): string { return name; }\n"
+        doc = parser.parse(src, "utils.ts")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("greet" in sym for sym in symbols)
+
+    def test_class_extracted(self, parser: TreeSitterParser) -> None:
+        src = b"class Greeter { greet(): void {} }\n"
+        doc = parser.parse(src, "greeter.ts")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("Greeter" in sym for sym in symbols)
+
+    def test_exported_function(self, parser: TreeSitterParser) -> None:
+        src = b"export function hello(): string { return 'hello'; }\n"
+        doc = parser.parse(src, "api.ts")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("hello" in sym for sym in symbols)
+
+    def test_arrow_function_named(self, parser: TreeSitterParser) -> None:
+        src = b"const double = (x: number) => x * 2;\n"
+        doc = parser.parse(src, "fns.ts")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("double" in sym for sym in symbols)
+
+    def test_language_set(self, parser: TreeSitterParser) -> None:
+        src = b"const x = 1;\n"
+        doc = parser.parse(src, "x.ts")
+        assert doc.language == "typescript"
+
+    def test_tsx_extension(self, parser: TreeSitterParser) -> None:
+        src = b"export function Btn(): void {}\n"
+        doc = parser.parse(src, "Btn.tsx")
+        assert doc.language == "typescript"
+
+
+# ---------------------------------------------------------------------------
+# Go
+# ---------------------------------------------------------------------------
+
+
+class TestGoExtraction:
+    def test_function_extracted(self, parser: TreeSitterParser) -> None:
+        src = b"package main\nfunc Greet(name string) string { return name }\n"
+        doc = parser.parse(src, "main.go")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("Greet" in sym for sym in symbols)
+
+    def test_method_extracted(self, parser: TreeSitterParser) -> None:
+        src = b'package main\ntype Foo struct{}\nfunc (f Foo) Bar() string { return "" }\n'
+        doc = parser.parse(src, "foo.go")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("Bar" in sym for sym in symbols)
+
+    def test_type_declaration_extracted(self, parser: TreeSitterParser) -> None:
+        src = b"package main\ntype MyStruct struct { Field string }\n"
+        doc = parser.parse(src, "types.go")
+        symbols = [s.symbol for s in doc.sections if s.symbol]
+        assert any("MyStruct" in sym for sym in symbols)
+
+    def test_language_set(self, parser: TreeSitterParser) -> None:
+        src = b"package main\n"
+        doc = parser.parse(src, "main.go")
+        assert doc.language == "go"
+
+
+# ---------------------------------------------------------------------------
+# Language detection by extension
+# ---------------------------------------------------------------------------
+
+
+class TestLanguageDetection:
+    def test_py_extension(self, parser: TreeSitterParser) -> None:
+        doc = parser.parse(b"def f(): pass\n", "x.py")
+        assert doc.language == "python"
+
+    def test_ts_extension(self, parser: TreeSitterParser) -> None:
+        doc = parser.parse(b"const x = 1;\n", "x.ts")
+        assert doc.language == "typescript"
+
+    def test_js_extension(self, parser: TreeSitterParser) -> None:
+        doc = parser.parse(b"function f() {}\n", "x.js")
+        assert doc.language == "javascript"
+
+    def test_go_extension(self, parser: TreeSitterParser) -> None:
+        doc = parser.parse(b"package main\n", "x.go")
+        assert doc.language == "go"
+
+    def test_rs_extension(self, parser: TreeSitterParser) -> None:
+        doc = parser.parse(b"fn main() {}\n", "x.rs")
+        assert doc.language == "rust"
+
+    def test_java_extension(self, parser: TreeSitterParser) -> None:
+        doc = parser.parse(b"class Foo {}\n", "Foo.java")
+        assert doc.language == "java"
+
+    def test_unsupported_extension_falls_back(self, parser: TreeSitterParser) -> None:
+        src = b"some random content"
+        doc = parser.parse(src, "file.xyz")
+        # Should fall back to plain text (one section, no language)
+        assert len(doc.sections) == 1
+        assert doc.language is None
+
+    def test_no_extension_falls_back(self, parser: TreeSitterParser) -> None:
+        src = b"just text"
+        doc = parser.parse(src, "README")
+        assert len(doc.sections) == 1
+
+
+# ---------------------------------------------------------------------------
+# Graceful error handling
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulErrors:
+    def test_completely_invalid_syntax_no_crash(self, parser: TreeSitterParser) -> None:
+        src = b"@@@@@@@@@@@ not valid python @@@@@@@@@"
+        doc = parser.parse(src, "bad.py")
+        assert doc is not None  # must not raise
+
+    def test_empty_file(self, parser: TreeSitterParser) -> None:
+        doc = parser.parse(b"", "empty.py")
+        assert doc is not None
+        assert len(doc.sections) >= 0
+
+    def test_binary_content_no_crash(self, parser: TreeSitterParser) -> None:
+        content = bytes(range(256))
+        doc = parser.parse(content, "data.py")
+        assert doc is not None
+
+    def test_can_handle_returns_true_for_known_extensions(self, parser: TreeSitterParser) -> None:
+        assert parser.can_handle("", ".py") is True
+        assert parser.can_handle("", ".ts") is True
+        assert parser.can_handle("", ".go") is True
+        assert parser.can_handle("", ".rs") is True
+        assert parser.can_handle("", ".java") is True
+
+    def test_can_handle_returns_false_for_unknown(self, parser: TreeSitterParser) -> None:
+        assert parser.can_handle("text/plain", ".txt") is False
+        assert parser.can_handle("application/json", ".json") is False

--- a/uv.lock
+++ b/uv.lock
@@ -820,6 +820,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -905,6 +917,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1054,6 +1075,7 @@ dev = [
     { name = "omniscience-core" },
     { name = "omniscience-embeddings" },
     { name = "omniscience-index" },
+    { name = "omniscience-parsers" },
     { name = "omniscience-server" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1075,6 +1097,7 @@ dev = [
     { name = "omniscience-core", editable = "packages/core" },
     { name = "omniscience-embeddings", editable = "packages/embeddings" },
     { name = "omniscience-index", editable = "packages/index" },
+    { name = "omniscience-parsers", editable = "packages/parsers" },
     { name = "omniscience-server", editable = "apps/server" },
     { name = "pre-commit", specifier = ">=3.7.1" },
     { name = "pytest", specifier = ">=8.2.2" },
@@ -1189,11 +1212,33 @@ name = "omniscience-parsers"
 version = "0.1.0"
 source = { editable = "packages/parsers" }
 dependencies = [
+    { name = "markdown-it-py" },
     { name = "omniscience-core" },
+    { name = "pydantic" },
+    { name = "python-frontmatter" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-go" },
+    { name = "tree-sitter-java" },
+    { name = "tree-sitter-javascript" },
+    { name = "tree-sitter-python" },
+    { name = "tree-sitter-rust" },
+    { name = "tree-sitter-typescript" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "omniscience-core", editable = "packages/core" }]
+requires-dist = [
+    { name = "markdown-it-py", specifier = ">=3.0.0" },
+    { name = "omniscience-core", editable = "packages/core" },
+    { name = "pydantic", specifier = ">=2.7.0" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
+    { name = "tree-sitter", specifier = ">=0.22.0" },
+    { name = "tree-sitter-go", specifier = ">=0.25.0" },
+    { name = "tree-sitter-java", specifier = ">=0.23.5" },
+    { name = "tree-sitter-javascript", specifier = ">=0.25.0" },
+    { name = "tree-sitter-python", specifier = ">=0.25.0" },
+    { name = "tree-sitter-rust", specifier = ">=0.24.2" },
+    { name = "tree-sitter-typescript", specifier = ">=0.23.2" },
+]
 
 [[package]]
 name = "omniscience-retrieval"
@@ -1690,6 +1735,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload-time = "2024-01-16T18:50:00.911Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
@@ -2000,6 +2057,129 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/05/727308adbbc79bcb1c92fc0ea10556a735f9d0f0a5435a18f59d40f7fd77/tree_sitter_go-0.25.0.tar.gz", hash = "sha256:a7466e9b8d94dda94cae8d91629f26edb2d26166fd454d4831c3bf6dfa2e8d68", size = 93890, upload-time = "2025-08-29T06:20:25.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/aa/0984707acc2b9bb461fe4a41e7e0fc5b2b1e245c32820f0c83b3c602957c/tree_sitter_go-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b852993063a3429a443e7bd0aa376dd7dd329d595819fabf56ac4cf9d7257b54", size = 47117, upload-time = "2025-08-29T06:20:14.286Z" },
+    { url = "https://files.pythonhosted.org/packages/32/16/dd4cb124b35e99239ab3624225da07d4cb8da4d8564ed81d03fcb3a6ba9f/tree_sitter_go-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:503b81a2b4c31e302869a1de3a352ad0912ccab3df9ac9950197b0a9ceeabd8f", size = 48674, upload-time = "2025-08-29T06:20:17.557Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fb/b30d63a08044115d8b8bd196c6c2ab4325fb8db5757249a4ef0563966e2e/tree_sitter_go-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04b3b3cb4aff18e74e28d49b716c6f24cb71ddfdd66768987e26e4d0fa812f74", size = 66418, upload-time = "2025-08-29T06:20:18.345Z" },
+    { url = "https://files.pythonhosted.org/packages/26/21/d3d88a30ad007419b2c97b3baeeef7431407faf9f686195b6f1cad0aedf9/tree_sitter_go-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:148255aca2f54b90d48c48a9dbb4c7faad6cad310a980b2c5a5a9822057ed145", size = 72006, upload-time = "2025-08-29T06:20:19.14Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d0/0dd6442353ced8a88bbda9e546f4ea29e381b59b5a40b122e5abb586bb6c/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4d338116cdf8a6c6ff990d2441929b41323ef17c710407abe0993c13417d6aad", size = 70603, upload-time = "2025-08-29T06:20:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e2/ee5e09f63504fc286539535d374d2eaa0e7d489b80f8f744bb3962aff22a/tree_sitter_go-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5608e089d2a29fa8d2b327abeb2ad1cdb8e223c440a6b0ceab0d3fa80bdeebae", size = 66088, upload-time = "2025-08-29T06:20:22.336Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b6/d9142583374720e79aca9ccb394b3795149a54c012e1dfd80738df2d984e/tree_sitter_go-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:30d4ada57a223dfc2c32d942f44d284d40f3d1215ddcf108f96807fd36d53022", size = 48152, upload-time = "2025-08-29T06:20:23.089Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/00/9a2638e7339236f5b01622952a4d71c1474dd3783d1982a89555fc1f03b1/tree_sitter_go-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:d5d62362059bf79997340773d47cc7e7e002883b527a05cca829c46e40b70ded", size = 46752, upload-time = "2025-08-29T06:20:24.235Z" },
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/dc/eb9c8f96304e5d8ae1663126d89967a622a80937ad2909903569ccb7ec8f/tree_sitter_java-0.23.5.tar.gz", hash = "sha256:f5cd57b8f1270a7f0438878750d02ccc79421d45cca65ff284f1527e9ef02e38", size = 138121, upload-time = "2024-12-21T18:24:26.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/21/b3399780b440e1567a11d384d0ebb1aea9b642d0d98becf30fa55c0e3a3b/tree_sitter_java-0.23.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:355ce0308672d6f7013ec913dee4a0613666f4cda9044a7824240d17f38209df", size = 58926, upload-time = "2024-12-21T18:24:12.53Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/6406b444e2a93bc72a04e802f4107e9ecf04b8de4a5528830726d210599c/tree_sitter_java-0.23.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:24acd59c4720dedad80d548fe4237e43ef2b7a4e94c8549b0ca6e4c4d7bf6e69", size = 62288, upload-time = "2024-12-21T18:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/6c/74b1c150d4f69c291ab0b78d5dd1b59712559bbe7e7daf6d8466d483463f/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9401e7271f0b333df39fc8a8336a0caf1b891d9a2b89ddee99fae66b794fc5b7", size = 85533, upload-time = "2024-12-21T18:24:16.695Z" },
+    { url = "https://files.pythonhosted.org/packages/29/09/e0d08f5c212062fd046db35c1015a2621c2631bc8b4aae5740d7adb276ad/tree_sitter_java-0.23.5-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:370b204b9500b847f6d0c5ad584045831cee69e9a3e4d878535d39e4a7e4c4f1", size = 84033, upload-time = "2024-12-21T18:24:18.758Z" },
+    { url = "https://files.pythonhosted.org/packages/43/56/7d06b23ddd09bde816a131aa504ee11a1bbe87c6b62ab9b2ed23849a3382/tree_sitter_java-0.23.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aae84449e330363b55b14a2af0585e4e0dae75eb64ea509b7e5b0e1de536846a", size = 82564, upload-time = "2024-12-21T18:24:20.493Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/0528c7e1e88a18221dbd8ccee3825bf274b1fa300f745fd74eb343878043/tree_sitter_java-0.23.5-cp39-abi3-win_amd64.whl", hash = "sha256:1ee45e790f8d31d416bc84a09dac2e2c6bc343e89b8a2e1d550513498eedfde7", size = 60650, upload-time = "2024-12-21T18:24:22.902Z" },
+    { url = "https://files.pythonhosted.org/packages/72/57/5bab54d23179350356515526fff3cc0f3ac23bfbc1a1d518a15978d4880e/tree_sitter_java-0.23.5-cp39-abi3-win_arm64.whl", hash = "sha256:402efe136104c5603b429dc26c7e75ae14faaca54cfd319ecc41c8f2534750f4", size = 59059, upload-time = "2024-12-21T18:24:24.934Z" },
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/e0/e63103c72a9d3dfd89a31e02e660263ad84b7438e5f44ee82e443e65bbde/tree_sitter_javascript-0.25.0.tar.gz", hash = "sha256:329b5414874f0588a98f1c291f1b28138286617aa907746ffe55adfdcf963f38", size = 132338, upload-time = "2025-09-01T07:13:44.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/df/5106ac250cd03661ebc3cc75da6b3d9f6800a3606393a0122eca58038104/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b70f887fb269d6e58c349d683f59fa647140c410cfe2bee44a883b20ec92e3dc", size = 64052, upload-time = "2025-09-01T07:13:36.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/8f/6b4b2bc90d8ab3955856ce852cc9d1e82c81d7ab9646385f0e75ffd5b5d3/tree_sitter_javascript-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8264a996b8845cfce06965152a013b5d9cbb7d199bc3503e12b5682e62bb1de1", size = 66440, upload-time = "2025-09-01T07:13:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c4/7da74ecdcd8a398f88bd003a87c65403b5fe0e958cdd43fbd5fd4a398fcf/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dc04ba91fc8583344e57c1f1ed5b2c97ecaaf47480011b92fbeab8dda96db75", size = 99728, upload-time = "2025-09-01T07:13:38.755Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c8/97da3af4796495e46421e9344738addb3602fa6426ea695be3fcbadbee37/tree_sitter_javascript-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:199d09985190852e0912da2b8d26c932159be314bc04952cf917ed0e4c633e6b", size = 106072, upload-time = "2025-09-01T07:13:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/13/be/c964e8130be08cc9bd6627d845f0e4460945b158429d39510953bbcb8fcc/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfcf789064c58dc13c0a4edb550acacfc6f0f280577f1e7a00de3e89fc7f8ddc", size = 104388, upload-time = "2025-09-01T07:13:40.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/89/9b773dee0f8961d1bb8d7baf0a204ab587618df19897c1ef260916f318ec/tree_sitter_javascript-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b852d3aee8a36186dbcc32c798b11b4869f9b5041743b63b65c2ef793db7a54", size = 98377, upload-time = "2025-09-01T07:13:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/d90cb1790f8cec9b4878d278ad9faf7c8f893189ce0f855304fd704fc274/tree_sitter_javascript-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:e5ed840f5bd4a3f0272e441d19429b26eedc257abe5574c8546da6b556865e3c", size = 62975, upload-time = "2025-09-01T07:13:42.828Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1f/f9eba1038b7d4394410f3c0a6ec2122b590cd7acb03f196e52fa57ebbe72/tree_sitter_javascript-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:622a69d677aa7f6ee2931d8c77c981a33f0ebb6d275aa9d43d3397c879a9bb0b", size = 61668, upload-time = "2025-09-01T07:13:43.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/8b/c992ff0e768cb6768d5c96234579bf8842b3a633db641455d86dd30d5dac/tree_sitter_python-0.25.0.tar.gz", hash = "sha256:b13e090f725f5b9c86aa455a268553c65cadf325471ad5b65cd29cac8a1a68ac", size = 159845, upload-time = "2025-09-11T06:47:58.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/64/a4e503c78a4eb3ac46d8e72a29c1b1237fa85238d8e972b063e0751f5a94/tree_sitter_python-0.25.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:14a79a47ddef72f987d5a2c122d148a812169d7484ff5c75a3db9609d419f361", size = 73790, upload-time = "2025-09-11T06:47:47.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/60d8c2a0cc63d6ec4ba4e99ce61b802d2e39ef9db799bdf2a8f932a6cd4b/tree_sitter_python-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:480c21dbd995b7fe44813e741d71fed10ba695e7caab627fb034e3828469d762", size = 76691, upload-time = "2025-09-11T06:47:49.038Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/d9b0b67d037922d60cbe0359e0c86457c2da721bc714381a63e2c8e35eba/tree_sitter_python-0.25.0-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:86f118e5eecad616ecdb81d171a36dde9bef5a0b21ed71ea9c3e390813c3baf5", size = 108133, upload-time = "2025-09-11T06:47:50.499Z" },
+    { url = "https://files.pythonhosted.org/packages/40/bd/bf4787f57e6b2860f3f1c8c62f045b39fb32d6bac4b53d7a9e66de968440/tree_sitter_python-0.25.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be71650ca2b93b6e9649e5d65c6811aad87a7614c8c1003246b303f6b150f61b", size = 110603, upload-time = "2025-09-11T06:47:51.985Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/25/feff09f5c2f32484fbce15db8b49455c7572346ce61a699a41972dea7318/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e6d5b5799628cc0f24691ab2a172a8e676f668fe90dc60468bee14084a35c16d", size = 108998, upload-time = "2025-09-11T06:47:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/4946da3d6c0df316ccb938316ce007fb565d08f89d02d854f2d308f0309f/tree_sitter_python-0.25.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71959832fc5d9642e52c11f2f7d79ae520b461e63334927e93ca46cd61cd9683", size = 107268, upload-time = "2025-09-11T06:47:54.388Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a2/996fc2dfa1076dc460d3e2f3c75974ea4b8f02f6bc925383aaae519920e8/tree_sitter_python-0.25.0-cp310-abi3-win_amd64.whl", hash = "sha256:9bcde33f18792de54ee579b00e1b4fe186b7926825444766f849bf7181793a76", size = 76073, upload-time = "2025-09-11T06:47:55.773Z" },
+    { url = "https://files.pythonhosted.org/packages/07/19/4b5569d9b1ebebb5907d11554a96ef3fa09364a30fcfabeff587495b512f/tree_sitter_python-0.25.0-cp310-abi3-win_arm64.whl", hash = "sha256:0fbf6a3774ad7e89ee891851204c2e2c47e12b63a5edbe2e9156997731c128bb", size = 74169, upload-time = "2025-09-11T06:47:56.747Z" },
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/87/75cbd22b927267d310f76cca1ab3c1d9d41035dfa3eb9cc95f96ee199440/tree_sitter_rust-0.24.2.tar.gz", hash = "sha256:54fb02a5911e345308b405174465112479f56dc39e3f1e7744d7568595f00db9", size = 339341, upload-time = "2026-03-27T21:08:55.629Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/24/2b2d33af5e27c84a4fde4e8cd2594bb4ab1e1cf48756a9f40dadc84956cc/tree_sitter_rust-0.24.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3620cfd12340efa43082d45df76349ff511893a9c361da2f8d6d51e307020a59", size = 129507, upload-time = "2026-03-27T21:08:47.585Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2a/cf39f881a545360b5a86bb1accba1f4acc713daab01fb9edd35b6e84f473/tree_sitter_rust-0.24.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:01a46622735498493f29f3e628a90de95c96a07bfbeb88996243eb986b1cee36", size = 136812, upload-time = "2026-03-27T21:08:48.761Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/45/a051bbd3045a61182dde25b93ae9a33d2677c935b16952283e12eaf46051/tree_sitter_rust-0.24.2-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e033c5a93b57c88e0a835880de39fc802909ff69f57aaff6000211c196ea5190", size = 164706, upload-time = "2026-03-27T21:08:49.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f6/a5a146df5c0a5daea3ffcd5d7245775fe7f084357770d5a313dd6245ae78/tree_sitter_rust-0.24.2-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d76d1208c3638b871236090759dfc13d478921320653a6c9da5336e7c58f65a", size = 170310, upload-time = "2026-03-27T21:08:50.424Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a8/f85b1ca75e01361ca5f92d226593ca4857cea49551b9f6c8fa6fc08ea917/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87930163a462408c49ab62c667e74029bc26b4cc7123dd1bdc7352215786c64a", size = 168668, upload-time = "2026-03-27T21:08:51.404Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/e1/3519f866a4679ca36acd9f5a06a779ecb8a92b18887c5546458d521df557/tree_sitter_rust-0.24.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:da2b86099028fd42c6cd32878b7b16b01f8aac0f7b0e98742b7fa6bc3cf09b89", size = 162403, upload-time = "2026-03-27T21:08:52.588Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/7ef609894dbfe5699eb16f7471f9b8af1d958d8ba3e29c238d7607e8cb47/tree_sitter_rust-0.24.2-cp39-abi3-win_amd64.whl", hash = "sha256:4529c125d928882ddfb879fdc6bc0704913261ecc078b6fa7902559e0daf200d", size = 129422, upload-time = "2026-03-27T21:08:54.031Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d8/050a781172745bc345f98abb7c56e72022ea0790f8e793de981c83c2ef15/tree_sitter_rust-0.24.2-cp39-abi3-win_arm64.whl", hash = "sha256:66ba90f61bd54f4c4f5d30434957daf64507c16b0313df76becb37d63f70a227", size = 128245, upload-time = "2026-03-27T21:08:54.803Z" },
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/fc/bb52958f7e399250aee093751e9373a6311cadbe76b6e0d109b853757f35/tree_sitter_typescript-0.23.2.tar.gz", hash = "sha256:7b167b5827c882261cb7a50dfa0fb567975f9b315e87ed87ad0a0a3aedb3834d", size = 773053, upload-time = "2024-11-11T02:36:11.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/95/4c00680866280e008e81dd621fd4d3f54aa3dad1b76b857a19da1b2cc426/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:3cd752d70d8e5371fdac6a9a4df9d8924b63b6998d268586f7d374c9fba2a478", size = 286677, upload-time = "2024-11-11T02:35:58.839Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/1f36fda564518d84593f2740d5905ac127d590baf5c5753cef2a88a89c15/tree_sitter_typescript-0.23.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:c7cc1b0ff5d91bac863b0e38b1578d5505e718156c9db577c8baea2557f66de8", size = 302008, upload-time = "2024-11-11T02:36:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2d/975c2dad292aa9994f982eb0b69cc6fda0223e4b6c4ea714550477d8ec3a/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b1eed5b0b3a8134e86126b00b743d667ec27c63fc9de1b7bb23168803879e31", size = 351987, upload-time = "2024-11-11T02:36:02.669Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d1/a71c36da6e2b8a4ed5e2970819b86ef13ba77ac40d9e333cb17df6a2c5db/tree_sitter_typescript-0.23.2-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e96d36b85bcacdeb8ff5c2618d75593ef12ebaf1b4eace3477e2bdb2abb1752c", size = 344960, upload-time = "2024-11-11T02:36:04.443Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/cb/f57b149d7beed1a85b8266d0c60ebe4c46e79c9ba56bc17b898e17daf88e/tree_sitter_typescript-0.23.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8d4f0f9bcb61ad7b7509d49a1565ff2cc363863644a234e1e0fe10960e55aea0", size = 340245, upload-time = "2024-11-11T02:36:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ab/dd84f0e2337296a5f09749f7b5483215d75c8fa9e33738522e5ed81f7254/tree_sitter_typescript-0.23.2-cp39-abi3-win_amd64.whl", hash = "sha256:3f730b66396bc3e11811e4465c41ee45d9e9edd6de355a58bbbc49fa770da8f9", size = 278015, upload-time = "2024-11-11T02:36:07.631Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e4/81f9a935789233cf412a0ed5fe04c883841d2c8fb0b7e075958a35c65032/tree_sitter_typescript-0.23.2-cp39-abi3-win_arm64.whl", hash = "sha256:05db58f70b95ef0ea126db5560f3775692f609589ed6f8dd0af84b7f19f1cbb7", size = 274052, upload-time = "2024-11-11T02:36:09.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Combined implementation of Issues #7, #8, and #9 in packages/parsers/.

### Issue #7 — Parser Framework + Markdown
- `Parser` protocol with `can_handle()` + `parse()` 
- `ParsedDocument` with sections, heading paths, metadata
- `MarkdownParser`: heading hierarchy, frontmatter extraction, code fence language hints
- `PlainTextParser`: fallback single-section parser
- `ParserDispatch`: route by content_type + extension with auto-fallback

### Issue #8 — Tree-sitter Code Parser
- `TreeSitterParser` for Python, TypeScript, JavaScript, Go, Rust, Java
- Language detection by file extension
- Symbol extraction: functions, classes, methods with FQN
- Uses individual `tree-sitter-{lang}` packages (not `tree-sitter-languages` — no 3.14 wheel)
- Graceful degradation: syntax errors → partial results, never crash

### Issue #9 — Chunking Strategies
- `CodeSymbolChunker`: one chunk per function/class, splits oversized symbols
- `MarkdownSectionChunker`: section chunks with parent heading context
- `FixedWindowChunker`: sliding window with configurable overlap
- Token budget enforcement, sequential ord, metadata on every chunk

## Test plan

- [ ] 97 new tests (30 parser + 34 tree-sitter + 33 chunking), 365 total pass
- [ ] `mypy --strict` clean
- [ ] `ruff` clean

Closes #7, closes #8, closes #9