### PR TITLE
feat: MCP server with search, get_document, list_sources, source_stats

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -7,6 +7,7 @@ Create the ASGI application by calling ``create_app()``.  The factory:
   - connects to NATS JetStream and ensures streams are provisioned
   - initialises the ingestion worker (placeholder — not consuming yet)
   - mounts the Prometheus metrics ASGI app at /metrics
+  - mounts the MCP ASGI app at /mcp (streamable-http transport)
   - adds TracingMiddleware
   - registers all route groups
 """
@@ -27,7 +28,9 @@ from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from starlette.requests import Request
 from starlette.responses import Response
 
+from omniscience_server.mcp.mount import create_mcp_asgi_app
 from omniscience_server.middleware import TracingMiddleware
+from omniscience_server.rest import api_v1_router, register_error_handlers
 from omniscience_server.routes import health_router, tokens_router
 
 log = structlog.get_logger(__name__)
@@ -107,26 +110,36 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     """
     resolved = settings or Settings()
 
+    # Disable Swagger UI in production; enable in dev/test
+    is_dev = str(resolved.environment).lower() in ("development", "dev", "test")
+
     app = FastAPI(
         title="Omniscience",
         description="Self-hosted knowledge retrieval service with MCP-first API",
         version=resolved.app_version,
         lifespan=_lifespan,
-        # Disable default /docs redirect to avoid confusion with /metrics
-        docs_url="/api/docs",
-        redoc_url="/api/redoc",
-        openapi_url="/api/openapi.json",
+        # OpenAPI served at /api/v1/openapi.json; UI only in dev
+        docs_url="/api/docs" if is_dev else None,
+        redoc_url="/api/redoc" if is_dev else None,
+        openapi_url="/api/v1/openapi.json",
     )
     app.state.settings = resolved
 
     # Metrics endpoint - mounted before middleware so scrapes don't hit TracingMiddleware
     app.add_route("/metrics", _metrics_endpoint, include_in_schema=False)
 
+    # MCP streamable-http endpoint
+    app.mount("/mcp", create_mcp_asgi_app(app))
+
     # Middleware (applied in reverse registration order by Starlette)
     app.add_middleware(TracingMiddleware)
+
+    # Exception handlers for spec-compliant error responses
+    register_error_handlers(app)
 
     # Routers
     app.include_router(health_router)
     app.include_router(tokens_router)
+    app.include_router(api_v1_router)
 
     return app

--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -30,7 +30,6 @@ from starlette.responses import Response
 
 from omniscience_server.mcp.mount import create_mcp_asgi_app
 from omniscience_server.middleware import TracingMiddleware
-from omniscience_server.rest import api_v1_router, register_error_handlers
 from omniscience_server.routes import health_router, tokens_router
 
 log = structlog.get_logger(__name__)
@@ -134,12 +133,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # Middleware (applied in reverse registration order by Starlette)
     app.add_middleware(TracingMiddleware)
 
-    # Exception handlers for spec-compliant error responses
-    register_error_handlers(app)
-
     # Routers
     app.include_router(health_router)
     app.include_router(tokens_router)
-    app.include_router(api_v1_router)
 
     return app

--- a/apps/server/src/omniscience_server/mcp/__init__.py
+++ b/apps/server/src/omniscience_server/mcp/__init__.py
@@ -1,0 +1,13 @@
+"""MCP server module for Omniscience.
+
+Exposes a FastMCP server with four tools:
+- search: hybrid retrieval
+- get_document: fetch full document with all chunks
+- list_sources: list configured sources with freshness
+- source_stats: per-source details
+"""
+
+from .mount import create_mcp_asgi_app, run_stdio
+from .server import mcp_server, set_fastapi_app
+
+__all__ = ["create_mcp_asgi_app", "mcp_server", "run_stdio", "set_fastapi_app"]

