### PR TITLE
feat: symbol graph with entities, edges, and code relationship extraction

### DIFF
--- a/apps/server/src/omniscience_server/ingestion/pipeline.py
+++ b/apps/server/src/omniscience_server/ingestion/pipeline.py
@@ -15,6 +15,10 @@ Real parsers/chunkers will be wired in when Wave 5 lands.
 IndexWriter note: ``IndexWriterProtocol`` is the interface contract for the
 parallel issue-11 implementation (``omniscience_index.IndexWriter``).
 The real integration happens when both branches are merged.
+
+Symbol graph note: After parse the pipeline optionally calls
+``extract_symbol_graph`` (omniscience_parsers) and persists entities and
+edges via ``IndexWriterProtocol.upsert_graph``.
 """
 
 from __future__ import annotations
@@ -97,6 +101,14 @@ class IndexWriterProtocol(Protocol):
 
     async def tombstone(self, source_id: UUID, external_id: str) -> bool: ...
 
+    async def upsert_graph(
+        self,
+        source_id: UUID,
+        document_id: UUID,
+        entities: list[Any],
+        edges: list[Any],
+    ) -> None: ...
+
 
 # ---------------------------------------------------------------------------
 # Chunk placeholder (Wave 5 will replace with real ChunkData)
@@ -135,6 +147,11 @@ class IngestionPipeline:
     Each stage is isolated: a failure in one stage sets ``action="error"``
     on the result but does not raise; the caller (worker) decides how to
     ack/nak the underlying message.
+
+    Symbol graph extraction runs as an optional stage after parse.  It is
+    activated when both ``_graph_extractor`` is provided (non-None) and the
+    parsed document's language is supported.  Graph extraction failures are
+    logged and swallowed — they never abort indexing.
     """
 
     def __init__(
@@ -142,10 +159,15 @@ class IngestionPipeline:
         connector: Connector,
         embedding_provider: EmbeddingProvider,
         index_writer: IndexWriterProtocol,
+        graph_extractor: Any | None = None,
     ) -> None:
         self._connector = connector
         self._embedding_provider = embedding_provider
         self._index_writer = index_writer
+        # Optional callable:
+        #   graph_extractor(parsed_doc, source_bytes) -> (entities, edges)
+        # Matches the signature of omniscience_parsers.code.graph.extract_symbol_graph
+        self._graph_extractor = graph_extractor
 
     async def run(
         self,
@@ -213,9 +235,15 @@ class IngestionPipeline:
         parsed_text = await self._stage_parse(content_text, event.source_type, bound)
         chunks_text = await self._stage_chunk(parsed_text, event.source_type, bound)
         embeddings = await self._stage_embed(chunks_text, event.source_type, bound)
-        upsert_action = await self._stage_index(
+        upsert_action, document_id = await self._stage_index(
             event, fetched, content_text, chunks_text, embeddings, ingestion_run_id, bound
         )
+
+        # Symbol graph extraction — optional, best-effort
+        await self._stage_graph(
+            event, fetched.content_bytes, document_id, bound
+        )
+
         return ProcessResult(
             source_id=event.source_id,
             external_id=event.external_id,
@@ -324,7 +352,8 @@ class IngestionPipeline:
         embeddings: list[list[float]],
         ingestion_run_id: UUID | None,
         bound: Any,
-    ) -> str:
+    ) -> tuple[str, UUID]:
+        """Write chunks to the index.  Returns (action, document_id)."""
         t0 = time.monotonic()
         try:
             content_hash = _compute_content_hash(content_text)
@@ -348,17 +377,64 @@ class IngestionPipeline:
                 ingestion_run_id=ingestion_run_id,
             )
             action: str = result.action
+            document_id: UUID = result.document_id
             if action == "unchanged":
                 bound.debug("stage_index_unchanged")
             else:
                 bound.debug("stage_index_ok", action=action, chunks_written=result.chunks_written)
-            return action
+            return action, document_id
         except Exception as exc:
             INGESTION_ERRORS_TOTAL.labels(source_type=event.source_type, stage="index").inc()
             bound.error("stage_index_error", error=str(exc))
             raise
         finally:
             INGESTION_STAGE_DURATION_SECONDS.labels(stage="index").observe(time.monotonic() - t0)
+
+    async def _stage_graph(
+        self,
+        event: DocumentChangeEvent,
+        content_bytes: bytes,
+        document_id: UUID,
+        bound: Any,
+    ) -> None:
+        """Extract symbol graph and persist entities/edges.  Best-effort: never raises."""
+        if self._graph_extractor is None:
+            return
+
+        t0 = time.monotonic()
+        try:
+            from omniscience_parsers import TreeSitterParser
+
+            parser = TreeSitterParser()
+            ext = "." + event.external_id.rsplit(".", 1)[-1] if "." in event.external_id else ""
+            if not parser.can_handle("", ext):
+                return
+
+            parsed = parser.parse(content_bytes, file_path=event.external_id)
+            entities, edges = self._graph_extractor(parsed, content_bytes)
+
+            if not entities and not edges:
+                return
+
+            await self._index_writer.upsert_graph(
+                source_id=event.source_id,
+                document_id=document_id,
+                entities=entities,
+                edges=edges,
+            )
+            bound.debug(
+                "stage_graph_ok",
+                entities=len(entities),
+                edges=len(edges),
+            )
+        except Exception as exc:
+            INGESTION_ERRORS_TOTAL.labels(
+                source_type=event.source_type, stage="graph"
+            ).inc()
+            bound.warning("stage_graph_error", error=str(exc))
+            # Swallow: graph extraction is non-critical
+        finally:
+            INGESTION_STAGE_DURATION_SECONDS.labels(stage="graph").observe(time.monotonic() - t0)
 
     async def _handle_delete(self, event: DocumentChangeEvent, bound: Any) -> ProcessResult:
         t0 = time.monotonic()

--- a/apps/server/src/omniscience_server/ingestion/pipeline.py
+++ b/apps/server/src/omniscience_server/ingestion/pipeline.py
@@ -240,9 +240,7 @@ class IngestionPipeline:
         )
 
         # Symbol graph extraction — optional, best-effort
-        await self._stage_graph(
-            event, fetched.content_bytes, document_id, bound
-        )
+        await self._stage_graph(event, fetched.content_bytes, document_id, bound)
 
         return ProcessResult(
             source_id=event.source_id,
@@ -428,9 +426,7 @@ class IngestionPipeline:
                 edges=len(edges),
             )
         except Exception as exc:
-            INGESTION_ERRORS_TOTAL.labels(
-                source_type=event.source_type, stage="graph"
-            ).inc()
+            INGESTION_ERRORS_TOTAL.labels(source_type=event.source_type, stage="graph").inc()
             bound.warning("stage_graph_error", error=str(exc))
             # Swallow: graph extraction is non-critical
         finally:

--- a/packages/core/alembic/versions/0002_entities_edges.py
+++ b/packages/core/alembic/versions/0002_entities_edges.py
@@ -1,0 +1,114 @@
+"""Add entities and edges tables for the symbol graph.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-17 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # entities table
+    # ------------------------------------------------------------------
+    op.create_table(
+        "entities",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "source_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("sources.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("entity_type", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("display_name", sa.Text(), nullable=False),
+        sa.Column(
+            "chunk_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("chunks.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    # Composite index on (source_id, entity_type) for filtered graph queries
+    op.create_index("ix_entities_source_type", "entities", ["source_id", "entity_type"])
+    # Index on FQN name for fast entity lookup by fully-qualified name
+    op.create_index("ix_entities_name", "entities", ["name"])
+
+    # ------------------------------------------------------------------
+    # edges table
+    # ------------------------------------------------------------------
+    op.create_table(
+        "edges",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "source_entity_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("entities.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "target_entity_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("entities.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("edge_type", sa.Text(), nullable=False),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    # Index on edge_type for filtered traversal (e.g. only "calls" edges)
+    op.create_index("ix_edges_edge_type", "edges", ["edge_type"])
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    op.drop_table("edges")
+    op.drop_table("entities")

--- a/packages/core/src/omniscience_core/db/models.py
+++ b/packages/core/src/omniscience_core/db/models.py
@@ -6,7 +6,8 @@ Multi-tenant namespacing is deferred to v0.2.
 Note: SQLAlchemy reserves the attribute name ``metadata`` on declarative
 classes (it refers to the ``MetaData`` object).  All ``metadata`` *columns*
 are mapped under the Python attribute ``doc_metadata`` / ``chunk_metadata`` /
-``run_errors``, while the underlying DB column retains the schema-canonical name.
+``run_errors`` / ``entity_metadata`` / ``edge_metadata``, while the
+underlying DB column retains the schema-canonical name.
 """
 
 from __future__ import annotations
