### PR TITLE
feat: enhanced webhook receiver with connector delegation and replay protection

### DIFF
--- a/apps/server/src/omniscience_server/rest/delivery_tracker.py
+++ b/apps/server/src/omniscience_server/rest/delivery_tracker.py
@@ -1,0 +1,96 @@
+"""Webhook delivery ID tracker for replay protection.
+
+Maintains an in-memory set of recently seen delivery IDs with TTL-based
+expiry so that duplicate webhook deliveries are rejected.
+
+This is a single-process in-memory implementation.  For multi-process
+deployments a shared store (Redis, etc.) would be required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Default window: 5 minutes
+_DEFAULT_WINDOW_SECONDS: float = 300.0
+
+
+class DeliveryTracker:
+    """Thread-safe (asyncio) in-memory tracker for webhook delivery IDs.
+
+    Each delivery ID is stored alongside its arrival timestamp.  IDs older
+    than *window_seconds* are evicted lazily on every call to
+    :meth:`is_duplicate` or :meth:`record`.
+
+    Args:
+        window_seconds: How long to remember a delivery ID (default 300 s).
+    """
+
+    def __init__(self, window_seconds: float = _DEFAULT_WINDOW_SECONDS) -> None:
+        self._window = window_seconds
+        # delivery_id -> arrival timestamp (monotonic)
+        self._seen: dict[str, float] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def is_duplicate(self, delivery_id: str) -> bool:
+        """Return ``True`` if *delivery_id* was already recorded within the window.
+
+        Performs a lazy TTL purge before checking.
+
+        Args:
+            delivery_id: Opaque unique identifier for the delivery (e.g. GitHub
+                ``X-GitHub-Delivery`` UUID, GitLab ``X-Gitlab-Event-UUID``).
+
+        Returns:
+            ``True`` if the ID is a duplicate; ``False`` otherwise.
+        """
+        async with self._lock:
+            self._purge_expired()
+            return delivery_id in self._seen
+
+    async def record(self, delivery_id: str) -> None:
+        """Record *delivery_id* as seen now.
+
+        If the ID was already recorded the timestamp is refreshed.
+
+        Args:
+            delivery_id: Opaque delivery identifier to remember.
+        """
+        async with self._lock:
+            self._purge_expired()
+            self._seen[delivery_id] = time.monotonic()
+            log.debug("delivery_tracked", delivery_id=delivery_id, tracked_count=len(self._seen))
+
+    async def size(self) -> int:
+        """Return the number of currently tracked (non-expired) IDs."""
+        async with self._lock:
+            self._purge_expired()
+            return len(self._seen)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _purge_expired(self) -> None:
+        """Remove IDs older than *window_seconds*.
+
+        Must be called with ``self._lock`` held.
+        """
+        cutoff = time.monotonic() - self._window
+        expired = [k for k, ts in self._seen.items() if ts < cutoff]
+        for key in expired:
+            del self._seen[key]
+        if expired:
+            log.debug("delivery_tracker_purged", count=len(expired))
+
+
+__all__ = ["DeliveryTracker"]

--- a/apps/server/src/omniscience_server/rest/webhooks.py
+++ b/apps/server/src/omniscience_server/rest/webhooks.py
@@ -3,9 +3,25 @@
 POST /api/v1/ingest/webhook/{source_name}
 
 Receives push events from source systems (GitHub, GitLab, Confluence).
-Validates the payload signature per source type, then enqueues a sync task.
 
-No authentication token required — webhook endpoints are authenticated via
+Processing pipeline:
+
+1. Look up the named source in the database (404 if not found).
+2. Attempt to obtain a :class:`~omniscience_connectors.base.WebhookHandler`
+   from the registered connector for this source type.  If no connector or no
+   handler is available the legacy built-in signature helpers are used as
+   fallback.
+3. Verify the HMAC / token signature (400 if invalid).
+4. Extract the delivery ID from request headers and reject duplicates within
+   the configured replay-protection window (400 if duplicate or too old).
+5. Check per-source rate limit (429 if exceeded).
+6. Delegate payload parsing to the connector's handler to obtain the list of
+   affected :class:`~omniscience_connectors.base.DocumentRef` objects.
+7. Enqueue a :class:`~omniscience_server.ingestion.events.DocumentChangeEvent`
+   for each affected document via NATS JetStream.
+8. Return 202 Accepted with ``{"accepted": true, "events_queued": N}``.
+
+No authentication token is required — webhook endpoints are authenticated via
 HMAC signature (the shared secret configured per source).
 """
 
@@ -14,19 +30,35 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import uuid
+import time
 from typing import Any
 
 import structlog
 from fastapi import APIRouter, HTTPException, Request
-from omniscience_core.db.models import IngestionRun, IngestionRunStatus, Source
+from omniscience_core.db.models import Source
+from omniscience_core.queue.producer import QueueProducer
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from omniscience_server.ingestion.events import DocumentChangeEvent
+from omniscience_server.rest.delivery_tracker import DeliveryTracker
+
 log = structlog.get_logger(__name__)
 
 router = APIRouter(tags=["webhooks"])
