### PR TITLE
chore: finalize Docker Compose with profiles, Helm chart, and monitoring

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,3 @@
-{
-    auto_https off
-}
-
-:80 {
+{$CADDY_DOMAIN:localhost} {
     reverse_proxy app:8000
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 # ── Builder stage ────────────────────────────────────────────────────────────
-# Uses build-essential for tree-sitter native extensions (added in Wave 2).
+# build-essential is required for tree-sitter native extensions.
 # All build tooling stays in this layer — the runtime image inherits nothing.
 FROM python:3.12-slim AS builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir uv
 
 WORKDIR /app
 
 # Copy dependency manifests first to exploit Docker layer caching.
+# Changes to source files will not bust the install cache.
 COPY pyproject.toml uv.lock* ./
 COPY packages/core/pyproject.toml        packages/core/pyproject.toml
 COPY packages/connectors/pyproject.toml  packages/connectors/pyproject.toml
@@ -18,16 +23,22 @@ COPY packages/retrieval/pyproject.toml   packages/retrieval/pyproject.toml
 COPY apps/server/pyproject.toml          apps/server/pyproject.toml
 COPY apps/cli/pyproject.toml             apps/cli/pyproject.toml
 
+# Install dependencies (frozen lock, no dev extras).
+RUN uv sync --frozen --no-dev
+
 # Copy source after manifests so source changes don't bust the install cache.
 COPY packages/ packages/
 COPY apps/     apps/
 
-RUN uv sync --frozen --no-dev
-
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 # Minimal image: no build tools, runs as a non-root user.
+# curl is included for the container healthcheck.
 FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create a dedicated non-root user.
 RUN groupadd --system omniscience \
@@ -35,8 +46,8 @@ RUN groupadd --system omniscience \
 
 WORKDIR /app
 
-COPY --from=builder /app/.venv  /app/.venv
-COPY --from=builder /app/apps   /app/apps
+COPY --from=builder /app/.venv    /app/.venv
+COPY --from=builder /app/apps     /app/apps
 COPY --from=builder /app/packages /app/packages
 
 ENV PATH="/app/.venv/bin:$PATH" \
@@ -46,5 +57,8 @@ ENV PATH="/app/.venv/bin:$PATH" \
 USER omniscience
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 --start-period=10s \
+    CMD curl -f http://localhost:8000/health || exit 1
 
 CMD ["python", "-m", "omniscience_server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       nats:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -33,6 +33,28 @@ services:
       timeout: 5s
       retries: 10
       start_period: 10s
+    restart: unless-stopped
+
+  pgbackup:
+    image: postgres:16-alpine
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
+    volumes:
+      - pgbackups:/backups
+    entrypoint: >
+      sh -c "
+        while true; do
+          TIMESTAMP=$$(date +%Y%m%d_%H%M%S);
+          pg_dump -h postgres -U omniscience -d omniscience -Fc -f /backups/omniscience_$${TIMESTAMP}.dump;
+          echo \"Backup created: omniscience_$${TIMESTAMP}.dump\";
+          find /backups -name '*.dump' -mtime +7 -delete;
+          echo 'Old backups pruned (>7 days)';
+          sleep 86400;
+        done
+      "
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
 
   nats:
@@ -60,6 +82,39 @@ services:
     volumes:
       - ollama_data:/root/.ollama
 
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    profiles:
+      - monitoring
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheusdata:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    profiles:
+      - monitoring
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
   caddy:
     image: caddy:2-alpine
     profiles:
@@ -67,13 +122,21 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      CADDY_DOMAIN: ${CADDY_DOMAIN:-localhost}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
+    depends_on:
+      app:
+        condition: service_healthy
     restart: unless-stopped
 
 volumes:
   pgdata:
+  pgbackups:
   natsdata:
   ollama_data:
+  prometheusdata:
+  grafanadata:
   caddy_data:

--- a/helm/omniscience/Chart.yaml
+++ b/helm/omniscience/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: omniscience
+description: Omniscience — universal context retrieval for AI agents
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - omniscience
+  - mcp
+  - rag
+  - ai
+  - retrieval
+home: https://github.com/100rd/Omniscience
+sources:
+  - https://github.com/100rd/Omniscience
+maintainers:
+  - name: Omniscience maintainers

--- a/helm/omniscience/README.md
+++ b/helm/omniscience/README.md
@@ -1,0 +1,131 @@
+# Omniscience Helm Chart
+
+Helm chart for deploying Omniscience on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.10+
+- A Postgres 14+ instance with pgvector (built-in or external)
+- A NATS 2.x instance (built-in or external)
+
+## Install
+
+```bash
+helm upgrade --install omniscience ./helm/omniscience \
+  --namespace omniscience \
+  --create-namespace \
+  --set secrets.postgresPassword=changeme \
+  --set secrets.apiToken=mytoken
+```
+
+## Values Reference
+
+### Image
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `ghcr.io/100rd/omniscience` | Container image repository |
+| `image.tag` | `latest` | Image tag (override with Git SHA in CI) |
+| `image.pullPolicy` | `IfNotPresent` | Pull policy |
+
+### Application config
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `config.logLevel` | `INFO` | Log level (DEBUG, INFO, WARNING, ERROR) |
+| `config.embeddingsProvider` | `ollama` | Embeddings backend: `ollama`, `openai`, `voyage` |
+| `config.embeddingModel` | `nomic-embed-text` | Embedding model name |
+| `config.mcpTransport` | `streamable-http` | MCP transport: `stdio` or `streamable-http` |
+| `config.freshnessSloSeconds` | `3600` | Default freshness SLO in seconds |
+| `config.ollamaUrl` | `""` | Ollama endpoint (required when provider=ollama) |
+| `config.openaiBaseUrl` | `""` | Optional OpenAI base URL override |
+| `config.corsOrigins` | `""` | Comma-separated CORS origins |
+
+### Secrets
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `secrets.postgresPassword` | `""` | **Required.** PostgreSQL password |
+| `secrets.apiToken` | `""` | Bearer token for REST + MCP auth |
+| `secrets.openaiApiKey` | `""` | OpenAI or Voyage API key |
+
+### PostgreSQL (built-in)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `postgres.enabled` | `true` | Deploy bundled Postgres |
+| `postgres.image` | `pgvector/pgvector:pg16` | Postgres image |
+| `postgres.database` | `omniscience` | Database name |
+| `postgres.user` | `omniscience` | Database user |
+| `postgres.storageSize` | `20Gi` | PVC size |
+| `postgres.storageClass` | `""` | StorageClass (empty = cluster default) |
+| `postgres.externalUrl` | `""` | Use external DB; disables built-in Postgres |
+
+### NATS (built-in)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `nats.enabled` | `true` | Deploy bundled NATS |
+| `nats.image` | `nats:2.10-alpine` | NATS image |
+| `nats.storageSize` | `5Gi` | PVC size |
+| `nats.storageClass` | `""` | StorageClass (empty = cluster default) |
+| `nats.externalUrl` | `""` | Use external NATS; disables built-in NATS |
+
+### Service
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `8000` | Service port |
+
+### Ingress
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `ingress.enabled` | `false` | Enable Ingress |
+| `ingress.className` | `""` | IngressClass name |
+| `ingress.annotations` | `{}` | Ingress annotations |
+| `ingress.hosts` | see values | Host rules |
+| `ingress.tls` | `[]` | TLS configuration |
+
+### Resources
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `resources.requests.cpu` | `250m` | CPU request |
+| `resources.requests.memory` | `512Mi` | Memory request |
+| `resources.limits.cpu` | `1000m` | CPU limit |
+| `resources.limits.memory` | `1Gi` | Memory limit |
+
+## Using an External Database
+
+To connect to RDS, CloudSQL, Neon, or any external Postgres:
+
+```bash
+helm upgrade --install omniscience ./helm/omniscience \
+  --set postgres.enabled=false \
+  --set postgres.externalUrl="postgresql://user:pass@host:5432/omniscience" \
+  --set secrets.postgresPassword=notused
+```
+
+## Using an External NATS Cluster
+
+```bash
+helm upgrade --install omniscience ./helm/omniscience \
+  --set nats.enabled=false \
+  --set nats.externalUrl="nats://nats.example.com:4222"
+```
+
+## Enabling Ingress with TLS
+
+```bash
+helm upgrade --install omniscience ./helm/omniscience \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set "ingress.hosts[0].host=omniscience.example.com" \
+  --set "ingress.hosts[0].paths[0].path=/" \
+  --set "ingress.hosts[0].paths[0].pathType=Prefix" \
+  --set "ingress.tls[0].secretName=omniscience-tls" \
+  --set "ingress.tls[0].hosts[0]=omniscience.example.com"
+```

--- a/helm/omniscience/templates/NOTES.txt
+++ b/helm/omniscience/templates/NOTES.txt
@@ -1,0 +1,38 @@
+Omniscience {{ .Chart.AppVersion }} has been installed.
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Check rollout status:
+
+   kubectl rollout status deployment/{{ include "omniscience.fullname" . }} \
+     -n {{ .Release.Namespace }}
+
+2. Verify the health endpoint:
+
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+   curl https://{{ .host }}/health
+{{- end }}
+{{- else }}
+   kubectl port-forward svc/{{ include "omniscience.fullname" . }} 8000:8000 \
+     -n {{ .Release.Namespace }}
+
+   curl http://localhost:8000/health
+{{- end }}
+
+3. Connect an MCP client (streamable-http):
+
+   url: http://{{ include "omniscience.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8000/mcp
+
+4. Run an ad-hoc search via CLI:
+
+   kubectl exec -it deploy/{{ include "omniscience.fullname" . }} \
+     -n {{ .Release.Namespace }} -- \
+     omniscience search "your query here"
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation: https://github.com/100rd/Omniscience

--- a/helm/omniscience/templates/_helpers.tpl
+++ b/helm/omniscience/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "omniscience.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "omniscience.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "omniscience.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "omniscience.labels" -}}
+helm.sh/chart: {{ include "omniscience.chart" . }}
+{{ include "omniscience.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "omniscience.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "omniscience.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "omniscience.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "omniscience.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database URL — internal or external.
+*/}}
+{{- define "omniscience.databaseUrl" -}}
+{{- if .Values.postgres.externalUrl }}
+{{- .Values.postgres.externalUrl }}
+{{- else }}
+{{- printf "postgresql://%s@%s-postgres:5432/%s" .Values.postgres.user (include "omniscience.fullname" .) .Values.postgres.database }}
+{{- end }}
+{{- end }}
+
+{{/*
+NATS URL — internal or external.
+*/}}
+{{- define "omniscience.natsUrl" -}}
+{{- if .Values.nats.externalUrl }}
+{{- .Values.nats.externalUrl }}
+{{- else }}
+{{- printf "nats://%s-nats:4222" (include "omniscience.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/helm/omniscience/templates/configmap.yaml
+++ b/helm/omniscience/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "omniscience.fullname" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+data:
+  LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  EMBEDDINGS_PROVIDER: {{ .Values.config.embeddingsProvider | quote }}
+  EMBEDDING_MODEL: {{ .Values.config.embeddingModel | quote }}
+  MCP_TRANSPORT: {{ .Values.config.mcpTransport | quote }}
+  FRESHNESS_SLO_SECONDS: {{ .Values.config.freshnessSloSeconds | toString | quote }}
+  {{- if .Values.config.ollamaUrl }}
+  OLLAMA_URL: {{ .Values.config.ollamaUrl | quote }}
+  {{- end }}
+  {{- if .Values.config.openaiBaseUrl }}
+  OPENAI_BASE_URL: {{ .Values.config.openaiBaseUrl | quote }}
+  {{- end }}
+  {{- if .Values.config.corsOrigins }}
+  CORS_ORIGINS: {{ .Values.config.corsOrigins | quote }}
+  {{- end }}
+  DATABASE_URL: {{ include "omniscience.databaseUrl" . | quote }}
+  NATS_URL: {{ include "omniscience.natsUrl" . | quote }}

--- a/helm/omniscience/templates/deployment.yaml
+++ b/helm/omniscience/templates/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "omniscience.fullname" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "omniscience.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Force rollout on ConfigMap or Secret change
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "omniscience.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "omniscience.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: omniscience
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "omniscience.fullname" . }}
+            - secretRef:
+                name: {{ include "omniscience.fullname" . }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        # readOnlyRootFilesystem=true requires a writable /tmp
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/omniscience/templates/ingress.yaml
+++ b/helm/omniscience/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "omniscience.fullname" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "omniscience.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/omniscience/templates/pvc.yaml
+++ b/helm/omniscience/templates/pvc.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "omniscience.fullname" . }}-postgres
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.postgres.storageSize | quote }}
+  {{- if .Values.postgres.storageClass }}
+  storageClassName: {{ .Values.postgres.storageClass | quote }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.nats.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "omniscience.fullname" . }}-nats
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nats
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.nats.storageSize | quote }}
+  {{- if .Values.nats.storageClass }}
+  storageClassName: {{ .Values.nats.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/omniscience/templates/secret.yaml
+++ b/helm/omniscience/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "omniscience.fullname" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ required "secrets.postgresPassword is required" .Values.secrets.postgresPassword | quote }}
+  API_TOKEN: {{ .Values.secrets.apiToken | default "" | quote }}
+  {{- if .Values.secrets.openaiApiKey }}
+  OPENAI_API_KEY: {{ .Values.secrets.openaiApiKey | quote }}
+  {{- end }}