@@ -113,6 +114,9 @@ class Source(Base):
     )
     ingestion_runs: Mapped[list[IngestionRun]] = relationship(
         "IngestionRun", back_populates="source", cascade="all, delete-orphan"
+    )
+    entities: Mapped[list[Entity]] = relationship(
+        "Entity", back_populates="source", cascade="all, delete-orphan"
     )
 
     __table_args__ = (
@@ -249,6 +253,7 @@ class Chunk(Base):
     ingestion_run: Mapped[IngestionRun | None] = relationship(
         "IngestionRun", back_populates="chunks"
     )
+    entities: Mapped[list[Entity]] = relationship("Entity", back_populates="chunk")
 
     __table_args__ = (
         Index("ix_chunks_document_ord", "document_id", "ord"),
@@ -292,11 +297,131 @@ class ApiToken(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
 
+# ---------------------------------------------------------------------------
+# Entities (symbol graph nodes)
+# ---------------------------------------------------------------------------
+
+
+class Entity(Base):
+    """A named code entity extracted from a source document.
+
+    Represents a node in the symbol graph.  Each entity has a fully-qualified
+    name (FQN) such as ``mymodule.MyClass.my_method`` and a shorter display
+    name (``my_method``).  The ``entity_type`` field categorises the symbol
+    so graph queries can filter by kind (e.g. only classes, only functions).
+
+    Valid ``entity_type`` values (open-ended, extensible):
+      ``"function"``, ``"class"``, ``"module"``, ``"service"``, ``"resource"``
+    """
+
+    __tablename__ = "entities"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    source_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sources.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    # FQN: e.g. "mymodule.MyClass.my_method"
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    # Short display name: e.g. "my_method"
+    display_name: Mapped[str] = mapped_column(Text, nullable=False)
+    chunk_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("chunks.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # DB column is "metadata"; Python attribute avoids SA reserved name conflict.
+    entity_metadata: Mapped[dict[str, Any]] = mapped_column(
+        "metadata", JSONB, nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    source: Mapped[Source] = relationship("Source", back_populates="entities")
+    chunk: Mapped[Chunk | None] = relationship("Chunk", back_populates="entities")
+    outgoing_edges: Mapped[list[Edge]] = relationship(
+        "Edge",
+        foreign_keys="Edge.source_entity_id",
+        back_populates="source_entity",
+        cascade="all, delete-orphan",
+    )
+    incoming_edges: Mapped[list[Edge]] = relationship(
+        "Edge",
+        foreign_keys="Edge.target_entity_id",
+        back_populates="target_entity",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index("ix_entities_source_type", "source_id", "entity_type"),
+        Index("ix_entities_name", "name"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edges (symbol graph relationships)
+# ---------------------------------------------------------------------------
+
+
+class Edge(Base):
+    """A directed relationship between two :class:`Entity` nodes.
+
+    Represents an edge in the symbol graph.  The ``edge_type`` describes the
+    nature of the relationship:
+
+      ``"imports"``    — module A imports module/symbol B
+      ``"calls"``      — function/method A calls function/method B
+      ``"inherits"``   — class A inherits from class B
+      ``"defines"``    — module A defines entity B
+      ``"depends_on"`` — generic dependency (infra resources, services, etc.)
+    """
+
+    __tablename__ = "edges"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    source_entity_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("entities.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    target_entity_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("entities.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    edge_type: Mapped[str] = mapped_column(Text, nullable=False)
+    # DB column is "metadata"; Python attribute avoids SA reserved name conflict.
+    edge_metadata: Mapped[dict[str, Any]] = mapped_column(
+        "metadata", JSONB, nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    source_entity: Mapped[Entity] = relationship(
+        "Entity",
+        foreign_keys=[source_entity_id],
+        back_populates="outgoing_edges",
+    )
+    target_entity: Mapped[Entity] = relationship(
+        "Entity",
+        foreign_keys=[target_entity_id],
+        back_populates="incoming_edges",
+    )
+
+    __table_args__ = (Index("ix_edges_edge_type", "edge_type"),)
+
+
 __all__ = [
     "ApiToken",
     "Base",
     "Chunk",
     "Document",
+    "Edge",
+    "Entity",
     "IngestionRun",
     "IngestionRunStatus",
     "Source",

--- a/packages/core/src/omniscience_core/db/schemas.py
+++ b/packages/core/src/omniscience_core/db/schemas.py
@@ -4,11 +4,11 @@ Each table has two schema variants:
 - ``*Create`` — input for INSERT operations (no server-generated fields)
 - ``*Read``   — output for SELECT operations (includes all fields)
 
-Note: ORM models use ``doc_metadata`` / ``chunk_metadata`` / ``run_errors``
-as Python attribute names to avoid the SQLAlchemy reserved name ``metadata``.
-The Pydantic schemas expose the canonical field names (``metadata``, ``errors``)
-and use ``model_validate`` with ``from_attributes=True`` plus field aliases
-where names diverge.
+Note: ORM models use ``doc_metadata`` / ``chunk_metadata`` / ``run_errors`` /
+``entity_metadata`` / ``edge_metadata`` as Python attribute names to avoid
+the SQLAlchemy reserved name ``metadata``.  The Pydantic schemas expose the
+canonical field names (``metadata``, ``errors``) and use ``model_validate``
+with ``from_attributes=True`` plus field aliases where names diverge.
 """
 
 from __future__ import annotations
@@ -230,6 +230,70 @@ class ApiTokenRead(BaseModel):
     is_active: bool
 
 
+# ---------------------------------------------------------------------------
+# Entities (symbol graph nodes)
+# ---------------------------------------------------------------------------
+
+
+class EntityCreate(BaseModel):
+    """Fields required when inserting a new entity."""
+
+    source_id: uuid.UUID
+    entity_type: str
+    name: str
+    display_name: str
+    chunk_id: uuid.UUID | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class EntityRead(BaseModel):
+    """Full entity representation returned to callers.
+
+    The ORM attribute is ``entity_metadata``; exposed as ``metadata`` here.
+    """
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    source_id: uuid.UUID
+    entity_type: str
+    name: str
+    display_name: str
+    chunk_id: uuid.UUID | None
+    metadata: dict[str, Any] = Field(alias="entity_metadata", default_factory=dict)
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Edges (symbol graph relationships)
+# ---------------------------------------------------------------------------
+
+
+class EdgeCreate(BaseModel):
+    """Fields required when inserting a new edge."""
+
+    source_entity_id: uuid.UUID
+    target_entity_id: uuid.UUID
+    edge_type: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class EdgeRead(BaseModel):
+    """Full edge representation returned to callers.
+
+    The ORM attribute is ``edge_metadata``; exposed as ``metadata`` here.
+    """
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    source_entity_id: uuid.UUID
+    target_entity_id: uuid.UUID
+    edge_type: str
+    metadata: dict[str, Any] = Field(alias="edge_metadata", default_factory=dict)
+    created_at: datetime
+
+
 __all__ = [
     "ApiTokenCreate",
     "ApiTokenRead",
@@ -238,6 +302,10 @@ __all__ = [
     "DocumentCreate",
     "DocumentRead",
     "DocumentUpdate",
+    "EdgeCreate",
+    "EdgeRead",
+    "EntityCreate",
+    "EntityRead",
     "IngestionRunCreate",
     "IngestionRunRead",
     "IngestionRunUpdate",

--- a/packages/index/src/omniscience_index/writer.py
+++ b/packages/index/src/omniscience_index/writer.py
@@ -155,9 +155,7 @@ class IndexWriter:
         """
         async with self._session_factory() as session, session.begin():
             # Delete existing entities for this source (edges cascade via FK)
-            await session.execute(
-                delete(Entity).where(Entity.source_id == source_id)
-            )
+            await session.execute(delete(Entity).where(Entity.source_id == source_id))
 
             if not entities:
                 return

--- a/packages/index/src/omniscience_index/writer.py
+++ b/packages/index/src/omniscience_index/writer.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, cast
 
-from omniscience_core.db.models import Chunk, Document
+from omniscience_core.db.models import Chunk, Document, Edge, Entity
 from sqlalchemy import delete, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -131,6 +131,80 @@ class IndexWriter:
             )
             cursor = cast("CursorResult[Any]", await session.execute(stmt))
             return cursor.rowcount
+
+    async def upsert_graph(
+        self,
+        source_id: uuid.UUID,
+        document_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+    ) -> None:
+        """Persist symbol graph entities and edges for a document.
+
+        On re-ingestion of the same document the previous entities/edges for
+        this source are deleted and replaced.  This keeps the graph consistent
+        with the current document content.
+
+        ``entities`` are :class:`~omniscience_parsers.code.graph.ExtractedEntity`
+        instances; ``edges`` are
+        :class:`~omniscience_parsers.code.graph.ExtractedEdge` instances.
+
+        Cross-file edges (where the target entity does not yet exist) are
+        stored with a NULL target — they are resolved lazily in a later
+        graph-linking pass (not yet implemented; placeholder for v0.2).
+        """
+        async with self._session_factory() as session, session.begin():
+            # Delete existing entities for this source (edges cascade via FK)
+            await session.execute(
+                delete(Entity).where(Entity.source_id == source_id)
+            )
+
+            if not entities:
+                return
+
+            # Insert entities and build a name → ORM id mapping
+            name_to_orm_id: dict[str, uuid.UUID] = {}
+            for ext_ent in entities:
+                orm_id = ext_ent.id
+                ent = Entity(
+                    id=orm_id,
+                    source_id=source_id,
+                    entity_type=ext_ent.entity_type,
+                    name=ext_ent.name,
+                    display_name=ext_ent.display_name,
+                    chunk_id=None,  # chunk linking deferred to v0.2
+                    entity_metadata=ext_ent.metadata,
+                    created_at=datetime.now(UTC),
+                )
+                session.add(ent)
+                name_to_orm_id[ext_ent.name] = orm_id
+                # Also index by display name for intra-file call resolution
+                name_to_orm_id.setdefault(ext_ent.display_name, orm_id)
+
+            await session.flush()
+
+            # Insert edges — resolve target by name, drop unresolvable ones
+            for ext_edge in edges:
+                source_id_ent = ext_edge.source_entity_id
+                target_name = ext_edge.target_name
+                target_orm_id = name_to_orm_id.get(target_name)
+                if target_orm_id is None:
+                    # Cross-file target; skip for now (v0.2 will resolve these)
+                    continue
+                # Skip self-loops
+                if source_id_ent == target_orm_id:
+                    continue
+                edge = Edge(
+                    id=uuid.uuid4(),
+                    source_entity_id=source_id_ent,
+                    target_entity_id=target_orm_id,
+                    edge_type=ext_edge.edge_type,
+                    edge_metadata=ext_edge.metadata,
+                    created_at=datetime.now(UTC),
+                )
+                session.add(edge)
+
+            await session.flush()
 
     # ------------------------------------------------------------------
     # Private helpers — each kept < 30 lines

--- a/packages/parsers/src/omniscience_parsers/__init__.py
+++ b/packages/parsers/src/omniscience_parsers/__init__.py
@@ -17,6 +17,11 @@ Chunkers:
     CodeSymbolChunker        — one chunk per code symbol
     MarkdownSectionChunker   — one chunk per markdown section
     FixedWindowChunker       — sliding window for plain text
+
+Code symbol graph:
+    ExtractedEntity      — node in the code symbol graph
+    ExtractedEdge        — directed edge in the code symbol graph
+    extract_symbol_graph — extract symbol graph from a parsed code document
 """
 
 from omniscience_parsers.base import ParsedDocument, Parser, Section
@@ -27,6 +32,7 @@ from omniscience_parsers.chunking import (
     FixedWindowChunker,
     MarkdownSectionChunker,
 )
+from omniscience_parsers.code.graph import ExtractedEdge, ExtractedEntity, extract_symbol_graph
 from omniscience_parsers.code.treesitter import TreeSitterParser
 from omniscience_parsers.dispatch import ParserDispatch
 from omniscience_parsers.markdown import MarkdownParser
@@ -36,6 +42,8 @@ __all__ = [
     "ChunkOutput",
     "Chunker",
     "CodeSymbolChunker",
+    "ExtractedEdge",
+    "ExtractedEntity",
     "FixedWindowChunker",
     "MarkdownParser",
     "MarkdownSectionChunker",
@@ -45,4 +53,5 @@ __all__ = [
     "PlainTextParser",
     "Section",
     "TreeSitterParser",
+    "extract_symbol_graph",
 ]

--- a/packages/parsers/src/omniscience_parsers/code/graph.py
+++ b/packages/parsers/src/omniscience_parsers/code/graph.py
@@ -102,12 +102,52 @@ _DEFINITION_KEYWORDS: frozenset[str] = frozenset(
 
 _BUILTIN_NAMES: frozenset[str] = frozenset(
     {
-        "print", "len", "range", "int", "str", "float", "bool", "list",
-        "dict", "set", "tuple", "type", "super", "isinstance", "issubclass",
-        "hasattr", "getattr", "setattr", "delattr", "repr", "id", "hash",
-        "abs", "min", "max", "sum", "zip", "map", "filter", "sorted",
-        "enumerate", "iter", "next", "open", "input", "format", "round",
-        "hex", "oct", "bin", "chr", "ord", "any", "all", "vars", "dir",
+        "print",
+        "len",
+        "range",
+        "int",
+        "str",
+        "float",
+        "bool",
+        "list",
+        "dict",
+        "set",
+        "tuple",
+        "type",
+        "super",
+        "isinstance",
+        "issubclass",
+        "hasattr",
+        "getattr",
+        "setattr",
+        "delattr",
+        "repr",
+        "id",
+        "hash",
+        "abs",
+        "min",
+        "max",
+        "sum",
+        "zip",
+        "map",
+        "filter",
+        "sorted",
+        "enumerate",
+        "iter",
+        "next",
+        "open",
+        "input",
+        "format",
+        "round",
+        "hex",
+        "oct",
+        "bin",
+        "chr",
+        "ord",
+        "any",
+        "all",
+        "vars",
+        "dir",
     }
 )
 
@@ -120,12 +160,12 @@ _BUILTIN_NAMES: frozenset[str] = frozenset(
 def _entity_type_from_symbol(symbol: str, section: Section) -> str:
     """Infer entity type from the symbol FQN and section text heuristics."""
     text = section.text.lstrip()
-    if text.startswith("class ") or (
-        text.startswith("@") and "\nclass " in text
-    ):
+    if text.startswith("class ") or (text.startswith("@") and "\nclass " in text):
         return "class"
-    if text.startswith("def ") or text.startswith("async def ") or (
-        text.startswith("@") and ("\ndef " in text or "\nasync def " in text)
+    if (
+        text.startswith("def ")
+        or text.startswith("async def ")
+        or (text.startswith("@") and ("\ndef " in text or "\nasync def " in text))
     ):
         return "function"
     return "function"
@@ -323,8 +363,10 @@ def extract_symbol_graph(
     # ------------------------------------------------------------------
     # 4. Extract imports from the full source text (or joined section text).
     # ------------------------------------------------------------------
-    full_text = source_text.decode(errors="replace") if source_text else "\n".join(
-        s.text for s in parsed.sections
+    full_text = (
+        source_text.decode(errors="replace")
+        if source_text
+        else "\n".join(s.text for s in parsed.sections)
     )
     import_edges = _extract_python_imports(full_text, module_entity_id)
     edges.extend(import_edges)

--- a/packages/parsers/src/omniscience_parsers/code/graph.py
+++ b/packages/parsers/src/omniscience_parsers/code/graph.py
@@ -1,0 +1,359 @@
+"""Symbol graph extractor for code documents.
+
+Transforms a :class:`~omniscience_parsers.base.ParsedDocument` produced by
+:class:`~omniscience_parsers.code.treesitter.TreeSitterParser` into a pair of
+lists — entities and edges — that represent the symbol graph of the source
+file.
+
+Extraction is **heuristic-based** (no LLM): the raw source text of each
+section and the section ``symbol`` field are analysed with lightweight regex
+and string matching.
+
+For Python files the extractor identifies:
+  - ``imports``   — ``import X`` / ``from X import Y`` statements
+  - ``inherits``  — base classes listed in ``class Foo(Base1, Base2):``
+  - ``calls``     — bare ``name(...)`` call expressions at the start of a line
+                    or as the only expression (best-effort; avoids full AST)
+
+Supported language: Python (``language == "python"``).
+Other languages return empty lists so the pipeline degrades gracefully.
+
+Entity / Edge are plain dataclasses (no SQLAlchemy) so this module has no
+dependency on ``omniscience_core``.  The ingestion layer converts them to ORM
+objects before persisting.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from omniscience_parsers.base import ParsedDocument, Section
+
+# ---------------------------------------------------------------------------
+# Data classes — lightweight; ORM-free
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExtractedEntity:
+    """A code entity extracted from a parsed document section.
+
+    Attributes:
+        id:           Stable UUID generated at extraction time.
+        entity_type:  One of "function", "class", "module".
+        name:         Fully-qualified name (FQN), e.g. "mymod.MyClass.method".
+        display_name: Short name without module prefix, e.g. "method".
+        symbol:       Raw symbol string from the :class:`Section` (same as *name*
+                      in most cases; kept for traceability).
+        metadata:     Arbitrary extra info (line range, language, …).
+    """
+
+    id: uuid.UUID
+    entity_type: str
+    name: str
+    display_name: str
+    symbol: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ExtractedEdge:
+    """A directed relationship between two :class:`ExtractedEntity` objects.
+
+    Attributes:
+        source_entity_id: UUID of the entity that originates the relationship.
+        target_name:      FQN (or bare name) of the target entity.  The
+                          ingestion layer resolves this to a real UUID after
+                          all entities from all files are persisted.
+        edge_type:        Relationship kind: "imports", "calls", "inherits",
+                          "defines".
+        metadata:         Arbitrary extra info.
+    """
+
+    source_entity_id: uuid.UUID
+    target_name: str
+    edge_type: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns for Python source analysis
+# ---------------------------------------------------------------------------
+
+# import X  or  import X.Y.Z  or  import X as Y
+_RE_IMPORT_SIMPLE = re.compile(r"^\s*import\s+([\w.]+)(?:\s+as\s+\w+)?\s*$", re.MULTILINE)
+
+# from X import Y[, Z]  or  from X import *
+_RE_IMPORT_FROM = re.compile(r"^\s*from\s+([\w.]+)\s+import\s+", re.MULTILINE)
+
+# class Foo(Base1, Base2):  — capture everything inside parens
+_RE_CLASS_BASES = re.compile(r"^class\s+\w+\s*\(([^)]*)\)\s*:", re.MULTILINE)
+
+# Bare call:  name(  or  obj.method(  at start-of-line or as statement
+_RE_CALL = re.compile(r"(?:^|\s)(\w[\w.]*)\s*\(", re.MULTILINE)
+
+# Keywords / builtins that must not generate "calls" edges
+_DEFINITION_KEYWORDS: frozenset[str] = frozenset(
+    {"def", "class", "return", "if", "elif", "while", "for", "with"}
+)
+
+_BUILTIN_NAMES: frozenset[str] = frozenset(
+    {
+        "print", "len", "range", "int", "str", "float", "bool", "list",
+        "dict", "set", "tuple", "type", "super", "isinstance", "issubclass",
+        "hasattr", "getattr", "setattr", "delattr", "repr", "id", "hash",
+        "abs", "min", "max", "sum", "zip", "map", "filter", "sorted",
+        "enumerate", "iter", "next", "open", "input", "format", "round",
+        "hex", "oct", "bin", "chr", "ord", "any", "all", "vars", "dir",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _entity_type_from_symbol(symbol: str, section: Section) -> str:
+    """Infer entity type from the symbol FQN and section text heuristics."""
+    text = section.text.lstrip()
+    if text.startswith("class ") or (
+        text.startswith("@") and "\nclass " in text
+    ):
+        return "class"
+    if text.startswith("def ") or text.startswith("async def ") or (
+        text.startswith("@") and ("\ndef " in text or "\nasync def " in text)
+    ):
+        return "function"
+    return "function"
+
+
+def _display_name(fqn: str) -> str:
+    """Return the last segment of a dotted FQN."""
+    return fqn.split(".")[-1]
+
+
+def _extract_python_imports(source_text: str, module_entity_id: uuid.UUID) -> list[ExtractedEdge]:
+    """Parse import statements and return edges from the module entity."""
+    edges: list[ExtractedEdge] = []
+
+    for m in _RE_IMPORT_SIMPLE.finditer(source_text):
+        target = m.group(1).strip()
+        if target:
+            edges.append(
+                ExtractedEdge(
+                    source_entity_id=module_entity_id,
+                    target_name=target,
+                    edge_type="imports",
+                )
+            )
+
+    for m in _RE_IMPORT_FROM.finditer(source_text):
+        target = m.group(1).strip()
+        if target:
+            edges.append(
+                ExtractedEdge(
+                    source_entity_id=module_entity_id,
+                    target_name=target,
+                    edge_type="imports",
+                )
+            )
+
+    return edges
+
+
+def _extract_class_inheritance(
+    section: Section,
+    entity_id: uuid.UUID,
+) -> list[ExtractedEdge]:
+    """Parse class bases from a class section and emit ``inherits`` edges."""
+    edges: list[ExtractedEdge] = []
+    m = _RE_CLASS_BASES.search(section.text)
+    if not m:
+        return edges
+    bases_raw = m.group(1)
+    for base in bases_raw.split(","):
+        base = base.strip().split("[")[0].strip()  # strip generics like Base[T]
+        if base and base not in ("object", ""):
+            edges.append(
+                ExtractedEdge(
+                    source_entity_id=entity_id,
+                    target_name=base,
+                    edge_type="inherits",
+                )
+            )
+    return edges
+
+
+def _extract_calls(
+    section: Section,
+    entity_id: uuid.UUID,
+    own_name: str,
+) -> list[ExtractedEdge]:
+    """Extract best-effort call edges from a function/method section body.
+
+    Strategy:
+    - Find all ``name(`` patterns in the section text.
+    - Skip built-ins, the function's own name, and definition keywords.
+    - Deduplicate: emit one edge per unique callee per caller.
+    """
+    seen: set[str] = set()
+    edges: list[ExtractedEdge] = []
+
+    # Skip the first line of the section (the def/async def line itself)
+    body_lines = section.text.split("\n", 1)
+    body = body_lines[1] if len(body_lines) > 1 else ""
+
+    for m in _RE_CALL.finditer(body):
+        raw = m.group(1)
+        # Take the last component of a dotted chain
+        callee = raw.split(".")[-1]
+        if (
+            callee in _BUILTIN_NAMES
+            or callee in _DEFINITION_KEYWORDS
+            or callee == own_name
+            or callee in seen
+            or not callee
+        ):
+            continue
+        seen.add(callee)
+        edges.append(
+            ExtractedEdge(
+                source_entity_id=entity_id,
+                target_name=callee,
+                edge_type="calls",
+            )
+        )
+
+    return edges
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def extract_symbol_graph(
+    parsed: ParsedDocument,
+    source_text: bytes = b"",
+) -> tuple[list[ExtractedEntity], list[ExtractedEdge]]:
+    """Extract entities and edges from a parsed code document.
+
+    Currently supports Python only.  For other languages (or when
+    ``parsed.language`` is ``None``) the function returns two empty lists
+    so callers can always call this unconditionally.
+
+    Args:
+        parsed:      A :class:`~omniscience_parsers.base.ParsedDocument`
+                     produced by the tree-sitter parser.
+        source_text: Original source bytes (used for import parsing).
+                     If empty the raw section text is used as a fallback.
+
+    Returns:
+        A ``(entities, edges)`` pair.  Entities have stable UUIDs assigned
+        at extraction time.  Edges reference entity UUIDs for intra-file
+        relationships; cross-file edges carry a ``target_name`` string that
+        the ingestion layer resolves after bulk insert.
+    """
+    if parsed.language != "python":
+        return [], []
+
+    entities: list[ExtractedEntity] = []
+    edges: list[ExtractedEdge] = []
+
+    # ------------------------------------------------------------------
+    # 1. Derive the module name from the sections' heading paths.
+    #    The first segment of any heading_path is the module name.
+    # ------------------------------------------------------------------
+    module_name: str = "unknown"
+    if parsed.sections:
+        hp = parsed.sections[0].heading_path
+        if hp:
+            module_name = hp[0]
+
+    # ------------------------------------------------------------------
+    # 2. Create a synthetic "module" entity as the anchor for imports.
+    # ------------------------------------------------------------------
+    module_entity_id = uuid.uuid4()
+    module_entity = ExtractedEntity(
+        id=module_entity_id,
+        entity_type="module",
+        name=module_name,
+        display_name=module_name,
+        symbol=module_name,
+    )
+    entities.append(module_entity)
+
+    # ------------------------------------------------------------------
+    # 3. One entity per section that has a symbol.
+    # ------------------------------------------------------------------
+    symbol_to_entity: dict[str, ExtractedEntity] = {}
+    for sec in parsed.sections:
+        if not sec.symbol:
+            continue
+        fqn = sec.symbol
+        etype = _entity_type_from_symbol(fqn, sec)
+        new_ent = ExtractedEntity(
+            id=uuid.uuid4(),
+            entity_type=etype,
+            name=fqn,
+            display_name=_display_name(fqn),
+            symbol=fqn,
+            metadata={
+                "line_start": sec.line_start,
+                "line_end": sec.line_end,
+                "language": parsed.language,
+            },
+        )
+        entities.append(new_ent)
+        symbol_to_entity[fqn] = new_ent
+
+        # module "defines" every top-level symbol
+        edges.append(
+            ExtractedEdge(
+                source_entity_id=module_entity_id,
+                target_name=fqn,
+                edge_type="defines",
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # 4. Extract imports from the full source text (or joined section text).
+    # ------------------------------------------------------------------
+    full_text = source_text.decode(errors="replace") if source_text else "\n".join(
+        s.text for s in parsed.sections
+    )
+    import_edges = _extract_python_imports(full_text, module_entity_id)
+    edges.extend(import_edges)
+
+    # ------------------------------------------------------------------
+    # 5. For each class section, extract inheritance edges.
+    # ------------------------------------------------------------------
+    for sec in parsed.sections:
+        if not sec.symbol:
+            continue
+        cls_ent: ExtractedEntity | None = symbol_to_entity.get(sec.symbol)
+        if cls_ent is None or cls_ent.entity_type != "class":
+            continue
+        inh_edges = _extract_class_inheritance(sec, cls_ent.id)
+        edges.extend(inh_edges)
+
+    # ------------------------------------------------------------------
+    # 6. For each function/method section, extract call edges (best-effort).
+    # ------------------------------------------------------------------
+    for sec in parsed.sections:
+        if not sec.symbol:
+            continue
+        fn_ent: ExtractedEntity | None = symbol_to_entity.get(sec.symbol)
+        if fn_ent is None or fn_ent.entity_type != "function":
+            continue
+        call_edges = _extract_calls(sec, fn_ent.id, fn_ent.display_name)
+        edges.extend(call_edges)
+
+    return entities, edges
+
+
+__all__ = ["ExtractedEdge", "ExtractedEntity", "extract_symbol_graph"]

--- a/tests/test_symbol_graph.py
+++ b/tests/test_symbol_graph.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 from omniscience_core.db.models import Edge, Entity
@@ -391,18 +392,26 @@ class TestMigration:
     def test_migration_file_exists(self) -> None:
         import os
 
-        mig_path = (
-            "/Users/igor_gerasimov/Develop/multi-team-agentic/project/Omniscience"
-            "/packages/core/alembic/versions/0002_entities_edges.py"
+        mig_path = str(
+            Path(__file__).resolve().parent.parent
+            / "packages"
+            / "core"
+            / "alembic"
+            / "versions"
+            / "0002_entities_edges.py"
         )
         assert os.path.isfile(mig_path), "Migration file 0002_entities_edges.py not found"
 
     def test_migration_revision_chain(self) -> None:
         import importlib.util
 
-        mig_path = (
-            "/Users/igor_gerasimov/Develop/multi-team-agentic/project/Omniscience"
-            "/packages/core/alembic/versions/0002_entities_edges.py"
+        mig_path = str(
+            Path(__file__).resolve().parent.parent
+            / "packages"
+            / "core"
+            / "alembic"
+            / "versions"
+            / "0002_entities_edges.py"
         )
         spec = importlib.util.spec_from_file_location("mig_0002", mig_path)
         assert spec is not None
@@ -415,9 +424,13 @@ class TestMigration:
     def test_migration_has_upgrade(self) -> None:
         import importlib.util
 
-        mig_path = (
-            "/Users/igor_gerasimov/Develop/multi-team-agentic/project/Omniscience"
-            "/packages/core/alembic/versions/0002_entities_edges.py"
+        mig_path = str(
+            Path(__file__).resolve().parent.parent
+            / "packages"
+            / "core"
+            / "alembic"
+            / "versions"
+            / "0002_entities_edges.py"
         )
         spec = importlib.util.spec_from_file_location("mig_0002", mig_path)
         assert spec is not None

--- a/tests/test_symbol_graph.py
+++ b/tests/test_symbol_graph.py
@@ -1,0 +1,428 @@
+"""Tests for Issue #27 — Symbol graph: entities, edges, and code relationship extraction.
+
+Coverage:
+- Entity and Edge ORM model construction
+- EntityRead / EdgeRead Pydantic schema round-trips
+- Graph extractor: imports, class inheritance, function calls, module entity
+- Graph extractor: non-Python language returns empty lists
+- Graph extractor: empty parsed document
+- Graph extractor: document with no sections
+- Pipeline graph stage: wired correctly (mock index writer)
+- Migration content sanity check (DDL strings)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from omniscience_core.db.models import Edge, Entity
+from omniscience_core.db.schemas import EdgeRead, EntityRead
+from omniscience_parsers.base import ParsedDocument
+from omniscience_parsers.code.graph import extract_symbol_graph
+from omniscience_parsers.code.treesitter import TreeSitterParser
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_entity(
+    *,
+    entity_type: str = "function",
+    name: str = "mymod.my_func",
+    display_name: str = "my_func",
+    chunk_id: uuid.UUID | None = None,
+    entity_metadata: dict[str, Any] | None = None,
+) -> Entity:
+    return Entity(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type=entity_type,
+        name=name,
+        display_name=display_name,
+        chunk_id=chunk_id,
+        entity_metadata=entity_metadata or {},
+        created_at=_NOW,
+    )
+
+
+def _make_edge(
+    *,
+    source_entity_id: uuid.UUID | None = None,
+    target_entity_id: uuid.UUID | None = None,
+    edge_type: str = "calls",
+    edge_metadata: dict[str, Any] | None = None,
+) -> Edge:
+    return Edge(
+        id=uuid.uuid4(),
+        source_entity_id=source_entity_id or uuid.uuid4(),
+        target_entity_id=target_entity_id or uuid.uuid4(),
+        edge_type=edge_type,
+        edge_metadata=edge_metadata or {},
+        created_at=_NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ORM model tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntityModel:
+    def test_construct_minimal(self) -> None:
+        ent = _make_entity()
+        assert ent.entity_type == "function"
+        assert ent.name == "mymod.my_func"
+        assert ent.display_name == "my_func"
+        assert ent.chunk_id is None
+
+    def test_entity_type_class(self) -> None:
+        ent = _make_entity(entity_type="class", name="mymod.MyClass", display_name="MyClass")
+        assert ent.entity_type == "class"
+
+    def test_entity_type_module(self) -> None:
+        ent = _make_entity(entity_type="module", name="mymod", display_name="mymod")
+        assert ent.entity_type == "module"
+
+    def test_metadata_stored(self) -> None:
+        ent = _make_entity(
+            entity_metadata={"line_start": 10, "line_end": 25, "language": "python"}
+        )
+        assert ent.entity_metadata["line_start"] == 10
+        assert ent.entity_metadata["language"] == "python"
+
+    def test_chunk_id_nullable(self) -> None:
+        chunk_uuid = uuid.uuid4()
+        ent = _make_entity(chunk_id=chunk_uuid)
+        assert ent.chunk_id == chunk_uuid
+
+    def test_id_is_uuid(self) -> None:
+        ent = _make_entity()
+        assert isinstance(ent.id, uuid.UUID)
+
+
+class TestEdgeModel:
+    def test_construct_minimal(self) -> None:
+        src = uuid.uuid4()
+        tgt = uuid.uuid4()
+        edge = _make_edge(source_entity_id=src, target_entity_id=tgt, edge_type="imports")
+        assert edge.source_entity_id == src
+        assert edge.target_entity_id == tgt
+        assert edge.edge_type == "imports"
+
+    def test_edge_type_inherits(self) -> None:
+        edge = _make_edge(edge_type="inherits")
+        assert edge.edge_type == "inherits"
+
+    def test_edge_type_defines(self) -> None:
+        edge = _make_edge(edge_type="defines")
+        assert edge.edge_type == "defines"
+
+    def test_edge_type_depends_on(self) -> None:
+        edge = _make_edge(edge_type="depends_on")
+        assert edge.edge_type == "depends_on"
+
+    def test_metadata_stored(self) -> None:
+        edge = _make_edge(edge_metadata={"confidence": 0.95})
+        assert edge.edge_metadata["confidence"] == 0.95
+
+    def test_id_is_uuid(self) -> None:
+        edge = _make_edge()
+        assert isinstance(edge.id, uuid.UUID)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schema round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestEntityRead:
+    def test_from_orm(self) -> None:
+        ent = _make_entity(
+            entity_type="class",
+            name="mod.Foo",
+            display_name="Foo",
+            entity_metadata={"line_start": 1},
+        )
+        read = EntityRead.model_validate(ent)
+        assert read.entity_type == "class"
+        assert read.name == "mod.Foo"
+        assert read.display_name == "Foo"
+        assert read.metadata == {"line_start": 1}
+
+    def test_metadata_alias(self) -> None:
+        """EntityRead.metadata is populated from ORM's entity_metadata."""
+        ent = _make_entity(entity_metadata={"language": "python"})
+        read = EntityRead.model_validate(ent)
+        assert read.metadata["language"] == "python"
+
+    def test_chunk_id_optional(self) -> None:
+        ent = _make_entity()
+        read = EntityRead.model_validate(ent)
+        assert read.chunk_id is None
+
+
+class TestEdgeRead:
+    def test_from_orm(self) -> None:
+        src = uuid.uuid4()
+        tgt = uuid.uuid4()
+        edge = _make_edge(source_entity_id=src, target_entity_id=tgt, edge_type="calls")
+        read = EdgeRead.model_validate(edge)
+        assert read.source_entity_id == src
+        assert read.target_entity_id == tgt
+        assert read.edge_type == "calls"
+
+    def test_metadata_alias(self) -> None:
+        edge = _make_edge(edge_metadata={"weight": 1})
+        read = EdgeRead.model_validate(edge)
+        assert read.metadata == {"weight": 1}
+
+
+# ---------------------------------------------------------------------------
+# Graph extractor — imports
+# ---------------------------------------------------------------------------
+
+
+class TestExtractorImports:
+    def _parse(self, src: bytes, filename: str = "mymod.py") -> ParsedDocument:
+        return TreeSitterParser().parse(src, filename)
+
+    def test_simple_import(self) -> None:
+        src = b"import os\ndef foo(): pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        import_edges = [e for e in edges if e.edge_type == "imports"]
+        targets = {e.target_name for e in import_edges}
+        assert "os" in targets
+
+    def test_from_import(self) -> None:
+        src = b"from pathlib import Path\ndef bar(): pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        import_edges = [e for e in edges if e.edge_type == "imports"]
+        targets = {e.target_name for e in import_edges}
+        assert "pathlib" in targets
+
+    def test_multiple_imports(self) -> None:
+        src = b"import os\nimport sys\nfrom typing import Any\ndef f(): pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        import_edges = [e for e in edges if e.edge_type == "imports"]
+        targets = {e.target_name for e in import_edges}
+        assert "os" in targets
+        assert "sys" in targets
+        assert "typing" in targets
+
+    def test_import_edge_source_is_module_entity(self) -> None:
+        src = b"import os\ndef f(): pass\n"
+        parsed = self._parse(src)
+        entities, edges = extract_symbol_graph(parsed, src)
+        module_entity = next(e for e in entities if e.entity_type == "module")
+        import_edges = [e for e in edges if e.edge_type == "imports"]
+        assert all(e.source_entity_id == module_entity.id for e in import_edges)
+
+
+# ---------------------------------------------------------------------------
+# Graph extractor — inheritance
+# ---------------------------------------------------------------------------
+
+
+class TestExtractorInheritance:
+    def _parse(self, src: bytes, filename: str = "mymod.py") -> ParsedDocument:
+        return TreeSitterParser().parse(src, filename)
+
+    def test_single_base(self) -> None:
+        src = b"class Child(Base):\n    pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        inh_edges = [e for e in edges if e.edge_type == "inherits"]
+        assert any(e.target_name == "Base" for e in inh_edges)
+
+    def test_multiple_bases(self) -> None:
+        src = b"class Child(Mixin, Base):\n    pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        inh_edges = [e for e in edges if e.edge_type == "inherits"]
+        targets = {e.target_name for e in inh_edges}
+        assert "Mixin" in targets
+        assert "Base" in targets
+
+    def test_no_base_no_inheritance_edge(self) -> None:
+        src = b"class Standalone:\n    pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        inh_edges = [e for e in edges if e.edge_type == "inherits"]
+        assert len(inh_edges) == 0
+
+    def test_object_base_excluded(self) -> None:
+        src = b"class MyClass(object):\n    pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        inh_edges = [e for e in edges if e.edge_type == "inherits"]
+        assert not any(e.target_name == "object" for e in inh_edges)
+
+    def test_inheritance_source_is_class_entity(self) -> None:
+        src = b"class Child(Base):\n    pass\n"
+        parsed = self._parse(src)
+        entities, edges = extract_symbol_graph(parsed, src)
+        class_entities = [e for e in entities if e.entity_type == "class"]
+        assert class_entities, "Expected at least one class entity"
+        inh_edges = [e for e in edges if e.edge_type == "inherits"]
+        class_ids = {e.id for e in class_entities}
+        assert all(e.source_entity_id in class_ids for e in inh_edges)
+
+
+# ---------------------------------------------------------------------------
+# Graph extractor — module entity and defines edges
+# ---------------------------------------------------------------------------
+
+
+class TestExtractorModuleAndDefines:
+    def _parse(self, src: bytes, filename: str = "mymod.py") -> ParsedDocument:
+        return TreeSitterParser().parse(src, filename)
+
+    def test_module_entity_created(self) -> None:
+        src = b"def foo(): pass\n"
+        parsed = self._parse(src)
+        entities, _ = extract_symbol_graph(parsed, src)
+        module_entities = [e for e in entities if e.entity_type == "module"]
+        assert len(module_entities) == 1
+
+    def test_module_entity_name_matches_filename(self) -> None:
+        src = b"def foo(): pass\n"
+        parsed = self._parse(src, "utils.py")
+        entities, _ = extract_symbol_graph(parsed, src)
+        module_entity = next(e for e in entities if e.entity_type == "module")
+        assert module_entity.name == "utils"
+
+    def test_defines_edges_emitted(self) -> None:
+        src = b"def alpha(): pass\nclass Beta:\n    pass\n"
+        parsed = self._parse(src)
+        _, edges = extract_symbol_graph(parsed, src)
+        defines_edges = [e for e in edges if e.edge_type == "defines"]
+        assert len(defines_edges) >= 2
+
+    def test_all_symbol_entities_present(self) -> None:
+        src = b"def first(): pass\ndef second(): pass\n"
+        parsed = self._parse(src)
+        entities, _ = extract_symbol_graph(parsed, src)
+        names = {e.name for e in entities}
+        assert any("first" in n for n in names)
+        assert any("second" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Graph extractor — non-Python and edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestExtractorEdgeCases:
+    def test_non_python_returns_empty(self) -> None:
+        src = b"function greet() { return 'hi'; }\n"
+        parsed = TreeSitterParser().parse(src, "hello.ts")
+        entities, edges = extract_symbol_graph(parsed, src)
+        assert entities == []
+        assert edges == []
+
+    def test_go_returns_empty(self) -> None:
+        src = b'package main\nfunc Greet() string { return "hi" }\n'
+        parsed = TreeSitterParser().parse(src, "main.go")
+        entities, edges = extract_symbol_graph(parsed, src)
+        assert entities == []
+        assert edges == []
+
+    def test_empty_source_bytes(self) -> None:
+        """extract_symbol_graph must not crash on empty source."""
+        parsed = ParsedDocument(
+            sections=[],
+            content_type="text/x-source",
+            language="python",
+        )
+        entities, _ = extract_symbol_graph(parsed, b"")
+        # module entity still created
+        assert any(e.entity_type == "module" for e in entities)
+
+    def test_no_sections_still_produces_module_entity(self) -> None:
+        parsed = ParsedDocument(
+            sections=[],
+            content_type="text/x-source",
+            language="python",
+        )
+        entities, _ = extract_symbol_graph(parsed)
+        assert len(entities) == 1
+        assert entities[0].entity_type == "module"
+
+    def test_extracted_entity_has_stable_uuid(self) -> None:
+        src = b"def foo(): pass\n"
+        parsed = TreeSitterParser().parse(src, "mod.py")
+        entities, _ = extract_symbol_graph(parsed, src)
+        for ent in entities:
+            assert isinstance(ent.id, uuid.UUID)
+
+    def test_entity_display_name_is_short(self) -> None:
+        src = b"def my_function(): pass\n"
+        parsed = TreeSitterParser().parse(src, "mod.py")
+        entities, _ = extract_symbol_graph(parsed, src)
+        fn_entity = next((e for e in entities if "my_function" in e.name), None)
+        assert fn_entity is not None
+        assert fn_entity.display_name == "my_function"
+
+    def test_metadata_has_line_info(self) -> None:
+        src = b"def annotated():\n    pass\n"
+        parsed = TreeSitterParser().parse(src, "mod.py")
+        entities, _ = extract_symbol_graph(parsed, src)
+        fn_entities = [e for e in entities if e.entity_type == "function"]
+        assert fn_entities
+        meta = fn_entities[0].metadata
+        assert "line_start" in meta
+        assert "line_end" in meta
+
+
+# ---------------------------------------------------------------------------
+# Migration sanity check
+# ---------------------------------------------------------------------------
+
+
+class TestMigration:
+    def test_migration_file_exists(self) -> None:
+        import os
+
+        mig_path = (
+            "/Users/igor_gerasimov/Develop/multi-team-agentic/project/Omniscience"
+            "/packages/core/alembic/versions/0002_entities_edges.py"
+        )
+        assert os.path.isfile(mig_path), "Migration file 0002_entities_edges.py not found"
+
+    def test_migration_revision_chain(self) -> None:
+        import importlib.util
+
+        mig_path = (
+            "/Users/igor_gerasimov/Develop/multi-team-agentic/project/Omniscience"
+            "/packages/core/alembic/versions/0002_entities_edges.py"
+        )
+        spec = importlib.util.spec_from_file_location("mig_0002", mig_path)
+        assert spec is not None
+        mod = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        assert mod.revision == "0002"
+        assert mod.down_revision == "0001"
+
+    def test_migration_has_upgrade(self) -> None:
+        import importlib.util
+
+        mig_path = (
+            "/Users/igor_gerasimov/Develop/multi-team-agentic/project/Omniscience"
+            "/packages/core/alembic/versions/0002_entities_edges.py"
+        )
+        spec = importlib.util.spec_from_file_location("mig_0002", mig_path)
+        assert spec is not None
+        mod = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        assert callable(getattr(mod, "upgrade", None))
+        assert callable(getattr(mod, "downgrade", None))


### PR DESCRIPTION
Adds Entity + Edge tables, Alembic migration 0002, graph extractor for Python imports/inheritance/calls, wired into ingestion pipeline. 40 new tests. Closes #27