+
+# ---------------------------------------------------------------------------
+# Module-level singletons (single-process; replace with Redis for multi-proc)
+# ---------------------------------------------------------------------------
+
+# Shared replay-protection tracker (configurable window; default 5 min)
+_REPLAY_WINDOW_SECONDS: float = 300.0
+_delivery_tracker = DeliveryTracker(window_seconds=_REPLAY_WINDOW_SECONDS)
+
+# Per-source rate-limiting: source_id (str) -> (tokens: float, last_refill: float)
+_source_buckets: dict[str, tuple[float, float]] = {}
+_DEFAULT_SOURCE_RPM: int = 120
 
 
 # ---------------------------------------------------------------------------
@@ -35,14 +67,14 @@ router = APIRouter(tags=["webhooks"])
 
 
 class WebhookAcceptedResponse(BaseModel):
-    """Confirmation that the webhook was accepted and a sync enqueued."""
+    """Confirmation that the webhook was accepted and events enqueued."""
 
     accepted: bool
-    run_id: uuid.UUID | None
+    events_queued: int
 
 
 # ---------------------------------------------------------------------------
-# Signature verification helpers
+# Signature verification helpers (legacy / fallback)
 # ---------------------------------------------------------------------------
 
 
@@ -95,14 +127,18 @@ def verify_webhook_signature(
 ) -> bool:
     """Dispatch to the appropriate signature verifier based on source type.
 
+    This is the *fallback* path used when no connector-specific
+    :class:`~omniscience_connectors.base.WebhookHandler` is registered for the
+    given source type.
+
     Args:
-        source_type: Source type string (e.g. "git", "gitlab", "confluence").
+        source_type: Source type string (e.g. ``"git"``, ``"gitlab"``, ``"confluence"``).
         payload:     Raw request body bytes.
         secret:      Shared secret configured on the source.
         request:     The FastAPI/Starlette request (for reading headers).
 
     Returns:
-        True if the signature is valid; False otherwise.
+        ``True`` if the signature is valid; ``False`` otherwise.
     """
     if source_type in ("git", "github"):
         sig = request.headers.get("X-Hub-Signature-256")
@@ -122,6 +158,94 @@ def verify_webhook_signature(
 
 
 # ---------------------------------------------------------------------------
+# Delivery ID extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_delivery_id(request: Request) -> str | None:
+    """Extract the source-specific delivery identifier from request headers.
+
+    * GitHub: ``X-GitHub-Delivery`` header
+    * GitLab: ``X-Gitlab-Event-UUID`` header
+
+    Returns ``None`` if no recognised delivery header is present.
+    """
+    for header in ("x-github-delivery", "x-gitlab-event-uuid"):
+        value = request.headers.get(header)
+        if value:
+            return value
+    return None
+
+
+def _extract_payload_timestamp(payload_data: Any) -> float | None:
+    """Try to read a UNIX timestamp from a webhook JSON payload.
+
+    GitHub includes a ``timestamp`` field in some events; GitLab uses
+    ``object_attributes.created_at``.  We do a best-effort extraction.
+    Returns the timestamp as a POSIX float, or ``None`` if not found.
+    """
+    if not isinstance(payload_data, dict):
+        return None
+
+    # Direct timestamp field (ISO 8601 or UNIX epoch integer)
+    for key in ("timestamp", "created_at", "pushed_at"):
+        value = payload_data.get(key)
+        if value is not None and isinstance(value, (int, float)):
+            return float(value)
+        # ISO 8601 strings are not parsed here to keep dependencies minimal;
+        # callers that need strict timestamp enforcement should extend this.
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-source rate limiting
+# ---------------------------------------------------------------------------
+
+
+def _check_source_rate_limit(source_id: str, rpm: int) -> tuple[bool, float]:
+    """Token-bucket rate limit check for a given source.
+
+    Args:
+        source_id: String form of the source UUID.
+        rpm:       Requests-per-minute limit.
+
+    Returns:
+        ``(allowed, retry_after_seconds)`` — when *allowed* is ``False``,
+        *retry_after_seconds* is approximate seconds until one token refills.
+    """
+    now = time.monotonic()
+    capacity = float(rpm)
+    refill_rate = capacity / 60.0  # tokens per second
+
+    if source_id not in _source_buckets:
+        _source_buckets[source_id] = (capacity - 1.0, now)
+        return True, 0.0
+
+    tokens, last_refill = _source_buckets[source_id]
+    elapsed = now - last_refill
+    tokens = min(capacity, tokens + elapsed * refill_rate)
+
+    if tokens >= 1.0:
+        _source_buckets[source_id] = (tokens - 1.0, now)
+        return True, 0.0
+
+    retry_after = (1.0 - tokens) / refill_rate
+    _source_buckets[source_id] = (tokens, now)
+    return False, retry_after
+
+
+def reset_source_rate_limit(source_id: str) -> None:
+    """Reset the rate-limit bucket for *source_id* (test helper)."""
+    _source_buckets.pop(source_id, None)
+
+
+def clear_all_source_buckets() -> None:
+    """Clear all per-source rate-limit buckets (test helper)."""
+    _source_buckets.clear()
+
+
+# ---------------------------------------------------------------------------
 # Endpoint
 # ---------------------------------------------------------------------------
 
@@ -138,94 +262,302 @@ async def receive_webhook(
 ) -> WebhookAcceptedResponse:
     """Receive a webhook payload from a push-event source.
 
-    1. Looks up the named source in the database.
-    2. Validates the HMAC/token signature using the secret stored in the source config.
-    3. Creates an ingestion run record.
-    4. Enqueues a sync task (placeholder — real NATS publish in issue #6).
-    5. Returns 202 Accepted with the run_id.
+    Processing steps:
 
-    Returns 404 if the source name is not found.
-    Returns 401 if signature verification fails.
+    1. Look up the named source in the database.
+    2. Check the per-source rate limit.
+    3. Verify the signature via the connector's :class:`WebhookHandler` or the
+       built-in fallback verifiers.
+    4. Check for duplicate or expired delivery IDs.
+    5. Parse the payload via the connector handler (or produce a generic event).
+    6. Enqueue :class:`~omniscience_server.ingestion.events.DocumentChangeEvent`
+       messages for each affected document.
+    7. Return 202 Accepted.
+
+    Returns:
+        :class:`WebhookAcceptedResponse` with ``accepted=True`` and
+        ``events_queued`` equal to the number of events published.
+
+    Raises:
+        HTTPException 404: Source name not found.
+        HTTPException 400: Signature invalid or duplicate/expired delivery.
+        HTTPException 429: Per-source rate limit exceeded.
     """
     factory = getattr(request.app.state, "db_session_factory", None)
     if factory is None:
-        # No DB: accept and drop (degraded mode)
         log.warning("webhook_no_db", source_name=source_name)
-        return WebhookAcceptedResponse(accepted=True, run_id=None)
+        return WebhookAcceptedResponse(accepted=True, events_queued=0)
 
-    # Read the raw body before anything else — needed for signature verification
+    # Read the raw body before anything else — needed for signature verification.
     payload_bytes = await request.body()
 
     db: AsyncSession
     async with factory() as db:
         result = await db.execute(select(Source).where(Source.name == source_name))
-        source = result.scalars().first()
+        source: Source | None = result.scalars().first()
 
-        if source is None:
-            raise HTTPException(
-                status_code=404,
-                detail={
-                    "code": "source_not_found",
-                    "message": f"Source '{source_name}' not found",
-                },
-            )
+    if source is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "source_not_found",
+                "message": f"Source '{source_name}' not found",
+            },
+        )
 
