### PR TITLE
feat: hybrid retrieval service with vector + BM25 + RRF merge

### DIFF
--- a/packages/retrieval/pyproject.toml
+++ b/packages/retrieval/pyproject.toml
@@ -5,10 +5,15 @@ description = "Hybrid retrieval service (vector + BM25 + RRF) for Omniscience"
 requires-python = ">=3.12"
 dependencies = [
     "omniscience-core",
+    "omniscience-embeddings",
+    "sqlalchemy[asyncio]>=2.0.30",
+    "asyncpg>=0.29.0",
+    "pgvector>=0.3.0",
 ]
 
 [tool.uv.sources]
 omniscience-core = { workspace = true }
+omniscience-embeddings = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/retrieval/src/omniscience_retrieval/__init__.py
+++ b/packages/retrieval/src/omniscience_retrieval/__init__.py
@@ -1,6 +1,28 @@
-"""Retrieval service — placeholder for Wave 2.
+"""Hybrid retrieval service (vector + BM25 + RRF) for Omniscience.
 
-Will implement staged hybrid retrieval: pgvector HNSW top-K, tsvector BM25,
+Implements staged hybrid retrieval: pgvector HNSW top-K, tsvector BM25,
 reciprocal rank fusion, ACL filter, and freshness filter.
 See docs/decisions/0004-retrieval-strategy-staged.md for the full design.
 """
+
+from .models import (
+    ChunkLineage,
+    Citation,
+    QueryStats,
+    SearchHit,
+    SearchRequest,
+    SearchResult,
+    SourceInfo,
+)
+from .search import RetrievalService
+
+__all__ = [
+    "ChunkLineage",
+    "Citation",
+    "QueryStats",
+    "RetrievalService",
+    "SearchHit",
+    "SearchRequest",
+    "SearchResult",
+    "SourceInfo",
+]

--- a/packages/retrieval/src/omniscience_retrieval/filters.py
+++ b/packages/retrieval/src/omniscience_retrieval/filters.py
@@ -1,0 +1,84 @@
+"""SQLAlchemy WHERE-clause builders for SearchRequest filters."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from omniscience_core.db.models import Chunk, Document, Source
+from sqlalchemy import ColumnElement, and_, or_
+from sqlalchemy.dialects.postgresql import JSONB
+
+from .models import SearchRequest
+
+
+def build_source_name_filter(sources: list[str]) -> ColumnElement[bool]:
+    """Return a clause restricting results to named sources."""
+    return or_(*[Source.name == name for name in sources])
+
+
+def build_source_type_filter(types: list[str]) -> ColumnElement[bool]:
+    """Return a clause restricting results to given source types."""
+    return or_(*[Source.type == t for t in types])
+
+
+def build_freshness_filter(max_age_seconds: int) -> ColumnElement[bool]:
+    """Return a clause keeping only chunks indexed within max_age_seconds."""
+    cutoff = datetime.now(tz=UTC) - timedelta(seconds=max_age_seconds)
+    return Document.indexed_at >= cutoff
+
+
+def build_tombstone_filter(include_tombstoned: bool) -> ColumnElement[bool] | None:
+    """Return a clause excluding tombstoned documents unless requested."""
+    if include_tombstoned:
+        return None
+    return Document.tombstoned_at.is_(None)
+
+
+def build_metadata_filter(filters: dict[str, object]) -> ColumnElement[bool]:
+    """Return a JSONB containment clause for metadata key/value filters."""
+    return Chunk.chunk_metadata.cast(JSONB).contains(filters)  # type: ignore[no-any-return]
+
+
+def build_where_clauses(request: SearchRequest) -> list[ColumnElement[bool]]:
+    """Assemble all applicable WHERE clauses from a SearchRequest.
+
+    The caller is responsible for joining Source and Document before applying
+    these clauses.
+    """
+    clauses: list[ColumnElement[bool]] = []
+
+    if request.sources:
+        clauses.append(build_source_name_filter(request.sources))
+
+    if request.types:
+        clauses.append(build_source_type_filter(request.types))
+
+    if request.max_age_seconds is not None:
+        clauses.append(build_freshness_filter(request.max_age_seconds))
+
+    tombstone_clause = build_tombstone_filter(request.include_tombstoned)
+    if tombstone_clause is not None:
+        clauses.append(tombstone_clause)
+
+    if request.filters:
+        clauses.append(build_metadata_filter(request.filters))
+
+    return clauses
+
+
+def combine_clauses(clauses: list[ColumnElement[bool]]) -> ColumnElement[bool] | None:
+    """AND all clauses together, or return None if the list is empty."""
+    if not clauses:
+        return None
+    return and_(*clauses)
+
+
+__all__ = [
+    "build_freshness_filter",
+    "build_metadata_filter",
+    "build_source_name_filter",
+    "build_source_type_filter",
+    "build_tombstone_filter",
+    "build_where_clauses",
+    "combine_clauses",
+]

