### PR TITLE
feat: omniscience CLI with sources, tokens, search, mcp serve, doctor

### DIFF
--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -5,10 +5,13 @@ description = "Omniscience operator CLI"
 requires-python = ">=3.12"
 dependencies = [
     "omniscience-core",
+    "typer>=0.12.0",
+    "rich>=13.7.0",
+    "httpx>=0.27.0",
 ]
 
 [project.scripts]
-omniscience = "omniscience_cli.main:main"
+omniscience = "omniscience_cli.main:app"
 
 [tool.uv.sources]
 omniscience-core = { workspace = true }

--- a/apps/cli/src/omniscience_cli/client.py
+++ b/apps/cli/src/omniscience_cli/client.py
@@ -1,0 +1,168 @@
+"""HTTP client for the Omniscience REST API."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+DEFAULT_URL = "http://localhost:8000"
+ENV_URL = "OMNISCIENCE_URL"
+ENV_TOKEN = "OMNISCIENCE_TOKEN"  # noqa: S105 — env var name, not a credential
+
+
+class OmniscienceClientError(Exception):
+    """Raised when the API returns an error response."""
+
+    def __init__(self, code: str, message: str, status: int) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status = status
+
+
+def _raise_for_error(response: httpx.Response) -> None:
+    """Parse error body and raise OmniscienceClientError."""
+    if response.is_success:
+        return
+    try:
+        body = response.json()
+        err = body.get("error", {})
+        code = err.get("code", "unknown")
+        message = err.get("message", response.text)
+    except Exception:
+        code = "unknown"
+        message = response.text
+    raise OmniscienceClientError(code=code, message=message, status=response.status_code)
+
+
+class OmniscienceClient:
+    """Thin synchronous wrapper around the Omniscience REST API."""
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self.base_url = (base_url or os.environ.get(ENV_URL, DEFAULT_URL)).rstrip("/")
+        self.token = token or os.environ.get(ENV_TOKEN, "")
+        headers: dict[str, str] = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        self._client = httpx.Client(
+            base_url=self.base_url,
+            headers=headers,
+            timeout=30.0,
+        )
+
+    # ------------------------------------------------------------------
+    # Health
+    # ------------------------------------------------------------------
+
+    def health(self) -> dict[str, Any]:
+        resp = self._client.get("/health")
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        *,
+        sources: list[str] | None = None,
+        top_k: int = 10,
+        max_age_seconds: int | None = None,
+        filters: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"query": query, "top_k": top_k}
+        if sources:
+            payload["sources"] = sources
+        if max_age_seconds is not None:
+            payload["max_age_seconds"] = max_age_seconds
+        if filters:
+            payload["filters"] = filters
+        resp = self._client.post("/api/v1/search", json=payload)
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    # ------------------------------------------------------------------
+    # Sources
+    # ------------------------------------------------------------------
+
+    def list_sources(
+        self,
+        *,
+        source_type: str | None = None,
+        status: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] = {}
+        if source_type:
+            params["type"] = source_type
+        if status:
+            params["status"] = status
+        resp = self._client.get("/api/v1/sources", params=params)
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    def create_source(self, body: dict[str, Any]) -> dict[str, Any]:
+        resp = self._client.post("/api/v1/sources", json=body)
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    def get_source(self, source_id: str) -> dict[str, Any]:
+        resp = self._client.get(f"/api/v1/sources/{source_id}")
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    def delete_source(self, source_id: str) -> None:
+        resp = self._client.delete(f"/api/v1/sources/{source_id}")
+        _raise_for_error(resp)
+
+    def validate_source(self, source_id: str) -> dict[str, Any]:
+        resp = self._client.get(f"/api/v1/sources/{source_id}/stats")
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    def sync_source(self, source_id: str) -> dict[str, Any]:
+        resp = self._client.post(f"/api/v1/sources/{source_id}/sync")
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    def get_ingestion_run(self, run_id: str) -> dict[str, Any]:
+        resp = self._client.get(f"/api/v1/ingestion-runs/{run_id}")
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    # ------------------------------------------------------------------
+    # Tokens
+    # ------------------------------------------------------------------
+
+    def list_tokens(self) -> dict[str, Any]:
+        resp = self._client.get("/api/v1/tokens")
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    def create_token(self, name: str, scopes: list[str]) -> dict[str, Any]:
+        resp = self._client.post(
+            "/api/v1/tokens",
+            json={"name": name, "scopes": scopes},
+        )
+        _raise_for_error(resp)
+        return resp.json()  # type: ignore[no-any-return]
+
+    def revoke_token(self, token_id: str) -> None:
+        resp = self._client.delete(f"/api/v1/tokens/{token_id}")
+        _raise_for_error(resp)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> OmniscienceClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()

--- a/apps/cli/src/omniscience_cli/commands/__init__.py
+++ b/apps/cli/src/omniscience_cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Command subpackage for the Omniscience CLI."""