-        # Signature verification — only if a webhook_secret is configured
-        webhook_secret: str | None = source.config.get("webhook_secret") if source.config else None
-        if webhook_secret:
+    source_id_str = str(source.id)
+    source_type = str(source.type)
+
+    # --- Per-source rate limit ---
+    settings = getattr(request.app.state, "settings", None)
+    rpm: int = (
+        int(getattr(settings, "webhook_rpm", _DEFAULT_SOURCE_RPM))
+        if settings
+        else _DEFAULT_SOURCE_RPM
+    )
+    allowed, retry_after = _check_source_rate_limit(source_id_str, rpm)
+    if not allowed:
+        retry_int = int(retry_after) + 1
+        log.warning("webhook_rate_limited", source_name=source_name, source_id=source_id_str)
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "rate_limited",
+                "message": "Webhook rate limit exceeded for this source",
+                "retry_after": str(retry_int),
+            },
+            headers={"Retry-After": str(retry_int)},
+        )
+
+    # --- Signature verification ---
+    webhook_secret: str | None = source.config.get("webhook_secret") if source.config else None
+
+    # Try connector-based handler first; fall back to built-in helpers.
+    connector_handler = _get_connector_handler(source_type)
+    headers_dict = dict(request.headers)
+
+    if webhook_secret:
+        if connector_handler is not None:
+            try:
+                valid = await connector_handler.verify_signature(
+                    payload=payload_bytes,
+                    headers=headers_dict,
+                    secret=webhook_secret,
+                )
+            except Exception as exc:  # pragma: no cover
+                log.warning(
+                    "webhook_handler_verify_error",
+                    source_name=source_name,
+                    error=str(exc),
+                )
+                valid = False
+        else:
             valid = verify_webhook_signature(
-                source_type=str(source.type),
+                source_type=source_type,
                 payload=payload_bytes,
                 secret=webhook_secret,
                 request=request,
             )
-            if not valid:
-                log.warning(
-                    "webhook_signature_invalid",
-                    source_name=source_name,
-                    source_id=str(source.id),
-                )
-                raise HTTPException(
-                    status_code=401,
-                    detail={
-                        "code": "unauthorized",
-                        "message": "Webhook signature verification failed",
-                    },
-                )
 
-        # Parse payload for logging (best-effort)
-        try:
-            _payload_data: Any = json.loads(payload_bytes)
-        except (json.JSONDecodeError, ValueError):
-            _payload_data = None
+        if not valid:
+            log.warning(
+                "webhook_signature_invalid",
+                source_name=source_name,
+                source_id=source_id_str,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "bad_request",
+                    "message": "Webhook signature verification failed",
+                },
+            )
 
-        # Create ingestion run
-        run = IngestionRun(
-            source_id=source.id,
-            status=IngestionRunStatus.running,
+    # --- Replay protection ---
+    delivery_id = _extract_delivery_id(request)
+
+    # Reject duplicate delivery IDs within the replay window.
+    if delivery_id is not None and await _delivery_tracker.is_duplicate(delivery_id):
+        log.warning(
+            "webhook_duplicate_delivery",
+            source_name=source_name,
+            delivery_id=delivery_id,
         )
-        db.add(run)
-        await db.flush()
-        await db.refresh(run)
-        await db.commit()
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "bad_request",
+                "message": "Duplicate webhook delivery rejected",
+            },
+        )
 
