### PR TITLE
fix: Docker image installs workspace packages correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN uv sync --frozen --no-dev
 COPY packages/ packages/
 COPY apps/     apps/
 
+# Re-sync to install workspace packages now that source is available.
+RUN uv sync --frozen --no-dev
+
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 # Minimal image: no build tools, runs as a non-root user.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "Self-hosted knowledge retrieval service with MCP-first API"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-    "nats-py>=2.14.0",
+    "omniscience-server",
+    "omniscience-cli",
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -1064,7 +1064,8 @@ name = "omniscience"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "nats-py" },
+    { name = "omniscience-cli" },
+    { name = "omniscience-server" },
 ]
 
 [package.dev-dependencies]
@@ -1091,7 +1092,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "nats-py", specifier = ">=2.14.0" }]
+requires-dist = [
+    { name = "omniscience-cli", editable = "apps/cli" },
+    { name = "omniscience-server", editable = "apps/server" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Two fixes discovered during E2E validation:

1. **Root `pyproject.toml`**: Added `omniscience-server` and `omniscience-cli` as production dependencies (were only in dev deps). Without this, `uv sync --no-dev` in Docker doesn't install the workspace packages.

2. **Dockerfile**: Added second `uv sync --frozen --no-dev` after copying source so workspace packages are built and installed in the venv.

## E2E Validation Results

After these fixes, `docker compose up -d` produces:

| Service | Status |
|---------|--------|
| app | healthy |
| postgres | healthy |
| nats | healthy |
| pgbackup | running |

Verified:
- `GET /health` → 200 `{"status": "healthy", "checks": {"postgres": "unchecked", "nats": "healthy"}, "version": "0.1.0"}`
- `GET /metrics` → 200 (Prometheus exposition format)
- `GET /api/v1/openapi.json` → full OpenAPI 3.1 spec with all endpoints
- `GET /api/docs` → Swagger UI
- Credential redaction working in logs (`***@postgres`)
- NATS connected successfully
- Structured JSON logging operational

## Test plan

- [ ] `docker compose build` succeeds
- [ ] `docker compose up -d` → all 4 services healthy
- [ ] `curl localhost:8000/health` → 200