--- a/apps/server/src/omniscience_server/mcp/mount.py
+++ b/apps/server/src/omniscience_server/mcp/mount.py
@@ -1,0 +1,48 @@
+"""Mount the FastMCP server into the FastAPI application.
+
+Provides:
+- create_mcp_asgi_app(app): wire the FastAPI app and return the Starlette
+  ASGI app for streamable-http transport.
+- run_stdio(): synchronous entry-point for stdio (CLI) usage.
+
+Usage in app.py:
+    from omniscience_server.mcp.mount import create_mcp_asgi_app
+    app.mount("/mcp", create_mcp_asgi_app(app))
+"""
+
+from __future__ import annotations
+
+import anyio
+from fastapi import FastAPI
+from starlette.types import ASGIApp
+
+from omniscience_server.mcp.server import mcp_server, set_fastapi_app
+
+
+def create_mcp_asgi_app(app: FastAPI) -> ASGIApp:
+    """Wire the FastAPI app reference and return the MCP ASGI sub-app.
+
+    Args:
+        app: The parent FastAPI application whose ``app.state`` provides
+             ``db_session_factory`` and ``retrieval_service``.
+
+    Returns:
+        A Starlette ASGI application handling streamable-http MCP traffic.
+        Mount this at ``/mcp`` in the parent application.
+    """
+    set_fastapi_app(app)
+    starlette_app = mcp_server.streamable_http_app()
+    return starlette_app
+
+
+def run_stdio(app: FastAPI) -> None:
+    """Run the MCP server in stdio mode (blocking).
+
+    Args:
+        app: The FastAPI application instance providing app.state deps.
+    """
+    set_fastapi_app(app)
+    anyio.run(mcp_server.run_stdio_async)
+
+
+__all__ = ["create_mcp_asgi_app", "run_stdio"]

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -1,0 +1,216 @@
+"""FastMCP server setup for Omniscience.
+
+Registers four tools:
+- search       (requires scope: search)
+- get_document (requires scope: search)
+- list_sources (requires scope: sources:read)
+- source_stats (requires scope: sources:read)
+
+Auth:
+- HTTP transport: Bearer token from Authorization header
+- stdio transport: OMNISCIENCE_TOKEN environment variable
+
+The FastMCP instance is module-level.  Before mounting, call
+``set_fastapi_app(app)`` so tool handlers can reach the FastAPI
+app.state (db_session_factory, retrieval_service).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import structlog
+from fastapi import FastAPI
+from mcp.server.fastmcp import Context, FastMCP
+from omniscience_core.auth.middleware import _lookup_token
+from omniscience_core.auth.scopes import Scope, check_scopes
+from omniscience_core.db.models import ApiToken
+
+from omniscience_server.mcp.tools import (
+    mcp_get_document,
+    mcp_list_sources,
+    mcp_search,
+    mcp_source_stats,
+)
+
+log = structlog.get_logger(__name__)
+
+mcp_server: FastMCP[None] = FastMCP("omniscience")
+
+# FastAPI app reference — set via set_fastapi_app() before first request
+_fastapi_app: FastAPI | None = None
+
+
+def set_fastapi_app(app: FastAPI) -> None:
+    """Store a reference to the FastAPI app for use in tool handlers."""
+    global _fastapi_app
+    _fastapi_app = app
+
+
+def _get_app() -> FastAPI:
+    if _fastapi_app is None:
+        raise RuntimeError("FastAPI app not configured — call set_fastapi_app() first")
+    return _fastapi_app
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_bearer(raw_request: Any) -> str | None:
+    """Return the bearer token string from an HTTP request, or None."""
+    if raw_request is None:
+        return None
+    headers = getattr(raw_request, "headers", None)
+    if headers is None:
+        return None
+    auth_header: str = headers.get("authorization", "") or ""
+    if auth_header.lower().startswith("bearer "):
+        return auth_header[7:]
+    return None
+
+
+async def _resolve_token(ctx: Context[Any, Any, Any]) -> ApiToken | None:
+    """Extract and verify the bearer token from the current request context."""
+    raw_request = ctx._request_context.request if ctx._request_context else None
+    plaintext = _extract_bearer(raw_request)
+
+    if plaintext is None:
+        # stdio transport: fall back to environment variable
+        plaintext = os.environ.get("OMNISCIENCE_TOKEN")
+
+    if not plaintext:
+        return None
+
+    app = _get_app()
+    factory = getattr(app.state, "db_session_factory", None)
+    if factory is None:
+        return None
+
+    async with factory() as session:
+        return await _lookup_token(session, plaintext)
+
+
+def _require_scope(token: ApiToken | None, scope: Scope) -> None:
+    """Raise ValueError with MCP error code if token lacks the required scope."""
+    if token is None:
+        raise ValueError("unauthorized:Token missing or invalid")
+    granted = {Scope(s) for s in token.scopes if s in Scope.__members__.values()}
+    if not check_scopes({scope}, granted):
+        raise ValueError(f"forbidden:Token lacks required scope '{scope}'")
+
+
+# ---------------------------------------------------------------------------
+# Tool: search
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    name="search",
+    description=(
+        "Hybrid vector + BM25 retrieval over the Omniscience index. "
+        "Returns ranked chunks with citations and lineage."
+    ),
+)
+async def search(
+    query: str,
+    ctx: Context[Any, Any, Any],
+    top_k: int = 10,
+    sources: list[str] | None = None,
+    types: list[str] | None = None,
+    max_age_seconds: int | None = None,
+    filters: dict[str, Any] | None = None,
+    include_tombstoned: bool = False,
+    retrieval_strategy: str = "hybrid",
+) -> dict[str, Any]:
+    """Search tool — requires scope 'search'."""
+    token = await _resolve_token(ctx)
+    _require_scope(token, Scope.search)
+
+    return await mcp_search(
+        app=_get_app(),
+        query=query,
+        top_k=top_k,
+        sources=sources,
+        types=types,
+        max_age_seconds=max_age_seconds,
+        filters=filters,
+        include_tombstoned=include_tombstoned,
+        retrieval_strategy=retrieval_strategy,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_document
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    name="get_document",
+    description="Retrieve a full document and all its chunks by document id.",
+)
+async def get_document(
+    document_id: str,
+    ctx: Context[Any, Any, Any],
+) -> dict[str, Any]:
+    """get_document tool — requires scope 'search'."""
+    token = await _resolve_token(ctx)
+    _require_scope(token, Scope.search)
+
+    try:
+        return await mcp_get_document(app=_get_app(), document_id=document_id)
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith("document_not_found:"):
+            raise ValueError(f"source_not_found:{document_id}") from exc
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Tool: list_sources
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    name="list_sources",
+    description="List configured sources with freshness information.",
+)
+async def list_sources(
+    ctx: Context[Any, Any, Any],
+) -> dict[str, Any]:
+    """list_sources tool — requires scope 'sources:read'."""
+    token = await _resolve_token(ctx)
+    _require_scope(token, Scope.sources_read)
+
+    return await mcp_list_sources(app=_get_app())
+
+
+# ---------------------------------------------------------------------------
+# Tool: source_stats
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    name="source_stats",
+    description="Return detailed statistics for a single source by id.",
+)
+async def source_stats(
+    source_id: str,
+    ctx: Context[Any, Any, Any],
+) -> dict[str, Any]:
+    """source_stats tool — requires scope 'sources:read'."""
+    token = await _resolve_token(ctx)
+    _require_scope(token, Scope.sources_read)
+
+    try:
+        return await mcp_source_stats(app=_get_app(), source_id=source_id)
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith("source_not_found:"):
+            raise
+        raise
+
+
+__all__ = ["mcp_server", "set_fastapi_app"]

--- a/apps/server/src/omniscience_server/mcp/tools.py
+++ b/apps/server/src/omniscience_server/mcp/tools.py
@@ -1,0 +1,241 @@
+"""MCP tool implementations for Omniscience.
+
+Each function is a standalone async callable that accepts the FastAPI
+app (for access to db_session_factory and retrieval_service) and the
+validated tool arguments.  The server.py module wires them to the
+FastMCP instance.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from fastapi import FastAPI
+from omniscience_core.db.models import Chunk, Document, IngestionRun, Source
+from omniscience_retrieval.models import SearchRequest
+from omniscience_retrieval.search import RetrievalService
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+
+
+async def mcp_search(
+    app: FastAPI,
+    query: str,
+    top_k: int = 10,
+    sources: list[str] | None = None,
+    types: list[str] | None = None,
+    max_age_seconds: int | None = None,
+    filters: dict[str, Any] | None = None,
+    include_tombstoned: bool = False,
+    retrieval_strategy: str = "hybrid",
+) -> dict[str, Any]:
+    """Execute hybrid retrieval and return hits with citations."""
+    service: RetrievalService | None = getattr(app.state, "retrieval_service", None)
+    if service is None:
+        raise RuntimeError("retrieval_service not available on app.state")
+
+    request = SearchRequest(
+        query=query,
+        top_k=top_k,
+        sources=sources,
+        types=types,
+        max_age_seconds=max_age_seconds,
+        filters=filters,
+        include_tombstoned=include_tombstoned,
+        retrieval_strategy=retrieval_strategy,  # type: ignore[arg-type]
+    )
+    result = await service.search(request)
+    return result.model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# get_document
+# ---------------------------------------------------------------------------
+
+
+async def mcp_get_document(app: FastAPI, document_id: str) -> dict[str, Any]:
+    """Fetch a full document and all its chunks by document id."""
+    factory = getattr(app.state, "db_session_factory", None)
+    if factory is None:
+        raise RuntimeError("db_session_factory not available on app.state")
+
+    doc_uuid = uuid.UUID(document_id)
+
+    session: AsyncSession
+    async with factory() as session:
+        doc_row = await session.get(Document, doc_uuid)
+        if doc_row is None:
+            raise ValueError(f"document_not_found:{document_id}")
+
+        source_row = await session.get(Source, doc_row.source_id)
+        chunk_result = await session.execute(
+            select(Chunk).where(Chunk.document_id == doc_uuid).order_by(Chunk.ord)
+        )
+        chunks = chunk_result.scalars().all()
+
+    doc_dict: dict[str, Any] = {
+        "id": str(doc_row.id),
+        "source_id": str(doc_row.source_id),
+        "external_id": doc_row.external_id,
+        "uri": doc_row.uri,
+        "title": doc_row.title,
+        "doc_version": doc_row.doc_version,
+        "indexed_at": doc_row.indexed_at.isoformat(),
+        "tombstoned_at": (doc_row.tombstoned_at.isoformat() if doc_row.tombstoned_at else None),
+        "metadata": doc_row.doc_metadata,
+        "source": {
+            "id": str(source_row.id) if source_row else None,
+            "name": source_row.name if source_row else None,
+            "type": str(source_row.type) if source_row else None,
+        },
+    }
+    chunk_list: list[dict[str, Any]] = [
+        {
+            "id": str(c.id),
+            "ord": c.ord,
+            "text": c.text,
+            "symbol": c.symbol,
+            "embedding_model": c.embedding_model,
+            "embedding_provider": c.embedding_provider,
+            "parser_version": c.parser_version,
+            "chunker_strategy": c.chunker_strategy,
+            "metadata": c.chunk_metadata,
+        }
+        for c in chunks
+    ]
+    return {"document": doc_dict, "chunks": chunk_list}
+
+
+# ---------------------------------------------------------------------------
+# list_sources
+# ---------------------------------------------------------------------------
+
+
+async def mcp_list_sources(app: FastAPI) -> dict[str, Any]:
+    """List all configured sources with freshness information."""
+    factory = getattr(app.state, "db_session_factory", None)
+    if factory is None:
+        raise RuntimeError("db_session_factory not available on app.state")
+
+    now = datetime.now(tz=UTC)
+
+    session: AsyncSession
+    async with factory() as session:
+        result = await session.execute(select(Source))
+        sources = result.scalars().all()
+
+        # Count indexed documents per source
+        count_result = await session.execute(
+            select(Document.source_id, func.count(Document.id).label("cnt"))
+            .where(Document.tombstoned_at.is_(None))
+            .group_by(Document.source_id)
+        )
+        counts: dict[uuid.UUID, int] = {row.source_id: row.cnt for row in count_result}
+
+    source_list: list[dict[str, Any]] = []
+    for src in sources:
+        sla = src.freshness_sla_seconds
+        last_sync = src.last_sync_at
+        is_stale = False
+        if sla is not None and last_sync is not None:
+            elapsed = (now - last_sync.replace(tzinfo=UTC)).total_seconds()
+            is_stale = elapsed > sla
+        elif sla is not None and last_sync is None:
+            is_stale = True
+
+        source_list.append(
+            {
+                "id": str(src.id),
+                "name": src.name,
+                "type": str(src.type),
+                "status": str(src.status),
+                "last_sync_at": last_sync.isoformat() if last_sync else None,
+                "freshness_sla_seconds": sla,
+                "is_stale": is_stale,
+                "indexed_document_count": counts.get(src.id, 0),
+            }
+        )
+    return {"sources": source_list}
+
+
+# ---------------------------------------------------------------------------
+# source_stats
+# ---------------------------------------------------------------------------
+
+
+async def mcp_source_stats(app: FastAPI, source_id: str) -> dict[str, Any]:
+    """Return detailed statistics for a single source."""
+    factory = getattr(app.state, "db_session_factory", None)
+    if factory is None:
+        raise RuntimeError("db_session_factory not available on app.state")
+
+    src_uuid = uuid.UUID(source_id)
+
+    session: AsyncSession
+    async with factory() as session:
+        src = await session.get(Source, src_uuid)
+        if src is None:
+            raise ValueError(f"source_not_found:{source_id}")
+
+        doc_count_result = await session.execute(
+            select(func.count(Document.id)).where(
+                Document.source_id == src_uuid,
+                Document.tombstoned_at.is_(None),
+            )
+        )
+        doc_count: int = doc_count_result.scalar_one()
+
+        chunk_count_result = await session.execute(
+            select(func.count(Chunk.id))
+            .join(Document, Chunk.document_id == Document.id)
+            .where(
+                Document.source_id == src_uuid,
+                Document.tombstoned_at.is_(None),
+            )
+        )
+        chunk_count: int = chunk_count_result.scalar_one()
+
+        last_run_result = await session.execute(
+            select(IngestionRun)
+            .where(IngestionRun.source_id == src_uuid)
+            .order_by(IngestionRun.started_at.desc())
+            .limit(1)
+        )
+        last_run = last_run_result.scalar_one_or_none()
+
+    last_run_dict: dict[str, Any] | None = None
+    if last_run is not None:
+        last_run_dict = {
+            "id": str(last_run.id),
+            "started_at": last_run.started_at.isoformat(),
+            "finished_at": (last_run.finished_at.isoformat() if last_run.finished_at else None),
+            "status": str(last_run.status),
+            "docs_new": last_run.docs_new,
+            "docs_updated": last_run.docs_updated,
+            "docs_removed": last_run.docs_removed,
+            "errors": last_run.run_errors,
+        }
+
+    return {
+        "id": str(src.id),
+        "name": src.name,
+        "type": str(src.type),
+        "status": str(src.status),
+        "last_sync_at": src.last_sync_at.isoformat() if src.last_sync_at else None,
+        "last_error": src.last_error,
+        "last_error_at": src.last_error_at.isoformat() if src.last_error_at else None,
+        "freshness_sla_seconds": src.freshness_sla_seconds,
+        "indexed_document_count": doc_count,
+        "indexed_chunk_count": chunk_count,
+        "last_ingestion_run": last_run_dict,
+    }

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,665 @@
+"""Tests for the MCP server module.
+
+Covers:
+- search tool returns correct response structure
+- get_document tool returns document + chunks
+- list_sources tool returns sources with freshness fields
+- source_stats tool returns stats + last_ingestion_run
+- Auth token extraction from Authorization header (HTTP transport)
+- Auth token extraction from OMNISCIENCE_TOKEN env var (stdio transport)
+- Scope enforcement: search requires 'search' scope
+- Scope enforcement: list_sources/source_stats require 'sources:read' scope
+- Error responses for missing/wrong token (unauthorized)
+- Error responses for insufficient scope (forbidden)
+- Error for unknown document id
+- Error for unknown source id
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from omniscience_core.db.models import (
+    ApiToken,
+    IngestionRun,
+    IngestionRunStatus,
+    Source,
+    SourceStatus,
+    SourceType,
+)
+
+# Fixture: import tool functions directly for unit testing
+from omniscience_server.mcp.tools import (
+    mcp_get_document,
+    mcp_list_sources,
+    mcp_search,
+    mcp_source_stats,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 17, 10, 0, 0, tzinfo=UTC)
+_SRC_ID = uuid.uuid4()
+_DOC_ID = uuid.uuid4()
+_CHUNK_ID = uuid.uuid4()
+_RUN_ID = uuid.uuid4()
+
+
+def _make_source(
+    src_id: uuid.UUID = _SRC_ID,
+    name: str = "main-git",
+    source_type: SourceType = SourceType.git,
+    status: SourceStatus = SourceStatus.active,
+    last_sync_at: datetime | None = None,
+    freshness_sla_seconds: int | None = 300,
+    last_error: str | None = None,
+    last_error_at: datetime | None = None,
+) -> MagicMock:
+    s = MagicMock(spec=Source)
+    s.id = src_id
+    s.name = name
+    s.type = source_type
+    s.status = status
+    s.last_sync_at = last_sync_at
+    s.freshness_sla_seconds = freshness_sla_seconds
+    s.last_error = last_error
+    s.last_error_at = last_error_at
+    return s
+
+
+def _make_doc(
+    doc_id: uuid.UUID = _DOC_ID,
+    source_id: uuid.UUID = _SRC_ID,
+    uri: str = "https://example.com/file.py",
+    title: str | None = "file.py",
+    doc_version: int = 1,
+    indexed_at: datetime = _NOW,
+    tombstoned_at: datetime | None = None,
+    doc_metadata: dict[str, Any] | None = None,
+) -> MagicMock:
+    d = MagicMock()
+    d.id = doc_id
+    d.source_id = source_id
+    d.external_id = "ext-001"
+    d.uri = uri
+    d.title = title
+    d.doc_version = doc_version
+    d.indexed_at = indexed_at
+    d.tombstoned_at = tombstoned_at
+    d.doc_metadata = doc_metadata or {}
+    return d
+
+
+def _make_chunk(
+    chunk_id: uuid.UUID = _CHUNK_ID,
+    doc_id: uuid.UUID = _DOC_ID,
+    text: str = "def foo(): pass",
+    chunk_ord: int = 0,
+) -> MagicMock:
+    c = MagicMock()
+    c.id = chunk_id
+    c.document_id = doc_id
+    c.ord = chunk_ord
+    c.text = text
+    c.symbol = "foo"
+    c.embedding_model = "text-embedding-004"
+    c.embedding_provider = "google-ai"
+    c.parser_version = "treesitter-python-0.21"
+    c.chunker_strategy = "code_symbol"
+    c.chunk_metadata = {"language": "python"}
+    c.ingestion_run_id = None
+    return c
+
+
+def _make_ingestion_run(
+    run_id: uuid.UUID = _RUN_ID,
+    source_id: uuid.UUID = _SRC_ID,
+) -> MagicMock:
+    r = MagicMock(spec=IngestionRun)
+    r.id = run_id
+    r.source_id = source_id
+    r.started_at = _NOW
+    r.finished_at = _NOW
+    r.status = IngestionRunStatus.ok
+    r.docs_new = 10
+    r.docs_updated = 2
+    r.docs_removed = 1
+    r.run_errors = {}
+    return r
+
+
+def _make_app(factory: Any = None, retrieval_service: Any = None) -> FastAPI:
+    """Build a minimal FastAPI app stub with mocked state."""
+    app = FastAPI()
+    app.state.db_session_factory = factory
+    app.state.retrieval_service = retrieval_service
+    return app
+
+
+def _make_session_factory(
+    get_result: Any = None,
+    scalars_results: list[Any] | None = None,
+    scalar_one_results: list[Any] | None = None,
+    scalar_one_or_none_result: Any = None,
+) -> MagicMock:
+    """Build an async session factory mock."""
+    session = AsyncMock()
+
+    # session.get(Model, id)
+    session.get = AsyncMock(return_value=get_result)
+
+    # session.execute() — returns a result object
+    execute_results: list[MagicMock] = []
+    for row_list in scalars_results or []:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = row_list
+        execute_results.append(res)
+    for scalar_val in scalar_one_results or []:
+        res = MagicMock()
+        res.scalar_one.return_value = scalar_val
+        execute_results.append(res)
+    if scalar_one_or_none_result is not None:
+        res = MagicMock()
+        res.scalar_one_or_none.return_value = scalar_one_or_none_result
+        execute_results.append(res)
+
+    session.execute = AsyncMock(side_effect=execute_results if execute_results else None)
+
+    # Context manager
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# mcp_search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_returns_hits_structure() -> None:
+    """mcp_search returns a dict with 'hits' and 'query_stats' keys."""
+    from omniscience_retrieval.models import (
+        ChunkLineage,
+        Citation,
+        QueryStats,
+        SearchHit,
+        SearchResult,
+        SourceInfo,
+    )
+
+    hit = SearchHit(
+        chunk_id=_CHUNK_ID,
+        document_id=_DOC_ID,
+        score=0.9,
+        text="def foo(): pass",
+        source=SourceInfo(id=_SRC_ID, name="main-git", type="git"),
+        citation=Citation(uri="https://x.com", title="f.py", indexed_at=_NOW, doc_version=1),
+        lineage=ChunkLineage(
+            ingestion_run_id=None,
+            embedding_model="m",
+            embedding_provider="p",
+            parser_version="v",
+            chunker_strategy="s",
+        ),
+        metadata={"language": "python"},
+    )
+    result = SearchResult(
+        hits=[hit],
+        query_stats=QueryStats(
+            total_matches_before_filters=5,
+            vector_matches=3,
+            text_matches=4,
+            duration_ms=12.0,
+        ),
+    )
+    service = AsyncMock()
+    service.search = AsyncMock(return_value=result)
+    app = _make_app(retrieval_service=service)
+
+    response = await mcp_search(app=app, query="foo function")
+
+    assert "hits" in response
+    assert "query_stats" in response
+    assert len(response["hits"]) == 1
+    assert response["hits"][0]["score"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_passes_all_params() -> None:
+    """mcp_search passes all parameters correctly to RetrievalService.search."""
+    from omniscience_retrieval.models import QueryStats, SearchResult
+
+    result = SearchResult(
+        hits=[],
+        query_stats=QueryStats(
+            total_matches_before_filters=0,
+            vector_matches=0,
+            text_matches=0,
+            duration_ms=1.0,
+        ),
+    )
+    service = AsyncMock()
+    service.search = AsyncMock(return_value=result)
+    app = _make_app(retrieval_service=service)
+
+    await mcp_search(
+        app=app,
+        query="search term",
+        top_k=5,
+        sources=["git-main"],
+        types=["git"],
+        max_age_seconds=3600,
+        filters={"language": "python"},
+        include_tombstoned=True,
+        retrieval_strategy="keyword",
+    )
+
+    call_args = service.search.call_args[0][0]
+    assert call_args.query == "search term"
+    assert call_args.top_k == 5
+    assert call_args.sources == ["git-main"]
+    assert call_args.types == ["git"]
+    assert call_args.max_age_seconds == 3600
+    assert call_args.filters == {"language": "python"}
+    assert call_args.include_tombstoned is True
+    assert call_args.retrieval_strategy == "keyword"
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_raises_when_no_service() -> None:
+    """mcp_search raises RuntimeError when retrieval_service is not on app.state."""
+    app = _make_app(retrieval_service=None)
+    with pytest.raises(RuntimeError, match="retrieval_service not available"):
+        await mcp_search(app=app, query="test")
+
+
+# ---------------------------------------------------------------------------
+# mcp_get_document
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_returns_document_and_chunks() -> None:
+    """mcp_get_document returns dict with 'document' and 'chunks' keys."""
+    doc = _make_doc()
+    src = _make_source()
+    chunk = _make_chunk()
+
+    session = AsyncMock()
+    # First call: get(Document) → doc; second call: get(Source) → src
+    session.get = AsyncMock(side_effect=[doc, src])
+    # execute → chunks
+    chunks_result = MagicMock()
+    chunks_result.scalars.return_value.all.return_value = [chunk]
+    session.execute = AsyncMock(return_value=chunks_result)
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    result = await mcp_get_document(app=app, document_id=str(_DOC_ID))
+
+    assert "document" in result
+    assert "chunks" in result
+    assert result["document"]["id"] == str(_DOC_ID)
+    assert len(result["chunks"]) == 1
+    assert result["chunks"][0]["text"] == "def foo(): pass"
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_raises_on_missing_doc() -> None:
+    """mcp_get_document raises ValueError with document_not_found when id unknown."""
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=None)
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    with pytest.raises(ValueError, match="document_not_found"):
+        await mcp_get_document(app=app, document_id=str(uuid.uuid4()))
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_invalid_uuid() -> None:
+    """mcp_get_document raises ValueError for malformed document_id."""
+    app = _make_app(factory=MagicMock())
+    with pytest.raises(ValueError):
+        await mcp_get_document(app=app, document_id="not-a-uuid")
+
+
+# ---------------------------------------------------------------------------
+# mcp_list_sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_sources_returns_sources_key() -> None:
+    """mcp_list_sources returns a dict with a 'sources' list."""
+    src = _make_source(last_sync_at=_NOW)
+
+    session = AsyncMock()
+    sources_result = MagicMock()
+    sources_result.scalars.return_value.all.return_value = [src]
+    counts_result = MagicMock()
+    counts_result.__iter__ = MagicMock(return_value=iter([MagicMock(source_id=_SRC_ID, cnt=42)]))
+    session.execute = AsyncMock(side_effect=[sources_result, counts_result])
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    result = await mcp_list_sources(app=app)
+
+    assert "sources" in result
+    assert len(result["sources"]) == 1
+    s = result["sources"][0]
+    assert s["id"] == str(_SRC_ID)
+    assert s["name"] == "main-git"
+    assert s["type"] == "git"
+    assert "is_stale" in s
+    assert "indexed_document_count" in s
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_sources_is_stale_when_no_sync() -> None:
+    """is_stale is True when freshness_sla_seconds set but last_sync_at is None."""
+    src = _make_source(last_sync_at=None, freshness_sla_seconds=300)
+
+    session = AsyncMock()
+    sources_result = MagicMock()
+    sources_result.scalars.return_value.all.return_value = [src]
+    counts_result = MagicMock()
+    counts_result.__iter__ = MagicMock(return_value=iter([]))
+    session.execute = AsyncMock(side_effect=[sources_result, counts_result])
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    result = await mcp_list_sources(app=app)
+
+    assert result["sources"][0]["is_stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_sources_not_stale_when_recent() -> None:
+    """is_stale is False when last_sync_at is within freshness_sla_seconds."""
+    from datetime import timedelta
+
+    recent = datetime.now(tz=UTC) - timedelta(seconds=10)
+    src = _make_source(last_sync_at=recent, freshness_sla_seconds=300)
+
+    session = AsyncMock()
+    sources_result = MagicMock()
+    sources_result.scalars.return_value.all.return_value = [src]
+    counts_result = MagicMock()
+    counts_result.__iter__ = MagicMock(return_value=iter([]))
+    session.execute = AsyncMock(side_effect=[sources_result, counts_result])
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    result = await mcp_list_sources(app=app)
+
+    assert result["sources"][0]["is_stale"] is False
+
+
+# ---------------------------------------------------------------------------
+# mcp_source_stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_stats_returns_full_stats() -> None:
+    """mcp_source_stats returns counts, freshness and last_ingestion_run."""
+    src = _make_source(last_sync_at=_NOW)
+    run = _make_ingestion_run()
+
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=src)
+    doc_count_result = MagicMock()
+    doc_count_result.scalar_one.return_value = 100
+    chunk_count_result = MagicMock()
+    chunk_count_result.scalar_one.return_value = 1500
+    last_run_result = MagicMock()
+    last_run_result.scalar_one_or_none.return_value = run
+    session.execute = AsyncMock(
+        side_effect=[doc_count_result, chunk_count_result, last_run_result]
+    )
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    result = await mcp_source_stats(app=app, source_id=str(_SRC_ID))
+
+    assert result["indexed_document_count"] == 100
+    assert result["indexed_chunk_count"] == 1500
+    assert result["last_ingestion_run"] is not None
+    assert result["last_ingestion_run"]["docs_new"] == 10
+    assert result["last_ingestion_run"]["status"] == str(IngestionRunStatus.ok)
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_stats_no_run() -> None:
+    """mcp_source_stats returns last_ingestion_run=None when no runs exist."""
+    src = _make_source()
+
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=src)
+    doc_count_result = MagicMock()
+    doc_count_result.scalar_one.return_value = 0
+    chunk_count_result = MagicMock()
+    chunk_count_result.scalar_one.return_value = 0
+    last_run_result = MagicMock()
+    last_run_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(
+        side_effect=[doc_count_result, chunk_count_result, last_run_result]
+    )
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    result = await mcp_source_stats(app=app, source_id=str(_SRC_ID))
+
+    assert result["last_ingestion_run"] is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_stats_raises_on_missing_source() -> None:
+    """mcp_source_stats raises ValueError with source_not_found for unknown id."""
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=None)
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(factory=factory)
+    with pytest.raises(ValueError, match="source_not_found"):
+        await mcp_source_stats(app=app, source_id=str(uuid.uuid4()))
+
+
+# ---------------------------------------------------------------------------
+# Auth token extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_extracts_bearer_from_http_header() -> None:
+    """_resolve_token reads bearer token from Authorization header."""
+    from omniscience_server.mcp.server import _resolve_token
+
+    token_obj = MagicMock(spec=ApiToken)
+    token_obj.scopes = ["search"]
+
+    mock_request = MagicMock()
+    mock_request.headers = {"authorization": "Bearer sk_test_abc123"}
+
+    ctx = MagicMock()
+    ctx._request_context = MagicMock()
+    ctx._request_context.request = mock_request
+
+    with patch(
+        "omniscience_server.mcp.server._lookup_token",
+        new_callable=AsyncMock,
+        return_value=token_obj,
+    ):
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        app = _make_app(factory=factory)
+
+        import omniscience_server.mcp.server as server_mod
+
+        server_mod._fastapi_app = app
+
+        result = await _resolve_token(ctx)
+
+    assert result is token_obj
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_uses_env_var_for_non_http() -> None:
+    """_resolve_token falls back to OMNISCIENCE_TOKEN env var for non-HTTP requests."""
+    import os
+
+    from omniscience_server.mcp.server import _resolve_token
+
+    token_obj = MagicMock(spec=ApiToken)
+    token_obj.scopes = ["search"]
+
+    ctx = MagicMock()
+    ctx._request_context = MagicMock()
+    ctx._request_context.request = None  # not a Starlette Request
+
+    with (
+        patch.dict(os.environ, {"OMNISCIENCE_TOKEN": "sk_test_envtoken"}),
+        patch(
+            "omniscience_server.mcp.server._lookup_token",
+            new_callable=AsyncMock,
+            return_value=token_obj,
+        ),
+    ):
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        app = _make_app(factory=factory)
+
+        import omniscience_server.mcp.server as server_mod
+
+        server_mod._fastapi_app = app
+
+        result = await _resolve_token(ctx)
+
+    assert result is token_obj
+
+
+@pytest.mark.asyncio
+async def test_resolve_token_returns_none_when_no_token() -> None:
+    """_resolve_token returns None when no token is present."""
+    import os
+
+    from omniscience_server.mcp.server import _resolve_token
+
+    ctx = MagicMock()
+    ctx._request_context = MagicMock()
+    ctx._request_context.request = None
+
+    with patch.dict(os.environ, {}, clear=True):
+        # Ensure OMNISCIENCE_TOKEN is not set
+        os.environ.pop("OMNISCIENCE_TOKEN", None)
+
+        import omniscience_server.mcp.server as server_mod
+
+        factory = MagicMock()
+        factory.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        factory.return_value.__aexit__ = AsyncMock(return_value=False)
+        app = _make_app(factory=factory)
+        server_mod._fastapi_app = app
+
+        result = await _resolve_token(ctx)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Scope enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_require_scope_raises_unauthorized_when_no_token() -> None:
+    """_require_scope raises ValueError with 'unauthorized' when token is None."""
+    from omniscience_core.auth.scopes import Scope
+    from omniscience_server.mcp.server import _require_scope
+
+    with pytest.raises(ValueError, match="unauthorized"):
+        _require_scope(None, Scope.search)
+
+
+def test_require_scope_raises_forbidden_when_wrong_scope() -> None:
+    """_require_scope raises ValueError with 'forbidden' for insufficient scope."""
+    from omniscience_core.auth.scopes import Scope
+    from omniscience_server.mcp.server import _require_scope
+
+    token = MagicMock(spec=ApiToken)
+    token.scopes = ["sources:read"]  # has sources:read, not search
+
+    with pytest.raises(ValueError, match="forbidden"):
+        _require_scope(token, Scope.search)
+
+
+def test_require_scope_passes_for_correct_scope() -> None:
+    """_require_scope does not raise when token has the required scope."""
+    from omniscience_core.auth.scopes import Scope
+    from omniscience_server.mcp.server import _require_scope
+
+    token = MagicMock(spec=ApiToken)
+    token.scopes = ["search"]
+
+    _require_scope(token, Scope.search)  # should not raise
+
+
+def test_require_scope_admin_implies_all_scopes() -> None:
+    """_require_scope passes for any scope when token has 'admin' scope."""
+    from omniscience_core.auth.scopes import Scope
+    from omniscience_server.mcp.server import _require_scope
+
+    token = MagicMock(spec=ApiToken)
+    token.scopes = ["admin"]
+
+    _require_scope(token, Scope.search)
+    _require_scope(token, Scope.sources_read)
+    _require_scope(token, Scope.sources_write)
+
+
+def test_require_scope_sources_read_needed_for_list_sources() -> None:
+    """Token with only 'search' scope is forbidden from list_sources."""
+    from omniscience_core.auth.scopes import Scope
+    from omniscience_server.mcp.server import _require_scope
+
+    token = MagicMock(spec=ApiToken)
+    token.scopes = ["search"]
+
+    with pytest.raises(ValueError, match="forbidden"):
+        _require_scope(token, Scope.sources_read)


### PR DESCRIPTION
## Summary
- FastMCP server with 4 tools matching docs/api/mcp.md
- Streamable-http transport mounted at `/mcp` in FastAPI app
- Stdio transport for CLI usage
- Auth: Bearer token (HTTP) or OMNISCIENCE_TOKEN env var (stdio)
- Scope enforcement per tool
- 20 new tests

## Test plan
- [ ] All tests pass, mypy --strict clean, ruff clean

Closes #14