--- a/packages/retrieval/src/omniscience_retrieval/models.py
+++ b/packages/retrieval/src/omniscience_retrieval/models.py
@@ -1,0 +1,78 @@
+"""Request / response models for the retrieval service."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class SearchRequest(BaseModel):
+    """Parameters for a hybrid search query."""
+
+    query: str
+    top_k: int = Field(default=10, ge=1, le=500)
+    sources: list[str] | None = None
+    types: list[str] | None = None
+    max_age_seconds: int | None = Field(default=None, ge=1)
+    filters: dict[str, Any] | None = None
+    include_tombstoned: bool = False
+    retrieval_strategy: Literal["hybrid", "keyword", "structural", "auto"] = "hybrid"
+
+
+class Citation(BaseModel):
+    """Provenance information for a retrieved chunk."""
+
+    uri: str
+    title: str | None
+    indexed_at: datetime
+    doc_version: int
+
+
+class ChunkLineage(BaseModel):
+    """Ingestion lineage metadata for a retrieved chunk."""
+
+    ingestion_run_id: uuid.UUID | None
+    embedding_model: str
+    embedding_provider: str
+    parser_version: str
+    chunker_strategy: str
+
+
+class SourceInfo(BaseModel):
+    """Minimal source descriptor embedded in each hit."""
+
+    id: uuid.UUID
+    name: str
+    type: str
+
+
+class SearchHit(BaseModel):
+    """A single result returned by the retrieval service."""
+
+    chunk_id: uuid.UUID
+    document_id: uuid.UUID
+    score: float
+    text: str
+    source: SourceInfo
+    citation: Citation
+    lineage: ChunkLineage
+    metadata: dict[str, Any]
+
+
+class QueryStats(BaseModel):
+    """Diagnostic counters for a completed search query."""
+
+    total_matches_before_filters: int
+    vector_matches: int
+    text_matches: int
+    duration_ms: float
+
+
+class SearchResult(BaseModel):
+    """Top-level response returned by RetrievalService.search()."""
+
+    hits: list[SearchHit]
+    query_stats: QueryStats

--- a/packages/retrieval/src/omniscience_retrieval/ranking.py
+++ b/packages/retrieval/src/omniscience_retrieval/ranking.py
@@ -1,0 +1,31 @@
+"""Reciprocal Rank Fusion for merging multiple ranked result lists."""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+
+
+def reciprocal_rank_fusion(
+    ranked_lists: list[list[tuple[uuid.UUID, float]]],
+    k: int = 60,
+) -> list[tuple[uuid.UUID, float]]:
+    """Merge multiple ranked lists using Reciprocal Rank Fusion.
+
+    Each element in a ranked list is a (chunk_id, original_score) tuple.
+    The original score is unused by RRF itself; only rank position matters.
+    Returns a list of (chunk_id, rrf_score) sorted descending by rrf_score.
+
+    Args:
+        ranked_lists: One list per retrieval method.  Each inner list must be
+            ordered best-first.  Items are (chunk_id, raw_score) pairs.
+        k: Smoothing constant (default 60, as per original RRF paper).
+
+    Returns:
+        Merged list of (chunk_id, rrf_score) sorted descending.
+    """
+    scores: dict[uuid.UUID, float] = defaultdict(float)
+    for ranked in ranked_lists:
+        for rank, (chunk_id, _raw_score) in enumerate(ranked, start=1):
+            scores[chunk_id] += 1.0 / (k + rank)
+    return sorted(scores.items(), key=lambda item: item[1], reverse=True)

--- a/packages/retrieval/src/omniscience_retrieval/search.py
+++ b/packages/retrieval/src/omniscience_retrieval/search.py
@@ -1,0 +1,195 @@
+"""Hybrid retrieval service: vector + BM25 + RRF merge."""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any, cast
+
+from omniscience_core.db.models import Chunk, Document, Source
+from omniscience_embeddings.base import EmbeddingProvider
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .filters import build_where_clauses, combine_clauses
+from .models import (
+    ChunkLineage,
+    Citation,
+    QueryStats,
+    SearchHit,
+    SearchRequest,
+    SearchResult,
+    SourceInfo,
+)
+from .ranking import reciprocal_rank_fusion
+
+logger = logging.getLogger(__name__)
+
+_NON_HYBRID_STRATEGIES = frozenset({"keyword", "structural", "auto"})
+
+
+class RetrievalService:
+    """Executes hybrid search queries against the Omniscience index.
+
+    Combines pgvector HNSW cosine-nearest-neighbour search with PostgreSQL
+    full-text (tsvector/BM25) search, merges the two result lists using
+    Reciprocal Rank Fusion, applies post-retrieval filters, and returns
+    richly annotated SearchHit objects.
+    """
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        embedding_provider: EmbeddingProvider,
+    ) -> None:
+        self._session_factory = session_factory
+        self._embedding_provider = embedding_provider
+
+    async def search(self, request: SearchRequest) -> SearchResult:
+        """Execute hybrid search and return top-k ranked results."""
+        if request.retrieval_strategy in _NON_HYBRID_STRATEGIES:
+            logger.warning(
+                "retrieval_strategy=%r is not yet implemented; falling back to 'hybrid'",
+                request.retrieval_strategy,
+            )
+
+        start = time.monotonic()
+        query_vector = await self._embed_query(request.query)
+
+        async with self._session_factory() as session:
+            oversample = request.top_k * 2
+
+            vector_rows = await self._vector_search(session, query_vector, oversample)
+            text_rows = await self._text_search(session, request.query, oversample)
+
+            vector_matches = len(vector_rows)
+            text_matches = len(text_rows)
+            total_before = len({r[0] for r in vector_rows} | {r[0] for r in text_rows})
+
+            merged = reciprocal_rank_fusion([vector_rows, text_rows])
+
+            chunk_ids = [cid for cid, _ in merged]
+            scores = {cid: score for cid, score in merged}
+
+            rows = await self._fetch_enriched(session, request, chunk_ids)
+
+        hits = self._build_hits(rows, scores, request.top_k)
+        duration_ms = (time.monotonic() - start) * 1000.0
+
+        return SearchResult(
+            hits=hits,
+            query_stats=QueryStats(
+                total_matches_before_filters=total_before,
+                vector_matches=vector_matches,
+                text_matches=text_matches,
+                duration_ms=duration_ms,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _embed_query(self, query: str) -> list[float]:
+        vectors = await self._embedding_provider.embed([query])
+        return vectors[0]
+
+    async def _vector_search(
+        self,
+        session: AsyncSession,
+        query_vector: list[float],
+        limit: int,
+    ) -> list[tuple[uuid.UUID, float]]:
+        stmt = (
+            select(Chunk.id, Chunk.embedding.cosine_distance(query_vector).label("dist"))
+            .where(Chunk.embedding.is_not(None))
+            .order_by(text("dist"))
+            .limit(limit)
+        )
+        result = await session.execute(stmt)
+        rows = result.all()
+        # Convert distance to similarity: similarity = 1 - distance
+        return [(row.id, 1.0 - float(row.dist)) for row in rows]
+
+    async def _text_search(
+        self,
+        session: AsyncSession,
+        query: str,
+        limit: int,
+    ) -> list[tuple[uuid.UUID, float]]:
+        tsquery = func.plainto_tsquery("english", query)
+        rank_expr = func.ts_rank_cd(Chunk.text_tsv, tsquery).label("rank")
+        stmt = (
+            select(Chunk.id, rank_expr)
+            .where(Chunk.text_tsv.op("@@")(tsquery))
+            .order_by(rank_expr.desc())
+            .limit(limit)
+        )
+        result = await session.execute(stmt)
+        rows = result.all()
+        return [(row.id, float(row.rank)) for row in rows]
+
+    async def _fetch_enriched(
+        self,
+        session: AsyncSession,
+        request: SearchRequest,
+        chunk_ids: list[uuid.UUID],
+    ) -> list[Any]:
+        """Fetch full chunk+document+source rows for the given chunk IDs."""
+        if not chunk_ids:
+            return []
+
+        where_clauses = build_where_clauses(request)
+        combined = combine_clauses(where_clauses)
+
+        stmt = (
+            select(Chunk, Document, Source)
+            .join(Document, Chunk.document_id == Document.id)
+            .join(Source, Document.source_id == Source.id)
+            .where(Chunk.id.in_(chunk_ids))
+        )
+        if combined is not None:
+            stmt = stmt.where(combined)
+
+        result = await session.execute(stmt)
+        return cast(list[Any], result.all())
+
+    def _build_hits(
+        self,
+        rows: list[Any],
+        scores: dict[uuid.UUID, float],
+        top_k: int,
+    ) -> list[SearchHit]:
+        """Convert enriched DB rows to SearchHit objects, sorted by RRF score."""
+        hits: list[SearchHit] = []
+        for chunk, doc, source in rows:
+            hit = SearchHit(
+                chunk_id=chunk.id,
+                document_id=doc.id,
+                score=scores.get(chunk.id, 0.0),
+                text=chunk.text,
+                source=SourceInfo(
+                    id=source.id,
+                    name=source.name,
+                    type=str(source.type),
+                ),
+                citation=Citation(
+                    uri=doc.uri,
+                    title=doc.title,
+                    indexed_at=doc.indexed_at,
+                    doc_version=doc.doc_version,
+                ),
+                lineage=ChunkLineage(
+                    ingestion_run_id=chunk.ingestion_run_id,
+                    embedding_model=chunk.embedding_model,
+                    embedding_provider=chunk.embedding_provider,
+                    parser_version=chunk.parser_version,
+                    chunker_strategy=chunk.chunker_strategy,
+                ),
+                metadata=chunk.chunk_metadata,
+            )
+            hits.append(hit)
+
+        hits.sort(key=lambda h: h.score, reverse=True)
+        return hits[:top_k]

--- a/packages/retrieval/src/omniscience_retrieval/search.py
+++ b/packages/retrieval/src/omniscience_retrieval/search.py
@@ -153,7 +153,7 @@ class RetrievalService:
             stmt = stmt.where(combined)
 
         result = await session.execute(stmt)
-        return cast(list[Any], result.all())
+        return cast("list[Any]", result.all())
 
     def _build_hits(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "tenacity>=9.1.4",
     "respx>=0.23.1",
     "omniscience-parsers",
+    "omniscience-retrieval",
 ]
 
 [tool.ruff]

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,580 @@
+"""Tests for the omniscience_retrieval package.
+
+Covers:
+- Hybrid search combining vector and BM25 results
+- RRF merge produces correct scores
+- Source name filter applied
+- Source type filter applied
+- max_age_seconds filter
+- Tombstone filter (default excludes, include_tombstoned includes)
+- Metadata filter
+- Empty results
+- query_stats populated correctly
+- Unsupported retrieval_strategy logs warning and falls back to hybrid
+- Citation includes all required fields
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_retrieval import (
+    RetrievalService,
+    SearchRequest,
+    SearchResult,
+)
+from omniscience_retrieval.ranking import reciprocal_rank_fusion
+
+# ---------------------------------------------------------------------------
+# Helpers / factories
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
+_EMBED_DIM = 768
+
+
+def _make_chunk(
+    chunk_id: uuid.UUID | None = None,
+    doc_id: uuid.UUID | None = None,
+    run_id: uuid.UUID | None = None,
+    text: str = "sample chunk text",
+    metadata: dict[str, Any] | None = None,
+) -> MagicMock:
+    c = MagicMock()
+    c.id = chunk_id or uuid.uuid4()
+    c.document_id = doc_id or uuid.uuid4()
+    c.text = text
+    c.ingestion_run_id = run_id
+    c.embedding_model = "text-embedding-004"
+    c.embedding_provider = "google-ai"
+    c.parser_version = "treesitter-python-0.21+oms-0.4.2"
+    c.chunker_strategy = "code_symbol"
+    c.chunk_metadata = metadata or {"language": "python"}
+    return c
+
+
+def _make_document(
+    doc_id: uuid.UUID | None = None,
+    source_id: uuid.UUID | None = None,
+    uri: str = "https://github.com/org/repo/blob/main/auth.py",
+    title: str | None = "auth.py",
+    tombstoned_at: datetime | None = None,
+) -> MagicMock:
+    d = MagicMock()
+    d.id = doc_id or uuid.uuid4()
+    d.source_id = source_id or uuid.uuid4()
+    d.uri = uri
+    d.title = title
+    d.indexed_at = _NOW
+    d.tombstoned_at = tombstoned_at
+    d.doc_version = 7
+    return d
+
+
+def _make_source(
+    source_id: uuid.UUID | None = None,
+    name: str = "main-gitlab",
+    stype: str = "git",
+) -> MagicMock:
+    s = MagicMock()
+    s.id = source_id or uuid.uuid4()
+    s.name = name
+    s.type = stype
+    return s
+
+
+def _make_embedding_provider(dim: int = _EMBED_DIM) -> AsyncMock:
+    provider = AsyncMock()
+    provider.dim = dim
+    provider.model_name = "text-embedding-004"
+    provider.provider_name = "google-ai"
+    provider.embed = AsyncMock(return_value=[[0.1] * dim])
+    return provider
+
+
+def _make_db_row(
+    chunk: MagicMock | None = None,
+    document: MagicMock | None = None,
+    source: MagicMock | None = None,
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    return (
+        chunk or _make_chunk(),
+        document or _make_document(),
+        source or _make_source(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session + service factory
+# ---------------------------------------------------------------------------
+
+
+def _make_session(
+    vector_rows: list[tuple[uuid.UUID, float]] | None = None,
+    text_rows: list[tuple[uuid.UUID, float]] | None = None,
+    enriched_rows: list[tuple[Any, Any, Any]] | None = None,
+) -> MagicMock:
+    """Return a mock async context-managed session wired to return test data."""
+    session = AsyncMock()
+
+    # Build fake execute results per call order
+    call_results: list[MagicMock] = []
+
+    # First execute -> vector search result
+    vec_result = MagicMock()
+    vec_rows_mock = []
+    for cid, score in vector_rows or []:
+        row = MagicMock()
+        row.id = cid
+        row.dist = 1.0 - score  # cosine distance = 1 - similarity
+        vec_rows_mock.append(row)
+    vec_result.all.return_value = vec_rows_mock
+    call_results.append(vec_result)
+
+    # Second execute -> text search result
+    txt_result = MagicMock()
+    txt_rows_mock = []
+    for cid, score in text_rows or []:
+        row = MagicMock()
+        row.id = cid
+        row.rank = score
+        txt_rows_mock.append(row)
+    txt_result.all.return_value = txt_rows_mock
+    call_results.append(txt_result)
+
+    # Third execute -> enriched fetch
+    enriched_result = MagicMock()
+    enriched_result.all.return_value = enriched_rows or []
+    call_results.append(enriched_result)
+
+    session.execute = AsyncMock(side_effect=call_results)
+    return session
+
+
+def _make_service(
+    vector_rows: list[tuple[uuid.UUID, float]] | None = None,
+    text_rows: list[tuple[uuid.UUID, float]] | None = None,
+    enriched_rows: list[tuple[Any, Any, Any]] | None = None,
+) -> tuple[RetrievalService, MagicMock]:
+    """Return (RetrievalService, session_mock) pair ready for testing."""
+    session = _make_session(vector_rows, text_rows, enriched_rows)
+
+    # async_sessionmaker context-manager protocol
+    session_factory = MagicMock()
+    session_factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    provider = _make_embedding_provider()
+    service = RetrievalService(session_factory=session_factory, embedding_provider=provider)
+    return service, session
+
+
+# ---------------------------------------------------------------------------
+# RRF unit tests (pure function — no DB)
+# ---------------------------------------------------------------------------
+
+
+class TestReciprocalRankFusion:
+    def test_single_list_scores_correctly(self) -> None:
+        """Score for rank 1 in a single list = 1/(60+1) ≈ 0.01639."""
+        ids = [uuid.uuid4(), uuid.uuid4()]
+        result = reciprocal_rank_fusion([([(ids[0], 0.9), (ids[1], 0.5)])])
+        assert result[0][0] == ids[0]
+        assert result[0][1] == pytest.approx(1 / 61)
+        assert result[1][1] == pytest.approx(1 / 62)
+
+    def test_two_lists_same_item_gets_boosted(self) -> None:
+        """An item appearing in both lists accumulates score from each."""
+        shared = uuid.uuid4()
+        only_vec = uuid.uuid4()
+        only_txt = uuid.uuid4()
+
+        vec_list = [(shared, 0.9), (only_vec, 0.7)]
+        txt_list = [(shared, 0.8), (only_txt, 0.6)]
+
+        result = reciprocal_rank_fusion([vec_list, txt_list])
+        by_id = {cid: score for cid, score in result}
+
+        # shared appears rank-1 in both → 1/61 + 1/61
+        assert by_id[shared] == pytest.approx(2 / 61)
+        assert by_id[only_vec] == pytest.approx(1 / 62)
+        assert by_id[only_txt] == pytest.approx(1 / 62)
+
+    def test_output_sorted_descending(self) -> None:
+        ids = [uuid.uuid4() for _ in range(5)]
+        ranked = [(i, float(idx)) for idx, i in enumerate(ids)]
+        result = reciprocal_rank_fusion([ranked])
+        scores = [s for _, s in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_empty_lists(self) -> None:
+        assert reciprocal_rank_fusion([[], []]) == []
+
+    def test_custom_k(self) -> None:
+        cid = uuid.uuid4()
+        result = reciprocal_rank_fusion([[(cid, 1.0)]], k=10)
+        assert result[0][1] == pytest.approx(1 / 11)
+
+    def test_disjoint_lists_equal_ranks(self) -> None:
+        """Two items each ranked #1 in their own list should have equal scores."""
+        a, b = uuid.uuid4(), uuid.uuid4()
+        result = reciprocal_rank_fusion([[(a, 0.9)], [(b, 0.9)]])
+        by_id = dict(result)
+        assert by_id[a] == pytest.approx(by_id[b])
+
+
+# ---------------------------------------------------------------------------
+# RetrievalService integration tests (mocked DB)
+# ---------------------------------------------------------------------------
+
+
+class TestRetrievalServiceHybrid:
+    @pytest.mark.asyncio
+    async def test_hybrid_combines_vector_and_bm25(self) -> None:
+        """Hits from both vector and text search appear in the result."""
+        vec_id = uuid.uuid4()
+        txt_id = uuid.uuid4()
+        shared_id = uuid.uuid4()
+
+        vec_rows = [(shared_id, 0.95), (vec_id, 0.8)]
+        txt_rows = [(shared_id, 1.2), (txt_id, 0.9)]
+
+        chunk_v = _make_chunk(chunk_id=vec_id)
+        chunk_t = _make_chunk(chunk_id=txt_id)
+        chunk_s = _make_chunk(chunk_id=shared_id)
+        doc = _make_document()
+        src = _make_source()
+
+        enriched = [
+            (chunk_s, doc, src),
+            (chunk_v, doc, src),
+            (chunk_t, doc, src),
+        ]
+
+        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        result = await service.search(SearchRequest(query="auth", top_k=10))
+
+        chunk_ids = {h.chunk_id for h in result.hits}
+        assert shared_id in chunk_ids
+        assert vec_id in chunk_ids
+        assert txt_id in chunk_ids
+
+    @pytest.mark.asyncio
+    async def test_top_k_limits_hits(self) -> None:
+        ids = [uuid.uuid4() for _ in range(5)]
+        vec_rows = [(i, 0.9 - idx * 0.05) for idx, i in enumerate(ids)]
+        doc = _make_document()
+        src = _make_source()
+        enriched = [(_make_chunk(chunk_id=i), doc, src) for i in ids]
+
+        service, _ = _make_service(vector_rows=vec_rows, enriched_rows=enriched)
+        result = await service.search(SearchRequest(query="test", top_k=3))
+
+        assert len(result.hits) <= 3
+
+    @pytest.mark.asyncio
+    async def test_hits_sorted_by_score_descending(self) -> None:
+        ids = [uuid.uuid4() for _ in range(3)]
+        vec_rows = [(ids[0], 0.9), (ids[1], 0.7), (ids[2], 0.5)]
+        txt_rows = [(ids[2], 1.0)]  # ids[2] appears in text → gets boosted
+
+        doc = _make_document()
+        src = _make_source()
+        enriched = [(_make_chunk(chunk_id=i), doc, src) for i in ids]
+
+        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        result = await service.search(SearchRequest(query="x", top_k=10))
+
+        scores = [h.score for h in result.hits]
+        assert scores == sorted(scores, reverse=True)
+
+
+class TestRetrievalServiceStats:
+    @pytest.mark.asyncio
+    async def test_query_stats_counts_are_populated(self) -> None:
+        ids = [uuid.uuid4(), uuid.uuid4()]
+        vec_rows = [(ids[0], 0.9)]
+        txt_rows = [(ids[1], 0.8)]
+        doc = _make_document()
+        src = _make_source()
+        enriched = [(_make_chunk(chunk_id=ids[0]), doc, src)]
+
+        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        result = await service.search(SearchRequest(query="test"))
+
+        stats = result.query_stats
+        assert stats.vector_matches == 1
+        assert stats.text_matches == 1
+        assert stats.total_matches_before_filters == 2  # two distinct IDs
+        assert stats.duration_ms >= 0.0
+
+    @pytest.mark.asyncio
+    async def test_query_stats_overlap_counted_once(self) -> None:
+        """When the same chunk appears in both lists, total_before should not double-count."""
+        cid = uuid.uuid4()
+        vec_rows = [(cid, 0.9)]
+        txt_rows = [(cid, 0.8)]
+        doc = _make_document()
+        src = _make_source()
+        enriched = [(_make_chunk(chunk_id=cid), doc, src)]
+
+        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        result = await service.search(SearchRequest(query="dupe"))
+
+        assert result.query_stats.total_matches_before_filters == 1
+
+
+class TestRetrievalServiceEmptyResults:
+    @pytest.mark.asyncio
+    async def test_empty_vector_and_text_returns_no_hits(self) -> None:
+        service, _ = _make_service(vector_rows=[], text_rows=[], enriched_rows=[])
+        result = await service.search(SearchRequest(query="nothing matches"))
+
+        assert result.hits == []
+        assert result.query_stats.vector_matches == 0
+        assert result.query_stats.text_matches == 0
+        assert result.query_stats.total_matches_before_filters == 0
+
+    @pytest.mark.asyncio
+    async def test_enriched_empty_returns_no_hits(self) -> None:
+        """Chunks found by search but filtered out at DB join level → empty hits."""
+        cid = uuid.uuid4()
+        service, _ = _make_service(
+            vector_rows=[(cid, 0.9)],
+            text_rows=[],
+            enriched_rows=[],
+        )
+        result = await service.search(SearchRequest(query="filtered out"))
+        assert result.hits == []
+
+
+class TestRetrievalServiceFilters:
+    @pytest.mark.asyncio
+    async def test_source_name_filter_passed_to_where_clauses(self) -> None:
+        """Verify that source name filter is built without raising and that
+        execute is called with a statement containing a WHERE."""
+        cid = uuid.uuid4()
+        service, session = _make_service(
+            vector_rows=[(cid, 0.9)],
+            enriched_rows=[(_make_chunk(chunk_id=cid), _make_document(), _make_source())],
+        )
+        req = SearchRequest(query="auth", sources=["main-gitlab"])
+        result = await service.search(req)
+        # Third execute (enriched fetch) must have been called
+        assert session.execute.call_count == 3
+        assert isinstance(result, SearchResult)
+
+    @pytest.mark.asyncio
+    async def test_source_type_filter_passed_to_where_clauses(self) -> None:
+        cid = uuid.uuid4()
+        service, session = _make_service(
+            vector_rows=[(cid, 0.9)],
+            enriched_rows=[(_make_chunk(chunk_id=cid), _make_document(), _make_source())],
+        )
+        req = SearchRequest(query="deploy", types=["git", "fs"])
+        result = await service.search(req)
+        assert session.execute.call_count == 3
+        assert isinstance(result, SearchResult)
+
+    @pytest.mark.asyncio
+    async def test_max_age_filter_passed_to_where_clauses(self) -> None:
+        cid = uuid.uuid4()
+        service, session = _make_service(
+            vector_rows=[(cid, 0.9)],
+            enriched_rows=[(_make_chunk(chunk_id=cid), _make_document(), _make_source())],
+        )
+        req = SearchRequest(query="recent stuff", max_age_seconds=3600)
+        result = await service.search(req)
+        assert session.execute.call_count == 3
+        assert isinstance(result, SearchResult)
+
+    @pytest.mark.asyncio
+    async def test_tombstone_filter_excludes_by_default(self) -> None:
+        """Default request excludes tombstoned docs — filter clause is built."""
+        cid = uuid.uuid4()
+        service, _ = _make_service(
+            vector_rows=[(cid, 0.9)],
+            enriched_rows=[],  # simulate all filtered out by tombstone
+        )
+        req = SearchRequest(query="deleted stuff")
+        result = await service.search(req)
+        assert result.hits == []
+
+    @pytest.mark.asyncio
+    async def test_tombstone_filter_includes_when_requested(self) -> None:
+        """include_tombstoned=True still fetches from DB (no tombstone WHERE clause)."""
+        cid = uuid.uuid4()
+        chunk = _make_chunk(chunk_id=cid)
+        doc = _make_document(tombstoned_at=_NOW)
+        src = _make_source()
+        service, _ = _make_service(
+            vector_rows=[(cid, 0.9)],
+            enriched_rows=[(chunk, doc, src)],
+        )
+        req = SearchRequest(query="deleted stuff", include_tombstoned=True)
+        result = await service.search(req)
+        assert len(result.hits) == 1
+
+    @pytest.mark.asyncio
+    async def test_metadata_filter_passed_to_where_clauses(self) -> None:
+        cid = uuid.uuid4()
+        service, session = _make_service(
+            vector_rows=[(cid, 0.9)],
+            enriched_rows=[
+                (
+                    _make_chunk(chunk_id=cid, metadata={"language": "python"}),
+                    _make_document(),
+                    _make_source(),
+                ),
+            ],
+        )
+        req = SearchRequest(query="python code", filters={"language": "python"})
+        result = await service.search(req)
+        assert session.execute.call_count == 3
+        assert isinstance(result, SearchResult)
+
+
+class TestRetrievalServiceCitation:
+    @pytest.mark.asyncio
+    async def test_citation_includes_all_required_fields(self) -> None:
+        run_id = uuid.uuid4()
+        cid = uuid.uuid4()
+        doc_id = uuid.uuid4()
+
+        chunk = _make_chunk(chunk_id=cid, doc_id=doc_id, run_id=run_id)
+        doc = _make_document(
+            doc_id=doc_id,
+            uri="https://github.com/org/repo/blob/abc/auth.py#L42-L60",
+            title="auth.py",
+        )
+        src = _make_source(name="main-gitlab", stype="git")
+
+        service, _ = _make_service(
+            vector_rows=[(cid, 0.9)],
+            enriched_rows=[(chunk, doc, src)],
+        )
+        result = await service.search(SearchRequest(query="auth"))
+
+        assert len(result.hits) == 1
+        hit = result.hits[0]
+
+        # Citation fields
+        assert hit.citation.uri == doc.uri
+        assert hit.citation.title == doc.title
+        assert hit.citation.indexed_at == _NOW
+        assert hit.citation.doc_version == 7
+
+        # Source info
+        assert hit.source.name == "main-gitlab"
+        assert hit.source.type == "git"
+
+        # Lineage fields
+        assert hit.lineage.ingestion_run_id == run_id
+        assert hit.lineage.embedding_model == "text-embedding-004"
+        assert hit.lineage.embedding_provider == "google-ai"
+        assert hit.lineage.chunker_strategy == "code_symbol"
+
+        # Basic hit fields
+        assert hit.chunk_id == cid
+        assert hit.document_id == doc_id
+        assert isinstance(hit.score, float)
+        assert hit.text == "sample chunk text"
+
+    @pytest.mark.asyncio
+    async def test_citation_title_can_be_none(self) -> None:
+        cid = uuid.uuid4()
+        chunk = _make_chunk(chunk_id=cid)
+        doc = _make_document(title=None)
+        src = _make_source()
+
+        service, _ = _make_service(vector_rows=[(cid, 0.9)], enriched_rows=[(chunk, doc, src)])
+        result = await service.search(SearchRequest(query="x"))
+
+        assert result.hits[0].citation.title is None
+
+    @pytest.mark.asyncio
+    async def test_lineage_ingestion_run_id_can_be_none(self) -> None:
+        cid = uuid.uuid4()
+        chunk = _make_chunk(chunk_id=cid, run_id=None)
+        doc = _make_document()
+        src = _make_source()
+
+        service, _ = _make_service(vector_rows=[(cid, 0.9)], enriched_rows=[(chunk, doc, src)])
+        result = await service.search(SearchRequest(query="x"))
+
+        assert result.hits[0].lineage.ingestion_run_id is None
+
+
+class TestRetrievalServiceStrategyFallback:
+    @pytest.mark.asyncio
+    async def test_keyword_strategy_logs_warning_and_falls_back(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        service, _ = _make_service(vector_rows=[], text_rows=[], enriched_rows=[])
+        with caplog.at_level(logging.WARNING, logger="omniscience_retrieval.search"):
+            result = await service.search(
+                SearchRequest(query="fn_auth", retrieval_strategy="keyword")
+            )
+        assert any("keyword" in msg for msg in caplog.messages)
+        assert isinstance(result, SearchResult)
+
+    @pytest.mark.asyncio
+    async def test_structural_strategy_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        service, _ = _make_service(vector_rows=[], text_rows=[], enriched_rows=[])
+        with caplog.at_level(logging.WARNING, logger="omniscience_retrieval.search"):
+            await service.search(
+                SearchRequest(query="depends on X", retrieval_strategy="structural")
+            )
+        assert any("structural" in msg for msg in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_auto_strategy_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        service, _ = _make_service(vector_rows=[], text_rows=[], enriched_rows=[])
+        with caplog.at_level(logging.WARNING, logger="omniscience_retrieval.search"):
+            await service.search(SearchRequest(query="anything", retrieval_strategy="auto"))
+        assert any("auto" in msg for msg in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_hybrid_strategy_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        service, _ = _make_service(vector_rows=[], text_rows=[], enriched_rows=[])
+        with caplog.at_level(logging.WARNING, logger="omniscience_retrieval.search"):
+            await service.search(SearchRequest(query="auth", retrieval_strategy="hybrid"))
+        assert not caplog.messages
+
+
+class TestSearchRequestModel:
+    def test_defaults(self) -> None:
+        req = SearchRequest(query="hello")
+        assert req.top_k == 10
+        assert req.retrieval_strategy == "hybrid"
+        assert req.include_tombstoned is False
+        assert req.sources is None
+        assert req.types is None
+        assert req.max_age_seconds is None
+        assert req.filters is None
+
+    def test_custom_values(self) -> None:
+        req = SearchRequest(
+            query="find me something",
+            top_k=5,
+            sources=["s1", "s2"],
+            types=["git"],
+            max_age_seconds=7200,
+            filters={"language": "go"},
+            include_tombstoned=True,
+            retrieval_strategy="keyword",
+        )
+        assert req.top_k == 5
+        assert req.sources == ["s1", "s2"]
+        assert req.types == ["git"]
+        assert req.max_age_seconds == 7200
+        assert req.filters == {"language": "go"}
+        assert req.include_tombstoned is True
+        assert req.retrieval_strategy == "keyword"

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -256,7 +256,11 @@ class TestRetrievalServiceHybrid:
             (chunk_t, doc, src),
         ]
 
-        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        service, _ = _make_service(
+            vector_rows=vec_rows,
+            text_rows=txt_rows,
+            enriched_rows=enriched,
+        )
         result = await service.search(SearchRequest(query="auth", top_k=10))
 
         chunk_ids = {h.chunk_id for h in result.hits}
@@ -287,7 +291,11 @@ class TestRetrievalServiceHybrid:
         src = _make_source()
         enriched = [(_make_chunk(chunk_id=i), doc, src) for i in ids]
 
-        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        service, _ = _make_service(
+            vector_rows=vec_rows,
+            text_rows=txt_rows,
+            enriched_rows=enriched,
+        )
         result = await service.search(SearchRequest(query="x", top_k=10))
 
         scores = [h.score for h in result.hits]
@@ -304,7 +312,11 @@ class TestRetrievalServiceStats:
         src = _make_source()
         enriched = [(_make_chunk(chunk_id=ids[0]), doc, src)]
 
-        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        service, _ = _make_service(
+            vector_rows=vec_rows,
+            text_rows=txt_rows,
+            enriched_rows=enriched,
+        )
         result = await service.search(SearchRequest(query="test"))
 
         stats = result.query_stats
@@ -323,7 +335,11 @@ class TestRetrievalServiceStats:
         src = _make_source()
         enriched = [(_make_chunk(chunk_id=cid), doc, src)]
 
-        service, _ = _make_service(vector_rows=vec_rows, text_rows=txt_rows, enriched_rows=enriched)
+        service, _ = _make_service(
+            vector_rows=vec_rows,
+            text_rows=txt_rows,
+            enriched_rows=enriched,
+        )
         result = await service.search(SearchRequest(query="dupe"))
 
         assert result.query_stats.total_matches_before_filters == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1076,6 +1076,7 @@ dev = [
     { name = "omniscience-embeddings" },
     { name = "omniscience-index" },
     { name = "omniscience-parsers" },
+    { name = "omniscience-retrieval" },
     { name = "omniscience-server" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -1098,6 +1099,7 @@ dev = [
     { name = "omniscience-embeddings", editable = "packages/embeddings" },
     { name = "omniscience-index", editable = "packages/index" },
     { name = "omniscience-parsers", editable = "packages/parsers" },
+    { name = "omniscience-retrieval", editable = "packages/retrieval" },
     { name = "omniscience-server", editable = "apps/server" },
     { name = "pre-commit", specifier = ">=3.7.1" },
     { name = "pytest", specifier = ">=8.2.2" },
@@ -1245,11 +1247,21 @@ name = "omniscience-retrieval"
 version = "0.1.0"
 source = { editable = "packages/retrieval" }
 dependencies = [
+    { name = "asyncpg" },
     { name = "omniscience-core" },
+    { name = "omniscience-embeddings" },
+    { name = "pgvector" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "omniscience-core", editable = "packages/core" }]
+requires-dist = [
+    { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "omniscience-core", editable = "packages/core" },
+    { name = "omniscience-embeddings", editable = "packages/embeddings" },
+    { name = "pgvector", specifier = ">=0.3.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.30" },
+]
 
 [[package]]
 name = "omniscience-server"


### PR DESCRIPTION
## Summary

- `RetrievalService.search()` — hybrid vector + BM25 search with reciprocal rank fusion
- Vector: pgvector cosine similarity top-K
- BM25: tsvector `ts_rank_cd` with `plainto_tsquery`
- RRF merge: `score = sum(1/(k+rank))` with k=60 (configurable)
- Filters: source names, source types, max_age_seconds, tombstones, metadata JSONB
- Response matches MCP API spec: hits with citations, lineage, query_stats
- Non-v0.1 strategies (keyword, structural, auto) accepted with warning, fall back to hybrid

## Test plan

- [ ] 28 tests pass (100% coverage on retrieval modules), 393 total
- [ ] `mypy --strict` clean
- [ ] `ruff` clean
- [ ] All search scenarios tested: filters, empty results, stats, RRF ranking

Closes #13