--- a/apps/cli/src/omniscience_cli/commands/mcp.py
+++ b/apps/cli/src/omniscience_cli/commands/mcp.py
@@ -1,0 +1,90 @@
+"""MCP serve command — launch Omniscience as an MCP server."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import Annotated
+
+import typer
+
+from omniscience_cli.output import abort, err_console
+
+app = typer.Typer(name="mcp", help="MCP server operations.")
+
+
+@app.command("serve")
+def mcp_serve(
+    transport: Annotated[
+        str,
+        typer.Option(
+            "--transport",
+            "-t",
+            help="Transport type: stdio or http",
+            metavar="TRANSPORT",
+        ),
+    ] = "stdio",
+    port: Annotated[
+        int, typer.Option("--port", "-p", help="HTTP port (http transport only)")
+    ] = 8000,
+) -> None:
+    """Launch the Omniscience MCP server.
+
+    For Claude Code / Cursor, use --transport stdio.
+    For hosted deployments, use --transport http.
+    """
+    if transport not in ("stdio", "http"):
+        abort(f"Unknown transport '{transport}'. Choose stdio or http.")
+        return
+
+    if transport == "stdio":
+        _serve_stdio()
+    else:
+        _serve_http(port)
+
+
+def _serve_stdio() -> None:
+    """Start the MCP server with stdio transport by launching the server process."""
+    server_mod = "omniscience_server.mcp_stdio"
+    err_console.print("[dim]Starting MCP server (stdio)...[/dim]")
+    env = os.environ.copy()
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [sys.executable, "-m", server_mod],
+            env=env,
+            check=False,
+        )
+        if proc.returncode not in (0, -2, -15):  # 0=clean, -2=SIGINT, -15=SIGTERM
+            abort(f"MCP stdio server exited with code {proc.returncode}.")
+    except FileNotFoundError:
+        abort(
+            "Could not launch omniscience server. "
+            "Ensure omniscience-server is installed in this environment."
+        )
+
+
+def _serve_http(port: int) -> None:
+    """Start the full HTTP server (Uvicorn) for streamable-http MCP."""
+    err_console.print(f"[dim]Starting MCP server (http) on port {port}...[/dim]")
+    env = os.environ.copy()
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "omniscience_server.app:create_app",
+                "--factory",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                str(port),
+            ],
+            env=env,
+            check=False,
+        )
+        if proc.returncode not in (0, -2, -15):
+            abort(f"MCP HTTP server exited with code {proc.returncode}.")
+    except FileNotFoundError:
+        abort("uvicorn not found. Install it with: uv add uvicorn")

--- a/apps/cli/src/omniscience_cli/commands/ops.py
+++ b/apps/cli/src/omniscience_cli/commands/ops.py
@@ -1,0 +1,54 @@
+"""Doctor check helpers used by the ops commands in main.py."""
+
+from __future__ import annotations
+
+from omniscience_cli.client import OmniscienceClient, OmniscienceClientError
+
+
+def _check_config() -> tuple[bool, str]:
+    """Validate that required env vars are set."""
+    import os
+
+    missing = [v for v in ("OMNISCIENCE_URL", "OMNISCIENCE_TOKEN") if not os.environ.get(v)]
+    if missing:
+        return False, f"Missing env vars: {', '.join(missing)}"
+    return True, ""
+
+
+def _check_api() -> tuple[bool, str]:
+    """Call /health on the configured API endpoint."""
+    try:
+        with OmniscienceClient() as client:
+            health = client.health()
+            version = health.get("version", "?")
+            return True, f"version={version}"
+    except OmniscienceClientError as exc:
+        return False, exc.message
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _check_nats() -> tuple[bool, str]:
+    """Attempt a TCP connection to the configured NATS URL."""
+    import os
+    import socket
+
+    nats_url = os.environ.get("NATS_URL", "nats://localhost:4222")
+    try:
+        host_port = nats_url.replace("nats://", "").split("/")[0]
+        host, _, port_str = host_port.partition(":")
+        port = int(port_str) if port_str else 4222
+        with socket.create_connection((host, port), timeout=3):
+            return True, nats_url
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _check_embeddings() -> tuple[bool, str]:
+    """Verify the embedding package is importable."""
+    try:
+        import omniscience_embeddings  # noqa: F401
+
+        return True, "omniscience-embeddings importable"
+    except ImportError as exc:
+        return False, str(exc)

--- a/apps/cli/src/omniscience_cli/commands/search.py
+++ b/apps/cli/src/omniscience_cli/commands/search.py
@@ -1,0 +1,10 @@
+"""Search command helpers."""
+
+from __future__ import annotations
+
+from omniscience_cli.client import OmniscienceClient
+
+
+def _make_client() -> OmniscienceClient:
+    """Return a configured client from environment."""
+    return OmniscienceClient()

--- a/apps/cli/src/omniscience_cli/commands/sources.py
+++ b/apps/cli/src/omniscience_cli/commands/sources.py
@@ -1,0 +1,175 @@
+"""Source management commands: add, list, remove, test, sync."""
+
+from __future__ import annotations
+
+import time
+from typing import Annotated, Any
+
+import typer
+
+from omniscience_cli.client import OmniscienceClient, OmniscienceClientError
+from omniscience_cli.output import (
+    abort,
+    console,
+    print_json,
+    print_success,
+    print_warning,
+    sources_table,
+)
+
+app = typer.Typer(name="sources", help="Manage data sources.")
+
+_KNOWN_TYPES = ["git", "fs", "confluence", "slack", "jira", "linear"]
+
+
+def _make_client() -> OmniscienceClient:
+    return OmniscienceClient()
+
+
+@app.command("add")
+def sources_add(
+    name: Annotated[str, typer.Option(prompt=True, help="Source name")],
+    source_type: Annotated[
+        str,
+        typer.Option("--type", "-t", prompt=True, help=f"Source type: {', '.join(_KNOWN_TYPES)}"),
+    ],
+    url: Annotated[str | None, typer.Option(prompt="URL (optional)", help="Remote URL")] = None,
+    branch: Annotated[
+        str | None, typer.Option(prompt="Branch (optional)", help="Git branch")
+    ] = None,
+) -> None:
+    """Add a new data source."""
+    body: dict[str, Any] = {"name": name, "type": source_type}
+    config: dict[str, str] = {}
+    if url:
+        config["url"] = url
+    if branch:
+        config["branch"] = branch
+    if config:
+        body["config"] = config
+    with _make_client() as client:
+        try:
+            result = client.create_source(body)
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    print_success(f"Source '{name}' created with id {result.get('id', '?')}.")
+
+
+@app.command("list")
+def sources_list(
+    source_type: Annotated[
+        str | None, typer.Option("--type", "-t", help="Filter by type")
+    ] = None,
+    status: Annotated[str | None, typer.Option(help="Filter by status")] = None,
+    as_json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+) -> None:
+    """List configured sources."""
+    with _make_client() as client:
+        try:
+            data = client.list_sources(source_type=source_type, status=status)
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    items: list[dict[str, Any]] = data.get("sources", [])
+    if as_json:
+        print_json(items)
+        return
+    sources_table(items)
+
+
+@app.command("remove")
+def sources_remove(
+    name: Annotated[str, typer.Argument(help="Source name or id")],
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
+) -> None:
+    """Remove a source and tombstone its documents."""
+    if not yes:
+        typer.confirm(f"Remove source '{name}' and tombstone all its documents?", abort=True)
+    with _make_client() as client:
+        try:
+            sources_data = client.list_sources()
+            source_id = _resolve_source_id(sources_data.get("sources", []), name)
+            if not source_id:
+                abort(f"Source '{name}' not found.")
+                return
+            client.delete_source(source_id)
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    print_success(f"Source '{name}' removed.")
+
+
+@app.command("test")
+def sources_test(
+    name: Annotated[str, typer.Argument(help="Source name or id")],
+) -> None:
+    """Test source connectivity and validate config."""
+    with _make_client() as client:
+        try:
+            sources_data = client.list_sources()
+            source_id = _resolve_source_id(sources_data.get("sources", []), name)
+            if not source_id:
+                abort(f"Source '{name}' not found.")
+                return
+            stats = client.validate_source(source_id)
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    print_success(f"Source '{name}' is reachable.")
+    console.print(stats)
+
+
+@app.command("sync")
+def sources_sync(
+    name: Annotated[str, typer.Argument(help="Source name or id")],
+    full: Annotated[bool, typer.Option("--full", help="Force a full re-sync")] = False,
+) -> None:
+    """Trigger a manual sync for a source."""
+    with _make_client() as client:
+        try:
+            sources_data = client.list_sources()
+            source_id = _resolve_source_id(sources_data.get("sources", []), name)
+            if not source_id:
+                abort(f"Source '{name}' not found.")
+                return
+            result = client.sync_source(source_id)
+            run_id: str = result.get("run_id", "")
+            console.print(f"Sync started — run_id={run_id}")
+            if full:
+                print_warning("--full flag noted; server determines sync scope per source type.")
+            _poll_run(client, run_id)
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+
+
+def _resolve_source_id(sources: list[Any], name: str) -> str | None:
+    """Return source id matching name or id field."""
+    for s in sources:
+        if not isinstance(s, dict):
+            continue
+        if s.get("name") == name or s.get("id") == name:
+            return str(s["id"])
+    return None
+
+
+def _poll_run(client: OmniscienceClient, run_id: str) -> None:
+    """Poll ingestion run until terminal state, showing progress."""
+    terminal = {"completed", "failed", "cancelled"}
+    for _ in range(60):
+        try:
+            run = client.get_ingestion_run(run_id)
+        except OmniscienceClientError:
+            break
+        state: str = run.get("status", "unknown")
+        docs: int = run.get("documents_processed", 0)
+        console.print(f"  status={state}  docs_processed={docs}", end="\r")
+        if state in terminal:
+            console.print()
+            if state == "completed":
+                print_success(f"Run {run_id} completed ({docs} docs).")
+            else:
+                abort(f"Run {run_id} ended with status '{state}'.")
+            return
+        time.sleep(2)
+    print_warning(f"Timed out polling run {run_id}. Check manually.")

--- a/apps/cli/src/omniscience_cli/commands/sources.py
+++ b/apps/cli/src/omniscience_cli/commands/sources.py
@@ -58,9 +58,7 @@ def sources_add(
 
 @app.command("list")
 def sources_list(
-    source_type: Annotated[
-        str | None, typer.Option("--type", "-t", help="Filter by type")
-    ] = None,
+    source_type: Annotated[str | None, typer.Option("--type", "-t", help="Filter by type")] = None,
     status: Annotated[str | None, typer.Option(help="Filter by status")] = None,
     as_json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
 ) -> None:

--- a/apps/cli/src/omniscience_cli/commands/tokens.py
+++ b/apps/cli/src/omniscience_cli/commands/tokens.py
@@ -1,0 +1,95 @@
+"""Token management commands: create, list, revoke."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+import typer
+
+from omniscience_cli.client import OmniscienceClient, OmniscienceClientError
+from omniscience_cli.output import abort, console, print_json, print_success, tokens_table
+
+app = typer.Typer(name="tokens", help="Manage API tokens.")
+
+_VALID_SCOPES = ["search", "sources:read", "sources:write", "admin"]
+_DEFAULT_SCOPES = "search,sources:read"
+
+
+def _make_client() -> OmniscienceClient:
+    return OmniscienceClient()
+
+
+@app.command("create")
+def tokens_create(
+    name: Annotated[str, typer.Option(prompt=True, help="Token name")],
+    scopes: Annotated[
+        str,
+        typer.Option(
+            prompt=True,
+            help=f"Comma-separated scopes. Valid: {', '.join(_VALID_SCOPES)}",
+        ),
+    ] = _DEFAULT_SCOPES,
+) -> None:
+    """Create a new API token. The plaintext value is shown once."""
+    scope_list = [s.strip() for s in scopes.split(",") if s.strip()]
+    invalid = [s for s in scope_list if s not in _VALID_SCOPES]
+    if invalid:
+        abort(f"Unknown scopes: {', '.join(invalid)}. Valid: {', '.join(_VALID_SCOPES)}")
+        return
+    with _make_client() as client:
+        try:
+            result = client.create_token(name, scope_list)
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    plaintext = result.get("token", result.get("plaintext", ""))
+    print_success(f"Token '{name}' created.")
+    if plaintext:
+        console.print(f"\n  [bold yellow]Token (shown once):[/bold yellow]  {plaintext}\n")
+    else:
+        console.print(result)
+
+
+@app.command("list")
+def tokens_list(
+    as_json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+) -> None:
+    """List all API tokens."""
+    with _make_client() as client:
+        try:
+            data = client.list_tokens()
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    items: list[dict[str, Any]] = data.get("tokens", [])
+    if as_json:
+        print_json(items)
+        return
+    tokens_table(items)
+
+
+@app.command("revoke")
+def tokens_revoke(
+    token_id: Annotated[str, typer.Argument(help="Token id to revoke")],
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip confirmation")] = False,
+) -> None:
+    """Revoke an API token."""
+    if not yes:
+        typer.confirm(f"Revoke token '{token_id}'?", abort=True)
+    with _make_client() as client:
+        try:
+            client.revoke_token(token_id)
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    print_success(f"Token '{token_id}' revoked.")
+
+
+def _resolve_token_id(tokens: list[Any], name_or_id: str) -> str | None:
+    """Return token id matching name or id field."""
+    for t in tokens:
+        if not isinstance(t, dict):
+            continue
+        if t.get("name") == name_or_id or t.get("id") == name_or_id:
+            return str(t["id"])
+    return None