-        run_id: uuid.UUID = run.id
+    # Best-effort timestamp check: reject payloads claiming to be older than window.
+    try:
+        payload_data: Any = json.loads(payload_bytes)
+    except (json.JSONDecodeError, ValueError):
+        payload_data = None
 
-    # TODO(issue-6): Publish sync task to NATS JetStream
-    # nats = getattr(request.app.state, "nats", None)
-    # if nats is not None:
-    #     msg = json.dumps(
-    #         {"source_id": str(source.id), "run_id": str(run_id), "trigger": "webhook"}
-    #     )
-    #     await nats.jetstream.publish("sync.trigger", msg.encode())
+    ts = _extract_payload_timestamp(payload_data)
+    if ts is not None:
+        age = time.time() - ts
+        if age > _REPLAY_WINDOW_SECONDS:
+            log.warning(
+                "webhook_expired_timestamp",
+                source_name=source_name,
+                age_seconds=age,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "bad_request",
+                    "message": "Webhook payload timestamp is too old",
+                },
+            )
+
+    # Record delivery ID now that all checks have passed.
+    if delivery_id is not None:
+        await _delivery_tracker.record(delivery_id)
+
+    # --- Parse payload and build change events ---
+    affected_refs = await _parse_payload(
+        source_type=source_type,
+        source_name=source_name,
+        payload_bytes=payload_bytes,
+        headers_dict=headers_dict,
+        connector_handler=connector_handler,
+    )
+
+    events: list[DocumentChangeEvent] = [
+        DocumentChangeEvent(
+            source_id=source.id,
+            source_type=source_type,
+            external_id=ref.external_id,
+            uri=ref.uri,
+            action="updated",
+        )
+        for ref in affected_refs
+    ]
+
+    # If no refs were parsed from the connector, emit a single generic event
+    # so that the ingestion worker still receives a signal to re-sync the source.
+    if not events:
+        events = [
+            DocumentChangeEvent(
+                source_id=source.id,
+                source_type=source_type,
+                external_id="*",
+                uri=f"webhook://{source_name}",
+                action="updated",
+            )
+        ]
+
+    # --- Enqueue to NATS JetStream ---
+    events_queued = await _enqueue_events(request, events, source_type)
 
     log.info(
         "webhook_accepted",
         source_name=source_name,
-        source_id=str(source.id),
-        run_id=str(run_id),
+        source_id=source_id_str,
+        events_queued=events_queued,
     )
-    return WebhookAcceptedResponse(accepted=True, run_id=run_id)
+    return WebhookAcceptedResponse(accepted=True, events_queued=events_queued)
 
 
-__all__ = ["router", "verify_webhook_signature"]
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_connector_handler(source_type: str) -> Any:
+    """Return the :class:`~omniscience_connectors.base.WebhookHandler` for
+    *source_type*, or ``None`` if not available.
+
+    Gracefully handles the case where the connector package is not registered.
+    """
+    try:
+        from omniscience_connectors.registry import get_connector
+
+        connector = get_connector(source_type)
+        return connector.webhook_handler()
+    except Exception:  # NotFoundError or any import error
+        return None
+
+
+async def _parse_payload(
+    source_type: str,
+    source_name: str,
+    payload_bytes: bytes,
+    headers_dict: dict[str, str],
+    connector_handler: Any,
+) -> list[Any]:
+    """Use the connector handler to parse the payload and return affected refs.
+
+    Falls back to an empty list when parsing fails or no handler is available.
+    """
+
+    if connector_handler is None:
+        return []
+
+    try:
+        webhook_payload = await connector_handler.parse_payload(
+            payload=payload_bytes,
+            headers=headers_dict,
+        )
+        return list(webhook_payload.affected_refs)
+    except Exception as exc:
+        log.warning(
+            "webhook_handler_parse_error",
+            source_name=source_name,
+            source_type=source_type,
+            error=str(exc),
+        )
+        return []
+
+
+async def _enqueue_events(
+    request: Request,
+    events: list[DocumentChangeEvent],
+    source_type: str,
+) -> int:
+    """Publish *events* to NATS JetStream.
+
+    Returns the number of successfully enqueued events.  Failures are logged
+    but do not cause the request to fail — the webhook is still acknowledged
+    so the source system does not retry unnecessarily.
+    """
+    nats_conn = getattr(request.app.state, "nats", None)
+    if nats_conn is None:
+        log.debug("webhook_nats_unavailable_skipping_enqueue", count=len(events))
+        return 0
+
+    js = getattr(nats_conn, "jetstream", None)
+    if js is None:
+        log.debug("webhook_nats_no_jetstream", count=len(events))
+        return 0
+
+    producer = QueueProducer(js)
+    subject = f"ingest.changes.{source_type}"
+    enqueued = 0
+
+    for event in events:
+        try:
+            await producer.publish(subject=subject, payload=event)
+            enqueued += 1
+        except Exception as exc:
+            log.error(
+                "webhook_enqueue_error",
+                subject=subject,
+                external_id=event.external_id,
+                error=str(exc),
+            )
+
+    return enqueued
+
+
+__all__ = [
+    "WebhookAcceptedResponse",
+    "clear_all_source_buckets",
+    "reset_source_rate_limit",
+    "router",
+    "verify_webhook_signature",
+]

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1199,8 +1199,8 @@ async def test_webhook_404_unknown_source() -> None:
 
 
 @pytest.mark.asyncio
