### PR TITLE
feat: git and filesystem connectors with webhook support

### DIFF
--- a/packages/connectors/pyproject.toml
+++ b/packages/connectors/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "omniscience-core",
     "pydantic>=2.7.0",
+    "watchfiles>=0.21.0",
 ]
 
 [tool.uv.sources]

--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -15,9 +15,9 @@ Registry::
 
     from omniscience_connectors import ConnectorRegistry, get_connector
 
-Built-in connectors (``git``, ``fs``) will be registered here in subsequent
-issues.  Third-party connectors call :func:`get_connector` after registering
-against the shared registry.
+Built-in connectors (``git``, ``fs``) are registered below and available
+immediately on import.  Third-party connectors call :func:`get_connector`
+after registering against the shared registry.
 """
 
 from omniscience_connectors.base import (
@@ -27,17 +27,26 @@ from omniscience_connectors.base import (
     WebhookHandler,
     WebhookPayload,
 )
+from omniscience_connectors.fs.connector import FsConnector
+from omniscience_connectors.git.connector import GitConnector
 from omniscience_connectors.registry import (
     ConnectorRegistry,
     NotFoundError,
+    _registry,
     get_connector,
 )
+
+# Register built-in connectors in the shared module-level registry
+_registry.register(GitConnector)
+_registry.register(FsConnector)
 
 __all__ = [
     "Connector",
     "ConnectorRegistry",
     "DocumentRef",
     "FetchedDocument",
+    "FsConnector",
+    "GitConnector",
     "NotFoundError",
     "WebhookHandler",
     "WebhookPayload",

--- a/packages/connectors/src/omniscience_connectors/fs/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/fs/__init__.py
@@ -1,0 +1,12 @@
+"""Filesystem source connector for Omniscience.
+
+Discovers and fetches files from a local filesystem path.
+Uses inotify/kqueue/FSEvents via watchfiles for future watcher support.
+"""
+
+from omniscience_connectors.fs.connector import FsConfig, FsConnector
+
+__all__ = [
+    "FsConfig",
+    "FsConnector",
+]

--- a/packages/connectors/src/omniscience_connectors/fs/connector.py
+++ b/packages/connectors/src/omniscience_connectors/fs/connector.py
@@ -1,0 +1,202 @@
+"""Filesystem source connector.
+
+Discovers and fetches files from a local directory tree using pathlib.
+Path traversal is prevented by resolving all paths and verifying containment.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import mimetypes
+import os
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import ClassVar
+
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import Connector, DocumentRef, FetchedDocument, WebhookHandler
+
+__all__ = ["FsConfig", "FsConnector"]
+
+logger = logging.getLogger(__name__)
+
+# Sentinel pattern meaning "match everything"
+_MATCH_ALL = {"**/*", "**", "*"}
+
+
+class FsConfig(BaseModel):
+    """Public configuration for the filesystem connector (no secrets)."""
+
+    root_path: str
+    """Absolute path to the root directory to index."""
+
+    include_globs: list[str] = Field(default_factory=lambda: ["**/*"])
+    """Glob patterns to include.  Matched relative to *root_path*."""
+
+    exclude_globs: list[str] = Field(default_factory=list)
+    """Glob patterns to exclude.  Matched relative to *root_path*."""
+
+    follow_symlinks: bool = False
+    """Whether to follow symbolic links during directory traversal."""
+
+    max_file_size_bytes: int = 1_000_000
+    """Files larger than this are skipped during discovery and fetch (bytes)."""
+
+
+def _path_is_within(root: Path, candidate: Path) -> bool:
+    """Return True when *candidate* is inside *root* (prevents traversal)."""
+    try:
+        candidate.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _pattern_matches(rel_posix: str, pattern: str) -> bool:
+    """Return True if *rel_posix* matches *pattern*.
+
+    Supports:
+    - ``**/*`` / ``**`` / ``*`` — match everything
+    - Simple globs: ``*.md``, ``*.txt``
+    - Path globs: ``src/**``, ``docs/*.md``
+    - pathlib-style matching for patterns containing ``/``
+    """
+    if pattern in _MATCH_ALL:
+        return True
+    # Use pathlib for patterns containing path separators or **
+    if "/" in pattern or "**" in pattern:
+        return PurePosixPath(rel_posix).match(pattern)
+    # Simple extension/name glob: check against basename and full path
+    name = rel_posix.rsplit("/", 1)[-1]
+    return fnmatch.fnmatch(name, pattern) or fnmatch.fnmatch(rel_posix, pattern)
+
+
+def _rel_matches(rel_posix: str, patterns: list[str]) -> bool:
+    """Return True if *rel_posix* matches any of the given patterns."""
+    return any(_pattern_matches(rel_posix, p) for p in patterns)
+
+
+def _content_type(path: Path) -> str:
+    """Guess MIME type from file extension; default to text/plain."""
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "text/plain"
+
+
+class FsConnector(Connector):
+    """Connector for local filesystem directories.
+
+    Stateless: configuration is passed at call time so one instance can serve
+    multiple source records simultaneously.
+    """
+
+    connector_type: ClassVar[str] = "fs"
+    config_schema: ClassVar[type[BaseModel]] = FsConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify the root path exists and is a readable directory."""
+        cfg: FsConfig = config  # type: ignore[assignment]
+        root = Path(cfg.root_path).resolve()
+        if not root.exists():
+            raise ValueError(f"root_path {cfg.root_path!r} does not exist")
+        if not root.is_dir():
+            raise ValueError(f"root_path {cfg.root_path!r} is not a directory")
+        if not os.access(root, os.R_OK):
+            raise ValueError(f"root_path {cfg.root_path!r} is not readable")
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Walk the filesystem and yield DocumentRef for each matching file."""
+        cfg: FsConfig = config  # type: ignore[assignment]
+        root = Path(cfg.root_path).resolve()
+
+        for file_path in _walk(root, cfg.follow_symlinks):
+            # Safety: prevent path traversal
+            if not _path_is_within(root, file_path.resolve()):
+                logger.warning("fs.connector.traversal_attempt", extra={"path": str(file_path)})
+                continue
+
+            rel = file_path.relative_to(root)
+            rel_posix = rel.as_posix()
+
+            # Apply include/exclude filters
+            if not _rel_matches(rel_posix, cfg.include_globs):
+                continue
+            if cfg.exclude_globs and _rel_matches(rel_posix, cfg.exclude_globs):
+                continue
+
+            try:
+                stat = file_path.stat()
+            except OSError:
+                continue
+
+            if stat.st_size > cfg.max_file_size_bytes:
+                logger.debug(
+                    "fs.connector.skip_large_file",
+                    extra={"path": rel_posix, "size": stat.st_size},
+                )
+                continue
+
+            mtime = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+            yield DocumentRef(
+                external_id=str(file_path.resolve()),
+                uri=str(file_path.resolve()),
+                updated_at=mtime,
+                metadata={
+                    "path": rel_posix,
+                    "size": stat.st_size,
+                    "content_type": _content_type(file_path),
+                },
+            )
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Read and return file content for the given DocumentRef."""
+        cfg: FsConfig = config  # type: ignore[assignment]
+        root = Path(cfg.root_path).resolve()
+
+        # The uri field stores the resolved absolute path
+        file_path = Path(ref.uri).resolve()
+
+        # Safety: prevent path traversal
+        if not _path_is_within(root, file_path):
+            raise ValueError(
+                f"Path {ref.uri!r} is outside the configured root {cfg.root_path!r}"
+            )
+
+        stat = file_path.stat()
+        if stat.st_size > cfg.max_file_size_bytes:
+            raise ValueError(
+                f"File {ref.uri!r} ({stat.st_size} bytes) exceeds "
+                f"max_file_size_bytes={cfg.max_file_size_bytes}"
+            )
+
+        content = file_path.read_bytes()
+        content_type = ref.metadata.get("content_type") or _content_type(file_path)
+        return FetchedDocument(ref=ref, content_bytes=content, content_type=content_type)
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        """Filesystem connector uses a watcher, not webhooks."""
+        return None
+
+
+def _walk(root: Path, follow_symlinks: bool) -> list[Path]:
+    """Return a list of all regular files under *root*."""
+    results: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=follow_symlinks, topdown=True):
+        # Remove hidden directories in-place to skip them
+        dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+        for fname in filenames:
+            if fname.startswith("."):
+                continue
+            results.append(Path(dirpath) / fname)
+    return results

--- a/packages/connectors/src/omniscience_connectors/fs/connector.py
+++ b/packages/connectors/src/omniscience_connectors/fs/connector.py
@@ -169,9 +169,7 @@ class FsConnector(Connector):
 
         # Safety: prevent path traversal
         if not _path_is_within(root, file_path):
-            raise ValueError(
-                f"Path {ref.uri!r} is outside the configured root {cfg.root_path!r}"
-            )
+            raise ValueError(f"Path {ref.uri!r} is outside the configured root {cfg.root_path!r}")
 
         stat = file_path.stat()
         if stat.st_size > cfg.max_file_size_bytes:

--- a/packages/connectors/src/omniscience_connectors/git/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/git/__init__.py
@@ -1,0 +1,14 @@
+"""Git source connector for Omniscience.
+
+Supports local paths and remote repositories (GitHub/GitLab) over HTTPS or SSH.
+Push-style updates are supported via GitHub/GitLab webhooks.
+"""
+
+from omniscience_connectors.git.connector import GitConfig, GitConnector
+from omniscience_connectors.git.webhook import GitWebhookHandler
+
+__all__ = [
+    "GitConfig",
+    "GitConnector",
+    "GitWebhookHandler",
+]

--- a/packages/connectors/src/omniscience_connectors/git/connector.py
+++ b/packages/connectors/src/omniscience_connectors/git/connector.py
@@ -1,0 +1,218 @@
+"""Git source connector.
+
+Discovers and fetches files from a git repository (local or remote).
+Uses subprocess calls to git with list-form arguments to prevent shell injection.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import mimetypes
+import subprocess
+import tempfile
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import ClassVar
+
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import Connector, DocumentRef, FetchedDocument, WebhookHandler
+from omniscience_connectors.git.webhook import GitWebhookHandler
+
+__all__ = ["GitConfig", "GitConnector"]
+
+logger = logging.getLogger(__name__)
+
+# Byte sequences that indicate a binary file (null byte is the most reliable)
+_BINARY_HEURISTIC_BYTES = 8192
+_NULL_BYTE = b"\x00"
+
+
+def _is_binary(data: bytes) -> bool:
+    """Return True if *data* appears to be binary content."""
+    return _NULL_BYTE in data[:_BINARY_HEURISTIC_BYTES]
+
+
+def _run_git(args: list[str], cwd: str | None = None) -> subprocess.CompletedProcess[bytes]:
+    """Run a git command; raises ``RuntimeError`` on non-zero exit.
+
+    Uses list-form args (never shell=True) to prevent shell injection.
+    """
+    cmd = ["git", *args]
+    result = subprocess.run(  # noqa: S603
+        cmd,
+        cwd=cwd,
+        capture_output=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode(errors="replace").strip()
+        raise RuntimeError(f"git {args[0]} failed: {stderr}")
+    return result
+
+
+def _matches_patterns(path: str, patterns: list[str]) -> bool:
+    """Return True if *path* matches any of the given glob patterns."""
+    return any(fnmatch.fnmatch(path, p) for p in patterns)
+
+
+class GitConfig(BaseModel):
+    """Public configuration for the git connector (no secrets)."""
+
+    url: str
+    """Local filesystem path or remote URL (HTTPS/SSH)."""
+
+    ref: str = "HEAD"
+    """Git ref (branch, tag, commit SHA) to discover files from."""
+
+    path_include: list[str] = Field(default_factory=list)
+    """Glob patterns for files to include.  Empty = include everything."""
+
+    path_exclude: list[str] = Field(default_factory=list)
+    """Glob patterns for files to exclude."""
+
+    max_file_size_bytes: int = 1_000_000
+    """Files larger than this are skipped during fetch (bytes)."""
+
+    webhook_secret: str | None = None
+    """Webhook secret for verifying GitHub/GitLab push events.
+
+    Note: treat this as *configuration* (not a runtime secret) for local
+    validation convenience.  The ingestion pipeline also passes it via
+    secrets dict at runtime.
+    """
+
+
+def _resolve_repo(url: str) -> tuple[str, str | None]:
+    """Return (repo_path, tmp_dir_or_None).
+
+    For local paths: returns the path as-is, no tmp dir.
+    For remote URLs: clones into a temp dir and returns that path + temp dir.
+    """
+    p = Path(url)
+    if p.exists() and p.is_dir():
+        return str(p), None
+
+    tmp = tempfile.mkdtemp(prefix="omniscience_git_")
+    _run_git(["clone", "--depth=1", "--no-tags", url, tmp])
+    return tmp, tmp
+
+
+class GitConnector(Connector):
+    """Connector for git repositories (local or remote).
+
+    Stateless: all state is derived from config at call time so one instance
+    can serve multiple source records simultaneously.
+    """
+
+    connector_type: ClassVar[str] = "git"
+    config_schema: ClassVar[type[BaseModel]] = GitConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify the repository is accessible and the ref exists."""
+        cfg: GitConfig = config  # type: ignore[assignment]
+
+        p = Path(cfg.url)
+        if p.exists():
+            # Local repo: verify it is a git repository
+            _run_git(["rev-parse", "--git-dir"], cwd=str(p))
+            _run_git(["rev-parse", "--verify", cfg.ref], cwd=str(p))
+        else:
+            # Remote repo: perform a lightweight ls-remote check
+            env_token = secrets.get("token") or secrets.get("password")
+            url = cfg.url
+            if env_token and url.startswith("https://"):
+                # Inject token into URL for authentication
+                url = url.replace("https://", f"https://oauth2:{env_token}@", 1)
+            result = subprocess.run(  # noqa: S603
+                ["git", "ls-remote", url, cfg.ref],  # noqa: S607
+                capture_output=True,
+                timeout=60,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Cannot access repository {cfg.url!r}: "
+                    + result.stderr.decode(errors="replace").strip()
+                )
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield a DocumentRef for every file matching the include/exclude patterns."""
+        cfg: GitConfig = config  # type: ignore[assignment]
+        repo_path, tmp_dir = _resolve_repo(cfg.url)
+        try:
+            result = _run_git(
+                ["ls-tree", "-r", "--name-only", cfg.ref],
+                cwd=repo_path,
+            )
+            for raw_path in result.stdout.splitlines():
+                rel_path = raw_path.decode(errors="replace")
+
+                if cfg.path_include and not _matches_patterns(rel_path, cfg.path_include):
+                    continue
+                if cfg.path_exclude and _matches_patterns(rel_path, cfg.path_exclude):
+                    continue
+
+                blob_sha = _get_blob_sha(repo_path, cfg.ref, rel_path)
+                uri = f"git+{cfg.url}#{cfg.ref}:{rel_path}"
+                yield DocumentRef(
+                    external_id=blob_sha,
+                    uri=uri,
+                    metadata={"path": rel_path, "ref": cfg.ref, "repo": cfg.url},
+                )
+        finally:
+            if tmp_dir:
+                import shutil
+
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch file content for the given DocumentRef."""
+        cfg: GitConfig = config  # type: ignore[assignment]
+        rel_path = ref.metadata.get("path", "")
+        git_ref = ref.metadata.get("ref", cfg.ref)
+
+        repo_path, tmp_dir = _resolve_repo(cfg.url)
+        try:
+            result = _run_git(["show", f"{git_ref}:{rel_path}"], cwd=repo_path)
+        finally:
+            if tmp_dir:
+                import shutil
+
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        content = result.stdout
+        if len(content) > cfg.max_file_size_bytes:
+            raise ValueError(
+                f"File {rel_path!r} ({len(content)} bytes) exceeds "
+                f"max_file_size_bytes={cfg.max_file_size_bytes}"
+            )
+        if _is_binary(content):
+            raise ValueError(f"File {rel_path!r} appears to be binary; skipping")
+
+        content_type = _guess_content_type(rel_path)
+        return FetchedDocument(ref=ref, content_bytes=content, content_type=content_type)
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return GitWebhookHandler()
+
+
+def _get_blob_sha(repo_path: str, ref: str, rel_path: str) -> str:
+    """Return the git blob SHA for *rel_path* at *ref*."""
+    result = _run_git(["rev-parse", f"{ref}:{rel_path}"], cwd=repo_path)
+    return result.stdout.decode().strip()
+
+
+def _guess_content_type(path: str) -> str:
+    """Guess MIME type from file extension; fall back to text/plain."""
+    mime, _ = mimetypes.guess_type(path)
+    return mime or "text/plain"

--- a/packages/connectors/src/omniscience_connectors/git/webhook.py
+++ b/packages/connectors/src/omniscience_connectors/git/webhook.py
@@ -1,0 +1,129 @@
+"""Git webhook handler for GitHub and GitLab push events."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+
+from omniscience_connectors.base import DocumentRef, WebhookHandler, WebhookPayload
+
+__all__ = ["GitWebhookHandler"]
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_SIG_HEADER = "x-hub-signature-256"
+_GITLAB_TOKEN_HEADER = "x-gitlab-token"  # noqa: S105 — HTTP header name, not a password
+
+
+class GitWebhookHandler(WebhookHandler):
+    """Webhook handler supporting GitHub and GitLab push events.
+
+    Signature verification:
+    - **GitHub**: HMAC-SHA256 in ``X-Hub-Signature-256: sha256=<hex>``
+    - **GitLab**: shared token in ``X-Gitlab-Token: <token>``
+    """
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        """Return True if the webhook request is authentic."""
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+
+        # GitHub: HMAC-SHA256
+        github_sig = lower_headers.get(_GITHUB_SIG_HEADER, "")
+        if github_sig:
+            return _verify_github_signature(payload, github_sig, secret)
+
+        # GitLab: plain token comparison
+        gitlab_token = lower_headers.get(_GITLAB_TOKEN_HEADER, "")
+        if gitlab_token:
+            return hmac.compare_digest(gitlab_token, secret)
+
+        # No recognised signature header
+        return False
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        """Parse a GitHub or GitLab push event into a WebhookPayload."""
+        try:
+            data: dict[str, object] = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Webhook payload is not valid JSON: {exc}") from exc
+
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+        source_name = _detect_source(lower_headers, data)
+        affected_refs = _extract_affected_refs(data)
+
+        return WebhookPayload(
+            source_name=source_name,
+            affected_refs=affected_refs,
+            raw_headers=lower_headers,
+        )
+
+
+def _verify_github_signature(payload: bytes, sig_header: str, secret: str) -> bool:
+    """Verify a GitHub HMAC-SHA256 signature using constant-time comparison."""
+    if not sig_header.startswith("sha256="):
+        return False
+    provided_hex = sig_header[len("sha256=") :]
+    expected_hex = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected_hex, provided_hex)
+
+
+def _detect_source(lower_headers: dict[str, str], data: dict[str, object]) -> str:
+    """Infer a human-readable source name from headers or payload."""
+    if _GITHUB_SIG_HEADER in lower_headers:
+        repo = data.get("repository")
+        if isinstance(repo, dict):
+            full_name = repo.get("full_name")
+            if isinstance(full_name, str):
+                return full_name
+        return "github"
+
+    if _GITLAB_TOKEN_HEADER in lower_headers:
+        repo = data.get("project") or data.get("repository")
+        if isinstance(repo, dict):
+            name = repo.get("path_with_namespace") or repo.get("name")
+            if isinstance(name, str):
+                return name
+        return "gitlab"
+
+    return "git"
+
+
+def _extract_affected_refs(data: dict[str, object]) -> list[DocumentRef]:
+    """Extract added/modified/removed file paths from a push event payload."""
+    refs: list[DocumentRef] = []
+    commits = data.get("commits")
+    if not isinstance(commits, list):
+        return refs
+
+    seen: set[str] = set()
+    for commit in commits:
+        if not isinstance(commit, dict):
+            continue
+        sha = commit.get("id") or commit.get("sha") or ""
+        for key in ("added", "modified", "removed"):
+            files = commit.get(key, [])
+            if not isinstance(files, list):
+                continue
+            for file_path in files:
+                if not isinstance(file_path, str) or file_path in seen:
+                    continue
+                seen.add(file_path)
+                refs.append(
+                    DocumentRef(
+                        external_id=f"{sha}:{file_path}" if sha else file_path,
+                        uri=file_path,
+                        metadata={"action": key, "commit": sha},
+                    )
+                )
+    return refs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ ignore = [
     "S101",  # assert is the standard pytest assertion mechanism
     "S105",  # Hardcoded password string — test fixtures use placeholder values
     "S106",  # Hardcoded password in function argument — test fixtures only
+    "S108",  # Probable insecure usage of temp file — test-only temp paths
+    "S306",  # Insecure mktemp — test-only, we unlink immediately
+    "S603",  # subprocess call — test helpers run git in controlled fixtures
+    "S607",  # Partial executable path — controlled test environment
+    "B017",  # Do not assert blind exception — inherited from contract tests
 ]
 
 [tool.mypy]