--- a/apps/cli/src/omniscience_cli/main.py
+++ b/apps/cli/src/omniscience_cli/main.py
@@ -1,12 +1,119 @@
-"""CLI entry point — placeholder for Wave 3.
-
-The full CLI will support source management, manual reindex,
-ad-hoc search, and status reporting.
-"""
+"""Omniscience CLI entry point."""
 
 from __future__ import annotations
 
+from typing import Annotated, Any
+
+import typer
+
+from omniscience_cli.client import OmniscienceClientError
+from omniscience_cli.commands import mcp, sources, tokens
+from omniscience_cli.commands.ops import _check_api, _check_config, _check_embeddings, _check_nats
+from omniscience_cli.commands.search import _make_client as _search_client
+from omniscience_cli.output import (
+    abort,
+    console,
+    doctor_row,
+    print_json,
+    print_success,
+    search_results,
+)
+
+app = typer.Typer(
+    name="omniscience",
+    help="Omniscience — self-hosted knowledge retrieval.",
+    no_args_is_help=True,
+)
+
+# Command groups
+app.add_typer(sources.app, name="sources")
+app.add_typer(tokens.app, name="tokens")
+app.add_typer(mcp.app, name="mcp")
+
+
+@app.command("search")
+def cmd_search(
+    query: Annotated[str, typer.Argument(help="Natural-language or keyword query")],
+    source: Annotated[
+        list[str] | None,
+        typer.Option("--source", "-s", help="Restrict to source names (repeatable)"),
+    ] = None,
+    top_k: Annotated[int, typer.Option("--top-k", "-k", help="Max results")] = 10,
+    max_age: Annotated[int | None, typer.Option("--max-age", help="Max age in seconds")] = None,
+    as_json: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+) -> None:
+    """Search Omniscience and display results."""
+    with _search_client() as client:
+        try:
+            data = client.search(
+                query,
+                sources=source,
+                top_k=top_k,
+                max_age_seconds=max_age,
+            )
+        except OmniscienceClientError as exc:
+            abort(exc.message, exc.code)
+            return
+    hits: list[dict[str, Any]] = data.get("hits", [])
+    stats: dict[str, Any] = data.get("query_stats", {})
+    if as_json:
+        print_json(data)
+        return
+    search_results(hits)
+    dur = stats.get("duration_ms", "?")
+    total = stats.get("total_matches_before_filters", "?")
+    console.print(
+        f"[dim]{len(hits)} results  total_before_filters={total}  duration={dur}ms[/dim]"
+    )
+
+
+@app.command("migrate")
+def cmd_migrate(
+    revision: Annotated[str, typer.Option("--revision", "-r", help="Alembic revision")] = "head",
+) -> None:
+    """Run database migrations via Alembic."""
+    import subprocess
+    import sys
+
+    console.print(f"[dim]Running migrations to revision '{revision}'...[/dim]")
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "alembic", "upgrade", revision],
+        check=False,
+    )
+    if result.returncode != 0:
+        abort(f"Alembic exited with code {result.returncode}.")
+        return
+    print_success(f"Migrations applied to '{revision}'.")
+
+
+@app.command("doctor")
+def cmd_doctor() -> None:
+    """Check system health: config, API, NATS, embedding model."""
+    all_ok = True
+
+    cfg_ok, cfg_detail = _check_config()
+    doctor_row("config", cfg_ok, cfg_detail)
+    all_ok = all_ok and cfg_ok
+
+    api_ok, api_detail = _check_api()
+    doctor_row("api (http)", api_ok, api_detail)
+    all_ok = all_ok and api_ok
+
+    nats_ok, nats_detail = _check_nats()
+    doctor_row("nats", nats_ok, nats_detail)
+    all_ok = all_ok and nats_ok
+
+    embed_ok, embed_detail = _check_embeddings()
+    doctor_row("embedding model", embed_ok, embed_detail)
+    all_ok = all_ok and embed_ok
+
+    console.print()
+    if all_ok:
+        print_success("All checks passed.")
+    else:
+        abort("One or more checks failed.")
+
 
 def main() -> None:
-    """Omniscience CLI entry point."""
-    print("omniscience CLI — not yet implemented")  # noqa: T201
+    """Legacy entry point kept for backwards compatibility."""
+    app()

--- a/apps/cli/src/omniscience_cli/output.py
+++ b/apps/cli/src/omniscience_cli/output.py
@@ -1,0 +1,112 @@
+"""Rich-based output helpers for human and machine-readable display."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def print_json(data: Any) -> None:
+    """Serialize data to JSON and write to stdout."""
+    sys.stdout.write(json.dumps(data, indent=2, default=str) + "\n")
+
+
+def print_error(message: str, code: str | None = None) -> None:
+    """Print a styled error message to stderr."""
+    prefix = "[red]error[/red]"
+    if code:
+        prefix = f"[red]error[/red] [dim]({code})[/dim]"
+    err_console.print(f"{prefix}: {message}")
+
+
+def print_success(message: str) -> None:
+    """Print a styled success message."""
+    console.print(f"[green]ok[/green]  {message}")
+
+
+def print_warning(message: str) -> None:
+    """Print a styled warning message to stderr."""
+    err_console.print(f"[yellow]warn[/yellow] {message}")
+
+
+def sources_table(sources: list[dict[str, Any]]) -> None:
+    """Render a Rich table of sources."""
+    table = Table(title="Sources", show_header=True, header_style="bold cyan")
+    table.add_column("Name", style="bold")
+    table.add_column("Type")
+    table.add_column("Status")
+    table.add_column("Last Sync")
+    table.add_column("Docs", justify="right")
+    table.add_column("Stale")
+    for s in sources:
+        last_sync = s.get("last_sync_at") or "—"
+        stale = "[red]yes[/red]" if s.get("is_stale") else "[green]no[/green]"
+        table.add_row(
+            s.get("name", ""),
+            s.get("type", ""),
+            s.get("status", ""),
+            str(last_sync),
+            str(s.get("indexed_document_count", 0)),
+            stale,
+        )
+    console.print(table)
+
+
+def tokens_table(tokens: list[dict[str, Any]]) -> None:
+    """Render a Rich table of API tokens."""
+    table = Table(title="Tokens", show_header=True, header_style="bold cyan")
+    table.add_column("Name", style="bold")
+    table.add_column("Prefix")
+    table.add_column("Scopes")
+    table.add_column("Last Used")
+    table.add_column("ID")
+    for t in tokens:
+        table.add_row(
+            t.get("name", ""),
+            t.get("prefix", ""),
+            ", ".join(t.get("scopes", [])),
+            str(t.get("last_used_at") or "never"),
+            t.get("id", ""),
+        )
+    console.print(table)
+
+
+def search_results(hits: list[dict[str, Any]]) -> None:
+    """Pretty-print search results with citations."""
+    if not hits:
+        console.print("[dim]No results.[/dim]")
+        return
+    for i, hit in enumerate(hits, 1):
+        score = hit.get("score", 0.0)
+        text = hit.get("text", "")
+        citation = hit.get("citation") or {}
+        uri = citation.get("uri", "")
+        title = citation.get("title", "")
+        source = hit.get("source") or {}
+        source_name = source.get("name", "")
+
+        console.rule(f"[bold]#{i}[/bold]  score={score:.4f}  {source_name}")
+        if uri:
+            console.print(f"  [link={uri}][cyan]{title or uri}[/cyan][/link]")
+        console.print(f"  {text[:300]}{'...' if len(text) > 300 else ''}")
+        console.print()
+
+
+def doctor_row(check: str, ok: bool, detail: str = "") -> None:
+    """Print a single doctor check result line."""
+    status = "[green]pass[/green]" if ok else "[red]FAIL[/red]"
+    suffix = f"  [dim]{detail}[/dim]" if detail else ""
+    console.print(f"  {status}  {check}{suffix}")
+
+
+def abort(message: str, code: str | None = None) -> None:
+    """Print error and exit with status 1."""
+    print_error(message, code)
+    sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ omniscience-index      = { workspace = true }
 omniscience-retrieval  = { workspace = true }
 omniscience-server     = { workspace = true }
 omniscience-cli        = { workspace = true }
-omniscience-parsers = { workspace = true }
+omniscience-parsers    = { workspace = true }
 
 [dependency-groups]
 dev = [
@@ -42,6 +42,9 @@ dev = [
     "respx>=0.23.1",
     "omniscience-parsers",
     "omniscience-retrieval",
+    "omniscience-cli",
+    "typer>=0.12.0",
+    "rich>=13.7.0",
 ]
 
 [tool.ruff]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,496 @@
+"""Tests for the Omniscience CLI."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from omniscience_cli.client import OmniscienceClient, OmniscienceClientError, _raise_for_error
+from omniscience_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SOURCES_PAYLOAD: dict[str, Any] = {
+    "sources": [
+        {
+            "id": "src-1",
+            "name": "main-repo",
+            "type": "git",
+            "status": "active",
+            "last_sync_at": "2026-04-17T10:00:00Z",
+            "freshness_sla_seconds": 300,
+            "is_stale": False,
+            "indexed_document_count": 100,
+        }
+    ]
+}
+
+TOKENS_PAYLOAD: dict[str, Any] = {
+    "tokens": [
+        {
+            "id": "tok-1",
+            "name": "claude-code",
+            "prefix": "sk_abc",
+            "scopes": ["search", "sources:read"],
+            "last_used_at": None,
+        }
+    ]
+}
+
+SEARCH_PAYLOAD: dict[str, Any] = {
+    "hits": [
+        {
+            "chunk_id": "chunk-1",
+            "document_id": "doc-1",
+            "score": 0.92,
+            "text": "def authenticate_token(token: str) -> User: ...",
+            "source": {"id": "src-1", "name": "main-repo", "type": "git"},
+            "citation": {
+                "uri": "https://github.com/org/repo/blob/main/auth.py#L10",
+                "title": "auth.py",
+                "indexed_at": "2026-04-17T10:00:00Z",
+                "doc_version": 3,
+            },
+            "lineage": {},
+            "metadata": {"language": "python"},
+        }
+    ],
+    "query_stats": {
+        "total_matches_before_filters": 42,
+        "vector_matches": 30,
+        "text_matches": 25,
+        "duration_ms": 18,
+    },
+}
+
+
+def _mock_client(**method_map: Any) -> MagicMock:
+    """Return a MagicMock that acts as an OmniscienceClient context manager."""
+    mock = MagicMock(spec=OmniscienceClient)
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    for name, value in method_map.items():
+        if isinstance(value, Exception):
+            getattr(mock, name).side_effect = value
+        else:
+            getattr(mock, name).return_value = value
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# client.py unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestOmniscienceClient:
+    def test_reads_env_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://custom:9000")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "tok")
+        c = OmniscienceClient()
+        assert c.base_url == "http://custom:9000"
+        c.close()
+
+    def test_reads_env_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://localhost:8000")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "sk_test")
+        c = OmniscienceClient()
+        assert c.token == "sk_test"
+        c.close()
+
+    def test_explicit_args_override_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://env:8000")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "env_tok")
+        c = OmniscienceClient(base_url="http://explicit:1234", token="explicit_tok")
+        assert c.base_url == "http://explicit:1234"
+        assert c.token == "explicit_tok"
+        c.close()
+
+    def test_trailing_slash_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://localhost:8000/")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "")
+        c = OmniscienceClient()
+        assert not c.base_url.endswith("/")
+        c.close()
+
+    def test_empty_token_no_auth_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OMNISCIENCE_TOKEN", raising=False)
+        c = OmniscienceClient(base_url="http://localhost:8000", token="")
+        assert "Authorization" not in c._client.headers
+        c.close()
+
+    def test_token_sets_auth_header(self) -> None:
+        c = OmniscienceClient(base_url="http://localhost:8000", token="sk_abc")
+        assert c._client.headers["authorization"] == "Bearer sk_abc"
+        c.close()
+
+    def test_context_manager(self) -> None:
+        with OmniscienceClient(base_url="http://localhost:8000", token="t") as c:
+            assert isinstance(c, OmniscienceClient)
+
+
+class TestRaiseForError:
+    def test_success_does_not_raise(self) -> None:
+        import httpx
+
+        resp = httpx.Response(200, json={"ok": True})
+        _raise_for_error(resp)  # should not raise
+
+    def test_structured_error_raises(self) -> None:
+        import httpx
+
+        body = {"error": {"code": "unauthorized", "message": "Bad token", "details": {}}}
+        resp = httpx.Response(401, json=body)
+        with pytest.raises(OmniscienceClientError) as exc_info:
+            _raise_for_error(resp)
+        assert exc_info.value.code == "unauthorized"
+        assert exc_info.value.status == 401
+
+    def test_unstructured_error_raises(self) -> None:
+        import httpx
+
+        resp = httpx.Response(500, text="Internal Server Error")
+        with pytest.raises(OmniscienceClientError) as exc_info:
+            _raise_for_error(resp)
+        assert exc_info.value.status == 500
+
+
+# ---------------------------------------------------------------------------
+# sources commands
+# ---------------------------------------------------------------------------
+
+
+class TestSourcesList:
+    def test_list_table_output(self) -> None:
+        mock = _mock_client(list_sources=SOURCES_PAYLOAD)
+        with patch("omniscience_cli.commands.sources.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["sources", "list"])
+        assert result.exit_code == 0
+        assert "main-repo" in result.output
+
+    def test_list_json_output(self) -> None:
+        mock = _mock_client(list_sources=SOURCES_PAYLOAD)
+        with patch("omniscience_cli.commands.sources.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["sources", "list", "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert isinstance(parsed, list)
+        assert parsed[0]["name"] == "main-repo"
+
+    def test_list_api_error(self) -> None:
+        err = OmniscienceClientError("unauthorized", "Bad token", 401)
+        mock = _mock_client(list_sources=err)
+        with patch("omniscience_cli.commands.sources.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["sources", "list"])
+        assert result.exit_code != 0
+
+
+class TestSourcesRemove:
+    def test_remove_with_yes_flag(self) -> None:
+        mock = _mock_client(list_sources=SOURCES_PAYLOAD, delete_source=None)
+        with patch("omniscience_cli.commands.sources.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["sources", "remove", "--yes", "main-repo"])
+        assert result.exit_code == 0
+        mock.delete_source.assert_called_once_with("src-1")
+
+    def test_remove_not_found(self) -> None:
+        mock = _mock_client(list_sources={"sources": []}, delete_source=None)
+        with patch("omniscience_cli.commands.sources.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["sources", "remove", "--yes", "ghost"])
+        assert result.exit_code != 0
+
+
+class TestSourcesSync:
+    def test_sync_starts_run(self) -> None:
+        run_resp = {"run_id": "run-123"}
+        ingestion_resp = {"status": "completed", "documents_processed": 10}
+        mock = _mock_client(
+            list_sources=SOURCES_PAYLOAD,
+            sync_source=run_resp,
+            get_ingestion_run=ingestion_resp,
+        )
+        with patch("omniscience_cli.commands.sources.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["sources", "sync", "main-repo"])
+        assert result.exit_code == 0
+        assert "run-123" in result.output
+
+
+class TestSourcesTest:
+    def test_test_success(self) -> None:
+        stats = {"indexed_document_count": 50, "freshness": "ok"}
+        mock = _mock_client(list_sources=SOURCES_PAYLOAD, validate_source=stats)
+        with patch("omniscience_cli.commands.sources.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["sources", "test", "main-repo"])
+        assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# tokens commands
+# ---------------------------------------------------------------------------
+
+
+class TestTokensList:
+    def test_list_table(self) -> None:
+        mock = _mock_client(list_tokens=TOKENS_PAYLOAD)
+        with patch("omniscience_cli.commands.tokens.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["tokens", "list"])
+        assert result.exit_code == 0
+        assert "claude-code" in result.output
+
+    def test_list_json(self) -> None:
+        mock = _mock_client(list_tokens=TOKENS_PAYLOAD)
+        with patch("omniscience_cli.commands.tokens.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["tokens", "list", "--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed[0]["name"] == "claude-code"
+
+
+class TestTokensCreate:
+    def test_create_shows_plaintext_once(self) -> None:
+        response = {"id": "tok-new", "name": "ci", "token": "sk_plaintext_value"}
+        mock = _mock_client(create_token=response)
+        with patch("omniscience_cli.commands.tokens.OmniscienceClient", return_value=mock):
+            result = runner.invoke(
+                app,
+                ["tokens", "create", "--name", "ci", "--scopes", "search"],
+            )
+        assert result.exit_code == 0
+        assert "sk_plaintext_value" in result.output
+
+    def test_create_rejects_invalid_scope(self) -> None:
+        mock = _mock_client(create_token={})
+        with patch("omniscience_cli.commands.tokens.OmniscienceClient", return_value=mock):
+            result = runner.invoke(
+                app,
+                ["tokens", "create", "--name", "bad", "--scopes", "invalid_scope"],
+            )
+        assert result.exit_code != 0
+        assert "Unknown scopes" in result.stderr
+
+    def test_create_api_error(self) -> None:
+        err = OmniscienceClientError("forbidden", "Forbidden", 403)
+        mock = _mock_client(create_token=err)
+        with patch("omniscience_cli.commands.tokens.OmniscienceClient", return_value=mock):
+            result = runner.invoke(
+                app,
+                ["tokens", "create", "--name", "x", "--scopes", "search"],
+            )
+        assert result.exit_code != 0
+
+
+class TestTokensRevoke:
+    def test_revoke_with_yes(self) -> None:
+        mock = _mock_client(revoke_token=None)
+        with patch("omniscience_cli.commands.tokens.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["tokens", "revoke", "--yes", "tok-1"])
+        assert result.exit_code == 0
+        mock.revoke_token.assert_called_once_with("tok-1")
+
+
+# ---------------------------------------------------------------------------
+# search command
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_search_human_output(self) -> None:
+        mock = _mock_client(search=SEARCH_PAYLOAD)
+        with patch("omniscience_cli.commands.search.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["search", "authentication"])
+        assert result.exit_code == 0
+        assert "authenticate_token" in result.output
+
+    def test_search_json_output(self) -> None:
+        mock = _mock_client(search=SEARCH_PAYLOAD)
+        with patch("omniscience_cli.commands.search.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["search", "--json", "authentication"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "hits" in parsed
+        assert parsed["hits"][0]["score"] == pytest.approx(0.92)
+
+    def test_search_passes_source_filter(self) -> None:
+        mock = _mock_client(search=SEARCH_PAYLOAD)
+        with patch("omniscience_cli.commands.search.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["search", "--source", "main-repo", "query"])
+        assert result.exit_code == 0
+        call_kwargs = mock.search.call_args
+        assert call_kwargs.kwargs.get("sources") == ["main-repo"]
+
+    def test_search_passes_top_k(self) -> None:
+        mock = _mock_client(search=SEARCH_PAYLOAD)
+        with patch("omniscience_cli.commands.search.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["search", "--top-k", "5", "query"])
+        assert result.exit_code == 0
+        assert mock.search.call_args.kwargs.get("top_k") == 5
+
+    def test_search_api_error(self) -> None:
+        err = OmniscienceClientError("rate_limited", "Too many requests", 429)
+        mock = _mock_client(search=err)
+        with patch("omniscience_cli.commands.search.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["search", "query"])
+        assert result.exit_code != 0
+
+    def test_search_no_results(self) -> None:
+        empty = {"hits": [], "query_stats": {"total_matches_before_filters": 0, "duration_ms": 5}}
+        mock = _mock_client(search=empty)
+        with patch("omniscience_cli.commands.search.OmniscienceClient", return_value=mock):
+            result = runner.invoke(app, ["search", "nothing"])
+        assert result.exit_code == 0
+        assert "No results" in result.output
+
+
+# ---------------------------------------------------------------------------
+# doctor command
+# ---------------------------------------------------------------------------
+
+
+class TestDoctor:
+    def test_all_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://localhost:8000")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "sk_test")
+        with (
+            patch(
+                "omniscience_cli.main._check_api",
+                return_value=(True, "version=0.1.0"),
+            ),
+            patch(
+                "omniscience_cli.main._check_nats",
+                return_value=(True, "nats://localhost:4222"),
+            ),
+            patch(
+                "omniscience_cli.main._check_embeddings",
+                return_value=(True, "omniscience-embeddings importable"),
+            ),
+        ):
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "All checks passed" in result.output
+
+    def test_missing_env_fails_config_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OMNISCIENCE_URL", raising=False)
+        monkeypatch.delenv("OMNISCIENCE_TOKEN", raising=False)
+        with (
+            patch(
+                "omniscience_cli.main._check_api",
+                return_value=(False, "connection refused"),
+            ),
+            patch(
+                "omniscience_cli.main._check_nats",
+                return_value=(False, "connection refused"),
+            ),
+            patch(
+                "omniscience_cli.main._check_embeddings",
+                return_value=(True, "ok"),
+            ),
+        ):
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code != 0
+        assert "FAIL" in result.output
+
+    def test_nats_failure_shown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://localhost:8000")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "sk_t")
+        with (
+            patch(
+                "omniscience_cli.main._check_api",
+                return_value=(True, "version=0.1.0"),
+            ),
+            patch(
+                "omniscience_cli.main._check_nats",
+                return_value=(False, "Connection refused"),
+            ),
+            patch(
+                "omniscience_cli.main._check_embeddings",
+                return_value=(True, "ok"),
+            ),
+        ):
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code != 0
+        assert "FAIL" in result.output
+
+    def test_embedding_failure_shown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://localhost:8000")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "sk_t")
+        with (
+            patch(
+                "omniscience_cli.main._check_api",
+                return_value=(True, "version=0.1.0"),
+            ),
+            patch(
+                "omniscience_cli.main._check_nats",
+                return_value=(True, "nats://localhost:4222"),
+            ),
+            patch(
+                "omniscience_cli.main._check_embeddings",
+                return_value=(False, "No module named 'omniscience_embeddings'"),
+            ),
+        ):
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# ops._check_* unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckHelpers:
+    def test_check_config_missing_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from omniscience_cli.commands.ops import _check_config
+
+        monkeypatch.delenv("OMNISCIENCE_URL", raising=False)
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "t")
+        ok, detail = _check_config()
+        assert not ok
+        assert "OMNISCIENCE_URL" in detail
+
+    def test_check_config_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from omniscience_cli.commands.ops import _check_config
+
+        monkeypatch.setenv("OMNISCIENCE_URL", "http://localhost:8000")
+        monkeypatch.setenv("OMNISCIENCE_TOKEN", "t")
+        ok, _ = _check_config()
+        assert ok
+
+    def test_check_api_success(self) -> None:
+        from omniscience_cli.commands.ops import _check_api
+
+        mock = _mock_client(health={"status": "ok", "version": "0.1.0"})
+        with patch("omniscience_cli.commands.ops.OmniscienceClient", return_value=mock):
+            ok, detail = _check_api()
+        assert ok
+        assert "version=0.1.0" in detail
+
+    def test_check_api_failure(self) -> None:
+        from omniscience_cli.commands.ops import _check_api
+
+        err = OmniscienceClientError("internal", "Service down", 500)
+        mock = _mock_client(health=err)
+        with patch("omniscience_cli.commands.ops.OmniscienceClient", return_value=mock):
+            ok, detail = _check_api()
+        assert not ok
+        assert "Service down" in detail
+
+    def test_check_embeddings_missing(self) -> None:
+        from omniscience_cli.commands.ops import _check_embeddings
+
+        with patch.dict("sys.modules", {"omniscience_embeddings": None}):
+            # Force an ImportError by removing the module
+            import sys
+
+            saved = sys.modules.pop("omniscience_embeddings", None)
+            try:
+                ok, _detail = _check_embeddings()
+                # If it's installed it's ok; if not it fails
+                assert isinstance(ok, bool)
+            finally:
+                if saved is not None:
+                    sys.modules["omniscience_embeddings"] = saved


### PR DESCRIPTION
## Summary
- Typer-based CLI: `omniscience` command with subgroups
- Commands: sources (add/list/remove/test/sync), tokens (create/list/revoke), search, mcp serve, migrate, doctor
- Rich tables for human output, --json for scripting
- OmniscienceClient wrapping REST API via httpx
- 38 new tests

## Test plan
- [ ] All tests pass, mypy --strict clean, ruff clean

Closes #16