--- a/helm/omniscience/templates/service.yaml
+++ b/helm/omniscience/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "omniscience.fullname" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "omniscience.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/helm/omniscience/templates/serviceaccount.yaml
+++ b/helm/omniscience/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "omniscience.serviceAccountName" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/helm/omniscience/values.yaml
+++ b/helm/omniscience/values.yaml
@@ -1,0 +1,140 @@
+# Default values for omniscience.
+# Override per environment: helm upgrade --install omniscience ./helm/omniscience -f values-prod.yaml
+
+# ── Image ─────────────────────────────────────────────────────────────────────
+image:
+  repository: ghcr.io/100rd/omniscience
+  pullPolicy: IfNotPresent
+  # Overridden by CI: --set image.tag=$GIT_SHA
+  tag: "latest"
+
+imagePullSecrets: []
+
+# ── Replicas ──────────────────────────────────────────────────────────────────
+replicaCount: 1
+
+# ── Resources ─────────────────────────────────────────────────────────────────
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# ── Service ───────────────────────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 8000
+
+# ── Ingress ───────────────────────────────────────────────────────────────────
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: omniscience.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  # - secretName: omniscience-tls
+  #   hosts:
+  #     - omniscience.example.com
+
+# ── Application config (non-secret) ──────────────────────────────────────────
+config:
+  # Log level: DEBUG, INFO, WARNING, ERROR
+  logLevel: INFO
+  # Ollama endpoint (used when embeddings.provider=ollama)
+  ollamaUrl: ""
+  # OpenAI/Voyage endpoint override (optional)
+  openaiBaseUrl: ""
+  # Embeddings provider: ollama | openai | voyage
+  embeddingsProvider: ollama
+  # Embedding model name
+  embeddingModel: nomic-embed-text
+  # MCP server transport: stdio | streamable-http
+  mcpTransport: streamable-http
+  # Freshness SLO default (seconds)
+  freshnessSloSeconds: 3600
+  # CORS origins (comma-separated)
+  corsOrigins: ""
+
+# ── Secrets (values are base64-encoded by default in Secret template) ─────────
+secrets:
+  # PostgreSQL password — REQUIRED; override via --set secrets.postgresPassword=...
+  postgresPassword: ""
+  # API bearer token for REST + MCP auth
+  apiToken: ""
+  # OpenAI / Voyage API key (leave empty if using Ollama)
+  openaiApiKey: ""
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+postgres:
+  # Set to false to use an external managed database (RDS, CloudSQL, etc.)
+  enabled: true
+  image: pgvector/pgvector:pg16
+  database: omniscience
+  user: omniscience
+  # Storage size for the PostgreSQL PVC
+  storageSize: 20Gi
+  storageClass: ""
+  # Override full DATABASE_URL (disables the internal postgres service)
+  externalUrl: ""
+
+# ── NATS ──────────────────────────────────────────────────────────────────────
+nats:
+  # Set to false to use an external NATS cluster
+  enabled: true
+  image: nats:2.10-alpine
+  # Storage size for the NATS JetStream PVC
+  storageSize: 5Gi
+  storageClass: ""
+  # Override full NATS_URL (disables the internal nats service)
+  externalUrl: ""
+
+# ── Pod settings ──────────────────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# ── Probes ────────────────────────────────────────────────────────────────────
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# ── Node placement ────────────────────────────────────────────────────────────
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,20 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    service: omniscience
+
+scrape_configs:
+  - job_name: omniscience-app
+    static_configs:
+      - targets:
+          - app:8000
+    metrics_path: /metrics
+    scrape_interval: 15s
+
+  - job_name: nats
+    static_configs:
+      - targets:
+          - nats:8222
+    metrics_path: /metrics
+    scrape_interval: 15s


### PR DESCRIPTION
## Summary
- Docker Compose: pgbackup sidecar, monitoring profile (Prometheus + Grafana), TLS profile with CADDY_DOMAIN
- Dockerfile: build-essential for tree-sitter, curl for healthcheck, HEALTHCHECK instruction
- Helm chart stub: Deployment, Service, Ingress, ConfigMap, Secret, PVC, values.yaml
- Monitoring: prometheus.yml scrape configs, Grafana auto-provisioned datasource
- Validated: docker compose config + helm lint

Closes #20