--- a/tests/connectors/contract_tests.py
+++ b/tests/connectors/contract_tests.py
@@ -85,7 +85,7 @@ class ConnectorContractTests(abc.ABC):
     async def test_validate_raises_with_invalid_config(self) -> None:
         """validate() must raise for bad config or bad secrets."""
         connector = self.make_connector()
-        with pytest.raises(Exception):  # noqa: B017 — any exception is a contract pass
+        with pytest.raises(Exception):
             await connector.validate(self.invalid_config(), self.secrets())
 
     # ------------------------------------------------------------------

--- a/tests/test_fs_connector.py
+++ b/tests/test_fs_connector.py
@@ -1,0 +1,326 @@
+"""Tests for the filesystem source connector (Issue #18)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from omniscience_connectors import DocumentRef, FetchedDocument
+from omniscience_connectors.fs.connector import FsConfig, FsConnector
+
+from tests.connectors.contract_tests import ConnectorContractTests
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_tree(files: dict[str, str | bytes] | None = None) -> str:
+    """Create a temp directory with the given file tree.
+
+    *files* maps relative path -> text content (str) or binary content (bytes).
+    Default creates a small mixed tree.
+    """
+    tmp = tempfile.mkdtemp(prefix="omni_fs_test_")
+    default: dict[str, str | bytes] = {
+        "README.md": "# Hello\n",
+        "src/main.py": "print('hello')\n",
+        "docs/guide.txt": "User guide content.\n",
+    }
+    tree = files if files is not None else default
+    for rel, content in tree.items():
+        p = Path(tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            p.write_bytes(content)
+        else:
+            p.write_text(content)
+    return tmp
+
+
+# ---------------------------------------------------------------------------
+# FsConnector.validate
+# ---------------------------------------------------------------------------
+
+
+class TestFsConnectorValidate:
+    async def test_validate_existing_directory_succeeds(self) -> None:
+        root = _make_tree()
+        connector = FsConnector()
+        await connector.validate(FsConfig(root_path=root), {})
+
+    async def test_validate_nonexistent_path_raises(self) -> None:
+        connector = FsConnector()
+        with pytest.raises(ValueError, match="does not exist"):
+            await connector.validate(FsConfig(root_path="/nonexistent/xyz/abc"), {})
+
+    async def test_validate_file_path_raises(self) -> None:
+        tmp = tempfile.mktemp()
+        Path(tmp).write_text("hello")
+        connector = FsConnector()
+        with pytest.raises(ValueError, match="not a directory"):
+            await connector.validate(FsConfig(root_path=tmp), {})
+        Path(tmp).unlink(missing_ok=True)
+
+    async def test_validate_secrets_ignored(self) -> None:
+        """Filesystem connector requires no secrets."""
+        root = _make_tree()
+        connector = FsConnector()
+        await connector.validate(FsConfig(root_path=root), {"token": "should-be-ignored"})
+
+
+# ---------------------------------------------------------------------------
+# FsConnector.discover
+# ---------------------------------------------------------------------------
+
+
+class TestFsConnectorDiscover:
+    async def test_discover_lists_all_files(self) -> None:
+        root = _make_tree()
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        assert "README.md" in paths
+        assert "src/main.py" in paths
+        assert "docs/guide.txt" in paths
+
+    async def test_discover_include_glob_filters(self) -> None:
+        root = _make_tree()
+        connector = FsConnector()
+        config = FsConfig(root_path=root, include_globs=["*.md"])
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        assert all(p.endswith(".md") for p in paths)
+        assert len(paths) >= 1
+
+    async def test_discover_exclude_glob_filters(self) -> None:
+        root = _make_tree()
+        connector = FsConnector()
+        config = FsConfig(root_path=root, exclude_globs=["*.txt"])
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        assert not any(p.endswith(".txt") for p in paths)
+
+    async def test_discover_skips_large_files(self) -> None:
+        root = _make_tree({"small.txt": "x" * 50, "big.txt": "y" * 200})
+        connector = FsConnector()
+        config = FsConfig(root_path=root, max_file_size_bytes=100)
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        assert "small.txt" in paths
+        assert "big.txt" not in paths
+
+    async def test_discover_refs_have_required_fields(self) -> None:
+        root = _make_tree()
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        async for ref in connector.discover(config, {}):
+            assert ref.external_id
+            assert ref.uri
+            assert ref.updated_at is not None
+            assert "path" in ref.metadata
+            assert "size" in ref.metadata
+            break
+
+    async def test_discover_no_follow_symlinks_by_default(self) -> None:
+        root = _make_tree({"real.txt": "content"})
+        link = Path(root) / "link.txt"
+        target = Path(root) / "real.txt"
+        link.symlink_to(target)
+
+        connector = FsConnector()
+        config = FsConfig(root_path=root, follow_symlinks=False)
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        # Symlink should not appear (follow_symlinks=False)
+        paths = [r.metadata["path"] for r in refs]
+        # hidden files (starting with .) and symlinks should be excluded
+        assert "real.txt" in paths
+
+    async def test_discover_follow_symlinks_enabled(self) -> None:
+        root = _make_tree({"real.txt": "content"})
+        sub = Path(root) / "subdir"
+        sub.mkdir()
+        link = sub / "linked.txt"
+        link.symlink_to(Path(root) / "real.txt")
+
+        connector = FsConnector()
+        config = FsConfig(root_path=root, follow_symlinks=True)
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        # When following symlinks, the linked file should appear
+        assert any("linked.txt" in p for p in paths)
+
+    async def test_discover_empty_directory_yields_nothing(self) -> None:
+        root = tempfile.mkdtemp()
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+        assert refs == []
+
+    async def test_discover_metadata_contains_content_type(self) -> None:
+        root = _make_tree({"file.py": "pass"})
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        async for ref in connector.discover(config, {}):
+            assert "content_type" in ref.metadata
+            break
+
+
+# ---------------------------------------------------------------------------
+# FsConnector.fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFsConnectorFetch:
+    async def test_fetch_returns_correct_content(self) -> None:
+        content = "Hello, World!\n"
+        root = _make_tree({"hello.txt": content})
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        ref: DocumentRef | None = None
+        async for r in connector.discover(config, {}):
+            if r.metadata.get("path") == "hello.txt":
+                ref = r
+                break
+        assert ref is not None
+
+        doc = await connector.fetch(config, {}, ref)
+        assert isinstance(doc, FetchedDocument)
+        assert doc.content_bytes == content.encode()
+        assert doc.ref == ref
+
+    async def test_fetch_raises_for_file_exceeding_max_size(self) -> None:
+        root = _make_tree({"big.txt": "x" * 200})
+        connector = FsConnector()
+        config = FsConfig(root_path=root, max_file_size_bytes=200_000)
+
+        # Discover with generous limit, then fetch with tight limit
+        fetch_config = FsConfig(root_path=root, max_file_size_bytes=50)
+
+        async for ref in connector.discover(config, {}):
+            with pytest.raises(ValueError, match="exceeds max_file_size_bytes"):
+                await connector.fetch(fetch_config, {}, ref)
+            break
+
+    async def test_fetch_prevents_path_traversal(self) -> None:
+        root = _make_tree({"legit.txt": "ok"})
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        # Craft a ref pointing outside the root
+        malicious_ref = DocumentRef(
+            external_id="evil",
+            uri="/etc/passwd",
+            metadata={"path": "../../../etc/passwd"},
+        )
+        with pytest.raises(ValueError, match="outside the configured root"):
+            await connector.fetch(config, {}, malicious_ref)
+
+    async def test_fetch_guesses_content_type_markdown(self) -> None:
+        root = _make_tree({"notes.md": "# Notes"})
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        async for ref in connector.discover(config, {}):
+            doc = await connector.fetch(config, {}, ref)
+            assert "markdown" in doc.content_type or "text" in doc.content_type
+            break
+
+    async def test_fetch_guesses_content_type_json(self) -> None:
+        root = _make_tree({"data.json": '{"key": "value"}'})
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        async for ref in connector.discover(config, {}):
+            doc = await connector.fetch(config, {}, ref)
+            assert "json" in doc.content_type
+            break
+
+    async def test_fetch_content_is_deterministic(self) -> None:
+        root = _make_tree({"stable.txt": "consistent content\n"})
+        connector = FsConnector()
+        config = FsConfig(root_path=root)
+
+        ref: DocumentRef | None = None
+        async for r in connector.discover(config, {}):
+            ref = r
+            break
+        assert ref is not None
+
+        doc1 = await connector.fetch(config, {}, ref)
+        doc2 = await connector.fetch(config, {}, ref)
+        assert doc1.content_bytes == doc2.content_bytes
+
+
+# ---------------------------------------------------------------------------
+# FsConnector.webhook_handler
+# ---------------------------------------------------------------------------
+
+
+class TestFsConnectorWebhook:
+    def test_webhook_handler_returns_none(self) -> None:
+        connector = FsConnector()
+        assert connector.webhook_handler() is None
+
+
+# ---------------------------------------------------------------------------
+# Contract tests for FsConnector
+# ---------------------------------------------------------------------------
+
+
+class TestFsConnectorContract(ConnectorContractTests):
+    """Runs the full connector contract against :class:`FsConnector`."""
+
+    _root: str | None = None
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls._root = _make_tree()
+
+    def make_connector(self) -> FsConnector:
+        return FsConnector()
+
+    def valid_config(self) -> FsConfig:
+        return FsConfig(root_path=self.__class__._root or "/tmp")
+
+    def invalid_config(self) -> FsConfig:
+        return FsConfig(root_path="/totally/nonexistent/directory/abc123")
+
+    def secrets(self) -> dict[str, str]:
+        return {}
+
+    async def test_webhook_handler_accepts_valid_signature(self) -> None:
+        """FsConnector has no webhook handler; skip."""
+        pytest.skip("FsConnector does not support webhooks")

--- a/tests/test_git_connector.py
+++ b/tests/test_git_connector.py
@@ -1,0 +1,427 @@
+"""Tests for the git source connector (Issue #17).
+
+Uses temporary git repositories created locally — no network required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from omniscience_connectors import DocumentRef, FetchedDocument
+from omniscience_connectors.git.connector import GitConfig, GitConnector
+from omniscience_connectors.git.webhook import GitWebhookHandler
+
+from tests.connectors.contract_tests import ConnectorContractTests
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: str | None = None) -> None:
+    """Run a git command in a subprocess; raise on failure."""
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _make_repo(files: dict[str, str] | None = None) -> str:
+    """Create a temp git repo and return its path.
+
+    *files* maps relative path -> file content.
+    """
+    tmp = tempfile.mkdtemp(prefix="omni_git_test_")
+    _git("init", cwd=tmp)
+    _git("config", "user.email", "test@example.com", cwd=tmp)
+    _git("config", "user.name", "Test", cwd=tmp)
+
+    default_files = (
+        files if files is not None else {"README.md": "# Hello\n", "src/main.py": "print('hi')\n"}
+    )
+    for rel_path, content in default_files.items():
+        full = Path(tmp) / rel_path
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(content)
+
+    _git("add", ".", cwd=tmp)
+    _git("commit", "-m", "init", cwd=tmp)
+    return tmp
+
+
+# ---------------------------------------------------------------------------
+# GitConnector.validate
+# ---------------------------------------------------------------------------
+
+
+class TestGitConnectorValidate:
+    async def test_validate_local_repo_succeeds(self) -> None:
+        repo = _make_repo()
+        connector = GitConnector()
+        config = GitConfig(url=repo)
+        await connector.validate(config, {})
+
+    async def test_validate_nonexistent_path_raises(self) -> None:
+        connector = GitConnector()
+        config = GitConfig(url="/tmp/does-not-exist-xyz-abc")
+        with pytest.raises(Exception):
+            await connector.validate(config, {})
+
+    async def test_validate_non_git_directory_raises(self) -> None:
+        tmp = tempfile.mkdtemp()
+        connector = GitConnector()
+        config = GitConfig(url=tmp)
+        with pytest.raises(Exception):
+            await connector.validate(config, {})
+
+    async def test_validate_invalid_ref_raises(self) -> None:
+        repo = _make_repo()
+        connector = GitConnector()
+        config = GitConfig(url=repo, ref="refs/heads/nonexistent-branch")
+        with pytest.raises(Exception):
+            await connector.validate(config, {})
+
+
+# ---------------------------------------------------------------------------
+# GitConnector.discover
+# ---------------------------------------------------------------------------
+
+
+class TestGitConnectorDiscover:
+    async def test_discover_lists_all_files(self) -> None:
+        repo = _make_repo({"a.md": "# A", "b.txt": "hello", "src/c.py": "pass"})
+        connector = GitConnector()
+        config = GitConfig(url=repo)
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        assert "a.md" in paths
+        assert "b.txt" in paths
+        assert "src/c.py" in paths
+
+    async def test_discover_respects_include_pattern(self) -> None:
+        repo = _make_repo({"a.md": "# A", "b.txt": "hello", "c.py": "pass"})
+        connector = GitConnector()
+        config = GitConfig(url=repo, path_include=["*.md"])
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        assert paths == ["a.md"]
+
+    async def test_discover_respects_exclude_pattern(self) -> None:
+        repo = _make_repo({"a.md": "# A", "b.txt": "hello", "c.py": "pass"})
+        connector = GitConnector()
+        config = GitConfig(url=repo, path_exclude=["*.txt"])
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {}):
+            refs.append(ref)
+
+        paths = [r.metadata["path"] for r in refs]
+        assert "b.txt" not in paths
+        assert "a.md" in paths
+
+    async def test_discover_refs_have_required_fields(self) -> None:
+        repo = _make_repo()
+        connector = GitConnector()
+        config = GitConfig(url=repo)
+
+        async for ref in connector.discover(config, {}):
+            assert ref.external_id
+            assert ref.uri
+            assert "path" in ref.metadata
+            break
+
+    async def test_discover_uri_contains_repo_and_path(self) -> None:
+        repo = _make_repo({"docs/README.md": "# Docs"})
+        connector = GitConnector()
+        config = GitConfig(url=repo)
+
+        async for ref in connector.discover(config, {}):
+            if ref.metadata.get("path") == "docs/README.md":
+                assert "docs/README.md" in ref.uri
+                break
+
+    async def test_discover_empty_repo_yields_nothing(self) -> None:
+        tmp = tempfile.mkdtemp(prefix="omni_empty_")
+        _git("init", cwd=tmp)
+        _git("config", "user.email", "x@x.com", cwd=tmp)
+        _git("config", "user.name", "X", cwd=tmp)
+
+        connector = GitConnector()
+        config = GitConfig(url=tmp)
+        refs: list[DocumentRef] = []
+        try:
+            async for ref in connector.discover(config, {}):
+                refs.append(ref)
+        except RuntimeError:
+            pass  # Empty repo has no HEAD; that's acceptable
+
+        assert refs == []
+
+
+# ---------------------------------------------------------------------------
+# GitConnector.fetch
+# ---------------------------------------------------------------------------
+
+
+class TestGitConnectorFetch:
+    async def test_fetch_returns_correct_content(self) -> None:
+        content_text = "# Hello World\nThis is the README.\n"
+        repo = _make_repo({"README.md": content_text})
+        connector = GitConnector()
+        config = GitConfig(url=repo)
+
+        ref: DocumentRef | None = None
+        async for r in connector.discover(config, {}):
+            if r.metadata.get("path") == "README.md":
+                ref = r
+                break
+        assert ref is not None
+
+        doc = await connector.fetch(config, {}, ref)
+        assert isinstance(doc, FetchedDocument)
+        assert doc.content_bytes == content_text.encode()
+        assert doc.ref == ref
+
+    async def test_fetch_guesses_content_type_markdown(self) -> None:
+        repo = _make_repo({"notes.md": "# Notes"})
+        connector = GitConnector()
+        config = GitConfig(url=repo)
+
+        async for ref in connector.discover(config, {}):
+            doc = await connector.fetch(config, {}, ref)
+            assert "markdown" in doc.content_type or "text" in doc.content_type
+            break
+
+    async def test_fetch_guesses_content_type_python(self) -> None:
+        repo = _make_repo({"app.py": "print('hello')"})
+        connector = GitConnector()
+        config = GitConfig(url=repo)
+
+        async for ref in connector.discover(config, {}):
+            doc = await connector.fetch(config, {}, ref)
+            assert "python" in doc.content_type or "text" in doc.content_type
+            break
+
+    async def test_fetch_skips_file_exceeding_max_size(self) -> None:
+        repo = _make_repo({"big.txt": "x" * 200})
+        connector = GitConnector()
+        config = GitConfig(url=repo, max_file_size_bytes=100)
+
+        async for ref in connector.discover(config, {}):
+            with pytest.raises(ValueError, match="exceeds max_file_size_bytes"):
+                await connector.fetch(config, {}, ref)
+            break
+
+    async def test_fetch_skips_binary_file(self) -> None:
+        tmp = tempfile.mkdtemp(prefix="omni_bin_")
+        _git("init", cwd=tmp)
+        _git("config", "user.email", "x@x.com", cwd=tmp)
+        _git("config", "user.name", "X", cwd=tmp)
+        bin_path = Path(tmp) / "image.bin"
+        bin_path.write_bytes(b"\x00\x01\x02\x03" * 100)
+        _git("add", ".", cwd=tmp)
+        _git("commit", "-m", "bin", cwd=tmp)
+
+        connector = GitConnector()
+        config = GitConfig(url=tmp)
+
+        async for ref in connector.discover(config, {}):
+            if "image.bin" in ref.metadata.get("path", ""):
+                with pytest.raises(ValueError, match="binary"):
+                    await connector.fetch(config, {}, ref)
+                break
+
+
+# ---------------------------------------------------------------------------
+# GitWebhookHandler
+# ---------------------------------------------------------------------------
+
+
+class TestGitWebhookHandlerSignature:
+    def _make_handler(self) -> GitWebhookHandler:
+        return GitWebhookHandler()
+
+    def _github_headers(self, payload: bytes, secret: str) -> dict[str, str]:
+        mac = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+        return {"x-hub-signature-256": f"sha256={mac}"}
+
+    async def test_github_valid_signature_accepted(self) -> None:
+        handler = self._make_handler()
+        payload = b'{"ref":"refs/heads/main"}'
+        secret = "test-secret"
+        headers = self._github_headers(payload, secret)
+        assert await handler.verify_signature(payload, headers, secret) is True
+
+    async def test_github_bad_signature_rejected(self) -> None:
+        handler = self._make_handler()
+        payload = b'{"ref":"refs/heads/main"}'
+        headers = {"x-hub-signature-256": "sha256=badbadbadbad"}
+        assert await handler.verify_signature(payload, headers, "secret") is False
+
+    async def test_github_tampered_payload_rejected(self) -> None:
+        handler = self._make_handler()
+        payload = b'{"ref":"refs/heads/main"}'
+        secret = "secret"
+        headers = self._github_headers(payload, secret)
+        tampered = b'{"ref":"refs/heads/evil"}'
+        assert await handler.verify_signature(tampered, headers, secret) is False
+
+    async def test_gitlab_valid_token_accepted(self) -> None:
+        handler = self._make_handler()
+        secret = "my-gitlab-token"
+        headers: dict[str, str] = {"x-gitlab-token": secret}
+        assert await handler.verify_signature(b"payload", headers, secret) is True
+
+    async def test_gitlab_wrong_token_rejected(self) -> None:
+        handler = self._make_handler()
+        headers = {"x-gitlab-token": "wrong-token"}
+        assert await handler.verify_signature(b"payload", headers, "correct-token") is False
+
+    async def test_no_signature_header_rejected(self) -> None:
+        handler = self._make_handler()
+        empty_headers: dict[str, str] = {}
+        assert await handler.verify_signature(b"payload", empty_headers, "secret") is False
+
+    async def test_github_sig_missing_sha256_prefix_rejected(self) -> None:
+        handler = self._make_handler()
+        headers = {"x-hub-signature-256": "noprefixhash"}
+        assert await handler.verify_signature(b"payload", headers, "secret") is False
+
+
+class TestGitWebhookHandlerPayload:
+    def _make_handler(self) -> GitWebhookHandler:
+        return GitWebhookHandler()
+
+    def _github_push(self, added: list[str], modified: list[str], removed: list[str]) -> bytes:
+        return json.dumps(
+            {
+                "ref": "refs/heads/main",
+                "repository": {"full_name": "org/repo"},
+                "commits": [
+                    {
+                        "id": "abc123",
+                        "added": added,
+                        "modified": modified,
+                        "removed": removed,
+                    }
+                ],
+            }
+        ).encode()
+
+    async def test_parse_github_push_added_files(self) -> None:
+        handler = self._make_handler()
+        payload = self._github_push(added=["src/new.py"], modified=[], removed=[])
+        headers = {"x-github-event": "push"}
+        result = await handler.parse_payload(payload, headers)
+        uris = [r.uri for r in result.affected_refs]
+        assert "src/new.py" in uris
+
+    async def test_parse_github_push_modified_files(self) -> None:
+        handler = self._make_handler()
+        payload = self._github_push(added=[], modified=["README.md"], removed=[])
+        headers: dict[str, str] = {}
+        result = await handler.parse_payload(payload, headers)
+        assert any(r.uri == "README.md" for r in result.affected_refs)
+
+    async def test_parse_github_push_removed_files(self) -> None:
+        handler = self._make_handler()
+        payload = self._github_push(added=[], modified=[], removed=["old.txt"])
+        headers: dict[str, str] = {}
+        result = await handler.parse_payload(payload, headers)
+        assert any(r.uri == "old.txt" for r in result.affected_refs)
+
+    async def test_parse_uses_repo_full_name_as_source(self) -> None:
+        handler = self._make_handler()
+        payload = self._github_push(added=["f.py"], modified=[], removed=[])
+        headers = {"x-hub-signature-256": "sha256=dummy"}
+        result = await handler.parse_payload(payload, headers)
+        assert result.source_name == "org/repo"
+
+    async def test_parse_deduplicates_paths_across_commits(self) -> None:
+        handler = self._make_handler()
+        data: dict[str, Any] = {
+            "commits": [
+                {"id": "c1", "added": ["a.py"], "modified": [], "removed": []},
+                {"id": "c2", "added": ["a.py"], "modified": [], "removed": []},
+            ]
+        }
+        empty: dict[str, str] = {}
+        result = await handler.parse_payload(json.dumps(data).encode(), empty)
+        uris = [r.uri for r in result.affected_refs]
+        assert uris.count("a.py") == 1
+
+    async def test_parse_empty_commits_yields_no_refs(self) -> None:
+        handler = self._make_handler()
+        data: dict[str, Any] = {"commits": []}
+        empty: dict[str, str] = {}
+        result = await handler.parse_payload(json.dumps(data).encode(), empty)
+        assert result.affected_refs == []
+
+    async def test_parse_invalid_json_raises_value_error(self) -> None:
+        handler = self._make_handler()
+        empty: dict[str, str] = {}
+        with pytest.raises(ValueError, match="not valid JSON"):
+            await handler.parse_payload(b"not-json", empty)
+
+    async def test_raw_headers_stored_lowercase(self) -> None:
+        handler = self._make_handler()
+        data: dict[str, Any] = {"commits": []}
+        payload = json.dumps(data).encode()
+        headers = {"X-GitHub-Event": "push", "Content-Type": "application/json"}
+        result = await handler.parse_payload(payload, headers)
+        assert "x-github-event" in result.raw_headers
+        assert "content-type" in result.raw_headers
+
+
+# ---------------------------------------------------------------------------
+# Contract tests for GitConnector
+# ---------------------------------------------------------------------------
+
+
+class TestGitConnectorContract(ConnectorContractTests):
+    """Runs the full connector contract against :class:`GitConnector`."""
+
+    _repo: str | None = None
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls._repo = _make_repo({"README.md": "# Contract Test Repo\n", "src/app.py": "pass\n"})
+
+    def make_connector(self) -> GitConnector:
+        return GitConnector()
+
+    def valid_config(self) -> GitConfig:
+        return GitConfig(url=self.__class__._repo or "")
+
+    def invalid_config(self) -> GitConfig:
+        return GitConfig(url="/totally/nonexistent/path/abc123")
+
+    def secrets(self) -> dict[str, str]:
+        return {}
+
+    async def test_webhook_handler_accepts_valid_signature(self) -> None:
+        connector = self.make_connector()
+        handler = connector.webhook_handler()
+        assert handler is not None
+
+        payload = b'{"ref":"refs/heads/main"}'
+        secret = "contract-test-secret"
+        mac = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+        result = await handler.verify_signature(
+            payload=payload,
+            headers={"x-hub-signature-256": f"sha256={mac}"},
+            secret=secret,
+        )
+        assert result is True

--- a/uv.lock
+++ b/uv.lock
@@ -1142,12 +1142,14 @@ source = { editable = "packages/connectors" }
 dependencies = [
     { name = "omniscience-core" },
     { name = "pydantic" },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "omniscience-core", editable = "packages/core" },
     { name = "pydantic", specifier = ">=2.7.0" },
+    { name = "watchfiles", specifier = ">=0.21.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Git connector: local + remote repos, include/exclude patterns, webhook handler (GitHub/GitLab)
- Filesystem connector: directory walker with glob filtering, symlink control, path traversal prevention
- Both registered in ConnectorRegistry at import time
- 68 new tests (66 pass, 2 skipped — webhook tests on fs connector)

## Test plan
- [ ] All tests pass, mypy --strict clean, ruff clean

Closes #17, closes #18