### PR TITLE
fix: wire DB engine in app lifespan and fix Alembic migration

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse, urlunparse
 import structlog
 from fastapi import FastAPI
 from omniscience_core.config import Settings
+from omniscience_core.db import create_async_engine, create_session_factory
 from omniscience_core.logging import configure_logging
 from omniscience_core.queue import NatsConnection, ensure_streams
 from omniscience_core.telemetry import init_telemetry
@@ -63,9 +64,12 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         environment=settings.environment,
     )
 
-    # --- Placeholder: Postgres connection (Wave 2, issue #2) ---
-    # TODO(wave-2, issue-#2): Replace with real asyncpg pool / SQLAlchemy engine.
-    log.info("postgres_connect_placeholder", url=_redact_url(settings.database_url))
+    # --- Postgres connection ---
+    engine = create_async_engine(settings)
+    session_factory = create_session_factory(engine)
+    app.state.db_engine = engine
+    app.state.db_session_factory = session_factory
+    log.info("postgres_connected", url=_redact_url(settings.database_url))
 
     # --- NATS JetStream connection ---
     nats_conn = NatsConnection()
@@ -84,7 +88,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # --- Shutdown ---
     log.info("shutdown", app=settings.app_name)
-    # TODO(wave-2): Close Postgres pool here.
+    await engine.dispose()
     await nats_conn.disconnect()
 
 

--- a/packages/core/alembic/env.py
+++ b/packages/core/alembic/env.py
@@ -24,10 +24,16 @@ if config.config_file_name is not None:
 # Import models so autogenerate can detect them
 # ---------------------------------------------------------------------------
 
-# Side-effect import — registers all mapped classes onto Base.metadata
-from omniscience_core.db.models import Base  # noqa: E402
-
-target_metadata = Base.metadata
+# NOTE: We intentionally do NOT import models here.  Importing models
+# registers PostgreSQL ENUM types on SQLAlchemy MetaData, and the
+# before_create event on those types fires unconditional CREATE TYPE
+# during op.create_table — even when the migration itself already created
+# them.  This causes "type already exists" errors.
+#
+# Trade-off: autogenerate (`alembic revision --autogenerate`) won't work.
+# All migrations must be written manually.  Re-enable the import when
+# SQLAlchemy/Alembic supports `checkfirst=True` in the table event path.
+target_metadata = None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/alembic/versions/0001_initial.py
+++ b/packages/core/alembic/versions/0001_initial.py
@@ -77,23 +77,7 @@ def upgrade() -> None:
     op.create_table(
         "sources",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
-        sa.Column(
-            "type",
-            sa.Enum(
-                "git",
-                "fs",
-                "confluence",
-                "notion",
-                "slack",
-                "jira",
-                "grafana",
-                "k8s",
-                "terraform",
-                name="source_type",
-                create_type=False,
-            ),
-            nullable=False,
-        ),
+        sa.Column("type", postgresql.ENUM(name="source_type", create_type=False), nullable=False),
         sa.Column("name", sa.Text(), nullable=False),
         sa.Column(
             "config",
@@ -104,7 +88,7 @@ def upgrade() -> None:
         sa.Column("secrets_ref", sa.Text(), nullable=True),
         sa.Column(
             "status",
-            sa.Enum("active", "paused", "error", name="source_status", create_type=False),
+            postgresql.ENUM(name="source_status", create_type=False),
             nullable=False,
             server_default="active",
         ),
@@ -150,14 +134,7 @@ def upgrade() -> None:
         sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column(
             "status",
-            sa.Enum(
-                "running",
-                "ok",
-                "partial",
-                "error",
-                name="ingestion_run_status",
-                create_type=False,
-            ),
+            postgresql.ENUM(name="ingestion_run_status", create_type=False),
             nullable=False,
             server_default="running",
         ),


### PR DESCRIPTION
## Summary

Two fixes to make the E2E flow work:

1. **App lifespan**: Replaced Postgres placeholder with real `create_async_engine()` + `create_session_factory()`, stored on `app.state.db_session_factory`. Engine disposed on shutdown.

2. **Alembic migration**: Fixed "type already exists" error. Root cause: `op.create_table` triggers SQLAlchemy's `before_create` event which auto-creates enum types even with `create_type=False`. Fix: use `postgresql.ENUM(name=..., create_type=False)` directly in column definitions + remove model import from env.py.

## E2E Validation

After these fixes:
- `docker compose up -d` → all services healthy
- `alembic upgrade head` → all 5 tables created
- `POST /api/v1/tokens` → token created with argon2 hash
- `GET /api/v1/sources` → authenticated, returns empty list
- `GET /api/v1/tokens` → shows token with `last_used_at` updated
- Token auth, scope enforcement, and DB operations all working

Closes the E2E validation gap.