-async def test_webhook_401_bad_signature() -> None:
-    """POST /api/v1/ingest/webhook/{name} returns 401 when signature is invalid."""
+async def test_webhook_400_bad_signature() -> None:
+    """POST /api/v1/ingest/webhook/{name} returns 400 when signature is invalid."""
     from omniscience_core.config import Settings
 
     settings = Settings(
@@ -1238,9 +1238,9 @@ async def test_webhook_401_bad_signature() -> None:
             },
         )
 
-    assert resp.status_code == 401
+    assert resp.status_code == 400
     body = resp.json()
-    assert body["error"]["code"] == "unauthorized"
+    assert body["error"]["code"] == "bad_request"
 
 
 @pytest.mark.asyncio
@@ -1291,7 +1291,7 @@ async def test_webhook_accepted_no_secret() -> None:
     assert resp.status_code == 202
     body = resp.json()
     assert body["accepted"] is True
-    assert body["run_id"] == str(run_id)
+    assert "events_queued" in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,796 @@
+"""Tests for the enhanced webhook receiver (Issue #19).
+
+Covers:
+- Connector delegation (signature verification + payload parsing)
+- Replay protection: duplicate delivery ID rejection
+- Replay protection: expired payload timestamp rejection
+- Per-source rate limiting (429)
+- 202 response with events_queued count
+- 404 for unknown source
+- 400 for invalid signature
+- Enqueues correct DocumentChangeEvent messages
+- Graceful fallback when connector is not registered
+- NATS not available -> events_queued=0 but still 202
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_connectors.base import DocumentRef, WebhookHandler, WebhookPayload
+from omniscience_core.config import Settings
+from omniscience_core.db.models import Source, SourceType
+from omniscience_server.app import create_app
+from omniscience_server.rest.delivery_tracker import DeliveryTracker
+from omniscience_server.rest.webhooks import (
+    WebhookAcceptedResponse,
+    _check_source_rate_limit,
+    _extract_delivery_id,
+    _extract_payload_timestamp,
+    clear_all_source_buckets,
+    verify_webhook_signature,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_settings() -> Settings:
+    return Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+
+
+def _make_source(
+    name: str = "test-repo",
+    source_type: SourceType = SourceType.git,
+    webhook_secret: str | None = None,
+) -> Source:
+    src: Source = MagicMock(spec=Source)
+    src.id = uuid.uuid4()
+    src.type = source_type
+    src.name = name
+    cfg: dict[str, Any] = {}
+    if webhook_secret is not None:
+        cfg["webhook_secret"] = webhook_secret
+    src.config = cfg
+    return src
+
+
+def _make_db_session(source: Source | None = None) -> AsyncMock:
+    """Build a fake async DB session that returns *source* on first .first() call."""
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = source
+        return result
+
+    session.execute = _execute
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_app_with_source(source: Source | None = None) -> FastAPI:
+    app = create_app(settings=_make_settings())
+    sess = _make_db_session(source)
+    app.state.db_session_factory = MagicMock(return_value=sess)
+    return app
+
+
+async def _client_for(app: FastAPI) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+def _github_sig(payload: bytes, secret: str) -> str:
+    digest = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _make_webhook_handler(
+    *,
+    valid: bool = True,
+    refs: list[DocumentRef] | None = None,
+) -> WebhookHandler:
+    """Build a mock WebhookHandler."""
+    handler = MagicMock(spec=WebhookHandler)
+    handler.verify_signature = AsyncMock(return_value=valid)
+    affected = refs or []
+    wp = WebhookPayload(
+        source_name="test-repo",
+        affected_refs=affected,
+        raw_headers={},
+    )
+    handler.parse_payload = AsyncMock(return_value=wp)
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_source_buckets() -> None:
+    """Clear per-source rate-limit state between tests."""
+    clear_all_source_buckets()
+
+
+# ---------------------------------------------------------------------------
+# DeliveryTracker unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delivery_tracker_not_duplicate_initially() -> None:
+    """A fresh delivery ID is not a duplicate."""
+    tracker = DeliveryTracker()
+    assert await tracker.is_duplicate("abc-123") is False
+
+
+@pytest.mark.asyncio
+async def test_delivery_tracker_duplicate_after_record() -> None:
+    """After recording, the same ID is a duplicate."""
+    tracker = DeliveryTracker()
+    await tracker.record("abc-123")
+    assert await tracker.is_duplicate("abc-123") is True
+
+
+@pytest.mark.asyncio
+async def test_delivery_tracker_different_ids_not_duplicate() -> None:
+    """Two distinct IDs do not collide."""
+    tracker = DeliveryTracker()
+    await tracker.record("id-1")
+    assert await tracker.is_duplicate("id-2") is False
+
+
+@pytest.mark.asyncio
+async def test_delivery_tracker_expired_not_duplicate() -> None:
+    """IDs older than the window are purged and no longer count as duplicates."""
+    tracker = DeliveryTracker(window_seconds=0.05)  # 50 ms window
+    await tracker.record("expiring-id")
+    await asyncio.sleep(0.1)
+    assert await tracker.is_duplicate("expiring-id") is False
+
+
+@pytest.mark.asyncio
+async def test_delivery_tracker_size() -> None:
+    """size() returns the correct count of tracked IDs."""
+    tracker = DeliveryTracker()
+    assert await tracker.size() == 0
+    await tracker.record("a")
+    await tracker.record("b")
+    assert await tracker.size() == 2
+
+
+@pytest.mark.asyncio
+async def test_delivery_tracker_concurrent_safe() -> None:
+    """Concurrent record + is_duplicate calls do not raise or corrupt state."""
+    tracker = DeliveryTracker()
+
+    async def _write(i: int) -> None:
+        await tracker.record(f"id-{i}")
+
+    async def _read(i: int) -> bool:
+        return await tracker.is_duplicate(f"id-{i}")
+
+    tasks = [_write(i) for i in range(50)] + [_read(i) for i in range(50)]
+    await asyncio.gather(*tasks)
+    # Should not raise; count <= 50
+    assert await tracker.size() <= 50
+
+
+# ---------------------------------------------------------------------------
+# Signature helper unit tests (legacy/fallback)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequest:
+    """Minimal Request stub for verify_webhook_signature tests."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_verify_github_valid_signature() -> None:
+    payload = b'{"action":"push"}'
+    secret = "mysecret"
+    sig = _github_sig(payload, secret)
+    req = _FakeRequest({"X-Hub-Signature-256": sig})
+    assert verify_webhook_signature("git", payload, secret, req) is True  # type: ignore[arg-type]
+
+
+def test_verify_github_invalid_signature() -> None:
+    payload = b'{"action":"push"}'
+    req = _FakeRequest({"X-Hub-Signature-256": "sha256=deadbeef"})
+    assert verify_webhook_signature("git", payload, "mysecret", req) is False  # type: ignore[arg-type]
+
+
+def test_verify_github_missing_header() -> None:
+    req = _FakeRequest({})
+    assert verify_webhook_signature("git", b"payload", "secret", req) is False  # type: ignore[arg-type]
+
+
+def test_verify_gitlab_valid_token() -> None:
+    req = _FakeRequest({"X-Gitlab-Token": "secret123"})
+    assert verify_webhook_signature("gitlab", b"payload", "secret123", req) is True  # type: ignore[arg-type]
+
+
+def test_verify_gitlab_wrong_token() -> None:
+    req = _FakeRequest({"X-Gitlab-Token": "wrong"})
+    assert verify_webhook_signature("gitlab", b"payload", "correct", req) is False  # type: ignore[arg-type]
+
+
+def test_verify_confluence_valid() -> None:
+    payload = b"hello"
+    secret = "sec"
+    sig = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    req = _FakeRequest({"X-Hub-Signature": f"sha256={sig}"})
+    assert verify_webhook_signature("confluence", payload, secret, req) is True  # type: ignore[arg-type]
+
+
+def test_verify_unknown_source_type_passes() -> None:
+    """Unknown source types bypass signature check (no secret defined for them)."""
+    req = _FakeRequest({})
+    assert verify_webhook_signature("notion", b"any", "secret", req) is True  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Delivery ID extraction unit tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequestWithHeaders:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_extract_delivery_id_github() -> None:
+    delivery = str(uuid.uuid4())
+    req = _FakeRequestWithHeaders({"x-github-delivery": delivery})
+    assert _extract_delivery_id(req) == delivery  # type: ignore[arg-type]
+
+
+def test_extract_delivery_id_gitlab() -> None:
+    event_uuid = str(uuid.uuid4())
+    req = _FakeRequestWithHeaders({"x-gitlab-event-uuid": event_uuid})
+    assert _extract_delivery_id(req) == event_uuid  # type: ignore[arg-type]
+
+
+def test_extract_delivery_id_missing() -> None:
+    req = _FakeRequestWithHeaders({})
+    assert _extract_delivery_id(req) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Timestamp extraction unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_payload_timestamp_found() -> None:
+    data = {"timestamp": 1_700_000_000}
+    assert _extract_payload_timestamp(data) == 1_700_000_000.0
+
+
+def test_extract_payload_timestamp_not_dict() -> None:
+    assert _extract_payload_timestamp("not a dict") is None
+
+
+def test_extract_payload_timestamp_missing() -> None:
+    assert _extract_payload_timestamp({"action": "push"}) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-source rate limit unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_source_rate_limit_allows_first_request() -> None:
+    allowed, _ = _check_source_rate_limit("src-abc", rpm=10)
+    assert allowed is True
+
+
+def test_source_rate_limit_exhausted() -> None:
+    # Exhaust bucket (initial capacity = rpm - 1 tokens after first call)
+    for _ in range(11):
+        _check_source_rate_limit("src-xyz", rpm=10)
+    allowed, retry_after = _check_source_rate_limit("src-xyz", rpm=10)
+    assert allowed is False
+    assert retry_after > 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: 404 for unknown source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_404_unknown_source() -> None:
+    """404 is returned when the source name is not in the database."""
+    app = _make_app_with_source(source=None)
+
+    async with await _client_for(app) as client:
+        resp = await client.post(
+            "/api/v1/ingest/webhook/nonexistent",
+            content=b'{"action":"push"}',
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "source_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Integration: 400 for invalid signature
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_400_invalid_signature_fallback() -> None:
+    """400 is returned when the fallback verifier rejects the signature."""
+    src = _make_source(webhook_secret="correct-secret")
+    src.type = SourceType.git
+
+    app = _make_app_with_source(source=src)
+
+    # Patch _get_connector_handler to return None so we use the fallback path.
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=None,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": "sha256=deadbeef",
+                },
+            )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["code"] == "bad_request"
+    assert "signature" in body["error"]["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_webhook_400_invalid_signature_connector() -> None:
+    """400 is returned when the connector's verify_signature returns False."""
+    src = _make_source(webhook_secret="secret")
+    src.type = SourceType.git
+
+    app = _make_app_with_source(source=src)
+    handler = _make_webhook_handler(valid=False)
+
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=handler,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={"Content-Type": "application/json"},
+            )
+
+    assert resp.status_code == 400
+    handler.verify_signature.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Integration: connector delegation (valid signature + payload parsing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_delegates_to_connector_handler() -> None:
+    """Connector's verify_signature and parse_payload are called."""
+    src = _make_source(webhook_secret="secret")
+    src.type = SourceType.git
+
+    refs = [
+        DocumentRef(external_id="sha-abc", uri="https://github.com/org/repo/blob/main/foo.py"),
+        DocumentRef(external_id="sha-def", uri="https://github.com/org/repo/blob/main/bar.py"),
+    ]
+    handler = _make_webhook_handler(valid=True, refs=refs)
+    app = _make_app_with_source(source=src)
+
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=handler,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": str(uuid.uuid4()),
+                },
+            )
+
+    assert resp.status_code == 202
+    handler.verify_signature.assert_awaited_once()  # type: ignore[attr-defined]
+    body = resp.json()
+    assert body["accepted"] is True
+    # 2 refs parsed but NATS unavailable in test → events_queued=0
+    assert body["events_queued"] == 0
+
+
+@pytest.mark.asyncio
+async def test_webhook_enqueues_correct_events() -> None:
+    """DocumentChangeEvent is published per affected ref when NATS is available."""
+    src = _make_source(webhook_secret="secret")
+    src.type = SourceType.git
+
+    refs = [
+        DocumentRef(external_id="id-1", uri="https://example.com/file1.py"),
+        DocumentRef(external_id="id-2", uri="https://example.com/file2.py"),
+    ]
+    handler = _make_webhook_handler(valid=True, refs=refs)
+    app = _make_app_with_source(source=src)
+
+    # Stub a fake NATS connection with a mock JetStream
+    mock_js = AsyncMock()
+    mock_js.publish = AsyncMock()
+    mock_nats = MagicMock()
+    mock_nats.jetstream = mock_js
+    app.state.nats = mock_nats
+
+    with (
+        patch(
+            "omniscience_server.rest.webhooks._get_connector_handler",
+            return_value=handler,
+        ),
+        patch(
+            "omniscience_server.rest.webhooks.QueueProducer.publish",
+            new_callable=AsyncMock,
+        ) as mock_publish,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": str(uuid.uuid4()),
+                },
+            )
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["accepted"] is True
+    assert body["events_queued"] == 2
+    assert mock_publish.call_count == 2
+
+    # Verify the subjects and event shapes
+    calls = mock_publish.call_args_list
+    for call in calls:
+        kwargs = call.kwargs
+        assert kwargs["subject"] == f"ingest.changes.{src.type}"
+        event = kwargs["payload"]
+        assert event.source_id == src.id
+        assert event.source_type == str(src.type)
+        assert event.action == "updated"
+
+
+@pytest.mark.asyncio
+async def test_webhook_generic_event_when_no_refs() -> None:
+    """A single generic event is emitted when the connector returns no refs."""
+    src = _make_source(webhook_secret="secret")
+    src.type = SourceType.git
+
+    # Handler returns empty refs list
+    handler = _make_webhook_handler(valid=True, refs=[])
+    app = _make_app_with_source(source=src)
+
+    mock_js = AsyncMock()
+    mock_nats = MagicMock()
+    mock_nats.jetstream = mock_js
+    app.state.nats = mock_nats
+
+    with (
+        patch(
+            "omniscience_server.rest.webhooks._get_connector_handler",
+            return_value=handler,
+        ),
+        patch(
+            "omniscience_server.rest.webhooks.QueueProducer.publish",
+            new_callable=AsyncMock,
+        ) as mock_publish,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": str(uuid.uuid4()),
+                },
+            )
+
+    assert resp.status_code == 202
+    assert mock_publish.call_count == 1
+    event = mock_publish.call_args.kwargs["payload"]
+    assert event.external_id == "*"
+
+
+# ---------------------------------------------------------------------------
+# Integration: 202 with no secret (no signature check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_202_no_secret() -> None:
+    """202 is returned when no webhook_secret is configured (no sig check)."""
+    src = _make_source(webhook_secret=None)
+    src.type = SourceType.git
+    app = _make_app_with_source(source=src)
+
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=None,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={"Content-Type": "application/json"},
+            )
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["accepted"] is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: replay protection — duplicate delivery ID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_400_duplicate_delivery_id() -> None:
+    """Second request with the same delivery ID is rejected with 400."""
+    src = _make_source(webhook_secret=None)
+    src.type = SourceType.git
+    app = _make_app_with_source(source=src)
+    delivery_id = str(uuid.uuid4())
+
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=None,
+    ):
+        async with await _client_for(app) as client:
+            # First delivery — should succeed
+            resp1 = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": delivery_id,
+                },
+            )
+            assert resp1.status_code == 202
+
+            # Second delivery with same ID — should be rejected
+            resp2 = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": delivery_id,
+                },
+            )
+
+    assert resp2.status_code == 400
+    body = resp2.json()
+    assert body["error"]["code"] == "bad_request"
+    assert "duplicate" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Integration: replay protection — expired timestamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_400_expired_timestamp() -> None:
+    """Payload with a timestamp older than the replay window is rejected."""
+    src = _make_source(webhook_secret=None)
+    src.type = SourceType.git
+    app = _make_app_with_source(source=src)
+
+    # Timestamp well outside the 5-minute window
+    old_ts = int(time.time()) - 600
+    payload = json.dumps({"timestamp": old_ts}).encode()
+
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=None,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=payload,
+                headers={"Content-Type": "application/json"},
+            )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["code"] == "bad_request"
+    assert "old" in body["error"]["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_webhook_202_fresh_timestamp() -> None:
+    """Payload with a current timestamp passes the age check."""
+    src = _make_source(webhook_secret=None)
+    src.type = SourceType.git
+    app = _make_app_with_source(source=src)
+
+    current_ts = int(time.time())
+    payload = json.dumps({"timestamp": current_ts}).encode()
+
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=None,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": str(uuid.uuid4()),
+                },
+            )
+
+    assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# Integration: per-source rate limiting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_429_rate_limited() -> None:
+    """429 is returned when the per-source rate limit is exceeded."""
+    src = _make_source(webhook_secret=None)
+    src.type = SourceType.git
+
+    # Each call uses a new session instance from the factory.
+    # We need an independent session for each request.
+    app = create_app(settings=_make_settings())
+    session = _make_db_session(source=src)
+    app.state.db_session_factory = MagicMock(return_value=session)
+
+    # Patch to use rpm=1 so the second request exceeds the limit.
+    with (
+        patch(
+            "omniscience_server.rest.webhooks._get_connector_handler",
+            return_value=None,
+        ),
+        patch(
+            "omniscience_server.rest.webhooks._DEFAULT_SOURCE_RPM",
+            1,
+        ),
+    ):
+        async with await _client_for(app) as client:
+            # Exhaust the single token.
+            r1 = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={"Content-Type": "application/json"},
+            )
+            # Second request — bucket empty.
+            r2 = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={"Content-Type": "application/json"},
+            )
+
+    assert r1.status_code == 202
+    assert r2.status_code == 429
+    body = r2.json()
+    assert body["error"]["code"] == "rate_limited"
+    assert "Retry-After" in r2.headers
+
+
+# ---------------------------------------------------------------------------
+# Integration: graceful fallback when connector not registered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_202_connector_not_registered() -> None:
+    """202 is returned even when the connector type is not in the registry."""
+    src = _make_source(webhook_secret=None)
+    src.type = SourceType.git
+    app = _make_app_with_source(source=src)
+
+    # Do NOT patch _get_connector_handler — let the real registry be used.
+    # Since "git" may not be registered, _get_connector_handler returns None gracefully.
+    async with await _client_for(app) as client:
+        resp = await client.post(
+            "/api/v1/ingest/webhook/test-repo",
+            content=b'{"action":"push"}',
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["accepted"] is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: NATS unavailable — events_queued=0 but still 202
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_webhook_202_nats_unavailable() -> None:
+    """202 is returned and events_queued=0 when NATS is not connected."""
+    src = _make_source(webhook_secret=None)
+    src.type = SourceType.git
+    app = _make_app_with_source(source=src)
+    # Explicitly unset nats on app state
+    app.state.nats = None
+
+    refs = [DocumentRef(external_id="id-1", uri="https://example.com/f.py")]
+    handler = _make_webhook_handler(valid=True, refs=refs)
+
+    with patch(
+        "omniscience_server.rest.webhooks._get_connector_handler",
+        return_value=handler,
+    ):
+        async with await _client_for(app) as client:
+            resp = await client.post(
+                "/api/v1/ingest/webhook/test-repo",
+                content=b'{"action":"push"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": str(uuid.uuid4()),
+                },
+            )
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["accepted"] is True
+    assert body["events_queued"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Response model unit test
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_accepted_response_model() -> None:
+    r = WebhookAcceptedResponse(accepted=True, events_queued=3)
+    assert r.accepted is True
+    assert r.events_queued == 3
+    data = r.model_dump()
+    assert data == {"accepted": True, "events_queued": 3}


### PR DESCRIPTION
## Summary
- Webhook delegates to connector's WebhookHandler for signature verification + payload parsing
- DeliveryTracker: in-memory replay protection with TTL (rejects duplicate delivery IDs + old timestamps)
- Per-source rate limiting on webhook endpoint
- Returns 202 with events_queued count
- Enqueues DocumentChangeEvent per affected file via NATS
- 35 new tests

## Test plan
- [ ] All tests pass, mypy --strict clean, ruff clean

Closes #19