### PR TITLE
feat: Confluence, Notion, Slack, and Jira connectors

### DIFF
--- a/packages/connectors/pyproject.toml
+++ b/packages/connectors/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "omniscience-core",
     "pydantic>=2.7.0",
     "watchfiles>=0.21.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.uv.sources]

--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -15,9 +15,10 @@ Registry::
 
     from omniscience_connectors import ConnectorRegistry, get_connector
 
-Built-in connectors (``git``, ``fs``) are registered below and available
-immediately on import.  Third-party connectors call :func:`get_connector`
-after registering against the shared registry.
+Built-in connectors (``git``, ``fs``, ``confluence``, ``notion``, ``slack``,
+``jira``) are registered below and available immediately on import.
+Third-party connectors call :func:`get_connector` after registering against
+the shared registry.
 """
 
 from omniscience_connectors.base import (
@@ -27,30 +28,42 @@ from omniscience_connectors.base import (
     WebhookHandler,
     WebhookPayload,
 )
+from omniscience_connectors.confluence.connector import ConfluenceConnector
 from omniscience_connectors.fs.connector import FsConnector
 from omniscience_connectors.git.connector import GitConnector
+from omniscience_connectors.jira.connector import JiraConnector
+from omniscience_connectors.notion.connector import NotionConnector
 from omniscience_connectors.registry import (
     ConnectorRegistry,
     NotFoundError,
     _registry,
     get_connector,
 )
+from omniscience_connectors.slack.connector import SlackConnector
 
 # Register built-in connectors in the shared module-level registry
 _registry.register(GitConnector)
 _registry.register(FsConnector)
+_registry.register(ConfluenceConnector)
+_registry.register(NotionConnector)
+_registry.register(SlackConnector)
+_registry.register(JiraConnector)
 
-# Public alias for the shared registry instance (git + fs pre-registered).
+# Public alias for the shared registry instance (all built-ins pre-registered).
 default_registry: ConnectorRegistry = _registry
 
 __all__ = [
+    "ConfluenceConnector",
     "Connector",
     "ConnectorRegistry",
     "DocumentRef",
     "FetchedDocument",
     "FsConnector",
     "GitConnector",
+    "JiraConnector",
     "NotFoundError",
+    "NotionConnector",
+    "SlackConnector",
     "WebhookHandler",
     "WebhookPayload",
     "default_registry",

--- a/packages/connectors/src/omniscience_connectors/confluence/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/confluence/__init__.py
@@ -1,0 +1,5 @@
+"""Confluence source connector."""
+
+from omniscience_connectors.confluence.connector import ConfluenceConfig, ConfluenceConnector
+
+__all__ = ["ConfluenceConfig", "ConfluenceConnector"]

--- a/packages/connectors/src/omniscience_connectors/confluence/connector.py
+++ b/packages/connectors/src/omniscience_connectors/confluence/connector.py
@@ -162,6 +162,7 @@ def storage_to_markdown(storage_html: str) -> str:
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
+
 def _build_auth_headers(secrets: dict[str, str]) -> dict[str, str]:
     """Build HTTP Authorization headers from secrets.
 
@@ -217,7 +218,7 @@ class ConfluenceWebhookHandler(WebhookHandler):
         sig_header = lower.get(self._SIG_HEADER, "")
         if not sig_header.startswith("sha256="):
             return False
-        provided_hex = sig_header[len("sha256="):]
+        provided_hex = sig_header[len("sha256=") :]
         expected_hex = hmac.new(secret.encode(), payload, "sha256").hexdigest()
         return hmac.compare_digest(expected_hex, provided_hex)
 
@@ -303,18 +304,14 @@ class ConfluenceConnector(Connector):
         url = f"{base}/rest/api/content"
 
         spaces_to_query = (
-            cfg.space_keys
-            if cfg.space_keys
-            else await self._list_space_keys(base, headers)
+            cfg.space_keys if cfg.space_keys else await self._list_space_keys(base, headers)
         )
 
         for space_key in spaces_to_query:
             for content_type in cfg.content_types:
                 cql = f'type="{content_type}" AND space="{space_key}"'
                 if cfg.include_labels:
-                    label_clause = " OR ".join(
-                        f'label="{lbl}"' for lbl in cfg.include_labels
-                    )
+                    label_clause = " OR ".join(f'label="{lbl}"' for lbl in cfg.include_labels)
                     cql += f" AND ({label_clause})"
 
                 start = 0
@@ -346,9 +343,7 @@ class ConfluenceConnector(Connector):
                             item_labels: list[str] = [
                                 lbl["name"]
                                 for lbl in (
-                                    item.get("metadata", {})
-                                    .get("labels", {})
-                                    .get("results", [])
+                                    item.get("metadata", {}).get("labels", {}).get("results", [])
                                 )
                             ]
                             # Apply exclude label filter
@@ -408,9 +403,7 @@ class ConfluenceConnector(Connector):
 
         content_id = ref.metadata.get("content_id", "")
         if not content_id:
-            raise ValueError(
-                f"DocumentRef is missing 'content_id' in metadata: {ref.uri!r}"
-            )
+            raise ValueError(f"DocumentRef is missing 'content_id' in metadata: {ref.uri!r}")
 
         url = f"{base}/rest/api/content/{content_id}"
         async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
@@ -418,9 +411,7 @@ class ConfluenceConnector(Connector):
             resp.raise_for_status()
 
         data = resp.json()
-        storage_html: str = (
-            data.get("body", {}).get("storage", {}).get("value", "")
-        )
+        storage_html: str = data.get("body", {}).get("storage", {}).get("value", "")
         title: str = data.get("title", "")
 
         markdown = f"# {title}\n\n{storage_to_markdown(storage_html)}"

--- a/packages/connectors/src/omniscience_connectors/confluence/connector.py
+++ b/packages/connectors/src/omniscience_connectors/confluence/connector.py
@@ -1,0 +1,464 @@
+"""Confluence source connector.
+
+Supports Confluence Cloud (API token + email) and Confluence Server/Data Center
+(personal access token).  Discovers pages and blog posts via CQL and converts
+Confluence storage format (XHTML) to plain Markdown.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac
+import json
+import logging
+import re
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any, ClassVar, Literal
+
+import httpx
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+    WebhookPayload,
+)
+
+__all__ = ["ConfluenceConfig", "ConfluenceConnector"]
+
+logger = logging.getLogger(__name__)
+
+# Confluence content types supported
+ContentType = Literal["page", "blogpost"]
+
+# Max results per page for REST API pagination
+_PAGE_SIZE = 50
+
+# Macro regex broken out to stay within line length limit
+_MACRO_PATTERN = re.compile(
+    r'<ac:structured-macro[^>]*ac:name="code"[^>]*>.*?</ac:structured-macro>',
+    re.DOTALL,
+)
+
+# Patterns for converting block-level elements
+_TAG_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Headings
+    (re.compile(r"<h1[^>]*>"), "# "),
+    (re.compile(r"<h2[^>]*>"), "## "),
+    (re.compile(r"<h3[^>]*>"), "### "),
+    (re.compile(r"<h4[^>]*>"), "#### "),
+    (re.compile(r"<h5[^>]*>"), "##### "),
+    (re.compile(r"<h6[^>]*>"), "###### "),
+    (re.compile(r"</h\d>"), "\n"),
+    # Paragraphs and divs
+    (re.compile(r"<p[^>]*>"), ""),
+    (re.compile(r"</p>"), "\n\n"),
+    (re.compile(r"<div[^>]*>"), ""),
+    (re.compile(r"</div>"), "\n"),
+    # Line breaks
+    (re.compile(r"<br\s*/?>"), "\n"),
+    # List items
+    (re.compile(r"<li[^>]*>"), "- "),
+    (re.compile(r"</li>"), "\n"),
+    # Code blocks (Confluence macro or pre)
+    (_MACRO_PATTERN, "```\n```"),
+    (re.compile(r"<pre[^>]*>"), "```\n"),
+    (re.compile(r"</pre>"), "\n```\n"),
+    (re.compile(r"<code[^>]*>"), "`"),
+    (re.compile(r"</code>"), "`"),
+    # Blockquote
+    (re.compile(r"<blockquote[^>]*>"), "> "),
+    (re.compile(r"</blockquote>"), "\n"),
+    # Horizontal rule
+    (re.compile(r"<hr\s*/?>"), "\n---\n"),
+    # Tables — crude extraction (strips table markup)
+    (re.compile(r"<th[^>]*>"), "| "),
+    (re.compile(r"</th>"), " |"),
+    (re.compile(r"<td[^>]*>"), "| "),
+    (re.compile(r"</td>"), " |"),
+    (re.compile(r"<tr[^>]*>"), ""),
+    (re.compile(r"</tr>"), " |\n"),
+    (re.compile(r"<t(?:head|body|foot)[^>]*>|</t(?:head|body|foot)>"), ""),
+    (re.compile(r"<table[^>]*>|</table>"), "\n"),
+]
+
+# Strip remaining XML/HTML tags (including Confluence macros)
+_STRIP_TAGS = re.compile(r"<[^>]+>")
+
+# Collapse excessive blank lines
+_EXCESS_BLANK = re.compile(r"\n{3,}")
+
+# HTML entity map (common ones; full decoding done via stdlib)
+_HTML_ENTITIES = {
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&quot;": '"',
+    "&#39;": "'",
+    "&nbsp;": " ",
+    "&mdash;": "\u2014",
+    # Use the unicode escape rather than the literal EN DASH character
+    "&ndash;": "\u2013",
+    "&hellip;": "\u2026",
+}
+
+
+class ConfluenceConfig(BaseModel):
+    """Public configuration for the Confluence connector (no secrets)."""
+
+    base_url: str
+    """Base URL of the Confluence instance (e.g. ``https://mycompany.atlassian.net/wiki``)."""
+
+    space_keys: list[str] = Field(default_factory=list)
+    """Confluence space keys to sync.  Empty list discovers all accessible spaces."""
+
+    content_types: list[ContentType] = Field(default=["page"])
+    """Content types to discover: ``page`` and/or ``blogpost``."""
+
+    include_labels: list[str] = Field(default_factory=list)
+    """Only include content tagged with at least one of these labels.  Empty = no filter."""
+
+    exclude_labels: list[str] = Field(default_factory=list)
+    """Exclude content tagged with any of these labels."""
+
+    webhook_secret: str | None = None
+    """HMAC secret for verifying Confluence webhook payloads."""
+
+
+def storage_to_markdown(storage_html: str) -> str:
+    """Convert Confluence storage format (XHTML) to approximate Markdown.
+
+    This is intentionally a best-effort conversion.  Full fidelity would
+    require a full XHTML parser; the goal here is to produce human-readable
+    text that preserves the document's informational content.
+    """
+    text = storage_html
+
+    # Apply block-level tag conversions
+    for pattern, replacement in _TAG_PATTERNS:
+        text = pattern.sub(replacement, text)
+
+    # Strip all remaining tags
+    text = _STRIP_TAGS.sub("", text)
+
+    # Decode HTML entities
+    for entity, char in _HTML_ENTITIES.items():
+        text = text.replace(entity, char)
+
+    # Decode numeric entities
+    text = re.sub(r"&#(\d+);", lambda m: chr(int(m.group(1))), text)
+    text = re.sub(r"&#x([0-9a-fA-F]+);", lambda m: chr(int(m.group(1), 16)), text)
+
+    # Normalise whitespace
+    text = _EXCESS_BLANK.sub("\n\n", text)
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _build_auth_headers(secrets: dict[str, str]) -> dict[str, str]:
+    """Build HTTP Authorization headers from secrets.
+
+    Supports:
+    - Cloud: ``api_token`` + ``email`` -> HTTP Basic with token as password
+    - Server: ``pat`` (personal access token) -> Bearer token
+    """
+    pat = secrets.get("pat", "")
+    if pat:
+        return {"Authorization": f"Bearer {pat}"}
+
+    api_token = secrets.get("api_token", "")
+    email = secrets.get("email", "")
+    if api_token and email:
+        import base64
+
+        creds = base64.b64encode(f"{email}:{api_token}".encode()).decode()
+        return {"Authorization": f"Basic {creds}"}
+
+    raise ValueError(
+        "Confluence secrets must contain either 'pat' (Server) "
+        "or both 'api_token' and 'email' (Cloud)."
+    )
+
+
+def _content_url(base_url: str, content_id: str) -> str:
+    """Return the human-readable URL for a Confluence content item."""
+    base = base_url.rstrip("/")
+    return f"{base}/pages/viewpage.action?pageId={content_id}"
+
+
+# ---------------------------------------------------------------------------
+# Webhook handler
+# ---------------------------------------------------------------------------
+
+
+class ConfluenceWebhookHandler(WebhookHandler):
+    """Handler for Confluence webhook events (page create/update).
+
+    Confluence sends an HMAC-SHA256 signature in the ``X-Hub-Signature`` header
+    using the format ``sha256=<hex>``.
+    """
+
+    _SIG_HEADER = "x-hub-signature"
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        lower = {k.lower(): v for k, v in headers.items()}
+        sig_header = lower.get(self._SIG_HEADER, "")
+        if not sig_header.startswith("sha256="):
+            return False
+        provided_hex = sig_header[len("sha256="):]
+        expected_hex = hmac.new(secret.encode(), payload, "sha256").hexdigest()
+        return hmac.compare_digest(expected_hex, provided_hex)
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        try:
+            data: dict[str, Any] = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Confluence webhook: invalid JSON: {exc}") from exc
+
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+        affected: list[DocumentRef] = []
+
+        page = data.get("page") or data.get("content")
+        if isinstance(page, dict):
+            page_id = str(page.get("id", ""))
+            page_title = str(page.get("title", ""))
+            space_key = ""
+            space = page.get("space")
+            if isinstance(space, dict):
+                space_key = str(space.get("key", ""))
+            if page_id:
+                affected.append(
+                    DocumentRef(
+                        external_id=page_id,
+                        uri=_content_url("", page_id),
+                        metadata={
+                            "title": page_title,
+                            "space_key": space_key,
+                            "event": data.get("webhookEvent", ""),
+                        },
+                    )
+                )
+
+        return WebhookPayload(
+            source_name="confluence",
+            affected_refs=affected,
+            raw_headers=lower_headers,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+class ConfluenceConnector(Connector):
+    """Source connector for Atlassian Confluence (Cloud and Server/DC).
+
+    Discovers pages and blog posts via the Confluence REST API and converts
+    storage format to Markdown for downstream ingestion.
+    """
+
+    connector_type: ClassVar[str] = "confluence"
+    config_schema: ClassVar[type[BaseModel]] = ConfluenceConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify connectivity by fetching current user info."""
+        cfg: ConfluenceConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.base_url.rstrip("/")
+
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
+            resp = await client.get(f"{base}/rest/api/user/current")
+            if resp.status_code == 401:
+                raise PermissionError(
+                    "Confluence authentication failed — check api_token/email or pat."
+                )
+            resp.raise_for_status()
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield DocumentRefs for all matching Confluence content."""
+        cfg: ConfluenceConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.base_url.rstrip("/")
+        url = f"{base}/rest/api/content"
+
+        spaces_to_query = (
+            cfg.space_keys
+            if cfg.space_keys
+            else await self._list_space_keys(base, headers)
+        )
+
+        for space_key in spaces_to_query:
+            for content_type in cfg.content_types:
+                cql = f'type="{content_type}" AND space="{space_key}"'
+                if cfg.include_labels:
+                    label_clause = " OR ".join(
+                        f'label="{lbl}"' for lbl in cfg.include_labels
+                    )
+                    cql += f" AND ({label_clause})"
+
+                start = 0
+                async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+                    while True:
+                        params: dict[str, Any] = {
+                            "cql": cql,
+                            "start": start,
+                            "limit": _PAGE_SIZE,
+                            "expand": "version,metadata.labels,space",
+                        }
+                        try:
+                            resp = await client.get(url, params=params)
+                            resp.raise_for_status()
+                        except httpx.HTTPStatusError as exc:
+                            logger.warning(
+                                "confluence.discover.api_error",
+                                extra={
+                                    "space": space_key,
+                                    "status": exc.response.status_code,
+                                },
+                            )
+                            break
+
+                        data = resp.json()
+                        results: list[dict[str, Any]] = data.get("results", [])
+
+                        for item in results:
+                            item_labels: list[str] = [
+                                lbl["name"]
+                                for lbl in (
+                                    item.get("metadata", {})
+                                    .get("labels", {})
+                                    .get("results", [])
+                                )
+                            ]
+                            # Apply exclude label filter
+                            if cfg.exclude_labels and any(
+                                lbl in cfg.exclude_labels for lbl in item_labels
+                            ):
+                                continue
+
+                            content_id = str(item.get("id", ""))
+                            title = str(item.get("title", ""))
+                            version_num = item.get("version", {}).get("number", 0)
+                            updated_raw = item.get("version", {}).get("when")
+                            updated_at: datetime | None = None
+                            if updated_raw:
+                                with contextlib.suppress(ValueError):
+                                    updated_at = datetime.fromisoformat(
+                                        updated_raw.replace("Z", "+00:00")
+                                    )
+
+                            # Use content_id + version for stable external_id
+                            # sha1 is used only as a compact fingerprint, not for security
+                            external_id = hashlib.sha1(  # noqa: S324
+                                f"{content_id}:{version_num}".encode()
+                            ).hexdigest()
+
+                            yield DocumentRef(
+                                external_id=external_id,
+                                uri=_content_url(base, content_id),
+                                updated_at=updated_at,
+                                metadata={
+                                    "content_id": content_id,
+                                    "title": title,
+                                    "content_type": content_type,
+                                    "space_key": space_key,
+                                    "labels": item_labels,
+                                    "version": version_num,
+                                },
+                            )
+
+                        # Pagination
+                        size = data.get("size", 0)
+                        total = data.get("totalSize", size)
+                        start += size
+                        if start >= total or size == 0:
+                            break
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch a Confluence page and return its content as Markdown."""
+        cfg: ConfluenceConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.base_url.rstrip("/")
+
+        content_id = ref.metadata.get("content_id", "")
+        if not content_id:
+            raise ValueError(
+                f"DocumentRef is missing 'content_id' in metadata: {ref.uri!r}"
+            )
+
+        url = f"{base}/rest/api/content/{content_id}"
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            resp = await client.get(url, params={"expand": "body.storage,version,space"})
+            resp.raise_for_status()
+
+        data = resp.json()
+        storage_html: str = (
+            data.get("body", {}).get("storage", {}).get("value", "")
+        )
+        title: str = data.get("title", "")
+
+        markdown = f"# {title}\n\n{storage_to_markdown(storage_html)}"
+        content_bytes = markdown.encode("utf-8")
+
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=content_bytes,
+            content_type="text/markdown",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return ConfluenceWebhookHandler()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _list_space_keys(self, base: str, headers: dict[str, str]) -> list[str]:
+        """Return all accessible space keys from the Confluence instance."""
+        keys: list[str] = []
+        start = 0
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            while True:
+                resp = await client.get(
+                    f"{base}/rest/api/space",
+                    params={"start": start, "limit": _PAGE_SIZE, "type": "global"},
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                results: list[dict[str, Any]] = data.get("results", [])
+                for space in results:
+                    key = space.get("key")
+                    if isinstance(key, str):
+                        keys.append(key)
+                size = data.get("size", 0)
+                total = data.get("totalSize", size)
+                start += size
+                if start >= total or size == 0:
+                    break
+        return keys

--- a/packages/connectors/src/omniscience_connectors/jira/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/jira/__init__.py
@@ -1,0 +1,5 @@
+"""Jira source connector."""
+
+from omniscience_connectors.jira.connector import JiraConfig, JiraConnector
+
+__all__ = ["JiraConfig", "JiraConnector"]

--- a/packages/connectors/src/omniscience_connectors/jira/connector.py
+++ b/packages/connectors/src/omniscience_connectors/jira/connector.py
@@ -33,10 +33,7 @@ logger = logging.getLogger(__name__)
 _PAGE_SIZE = 50
 
 # Jira field names requested during discover (kept under line length limit)
-_DISCOVER_FIELDS = (
-    "summary,status,priority,issuetype,updated,created,"
-    "assignee,reporter,labels"
-)
+_DISCOVER_FIELDS = "summary,status,priority,issuetype,updated,created,assignee,reporter,labels"
 
 
 class JiraConfig(BaseModel):
@@ -90,7 +87,7 @@ class JiraWebhookHandler(WebhookHandler):
             return not secret
         if not sig_header.startswith("sha256="):
             return False
-        provided_hex = sig_header[len("sha256="):]
+        provided_hex = sig_header[len("sha256=") :]
         expected_hex = hmac.new(secret.encode(), payload, "sha256").hexdigest()
         return hmac.compare_digest(expected_hex, provided_hex)
 
@@ -114,9 +111,7 @@ class JiraWebhookHandler(WebhookHandler):
             issue_key = str(issue_data.get("key", ""))
             if issue_id:
                 fields = issue_data.get("fields", {})
-                updated_raw = (
-                    fields.get("updated", "") if isinstance(fields, dict) else ""
-                )
+                updated_raw = fields.get("updated", "") if isinstance(fields, dict) else ""
                 # sha1 used only as a compact fingerprint, not for security
                 external_id = hashlib.sha1(  # noqa: S324
                     f"{issue_id}:{updated_raw}".encode()
@@ -160,8 +155,7 @@ def _build_auth_headers(secrets: dict[str, str]) -> dict[str, str]:
         return {"Authorization": f"Basic {creds}"}
 
     raise ValueError(
-        "Jira secrets must contain either 'pat' (Server) "
-        "or both 'api_token' and 'email' (Cloud)."
+        "Jira secrets must contain either 'pat' (Server) or both 'api_token' and 'email' (Cloud)."
     )
 
 
@@ -236,9 +230,7 @@ def _adf_to_markdown(node: dict[str, Any], depth: int = 0) -> str:
     if node_type == "orderedList":
         lines: list[str] = []
         for i, item in enumerate(content, start=1):
-            inner = "".join(
-                _adf_to_markdown(c, depth + 1) for c in item.get("content", [])
-            )
+            inner = "".join(_adf_to_markdown(c, depth + 1) for c in item.get("content", []))
             lines.append(f"{i}. {inner.strip()}\n")
         return "".join(lines) + "\n"
 
@@ -327,9 +319,7 @@ class JiraConnector(Connector):
         async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
             resp = await client.get(f"{base}/rest/api/3/myself")
             if resp.status_code == 401:
-                raise PermissionError(
-                    "Jira authentication failed — check api_token/email or pat."
-                )
+                raise PermissionError("Jira authentication failed — check api_token/email or pat.")
             resp.raise_for_status()
 
     async def discover(
@@ -354,9 +344,7 @@ class JiraConnector(Connector):
                     "fields": _DISCOVER_FIELDS,
                 }
                 try:
-                    resp = await client.get(
-                        f"{base}/rest/api/3/search", params=params
-                    )
+                    resp = await client.get(f"{base}/rest/api/3/search", params=params)
                     resp.raise_for_status()
                 except httpx.HTTPStatusError as exc:
                     logger.warning(
@@ -391,9 +379,7 @@ class JiraConnector(Connector):
 
         issue_key = ref.metadata.get("issue_key", "")
         if not issue_key:
-            raise ValueError(
-                f"DocumentRef missing 'issue_key' in metadata: {ref.uri!r}"
-            )
+            raise ValueError(f"DocumentRef missing 'issue_key' in metadata: {ref.uri!r}")
 
         async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
             # Fetch full issue with all fields
@@ -502,9 +488,9 @@ def _issue_to_markdown(
     updated = str(fields.get("updated", ""))
 
     # Description — can be ADF (dict) or plain string
-    description_raw = fields.get("description") or (
-        issue.get("renderedFields", {}) or {}
-    ).get("description", "")
+    description_raw = fields.get("description") or (issue.get("renderedFields", {}) or {}).get(
+        "description", ""
+    )
     if isinstance(description_raw, dict):
         description = _adf_to_markdown(description_raw).strip()
     else:

--- a/packages/connectors/src/omniscience_connectors/jira/connector.py
+++ b/packages/connectors/src/omniscience_connectors/jira/connector.py
@@ -1,0 +1,543 @@
+"""Jira source connector.
+
+Discovers Jira issues via JQL search and fetches issue body + comments.
+Supports Jira Cloud (API token + email) and Jira Server/Data Center (PAT).
+Implements webhooks for issue create/update/comment events.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any, ClassVar
+
+import httpx
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+    WebhookPayload,
+)
+
+__all__ = ["JiraConfig", "JiraConnector"]
+
+logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 50
+
+# Jira field names requested during discover (kept under line length limit)
+_DISCOVER_FIELDS = (
+    "summary,status,priority,issuetype,updated,created,"
+    "assignee,reporter,labels"
+)
+
+
+class JiraConfig(BaseModel):
+    """Public configuration for the Jira connector (no secrets)."""
+
+    base_url: str
+    """Base URL of the Jira instance (e.g. ``https://mycompany.atlassian.net``)."""
+
+    project_keys: list[str] = Field(default_factory=list)
+    """Jira project keys to sync (e.g. ``["PROJ", "BACKEND"]``).
+    Empty = query all projects accessible to the credentials."""
+
+    jql_filter: str = ""
+    """Additional JQL clause appended to the base project filter.
+    Example: ``"priority = High AND status != Done"``."""
+
+    issue_types: list[str] = Field(default_factory=list)
+    """Issue types to include (e.g. ``["Bug", "Story"]``).
+    Empty = include all issue types."""
+
+    webhook_secret: str | None = None
+    """HMAC secret for verifying Jira webhook payloads."""
+
+
+# ---------------------------------------------------------------------------
+# Webhook handler
+# ---------------------------------------------------------------------------
+
+
+class JiraWebhookHandler(WebhookHandler):
+    """Handler for Jira webhook events (issue create/update/comment).
+
+    Jira Cloud signs webhooks with HMAC-SHA256 in the
+    ``X-Hub-Signature`` header (``sha256=<hex>``).
+    Jira Server/DC sends an optional secret query parameter — the
+    framework passes the full raw body for verification.
+    """
+
+    _SIG_HEADER = "x-hub-signature"
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        lower = {k.lower(): v for k, v in headers.items()}
+        sig_header = lower.get(self._SIG_HEADER, "")
+        if not sig_header:
+            # No signature header — accept if no secret is configured
+            return not secret
+        if not sig_header.startswith("sha256="):
+            return False
+        provided_hex = sig_header[len("sha256="):]
+        expected_hex = hmac.new(secret.encode(), payload, "sha256").hexdigest()
+        return hmac.compare_digest(expected_hex, provided_hex)
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+        try:
+            data: dict[str, Any] = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Jira webhook: invalid JSON: {exc}") from exc
+
+        affected: list[DocumentRef] = []
+        event_type = str(data.get("webhookEvent", ""))
+        issue_data = data.get("issue")
+
+        if isinstance(issue_data, dict):
+            issue_id = str(issue_data.get("id", ""))
+            issue_key = str(issue_data.get("key", ""))
+            if issue_id:
+                fields = issue_data.get("fields", {})
+                updated_raw = (
+                    fields.get("updated", "") if isinstance(fields, dict) else ""
+                )
+                # sha1 used only as a compact fingerprint, not for security
+                external_id = hashlib.sha1(  # noqa: S324
+                    f"{issue_id}:{updated_raw}".encode()
+                ).hexdigest()
+                affected.append(
+                    DocumentRef(
+                        external_id=external_id,
+                        uri=issue_key,
+                        metadata={
+                            "issue_id": issue_id,
+                            "issue_key": issue_key,
+                            "event_type": event_type,
+                        },
+                    )
+                )
+
+        return WebhookPayload(
+            source_name="jira",
+            affected_refs=affected,
+            raw_headers=lower_headers,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_auth_headers(secrets: dict[str, str]) -> dict[str, str]:
+    """Build HTTP auth headers for Jira Cloud or Server."""
+    pat = secrets.get("pat", "")
+    if pat:
+        return {"Authorization": f"Bearer {pat}"}
+
+    api_token = secrets.get("api_token", "")
+    email = secrets.get("email", "")
+    if api_token and email:
+        import base64
+
+        creds = base64.b64encode(f"{email}:{api_token}".encode()).decode()
+        return {"Authorization": f"Basic {creds}"}
+
+    raise ValueError(
+        "Jira secrets must contain either 'pat' (Server) "
+        "or both 'api_token' and 'email' (Cloud)."
+    )
+
+
+def _parse_jira_date(date_str: str | None) -> datetime | None:
+    if not date_str:
+        return None
+    # Jira dates: "2023-11-15T10:30:00.000+0000"
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%S.%f%z",
+        "%Y-%m-%dT%H:%M:%S%z",
+    ):
+        try:
+            return datetime.strptime(date_str, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Content conversion
+# ---------------------------------------------------------------------------
+
+
+def _adf_to_markdown(node: dict[str, Any], depth: int = 0) -> str:
+    """Recursively convert Atlassian Document Format (ADF) nodes to Markdown.
+
+    ADF is used by Jira Cloud for rich text fields.
+    """
+    node_type = node.get("type", "")
+    content: list[dict[str, Any]] = node.get("content", [])
+    text: str = node.get("text", "")
+    attrs: dict[str, Any] = node.get("attrs", {})
+
+    if node_type == "text":
+        marks: list[dict[str, Any]] = node.get("marks", [])
+        result = text
+        for mark in marks:
+            mt = mark.get("type", "")
+            if mt == "strong":
+                result = f"**{result}**"
+            elif mt == "em":
+                result = f"_{result}_"
+            elif mt == "code":
+                result = f"`{result}`"
+            elif mt == "strike":
+                result = f"~~{result}~~"
+            elif mt == "link":
+                href = mark.get("attrs", {}).get("href", "")
+                result = f"[{result}]({href})"
+        return result
+
+    if node_type == "doc":
+        return "\n\n".join(_adf_to_markdown(c, depth) for c in content)
+
+    if node_type == "paragraph":
+        inner = "".join(_adf_to_markdown(c, depth) for c in content)
+        return f"{inner}\n\n"
+
+    if node_type == "heading":
+        level = min(attrs.get("level", 1), 6)
+        prefix = "#" * level
+        inner = "".join(_adf_to_markdown(c, depth) for c in content)
+        return f"{prefix} {inner}\n\n"
+
+    if node_type == "bulletList":
+        items = [_adf_to_markdown(c, depth + 1) for c in content]
+        return "".join(items)
+
+    if node_type == "orderedList":
+        lines: list[str] = []
+        for i, item in enumerate(content, start=1):
+            inner = "".join(
+                _adf_to_markdown(c, depth + 1) for c in item.get("content", [])
+            )
+            lines.append(f"{i}. {inner.strip()}\n")
+        return "".join(lines) + "\n"
+
+    if node_type == "listItem":
+        indent = "  " * (depth - 1)
+        inner = "".join(_adf_to_markdown(c, depth) for c in content)
+        return f"{indent}- {inner.strip()}\n"
+
+    if node_type == "codeBlock":
+        lang = attrs.get("language", "")
+        inner = "".join(_adf_to_markdown(c, depth) for c in content)
+        return f"```{lang}\n{inner}\n```\n\n"
+
+    if node_type == "blockquote":
+        inner = "".join(_adf_to_markdown(c, depth) for c in content)
+        quoted = "\n".join(f"> {line}" for line in inner.splitlines())
+        return f"{quoted}\n\n"
+
+    if node_type == "rule":
+        return "---\n\n"
+
+    if node_type == "hardBreak":
+        return "\n"
+
+    if node_type == "inlineCard":
+        url = attrs.get("url", "")
+        return f"[{url}]({url})"
+
+    if node_type == "mention":
+        display = attrs.get("text", attrs.get("id", ""))
+        return f"@{display}"
+
+    # Tables (simplified)
+    if node_type == "table":
+        rows = [_adf_to_markdown(c, depth) for c in content]
+        return "".join(rows) + "\n"
+
+    if node_type in ("tableRow", "tableHeader", "tableCell"):
+        cells = [_adf_to_markdown(c, depth) for c in content]
+        return "| " + " | ".join(c.strip() for c in cells) + " |\n"
+
+    # Fallback: recurse into children
+    return "".join(_adf_to_markdown(c, depth) for c in content)
+
+
+def _field_to_text(value: Any) -> str:
+    """Convert a Jira field value to a plain string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        # ADF document
+        if value.get("type") == "doc":
+            return _adf_to_markdown(value).strip()
+        # Simple value objects (status, priority, issuetype, user, etc.)
+        for key in ("displayName", "name", "value", "key"):
+            if key in value:
+                return str(value[key])
+        return str(value)
+    if isinstance(value, list):
+        return ", ".join(_field_to_text(v) for v in value)
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+class JiraConnector(Connector):
+    """Source connector for Atlassian Jira (Cloud and Server/DC).
+
+    Discovers issues via JQL search and fetches issue body + comments.
+    """
+
+    connector_type: ClassVar[str] = "jira"
+    config_schema: ClassVar[type[BaseModel]] = JiraConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify connectivity by fetching the current user."""
+        cfg: JiraConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.base_url.rstrip("/")
+
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
+            resp = await client.get(f"{base}/rest/api/3/myself")
+            if resp.status_code == 401:
+                raise PermissionError(
+                    "Jira authentication failed — check api_token/email or pat."
+                )
+            resp.raise_for_status()
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield DocumentRefs for all matching Jira issues via JQL."""
+        cfg: JiraConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.base_url.rstrip("/")
+
+        jql = _build_jql(cfg)
+        start_at = 0
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            while True:
+                params: dict[str, Any] = {
+                    "jql": jql,
+                    "startAt": start_at,
+                    "maxResults": _PAGE_SIZE,
+                    "fields": _DISCOVER_FIELDS,
+                }
+                try:
+                    resp = await client.get(
+                        f"{base}/rest/api/3/search", params=params
+                    )
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    logger.warning(
+                        "jira.discover.api_error",
+                        extra={"status": exc.response.status_code, "jql": jql},
+                    )
+                    break
+
+                data = resp.json()
+                issues: list[dict[str, Any]] = data.get("issues", [])
+
+                for issue in issues:
+                    ref = _issue_to_ref(issue, base)
+                    if ref is not None:
+                        yield ref
+
+                total = data.get("total", 0)
+                start_at += len(issues)
+                if start_at >= total or not issues:
+                    break
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch a Jira issue body + comments as Markdown."""
+        cfg: JiraConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.base_url.rstrip("/")
+
+        issue_key = ref.metadata.get("issue_key", "")
+        if not issue_key:
+            raise ValueError(
+                f"DocumentRef missing 'issue_key' in metadata: {ref.uri!r}"
+            )
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            # Fetch full issue with all fields
+            issue_resp = await client.get(
+                f"{base}/rest/api/3/issue/{issue_key}",
+                params={"expand": "renderedFields,names"},
+            )
+            issue_resp.raise_for_status()
+            issue_data = issue_resp.json()
+
+            # Fetch comments
+            comments_resp = await client.get(
+                f"{base}/rest/api/3/issue/{issue_key}/comment",
+                params={"maxResults": 500},
+            )
+            comments_resp.raise_for_status()
+            comments_data = comments_resp.json()
+
+        markdown = _issue_to_markdown(issue_data, comments_data, base)
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=markdown.encode("utf-8"),
+            content_type="text/markdown",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return JiraWebhookHandler()
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_jql(cfg: JiraConfig) -> str:
+    """Build a JQL query from the connector configuration."""
+    clauses: list[str] = []
+
+    if cfg.project_keys:
+        keys = ", ".join(f'"{k}"' for k in cfg.project_keys)
+        clauses.append(f"project in ({keys})")
+
+    if cfg.issue_types:
+        types = ", ".join(f'"{t}"' for t in cfg.issue_types)
+        clauses.append(f"issuetype in ({types})")
+
+    if cfg.jql_filter:
+        clauses.append(f"({cfg.jql_filter})")
+
+    if not clauses:
+        return "ORDER BY updated DESC"
+
+    return " AND ".join(clauses) + " ORDER BY updated DESC"
+
+
+def _issue_to_ref(issue: dict[str, Any], base_url: str) -> DocumentRef | None:
+    """Convert a Jira issue search result to a DocumentRef."""
+    issue_id = str(issue.get("id", ""))
+    issue_key = str(issue.get("key", ""))
+    if not issue_id or not issue_key:
+        return None
+
+    fields: dict[str, Any] = issue.get("fields", {}) or {}
+    updated_raw = str(fields.get("updated", ""))
+    updated_at = _parse_jira_date(updated_raw)
+
+    # sha1 used only as a compact fingerprint, not for security
+    external_id = hashlib.sha1(  # noqa: S324
+        f"{issue_id}:{updated_raw}".encode()
+    ).hexdigest()
+    uri = f"{base_url.rstrip('/')}/browse/{issue_key}"
+
+    return DocumentRef(
+        external_id=external_id,
+        uri=uri,
+        updated_at=updated_at,
+        metadata={
+            "issue_id": issue_id,
+            "issue_key": issue_key,
+            "summary": _field_to_text(fields.get("summary")),
+            "status": _field_to_text(fields.get("status")),
+            "issue_type": _field_to_text(fields.get("issuetype")),
+            "priority": _field_to_text(fields.get("priority")),
+            "labels": fields.get("labels", []),
+        },
+    )
+
+
+def _issue_to_markdown(
+    issue: dict[str, Any],
+    comments_data: dict[str, Any],
+    base_url: str,
+) -> str:
+    """Format a full Jira issue + comments as Markdown."""
+    key = str(issue.get("key", ""))
+    fields: dict[str, Any] = issue.get("fields", {}) or {}
+
+    summary = _field_to_text(fields.get("summary"))
+    status = _field_to_text(fields.get("status"))
+    priority = _field_to_text(fields.get("priority"))
+    issue_type = _field_to_text(fields.get("issuetype"))
+    assignee = _field_to_text(fields.get("assignee"))
+    reporter = _field_to_text(fields.get("reporter"))
+    labels: list[str] = fields.get("labels", [])
+    created = str(fields.get("created", ""))
+    updated = str(fields.get("updated", ""))
+
+    # Description — can be ADF (dict) or plain string
+    description_raw = fields.get("description") or (
+        issue.get("renderedFields", {}) or {}
+    ).get("description", "")
+    if isinstance(description_raw, dict):
+        description = _adf_to_markdown(description_raw).strip()
+    else:
+        description = str(description_raw).strip()
+
+    url = f"{base_url.rstrip('/')}/browse/{key}"
+
+    parts = [
+        f"# [{key}] {summary}",
+        f"**URL**: {url}",
+        f"**Type**: {issue_type} | **Status**: {status} | **Priority**: {priority}",
+        f"**Assignee**: {assignee} | **Reporter**: {reporter}",
+        f"**Created**: {created} | **Updated**: {updated}",
+    ]
+    if labels:
+        parts.append(f"**Labels**: {', '.join(labels)}")
+
+    if description:
+        parts.append("\n## Description\n")
+        parts.append(description)
+
+    # Comments
+    comments: list[dict[str, Any]] = comments_data.get("comments", [])
+    if comments:
+        parts.append("\n## Comments\n")
+        for comment in comments:
+            author = _field_to_text(comment.get("author"))
+            created_at = str(comment.get("created", ""))
+            body_raw = comment.get("body")
+            if isinstance(body_raw, dict):
+                body = _adf_to_markdown(body_raw).strip()
+            else:
+                body = str(body_raw or "").strip()
+            parts.append(f"**{author}** ({created_at}):\n{body}\n")
+
+    return "\n\n".join(parts)

--- a/packages/connectors/src/omniscience_connectors/notion/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/notion/__init__.py
@@ -1,0 +1,5 @@
+"""Notion source connector."""
+
+from omniscience_connectors.notion.connector import NotionConfig, NotionConnector
+
+__all__ = ["NotionConfig", "NotionConnector"]

--- a/packages/connectors/src/omniscience_connectors/notion/connector.py
+++ b/packages/connectors/src/omniscience_connectors/notion/connector.py
@@ -1,0 +1,459 @@
+"""Notion source connector.
+
+Discovers pages and database entries via the Notion API and converts
+Notion block trees to Markdown.  Uses polling only (no webhook support).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Any, ClassVar
+
+import httpx
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+)
+
+__all__ = ["NotionConfig", "NotionConnector"]
+
+logger = logging.getLogger(__name__)
+
+_NOTION_API_BASE = "https://api.notion.com/v1"
+_NOTION_VERSION = "2022-06-28"
+_PAGE_SIZE = 100
+
+
+class NotionConfig(BaseModel):
+    """Public configuration for the Notion connector (no secrets)."""
+
+    database_ids: list[str] = Field(default_factory=list)
+    """Notion database IDs to query.  UUIDs with or without dashes."""
+
+    page_ids: list[str] = Field(default_factory=list)
+    """Individual Notion page IDs to include."""
+
+    include_properties: list[str] = Field(default_factory=list)
+    """Database property names to include in metadata.  Empty = include all."""
+
+
+# ---------------------------------------------------------------------------
+# Notion blocks -> Markdown
+# ---------------------------------------------------------------------------
+
+
+def _rich_text_to_str(rich_texts: list[dict[str, Any]]) -> str:
+    """Concatenate plain_text values from a Notion rich_text array."""
+    return "".join(rt.get("plain_text", "") for rt in rich_texts)
+
+
+def _block_to_markdown(block: dict[str, Any], depth: int = 0) -> str:
+    """Convert a single Notion block dict to a Markdown string.
+
+    *depth* is used for nested lists (children are handled by the caller).
+    """
+    block_type: str = block.get("type", "")
+    data: dict[str, Any] = block.get(block_type, {})
+    rich_texts: list[dict[str, Any]] = data.get("rich_text", [])
+    text = _rich_text_to_str(rich_texts)
+    indent = "  " * depth
+
+    if block_type == "paragraph":
+        return f"{text}\n\n" if text else ""
+
+    if block_type in ("heading_1", "heading_2", "heading_3"):
+        level = {"heading_1": "#", "heading_2": "##", "heading_3": "###"}[block_type]
+        return f"{level} {text}\n\n"
+
+    if block_type == "bulleted_list_item":
+        return f"{indent}- {text}\n"
+
+    if block_type == "numbered_list_item":
+        return f"{indent}1. {text}\n"
+
+    if block_type == "to_do":
+        checked = "x" if data.get("checked") else " "
+        return f"{indent}- [{checked}] {text}\n"
+
+    if block_type == "toggle":
+        return f"{indent}> {text}\n"
+
+    if block_type == "quote":
+        return f"> {text}\n\n"
+
+    if block_type == "callout":
+        icon = ""
+        emoji_data = data.get("icon")
+        if isinstance(emoji_data, dict) and emoji_data.get("type") == "emoji":
+            icon = emoji_data.get("emoji", "") + " "
+        return f"> {icon}{text}\n\n"
+
+    if block_type == "code":
+        lang = data.get("language", "")
+        return f"```{lang}\n{text}\n```\n\n"
+
+    if block_type == "divider":
+        return "---\n\n"
+
+    if block_type in ("image", "video", "file", "pdf"):
+        src_data = data.get("external") or data.get("file") or {}
+        src_url = src_data.get("url", "")
+        caption_texts: list[dict[str, Any]] = data.get("caption", [])
+        caption = _rich_text_to_str(caption_texts)
+        alt = caption or block_type
+        if block_type == "image":
+            return f"![{alt}]({src_url})\n\n"
+        return f"[{alt}]({src_url})\n\n"
+
+    if block_type == "table_row":
+        cells: list[list[dict[str, Any]]] = data.get("cells", [])
+        cell_texts = [_rich_text_to_str(c) for c in cells]
+        return "| " + " | ".join(cell_texts) + " |\n"
+
+    if block_type == "child_page":
+        title = data.get("title", "")
+        return f"**[Page: {title}]**\n\n"
+
+    if block_type == "child_database":
+        title = data.get("title", "")
+        return f"**[Database: {title}]**\n\n"
+
+    # Unknown block type — emit a placeholder so content is not silently lost
+    return f"<!-- {block_type} -->\n" if block_type else ""
+
+
+def blocks_to_markdown(blocks: list[dict[str, Any]]) -> str:
+    """Convert a flat list of Notion block dicts to a Markdown string.
+
+    Nested blocks (children) are indented by one level.  This function does
+    not fetch children from the API; callers must pre-flatten the tree.
+    """
+    parts: list[str] = []
+    depth = 0
+    list_types = {"bulleted_list_item", "numbered_list_item", "to_do"}
+    prev_type = ""
+
+    for block in blocks:
+        block_type = block.get("type", "")
+        # Reset indent depth when transitioning into or out of a list
+        if (block_type in list_types) != (prev_type in list_types):
+            depth = 0
+
+        parts.append(_block_to_markdown(block, depth=depth))
+        prev_type = block_type
+
+    return "".join(parts).strip()
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(secrets: dict[str, str]) -> dict[str, str]:
+    token = secrets.get("integration_token", "")
+    if not token:
+        raise ValueError("Notion secrets must contain 'integration_token'.")
+    return {
+        "Authorization": f"Bearer {token}",
+        "Notion-Version": _NOTION_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+def _parse_date(date_str: str | None) -> datetime | None:
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _page_title(page: dict[str, Any]) -> str:
+    """Extract the title from a Notion page object."""
+    props = page.get("properties", {})
+    for prop_val in props.values():
+        if isinstance(prop_val, dict) and prop_val.get("type") == "title":
+            rich_texts = prop_val.get("title", [])
+            title = _rich_text_to_str(rich_texts)
+            if title:
+                return title
+    return str(page.get("id", ""))
+
+
+def _page_metadata(
+    page: dict[str, Any], include_properties: list[str]
+) -> dict[str, Any]:
+    """Extract selected properties as metadata."""
+    meta: dict[str, Any] = {
+        "page_id": page.get("id", ""),
+        "created_time": page.get("created_time", ""),
+        "last_edited_time": page.get("last_edited_time", ""),
+        "url": page.get("url", ""),
+    }
+    props = page.get("properties", {})
+    for key, val in props.items():
+        if include_properties and key not in include_properties:
+            continue
+        prop_type = val.get("type", "")
+        # Serialise simple property types into the metadata dict
+        if prop_type == "rich_text":
+            meta[key] = _rich_text_to_str(val.get("rich_text", []))
+        elif prop_type == "title":
+            meta[key] = _rich_text_to_str(val.get("title", []))
+        elif prop_type == "select":
+            sel = val.get("select")
+            meta[key] = sel.get("name", "") if isinstance(sel, dict) else ""
+        elif prop_type == "multi_select":
+            meta[key] = [s.get("name", "") for s in val.get("multi_select", [])]
+        elif prop_type == "checkbox":
+            meta[key] = val.get("checkbox", False)
+        elif prop_type in ("number", "date", "url", "email", "phone_number"):
+            meta[key] = val.get(prop_type)
+        # Complex types (relations, rollups, formulas) are skipped intentionally
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+class NotionConnector(Connector):
+    """Source connector for Notion workspaces.
+
+    Discovers pages from configured databases and individual page IDs.
+    Converts Notion block trees to Markdown.  Webhook support is not
+    available in the Notion API — polling is used instead.
+    """
+
+    connector_type: ClassVar[str] = "notion"
+    config_schema: ClassVar[type[BaseModel]] = NotionConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify the integration token works by calling /v1/users/me."""
+        headers = _auth_headers(secrets)
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
+            resp = await client.get(f"{_NOTION_API_BASE}/users/me")
+            if resp.status_code == 401:
+                raise PermissionError(
+                    "Notion authentication failed — check integration_token."
+                )
+            resp.raise_for_status()
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield DocumentRefs for all Notion pages in configured databases + individual IDs."""
+        cfg: NotionConfig = config  # type: ignore[assignment]
+        headers = _auth_headers(secrets)
+
+        # Discover from databases
+        for db_id in cfg.database_ids:
+            async for ref in self._discover_database(db_id, cfg, headers):
+                yield ref
+
+        # Discover individual pages
+        for page_id in cfg.page_ids:
+            page_ref = await self._page_ref(page_id, cfg, headers)
+            if page_ref is not None:
+                yield page_ref
+
+        # If neither databases nor pages are specified, use /v1/search
+        if not cfg.database_ids and not cfg.page_ids:
+            async for ref in self._search_all(cfg, headers):
+                yield ref
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch a Notion page's block tree and return it as Markdown."""
+        headers = _auth_headers(secrets)
+
+        page_id = ref.metadata.get("page_id", "")
+        if not page_id:
+            raise ValueError(f"DocumentRef missing 'page_id' in metadata: {ref.uri!r}")
+
+        # Fetch page metadata for the title
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            page_resp = await client.get(f"{_NOTION_API_BASE}/pages/{page_id}")
+            page_resp.raise_for_status()
+            page_data = page_resp.json()
+
+        title = _page_title(page_data)
+
+        # Fetch all blocks (paginated)
+        blocks = await self._fetch_all_blocks(page_id, headers)
+
+        md_body = blocks_to_markdown(blocks)
+        markdown = f"# {title}\n\n{md_body}" if md_body else f"# {title}\n"
+
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=markdown.encode("utf-8"),
+            content_type="text/markdown",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        """Notion does not support webhooks — polling only."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _discover_database(
+        self,
+        db_id: str,
+        cfg: NotionConfig,
+        headers: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield DocumentRefs for all pages in a Notion database."""
+        url = f"{_NOTION_API_BASE}/databases/{db_id}/query"
+        cursor: str | None = None
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            while True:
+                body: dict[str, Any] = {"page_size": _PAGE_SIZE}
+                if cursor:
+                    body["start_cursor"] = cursor
+
+                try:
+                    resp = await client.post(url, json=body)
+                    resp.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    logger.warning(
+                        "notion.discover.database_error",
+                        extra={"db_id": db_id, "status": exc.response.status_code},
+                    )
+                    return
+
+                data = resp.json()
+                for page in data.get("results", []):
+                    page_ref = _page_to_ref(page, cfg.include_properties)
+                    if page_ref is not None:
+                        yield page_ref
+
+                if data.get("has_more"):
+                    cursor = data.get("next_cursor")
+                else:
+                    break
+
+    async def _page_ref(
+        self,
+        page_id: str,
+        cfg: NotionConfig,
+        headers: dict[str, str],
+    ) -> DocumentRef | None:
+        """Fetch a single page by ID and return its DocumentRef."""
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
+            try:
+                resp = await client.get(f"{_NOTION_API_BASE}/pages/{page_id}")
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                logger.warning(
+                    "notion.discover.page_error",
+                    extra={"page_id": page_id, "status": exc.response.status_code},
+                )
+                return None
+        return _page_to_ref(resp.json(), cfg.include_properties)
+
+    async def _search_all(
+        self,
+        cfg: NotionConfig,
+        headers: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Use /v1/search to find all accessible pages."""
+        url = f"{_NOTION_API_BASE}/search"
+        cursor: str | None = None
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            while True:
+                body: dict[str, Any] = {
+                    "filter": {"property": "object", "value": "page"},
+                    "page_size": _PAGE_SIZE,
+                }
+                if cursor:
+                    body["start_cursor"] = cursor
+
+                resp = await client.post(url, json=body)
+                resp.raise_for_status()
+                data = resp.json()
+
+                for page in data.get("results", []):
+                    page_ref = _page_to_ref(page, cfg.include_properties)
+                    if page_ref is not None:
+                        yield page_ref
+
+                if data.get("has_more"):
+                    cursor = data.get("next_cursor")
+                else:
+                    break
+
+    async def _fetch_all_blocks(
+        self,
+        page_id: str,
+        headers: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        """Fetch all blocks for a page (paginated), returning a flat list."""
+        blocks: list[dict[str, Any]] = []
+        cursor: str | None = None
+        url = f"{_NOTION_API_BASE}/blocks/{page_id}/children"
+
+        async with httpx.AsyncClient(headers=headers, timeout=60.0) as client:
+            while True:
+                params: dict[str, Any] = {"page_size": _PAGE_SIZE}
+                if cursor:
+                    params["start_cursor"] = cursor
+
+                resp = await client.get(url, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+                blocks.extend(data.get("results", []))
+
+                if data.get("has_more"):
+                    cursor = data.get("next_cursor")
+                else:
+                    break
+
+        return blocks
+
+
+def _page_to_ref(
+    page: dict[str, Any], include_properties: list[str]
+) -> DocumentRef | None:
+    """Convert a Notion page API response to a DocumentRef."""
+    page_id = page.get("id", "")
+    if not page_id:
+        return None
+
+    last_edited = page.get("last_edited_time", "")
+    updated_at = _parse_date(last_edited)
+
+    # sha1 used as a compact fingerprint for change detection, not for security
+    external_id = hashlib.sha1(  # noqa: S324
+        f"{page_id}:{last_edited}".encode()
+    ).hexdigest()
+
+    url = page.get("url", f"https://notion.so/{page_id.replace('-', '')}")
+    meta = _page_metadata(page, include_properties)
+
+    return DocumentRef(
+        external_id=external_id,
+        uri=url,
+        updated_at=updated_at,
+        metadata=meta,
+    )

--- a/packages/connectors/src/omniscience_connectors/notion/connector.py
+++ b/packages/connectors/src/omniscience_connectors/notion/connector.py
@@ -189,9 +189,7 @@ def _page_title(page: dict[str, Any]) -> str:
     return str(page.get("id", ""))
 
 
-def _page_metadata(
-    page: dict[str, Any], include_properties: list[str]
-) -> dict[str, Any]:
+def _page_metadata(page: dict[str, Any], include_properties: list[str]) -> dict[str, Any]:
     """Extract selected properties as metadata."""
     meta: dict[str, Any] = {
         "page_id": page.get("id", ""),
@@ -244,9 +242,7 @@ class NotionConnector(Connector):
         async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
             resp = await client.get(f"{_NOTION_API_BASE}/users/me")
             if resp.status_code == 401:
-                raise PermissionError(
-                    "Notion authentication failed — check integration_token."
-                )
+                raise PermissionError("Notion authentication failed — check integration_token.")
             resp.raise_for_status()
 
     async def discover(
@@ -432,9 +428,7 @@ class NotionConnector(Connector):
         return blocks
 
 
-def _page_to_ref(
-    page: dict[str, Any], include_properties: list[str]
-) -> DocumentRef | None:
+def _page_to_ref(page: dict[str, Any], include_properties: list[str]) -> DocumentRef | None:
     """Convert a Notion page API response to a DocumentRef."""
     page_id = page.get("id", "")
     if not page_id:

--- a/packages/connectors/src/omniscience_connectors/slack/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/slack/__init__.py
@@ -1,0 +1,5 @@
+"""Slack source connector."""
+
+from omniscience_connectors.slack.connector import SlackConfig, SlackConnector
+
+__all__ = ["SlackConfig", "SlackConnector"]

--- a/packages/connectors/src/omniscience_connectors/slack/connector.py
+++ b/packages/connectors/src/omniscience_connectors/slack/connector.py
@@ -184,9 +184,7 @@ class SlackConnector(Connector):
             data = resp.json()
             if not data.get("ok"):
                 error = data.get("error", "unknown")
-                raise PermissionError(
-                    f"Slack authentication failed ({error}) — check bot_token."
-                )
+                raise PermissionError(f"Slack authentication failed ({error}) — check bot_token.")
 
     async def discover(
         self,
@@ -198,9 +196,7 @@ class SlackConnector(Connector):
         headers = _auth_headers(secrets)
         oldest = _oldest_ts(cfg.max_age_days)
 
-        channels = (
-            cfg.channel_ids if cfg.channel_ids else await self._list_channels(headers)
-        )
+        channels = cfg.channel_ids if cfg.channel_ids else await self._list_channels(headers)
 
         for channel_id in channels:
             async for ref in self._discover_channel(channel_id, oldest, headers):
@@ -234,9 +230,7 @@ class SlackConnector(Connector):
         reply_text = ""
         if cfg.include_threads:
             replies = await self._fetch_replies(channel_id, thread_ts, headers)
-            reply_lines = [
-                _message_to_markdown(m) for m in replies if m.get("ts") != thread_ts
-            ]
+            reply_lines = [_message_to_markdown(m) for m in replies if m.get("ts") != thread_ts]
             if reply_lines:
                 reply_text = "\n\n".join(reply_lines)
 
@@ -277,9 +271,7 @@ class SlackConnector(Connector):
                 if cursor:
                     params["cursor"] = cursor
 
-                resp = await client.get(
-                    f"{_SLACK_API_BASE}/conversations.list", params=params
-                )
+                resp = await client.get(f"{_SLACK_API_BASE}/conversations.list", params=params)
                 data = resp.json()
                 if not data.get("ok"):
                     logger.warning(
@@ -415,9 +407,7 @@ class SlackConnector(Connector):
                 if cursor:
                     params["cursor"] = cursor
 
-                resp = await client.get(
-                    f"{_SLACK_API_BASE}/conversations.replies", params=params
-                )
+                resp = await client.get(f"{_SLACK_API_BASE}/conversations.replies", params=params)
                 data = resp.json()
                 if not data.get("ok"):
                     break

--- a/packages/connectors/src/omniscience_connectors/slack/connector.py
+++ b/packages/connectors/src/omniscience_connectors/slack/connector.py
@@ -1,0 +1,477 @@
+"""Slack source connector.
+
+Discovers messages from configured channels via the Slack Web API
+(conversations.history) and assembles thread replies.  Supports the
+Slack Events API for real-time message ingestion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any, ClassVar
+
+import httpx
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+    WebhookPayload,
+)
+
+__all__ = ["SlackConfig", "SlackConnector"]
+
+logger = logging.getLogger(__name__)
+
+_SLACK_API_BASE = "https://slack.com/api"
+_PAGE_SIZE = 200
+
+
+class SlackConfig(BaseModel):
+    """Public configuration for the Slack connector (no secrets)."""
+
+    channel_ids: list[str] = Field(default_factory=list)
+    """Slack channel IDs (C... format) to discover messages from."""
+
+    include_threads: bool = True
+    """Whether to fetch thread replies for each message."""
+
+    max_age_days: int = 90
+    """Ignore messages older than this many days."""
+
+
+# ---------------------------------------------------------------------------
+# Slack Events API webhook handler
+# ---------------------------------------------------------------------------
+
+
+class SlackWebhookHandler(WebhookHandler):
+    """Handler for Slack Events API push events.
+
+    Slack signs requests with HMAC-SHA256 using a signing secret.
+    The signature is in the ``X-Slack-Signature`` header as ``v0=<hex>``,
+    computed over ``v0:<timestamp>:<raw_body>``.
+    """
+
+    _SIG_HEADER = "x-slack-signature"
+    _TS_HEADER = "x-slack-request-timestamp"
+    # Reject requests older than 5 minutes to prevent replay attacks
+    _MAX_AGE_SECONDS = 300
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        lower = {k.lower(): v for k, v in headers.items()}
+        sig_header = lower.get(self._SIG_HEADER, "")
+        ts_header = lower.get(self._TS_HEADER, "")
+
+        if not sig_header or not ts_header:
+            return False
+
+        try:
+            ts = int(ts_header)
+        except ValueError:
+            return False
+
+        # Reject stale requests
+        if abs(time.time() - ts) > self._MAX_AGE_SECONDS:
+            return False
+
+        base_str = f"v0:{ts}:{payload.decode('utf-8', errors='replace')}".encode()
+        expected = "v0=" + hmac.new(secret.encode(), base_str, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, sig_header)
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+
+        try:
+            data: dict[str, Any] = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Slack webhook: invalid JSON: {exc}") from exc
+
+        # Handle Slack URL verification challenge
+        if data.get("type") == "url_verification":
+            # The framework should return the challenge — we yield no refs.
+            return WebhookPayload(
+                source_name="slack",
+                affected_refs=[],
+                raw_headers=lower_headers,
+            )
+
+        affected: list[DocumentRef] = []
+        event = data.get("event", {})
+        if isinstance(event, dict):
+            event_type = event.get("type", "")
+            if event_type in ("message", "message.channels", "message.groups"):
+                channel = str(event.get("channel", ""))
+                ts = str(event.get("ts", ""))
+                thread_ts = str(event.get("thread_ts", ts))
+                if channel and ts:
+                    # Use thread_ts as the document ID (threads are the unit)
+                    # sha1 used only as a compact fingerprint, not for security
+                    external_id = hashlib.sha1(  # noqa: S324
+                        f"{channel}:{thread_ts}".encode()
+                    ).hexdigest()
+                    affected.append(
+                        DocumentRef(
+                            external_id=external_id,
+                            uri=f"slack://channel/{channel}/thread/{thread_ts}",
+                            metadata={
+                                "channel_id": channel,
+                                "thread_ts": thread_ts,
+                                "event_type": event_type,
+                            },
+                        )
+                    )
+
+        return WebhookPayload(
+            source_name="slack",
+            affected_refs=affected,
+            raw_headers=lower_headers,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+def _ts_to_datetime(ts: str) -> datetime | None:
+    """Convert a Slack timestamp string (e.g. '1609459200.000000') to datetime."""
+    try:
+        return datetime.fromtimestamp(float(ts), tz=UTC)
+    except (ValueError, OSError):
+        return None
+
+
+def _oldest_ts(max_age_days: int) -> str:
+    """Return the Unix timestamp (as string) for max_age_days ago."""
+    cutoff = datetime.now(tz=UTC) - timedelta(days=max_age_days)
+    return str(cutoff.timestamp())
+
+
+class SlackConnector(Connector):
+    """Source connector for Slack workspaces.
+
+    Discovers messages from configured channels and optionally assembles
+    thread replies.  File metadata is included in the document text.
+    Supports the Slack Events API for push-based ingestion.
+    """
+
+    connector_type: ClassVar[str] = "slack"
+    config_schema: ClassVar[type[BaseModel]] = SlackConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify the bot token by calling auth.test."""
+        headers = _auth_headers(secrets)
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
+            resp = await client.post(f"{_SLACK_API_BASE}/auth.test")
+            data = resp.json()
+            if not data.get("ok"):
+                error = data.get("error", "unknown")
+                raise PermissionError(
+                    f"Slack authentication failed ({error}) — check bot_token."
+                )
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield DocumentRefs for Slack thread roots in configured channels."""
+        cfg: SlackConfig = config  # type: ignore[assignment]
+        headers = _auth_headers(secrets)
+        oldest = _oldest_ts(cfg.max_age_days)
+
+        channels = (
+            cfg.channel_ids if cfg.channel_ids else await self._list_channels(headers)
+        )
+
+        for channel_id in channels:
+            async for ref in self._discover_channel(channel_id, oldest, headers):
+                yield ref
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch a Slack thread (root + replies) and return as Markdown."""
+        cfg: SlackConfig = config  # type: ignore[assignment]
+        headers = _auth_headers(secrets)
+
+        channel_id = ref.metadata.get("channel_id", "")
+        thread_ts = ref.metadata.get("thread_ts", "")
+
+        if not channel_id or not thread_ts:
+            raise ValueError(
+                f"DocumentRef missing 'channel_id' or 'thread_ts' in metadata: {ref.uri!r}"
+            )
+
+        # Fetch root message
+        root_messages = await self._history_page(channel_id, thread_ts, thread_ts, headers)
+        root_text = ""
+        if root_messages:
+            root_text = _message_to_markdown(root_messages[0])
+
+        # Fetch replies if configured
+        reply_text = ""
+        if cfg.include_threads:
+            replies = await self._fetch_replies(channel_id, thread_ts, headers)
+            reply_lines = [
+                _message_to_markdown(m) for m in replies if m.get("ts") != thread_ts
+            ]
+            if reply_lines:
+                reply_text = "\n\n".join(reply_lines)
+
+        # Assemble document
+        channel_name = ref.metadata.get("channel_name", channel_id)
+        parts = [f"## #{channel_name} — Thread {thread_ts}"]
+        if root_text:
+            parts.append(root_text)
+        if reply_text:
+            parts.append("### Replies\n\n" + reply_text)
+
+        content = "\n\n".join(parts)
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=content.encode("utf-8"),
+            content_type="text/markdown",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return SlackWebhookHandler()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _list_channels(self, headers: dict[str, str]) -> list[str]:
+        """Return IDs of all public channels the bot has access to."""
+        channel_ids: list[str] = []
+        cursor: str | None = None
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            while True:
+                params: dict[str, Any] = {
+                    "types": "public_channel",
+                    "limit": 200,
+                    "exclude_archived": "true",
+                }
+                if cursor:
+                    params["cursor"] = cursor
+
+                resp = await client.get(
+                    f"{_SLACK_API_BASE}/conversations.list", params=params
+                )
+                data = resp.json()
+                if not data.get("ok"):
+                    logger.warning(
+                        "slack.list_channels.error",
+                        extra={"error": data.get("error", "unknown")},
+                    )
+                    break
+
+                for ch in data.get("channels", []):
+                    ch_id = ch.get("id")
+                    if isinstance(ch_id, str):
+                        channel_ids.append(ch_id)
+
+                cursor = data.get("response_metadata", {}).get("next_cursor", "")
+                if not cursor:
+                    break
+
+        return channel_ids
+
+    async def _discover_channel(
+        self,
+        channel_id: str,
+        oldest: str,
+        headers: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield DocumentRefs for thread roots in one channel."""
+        # Get channel info for name
+        channel_name = await self._channel_name(channel_id, headers)
+
+        cursor: str | None = None
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            while True:
+                params: dict[str, Any] = {
+                    "channel": channel_id,
+                    "oldest": oldest,
+                    "limit": _PAGE_SIZE,
+                }
+                if cursor:
+                    params["cursor"] = cursor
+
+                try:
+                    resp = await client.get(
+                        f"{_SLACK_API_BASE}/conversations.history", params=params
+                    )
+                    data = resp.json()
+                except httpx.HTTPError as exc:
+                    logger.warning(
+                        "slack.discover.http_error",
+                        extra={"channel_id": channel_id, "error": str(exc)},
+                    )
+                    return
+
+                if not data.get("ok"):
+                    logger.warning(
+                        "slack.discover.api_error",
+                        extra={
+                            "channel_id": channel_id,
+                            "error": data.get("error", "unknown"),
+                        },
+                    )
+                    return
+
+                for msg in data.get("messages", []):
+                    # Only yield thread roots (skip bot messages and system subtypes)
+                    if msg.get("subtype"):
+                        continue
+                    ts = str(msg.get("ts", ""))
+                    if not ts:
+                        continue
+
+                    updated_at = _ts_to_datetime(ts)
+                    # sha1 used only as a compact fingerprint, not for security
+                    external_id = hashlib.sha1(  # noqa: S324
+                        f"{channel_id}:{ts}".encode()
+                    ).hexdigest()
+
+                    yield DocumentRef(
+                        external_id=external_id,
+                        uri=f"slack://channel/{channel_id}/thread/{ts}",
+                        updated_at=updated_at,
+                        metadata={
+                            "channel_id": channel_id,
+                            "channel_name": channel_name,
+                            "thread_ts": ts,
+                            "reply_count": msg.get("reply_count", 0),
+                        },
+                    )
+
+                cursor = data.get("response_metadata", {}).get("next_cursor", "")
+                if not cursor or not data.get("has_more"):
+                    break
+
+    async def _history_page(
+        self,
+        channel_id: str,
+        oldest: str,
+        latest: str,
+        headers: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        """Fetch a page of messages from a channel around a timestamp."""
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
+            resp = await client.get(
+                f"{_SLACK_API_BASE}/conversations.history",
+                params={
+                    "channel": channel_id,
+                    "oldest": oldest,
+                    "latest": latest,
+                    "inclusive": "true",
+                    "limit": 1,
+                },
+            )
+            data = resp.json()
+            messages_raw: list[dict[str, Any]] = data.get("messages", [])
+            return messages_raw
+
+    async def _fetch_replies(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        headers: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        """Fetch all replies for a thread."""
+        messages: list[dict[str, Any]] = []
+        cursor: str | None = None
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            while True:
+                params: dict[str, Any] = {
+                    "channel": channel_id,
+                    "ts": thread_ts,
+                    "limit": _PAGE_SIZE,
+                }
+                if cursor:
+                    params["cursor"] = cursor
+
+                resp = await client.get(
+                    f"{_SLACK_API_BASE}/conversations.replies", params=params
+                )
+                data = resp.json()
+                if not data.get("ok"):
+                    break
+
+                messages.extend(data.get("messages", []))
+                cursor = data.get("response_metadata", {}).get("next_cursor", "")
+                if not cursor or not data.get("has_more"):
+                    break
+
+        return messages
+
+    async def _channel_name(self, channel_id: str, headers: dict[str, str]) -> str:
+        """Fetch the human-readable channel name."""
+        async with httpx.AsyncClient(headers=headers, timeout=10.0) as client:
+            resp = await client.get(
+                f"{_SLACK_API_BASE}/conversations.info",
+                params={"channel": channel_id},
+            )
+            data = resp.json()
+            if data.get("ok"):
+                ch = data.get("channel", {})
+                return str(ch.get("name", channel_id))
+        return channel_id
+
+
+def _auth_headers(secrets: dict[str, str]) -> dict[str, str]:
+    token = secrets.get("bot_token", "")
+    if not token:
+        raise ValueError("Slack secrets must contain 'bot_token'.")
+    if not token.startswith("xoxb-"):
+        raise ValueError("Slack 'bot_token' must start with 'xoxb-'.")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _message_to_markdown(msg: dict[str, Any]) -> str:
+    """Convert a Slack message dict to a simple Markdown string."""
+    user = str(msg.get("user", msg.get("username", "unknown")))
+    ts = str(msg.get("ts", ""))
+    text = str(msg.get("text", ""))
+
+    dt_str = ""
+    dt = _ts_to_datetime(ts)
+    if dt:
+        dt_str = dt.strftime("%Y-%m-%d %H:%M UTC")
+
+    header = f"**{user}** ({dt_str})" if dt_str else f"**{user}**"
+    lines = [header, text]
+
+    # Include file metadata
+    files: list[dict[str, Any]] = msg.get("files", [])
+    for f in files:
+        name = f.get("name", "file")
+        mimetype = f.get("mimetype", "")
+        size = f.get("size", 0)
+        lines.append(f"_Attachment: {name} ({mimetype}, {size} bytes)_")
+
+    return "\n".join(line for line in lines if line)

--- a/tests/test_connectors_v2.py
+++ b/tests/test_connectors_v2.py
@@ -255,9 +255,7 @@ class TestConfluenceDiscover:
     @respx.mock
     @pytest.mark.asyncio
     async def test_discover_handles_api_error_gracefully(self) -> None:
-        respx.get(f"{_CONFLUENCE_BASE}/rest/api/content").mock(
-            return_value=httpx.Response(403)
-        )
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/content").mock(return_value=httpx.Response(403))
         connector = ConfluenceConnector()
         config = ConfluenceConfig(base_url=_CONFLUENCE_BASE, space_keys=["DOCS"])
         secrets = {"email": "u@x.com", "api_token": "tok"}
@@ -340,14 +338,16 @@ class TestConfluenceWebhook:
 
     async def test_parse_page_created_event(self) -> None:
         handler = ConfluenceWebhookHandler()
-        payload = json.dumps({
-            "webhookEvent": "page_created",
-            "page": {
-                "id": "789",
-                "title": "New Page",
-                "space": {"key": "TEAM"},
-            },
-        }).encode()
+        payload = json.dumps(
+            {
+                "webhookEvent": "page_created",
+                "page": {
+                    "id": "789",
+                    "title": "New Page",
+                    "space": {"key": "TEAM"},
+                },
+            }
+        ).encode()
         result = await handler.parse_payload(payload, {})
         assert result.source_name == "confluence"
         assert len(result.affected_refs) == 1
@@ -650,9 +650,7 @@ class TestSlackValidate:
     @pytest.mark.asyncio
     async def test_validate_success(self) -> None:
         respx.post("https://slack.com/api/auth.test").mock(
-            return_value=httpx.Response(
-                200, json={"ok": True, "user": "bot", "team": "myteam"}
-            )
+            return_value=httpx.Response(200, json={"ok": True, "user": "bot", "team": "myteam"})
         )
         connector = SlackConnector()
         config = SlackConfig(channel_ids=["C123"])
@@ -701,9 +699,7 @@ class TestSlackDiscover:
             return_value=httpx.Response(200, json=self._history_response())
         )
         respx.get("https://slack.com/api/conversations.info").mock(
-            return_value=httpx.Response(
-                200, json={"ok": True, "channel": {"name": "general"}}
-            )
+            return_value=httpx.Response(200, json={"ok": True, "channel": {"name": "general"}})
         )
 
         connector = SlackConnector()
@@ -769,9 +765,7 @@ class TestSlackFetch:
         thread_ts = "1609459200.000000"
         root_message = {
             "ok": True,
-            "messages": [
-                {"user": "U1", "ts": thread_ts, "text": "Root message"}
-            ],
+            "messages": [{"user": "U1", "ts": thread_ts, "text": "Root message"}],
         }
         replies = {
             "ok": True,
@@ -861,15 +855,17 @@ class TestSlackWebhook:
 
     async def test_parse_message_event(self) -> None:
         handler = SlackWebhookHandler()
-        payload = json.dumps({
-            "type": "event_callback",
-            "event": {
-                "type": "message",
-                "channel": "C123",
-                "ts": "1609459200.000000",
-                "thread_ts": "1609459200.000000",
-            },
-        }).encode()
+        payload = json.dumps(
+            {
+                "type": "event_callback",
+                "event": {
+                    "type": "message",
+                    "channel": "C123",
+                    "ts": "1609459200.000000",
+                    "thread_ts": "1609459200.000000",
+                },
+            }
+        ).encode()
         result = await handler.parse_payload(payload, {})
         assert result.source_name == "slack"
         assert len(result.affected_refs) == 1
@@ -1017,9 +1013,7 @@ class TestJiraValidate:
     @respx.mock
     @pytest.mark.asyncio
     async def test_validate_unauthorized_raises(self) -> None:
-        respx.get(f"{_JIRA_BASE}/rest/api/3/myself").mock(
-            return_value=httpx.Response(401)
-        )
+        respx.get(f"{_JIRA_BASE}/rest/api/3/myself").mock(return_value=httpx.Response(401))
         connector = JiraConnector()
         config = JiraConfig(base_url=_JIRA_BASE)
         with pytest.raises(PermissionError):
@@ -1206,14 +1200,16 @@ class TestJiraWebhook:
 
     async def test_parse_issue_created(self) -> None:
         handler = JiraWebhookHandler()
-        payload = json.dumps({
-            "webhookEvent": "jira:issue_created",
-            "issue": {
-                "id": "10001",
-                "key": "PROJ-1",
-                "fields": {"updated": "2024-01-01T00:00:00.000+0000"},
-            },
-        }).encode()
+        payload = json.dumps(
+            {
+                "webhookEvent": "jira:issue_created",
+                "issue": {
+                    "id": "10001",
+                    "key": "PROJ-1",
+                    "fields": {"updated": "2024-01-01T00:00:00.000+0000"},
+                },
+            }
+        ).encode()
         result = await handler.parse_payload(payload, {})
         assert result.source_name == "jira"
         assert len(result.affected_refs) == 1

--- a/tests/test_connectors_v2.py
+++ b/tests/test_connectors_v2.py
@@ -1,0 +1,1229 @@
+"""Tests for Confluence, Notion, Slack, and Jira connectors (Issues #53-#56).
+
+All HTTP calls are mocked via respx so no network access is required.
+Covers validate, discover, fetch, and webhook handling for each connector,
+plus content conversion helpers.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from omniscience_connectors import (
+    ConfluenceConnector,
+    DocumentRef,
+    FetchedDocument,
+    JiraConnector,
+    NotionConnector,
+    SlackConnector,
+    get_connector,
+)
+from omniscience_connectors.confluence.connector import (
+    ConfluenceConfig,
+    ConfluenceWebhookHandler,
+    storage_to_markdown,
+)
+from omniscience_connectors.jira.connector import (
+    JiraConfig,
+    JiraWebhookHandler,
+    _adf_to_markdown,
+    _build_jql,
+)
+from omniscience_connectors.notion.connector import (
+    NotionConfig,
+    _block_to_markdown,
+    _rich_text_to_str,
+    blocks_to_markdown,
+)
+from omniscience_connectors.slack.connector import (
+    SlackConfig,
+    SlackWebhookHandler,
+    _message_to_markdown,
+    _ts_to_datetime,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CONFLUENCE_BASE = "https://example.atlassian.net/wiki"
+_NOTION_TOKEN = "secret_abc123"
+_SLACK_TOKEN = "xoxb-fake-token"
+_JIRA_BASE = "https://example.atlassian.net"
+
+
+def _b64_creds(email: str, token: str) -> str:
+    return base64.b64encode(f"{email}:{token}".encode()).decode()
+
+
+# ---------------------------------------------------------------------------
+# Registry: all 4 connectors are auto-registered
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_confluence() -> None:
+    c = get_connector("confluence")
+    assert isinstance(c, ConfluenceConnector)
+
+
+def test_registry_has_notion() -> None:
+    c = get_connector("notion")
+    assert isinstance(c, NotionConnector)
+
+
+def test_registry_has_slack() -> None:
+    c = get_connector("slack")
+    assert isinstance(c, SlackConnector)
+
+
+def test_registry_has_jira() -> None:
+    c = get_connector("jira")
+    assert isinstance(c, JiraConnector)
+
+
+# ===========================================================================
+# CONFLUENCE
+# ===========================================================================
+
+
+class TestConfluenceStorageToMarkdown:
+    def test_paragraph(self) -> None:
+        html = "<p>Hello world</p>"
+        md = storage_to_markdown(html)
+        assert "Hello world" in md
+
+    def test_heading(self) -> None:
+        md = storage_to_markdown("<h1>Title</h1>")
+        assert md.startswith("# Title")
+
+    def test_h2(self) -> None:
+        md = storage_to_markdown("<h2>Section</h2>")
+        assert "## Section" in md
+
+    def test_code_block(self) -> None:
+        md = storage_to_markdown("<pre>print('hello')</pre>")
+        assert "```" in md
+        assert "print" in md
+
+    def test_list_items(self) -> None:
+        html = "<ul><li>Item A</li><li>Item B</li></ul>"
+        md = storage_to_markdown(html)
+        assert "- Item A" in md
+        assert "- Item B" in md
+
+    def test_html_entity_amp(self) -> None:
+        md = storage_to_markdown("<p>a &amp; b</p>")
+        assert "a & b" in md
+
+    def test_html_entity_nbsp(self) -> None:
+        md = storage_to_markdown("<p>hello&nbsp;world</p>")
+        assert "hello" in md
+        assert "world" in md
+
+    def test_strips_all_tags(self) -> None:
+        md = storage_to_markdown("<ac:structured-macro>stuff</ac:structured-macro>")
+        assert "<" not in md
+
+    def test_horizontal_rule(self) -> None:
+        md = storage_to_markdown("<hr/>")
+        assert "---" in md
+
+    def test_empty_input(self) -> None:
+        md = storage_to_markdown("")
+        assert md == ""
+
+    def test_numeric_entity(self) -> None:
+        md = storage_to_markdown("&#65;")
+        assert "A" in md
+
+
+class TestConfluenceValidate:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_success(self) -> None:
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/user/current").mock(
+            return_value=httpx.Response(200, json={"accountId": "abc123"})
+        )
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(base_url=_CONFLUENCE_BASE, space_keys=["DOCS"])
+        secrets = {"email": "user@example.com", "api_token": "mytoken"}
+        await connector.validate(config, secrets)  # should not raise
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_unauthorized_raises(self) -> None:
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/user/current").mock(
+            return_value=httpx.Response(401, json={"message": "Unauthorized"})
+        )
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(base_url=_CONFLUENCE_BASE)
+        secrets = {"email": "user@example.com", "api_token": "bad"}
+        with pytest.raises(PermissionError):
+            await connector.validate(config, secrets)
+
+    @pytest.mark.asyncio
+    async def test_validate_missing_secrets_raises(self) -> None:
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(base_url=_CONFLUENCE_BASE)
+        with pytest.raises(ValueError):
+            await connector.validate(config, {})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_with_pat(self) -> None:
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/user/current").mock(
+            return_value=httpx.Response(200, json={"accountId": "abc"})
+        )
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(base_url=_CONFLUENCE_BASE)
+        await connector.validate(config, {"pat": "myPAT"})
+
+
+class TestConfluenceDiscover:
+    def _make_result(
+        self, content_id: str = "123", title: str = "My Page", version: int = 1
+    ) -> dict[str, Any]:
+        return {
+            "id": content_id,
+            "title": title,
+            "type": "page",
+            "version": {"number": version, "when": "2024-01-15T10:00:00.000Z"},
+            "metadata": {"labels": {"results": [{"name": "public"}]}},
+            "space": {"key": "DOCS"},
+        }
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_yields_refs(self) -> None:
+        page_response = {
+            "results": [self._make_result()],
+            "size": 1,
+            "totalSize": 1,
+        }
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/content").mock(
+            return_value=httpx.Response(200, json=page_response)
+        )
+
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(
+            base_url=_CONFLUENCE_BASE, space_keys=["DOCS"], content_types=["page"]
+        )
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, secrets):
+            refs.append(ref)
+
+        assert len(refs) == 1
+        assert refs[0].metadata["content_id"] == "123"
+        assert refs[0].metadata["title"] == "My Page"
+        assert refs[0].metadata["space_key"] == "DOCS"
+        assert refs[0].external_id  # non-empty
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_excludes_labels(self) -> None:
+        result = self._make_result()
+        result["metadata"]["labels"]["results"] = [{"name": "internal"}]
+        page_response = {"results": [result], "size": 1, "totalSize": 1}
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/content").mock(
+            return_value=httpx.Response(200, json=page_response)
+        )
+
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(
+            base_url=_CONFLUENCE_BASE,
+            space_keys=["DOCS"],
+            exclude_labels=["internal"],
+        )
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, secrets):
+            refs.append(ref)
+
+        assert refs == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_handles_api_error_gracefully(self) -> None:
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/content").mock(
+            return_value=httpx.Response(403)
+        )
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(base_url=_CONFLUENCE_BASE, space_keys=["DOCS"])
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, secrets):
+            refs.append(ref)
+
+        assert refs == []  # graceful — no crash
+
+
+class TestConfluenceFetch:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_returns_markdown(self) -> None:
+        content_response = {
+            "id": "456",
+            "title": "Test Page",
+            "body": {
+                "storage": {
+                    "value": "<h1>Hello</h1><p>World content here.</p>",
+                    "representation": "storage",
+                }
+            },
+            "space": {"key": "DOCS"},
+            "version": {"number": 2},
+        }
+        respx.get(f"{_CONFLUENCE_BASE}/rest/api/content/456").mock(
+            return_value=httpx.Response(200, json=content_response)
+        )
+
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(base_url=_CONFLUENCE_BASE)
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+        ref = DocumentRef(
+            external_id="sha1abc",
+            uri=f"{_CONFLUENCE_BASE}/pages/viewpage.action?pageId=456",
+            metadata={"content_id": "456", "title": "Test Page", "space_key": "DOCS"},
+        )
+
+        result = await connector.fetch(config, secrets, ref)
+
+        assert isinstance(result, FetchedDocument)
+        assert result.content_type == "text/markdown"
+        decoded = result.content_bytes.decode()
+        assert "# Test Page" in decoded
+        assert "Hello" in decoded
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_content_id_raises(self) -> None:
+        connector = ConfluenceConnector()
+        config = ConfluenceConfig(base_url=_CONFLUENCE_BASE)
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+        ref = DocumentRef(external_id="x", uri="http://example.com", metadata={})
+
+        with pytest.raises(ValueError, match="content_id"):
+            await connector.fetch(config, secrets, ref)
+
+
+class TestConfluenceWebhook:
+    async def test_verify_signature_valid(self) -> None:
+        handler = ConfluenceWebhookHandler()
+        secret = "mysecret"
+        payload = b'{"webhookEvent": "page_created"}'
+        sig = hmac.new(secret.encode(), payload, "sha256").hexdigest()
+        headers = {"x-hub-signature": f"sha256={sig}"}
+        result = await handler.verify_signature(payload, headers, secret)
+        assert result is True
+
+    async def test_verify_signature_invalid(self) -> None:
+        handler = ConfluenceWebhookHandler()
+        headers = {"x-hub-signature": "sha256=badhash"}
+        result = await handler.verify_signature(b"payload", headers, "secret")
+        assert result is False
+
+    async def test_verify_signature_missing_header(self) -> None:
+        handler = ConfluenceWebhookHandler()
+        result = await handler.verify_signature(b"payload", {}, "secret")
+        assert result is False
+
+    async def test_parse_page_created_event(self) -> None:
+        handler = ConfluenceWebhookHandler()
+        payload = json.dumps({
+            "webhookEvent": "page_created",
+            "page": {
+                "id": "789",
+                "title": "New Page",
+                "space": {"key": "TEAM"},
+            },
+        }).encode()
+        result = await handler.parse_payload(payload, {})
+        assert result.source_name == "confluence"
+        assert len(result.affected_refs) == 1
+        assert result.affected_refs[0].external_id == "789"
+
+    async def test_parse_invalid_json_raises(self) -> None:
+        handler = ConfluenceWebhookHandler()
+        with pytest.raises(ValueError):
+            await handler.parse_payload(b"not json", {})
+
+    def test_connector_returns_handler(self) -> None:
+        connector = ConfluenceConnector()
+        handler = connector.webhook_handler()
+        assert handler is not None
+
+
+# ===========================================================================
+# NOTION
+# ===========================================================================
+
+
+class TestNotionBlocksToMarkdown:
+    def _rt(self, text: str) -> dict[str, Any]:
+        return {"plain_text": text, "annotations": {}, "type": "text"}
+
+    def test_paragraph(self) -> None:
+        block = {
+            "type": "paragraph",
+            "paragraph": {"rich_text": [self._rt("Hello world")]},
+        }
+        md = _block_to_markdown(block)
+        assert "Hello world" in md
+
+    def test_heading_1(self) -> None:
+        block = {
+            "type": "heading_1",
+            "heading_1": {"rich_text": [self._rt("Top Heading")]},
+        }
+        md = _block_to_markdown(block)
+        assert md.startswith("# Top Heading")
+
+    def test_heading_2(self) -> None:
+        block = {
+            "type": "heading_2",
+            "heading_2": {"rich_text": [self._rt("Sub Heading")]},
+        }
+        md = _block_to_markdown(block)
+        assert md.startswith("## Sub Heading")
+
+    def test_bullet_list(self) -> None:
+        block = {
+            "type": "bulleted_list_item",
+            "bulleted_list_item": {"rich_text": [self._rt("List item")]},
+        }
+        md = _block_to_markdown(block)
+        assert md.startswith("- List item")
+
+    def test_numbered_list(self) -> None:
+        block = {
+            "type": "numbered_list_item",
+            "numbered_list_item": {"rich_text": [self._rt("First")]},
+        }
+        md = _block_to_markdown(block)
+        assert md.startswith("1. First")
+
+    def test_code_block(self) -> None:
+        block = {
+            "type": "code",
+            "code": {
+                "rich_text": [self._rt("print('hi')")],
+                "language": "python",
+            },
+        }
+        md = _block_to_markdown(block)
+        assert "```python" in md
+        assert "print('hi')" in md
+
+    def test_divider(self) -> None:
+        block = {"type": "divider", "divider": {}}
+        md = _block_to_markdown(block)
+        assert "---" in md
+
+    def test_to_do_checked(self) -> None:
+        block = {
+            "type": "to_do",
+            "to_do": {"rich_text": [self._rt("Done task")], "checked": True},
+        }
+        md = _block_to_markdown(block)
+        assert "[x]" in md
+        assert "Done task" in md
+
+    def test_to_do_unchecked(self) -> None:
+        block = {
+            "type": "to_do",
+            "to_do": {"rich_text": [self._rt("Pending task")], "checked": False},
+        }
+        md = _block_to_markdown(block)
+        assert "[ ]" in md
+
+    def test_rich_text_concatenation(self) -> None:
+        rich_texts = [{"plain_text": "Hello"}, {"plain_text": " World"}]
+        assert _rich_text_to_str(rich_texts) == "Hello World"
+
+    def test_blocks_to_markdown_multiple_blocks(self) -> None:
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "heading_1",
+                "heading_1": {"rich_text": [self._rt("Title")]},
+            },
+            {
+                "type": "paragraph",
+                "paragraph": {"rich_text": [self._rt("Body text")]},
+            },
+        ]
+        md = blocks_to_markdown(blocks)
+        assert "# Title" in md
+        assert "Body text" in md
+
+
+class TestNotionValidate:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_success(self) -> None:
+        respx.get("https://api.notion.com/v1/users/me").mock(
+            return_value=httpx.Response(200, json={"object": "user", "id": "uid123"})
+        )
+        connector = NotionConnector()
+        config = NotionConfig()
+        await connector.validate(config, {"integration_token": _NOTION_TOKEN})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_unauthorized_raises(self) -> None:
+        respx.get("https://api.notion.com/v1/users/me").mock(
+            return_value=httpx.Response(401, json={"code": "unauthorized"})
+        )
+        connector = NotionConnector()
+        config = NotionConfig()
+        with pytest.raises(PermissionError):
+            await connector.validate(config, {"integration_token": "bad"})
+
+    @pytest.mark.asyncio
+    async def test_validate_missing_token_raises(self) -> None:
+        connector = NotionConnector()
+        config = NotionConfig()
+        with pytest.raises(ValueError, match="integration_token"):
+            await connector.validate(config, {})
+
+
+class TestNotionDiscover:
+    def _make_page(self, page_id: str = "page-1") -> dict[str, Any]:
+        return {
+            "object": "page",
+            "id": page_id,
+            "url": f"https://notion.so/{page_id}",
+            "created_time": "2024-01-01T00:00:00.000Z",
+            "last_edited_time": "2024-06-01T12:00:00.000Z",
+            "properties": {
+                "Name": {
+                    "type": "title",
+                    "title": [{"plain_text": "Test Page"}],
+                }
+            },
+        }
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_from_database(self) -> None:
+        db_id = "db-abc"
+        respx.post(f"https://api.notion.com/v1/databases/{db_id}/query").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": "list", "results": [self._make_page()], "has_more": False},
+            )
+        )
+        connector = NotionConnector()
+        config = NotionConfig(database_ids=[db_id])
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {"integration_token": _NOTION_TOKEN}):
+            refs.append(ref)
+
+        assert len(refs) == 1
+        assert refs[0].metadata["page_id"] == "page-1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_handles_api_error_gracefully(self) -> None:
+        db_id = "db-bad"
+        respx.post(f"https://api.notion.com/v1/databases/{db_id}/query").mock(
+            return_value=httpx.Response(403)
+        )
+        connector = NotionConnector()
+        config = NotionConfig(database_ids=[db_id])
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {"integration_token": _NOTION_TOKEN}):
+            refs.append(ref)
+        assert refs == []
+
+
+class TestNotionFetch:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_returns_markdown(self) -> None:
+        page_id = "page-xyz"
+        page_data = {
+            "id": page_id,
+            "url": f"https://notion.so/{page_id}",
+            "properties": {
+                "Name": {
+                    "type": "title",
+                    "title": [{"plain_text": "My Notion Page"}],
+                }
+            },
+        }
+        blocks_data = {
+            "object": "list",
+            "results": [
+                {
+                    "type": "paragraph",
+                    "paragraph": {"rich_text": [{"plain_text": "Hello from Notion"}]},
+                }
+            ],
+            "has_more": False,
+        }
+
+        respx.get(f"https://api.notion.com/v1/pages/{page_id}").mock(
+            return_value=httpx.Response(200, json=page_data)
+        )
+        respx.get(f"https://api.notion.com/v1/blocks/{page_id}/children").mock(
+            return_value=httpx.Response(200, json=blocks_data)
+        )
+
+        connector = NotionConnector()
+        config = NotionConfig()
+        secrets = {"integration_token": _NOTION_TOKEN}
+        ref = DocumentRef(
+            external_id="sha1abc",
+            uri=f"https://notion.so/{page_id}",
+            metadata={"page_id": page_id},
+        )
+
+        result = await connector.fetch(config, secrets, ref)
+
+        assert result.content_type == "text/markdown"
+        decoded = result.content_bytes.decode()
+        assert "My Notion Page" in decoded
+        assert "Hello from Notion" in decoded
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_page_id_raises(self) -> None:
+        connector = NotionConnector()
+        config = NotionConfig()
+        ref = DocumentRef(external_id="x", uri="https://notion.so/x", metadata={})
+        with pytest.raises(ValueError, match="page_id"):
+            await connector.fetch(config, {"integration_token": _NOTION_TOKEN}, ref)
+
+    def test_no_webhook_handler(self) -> None:
+        connector = NotionConnector()
+        assert connector.webhook_handler() is None
+
+
+# ===========================================================================
+# SLACK
+# ===========================================================================
+
+
+class TestSlackHelpers:
+    def test_ts_to_datetime(self) -> None:
+        dt = _ts_to_datetime("1609459200.000000")
+        assert dt is not None
+        assert dt.year == 2021
+
+    def test_ts_to_datetime_invalid(self) -> None:
+        assert _ts_to_datetime("not-a-ts") is None
+
+    def test_message_to_markdown_basic(self) -> None:
+        msg: dict[str, Any] = {
+            "user": "U12345",
+            "ts": "1609459200.000000",
+            "text": "Hello team!",
+        }
+        md = _message_to_markdown(msg)
+        assert "U12345" in md
+        assert "Hello team!" in md
+
+    def test_message_to_markdown_with_files(self) -> None:
+        msg: dict[str, Any] = {
+            "user": "U99",
+            "ts": "1609459200.000000",
+            "text": "See attached",
+            "files": [{"name": "report.pdf", "mimetype": "application/pdf", "size": 1024}],
+        }
+        md = _message_to_markdown(msg)
+        assert "report.pdf" in md
+        assert "application/pdf" in md
+
+
+class TestSlackValidate:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_success(self) -> None:
+        respx.post("https://slack.com/api/auth.test").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "user": "bot", "team": "myteam"}
+            )
+        )
+        connector = SlackConnector()
+        config = SlackConfig(channel_ids=["C123"])
+        await connector.validate(config, {"bot_token": _SLACK_TOKEN})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_bad_token_raises(self) -> None:
+        respx.post("https://slack.com/api/auth.test").mock(
+            return_value=httpx.Response(200, json={"ok": False, "error": "invalid_auth"})
+        )
+        connector = SlackConnector()
+        config = SlackConfig()
+        with pytest.raises(PermissionError):
+            await connector.validate(config, {"bot_token": _SLACK_TOKEN})
+
+    @pytest.mark.asyncio
+    async def test_validate_missing_token_raises(self) -> None:
+        connector = SlackConnector()
+        config = SlackConfig()
+        with pytest.raises(ValueError, match="bot_token"):
+            await connector.validate(config, {})
+
+    @pytest.mark.asyncio
+    async def test_validate_wrong_token_prefix_raises(self) -> None:
+        connector = SlackConnector()
+        config = SlackConfig()
+        with pytest.raises(ValueError, match="xoxb-"):
+            await connector.validate(config, {"bot_token": "xoxa-bad-token"})
+
+
+class TestSlackDiscover:
+    def _history_response(self, ts: str = "1609459200.000000") -> dict[str, Any]:
+        return {
+            "ok": True,
+            "messages": [{"type": "message", "ts": ts, "text": "hi"}],
+            "has_more": False,
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_yields_refs_for_channel(self) -> None:
+        channel_id = "C123"
+        respx.get("https://slack.com/api/conversations.history").mock(
+            return_value=httpx.Response(200, json=self._history_response())
+        )
+        respx.get("https://slack.com/api/conversations.info").mock(
+            return_value=httpx.Response(
+                200, json={"ok": True, "channel": {"name": "general"}}
+            )
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(channel_ids=[channel_id], max_age_days=365)
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {"bot_token": _SLACK_TOKEN}):
+            refs.append(ref)
+
+        assert len(refs) == 1
+        assert refs[0].metadata["channel_id"] == channel_id
+        assert refs[0].metadata["thread_ts"] == "1609459200.000000"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_skips_subtypes(self) -> None:
+        channel_id = "C456"
+        history = {
+            "ok": True,
+            "messages": [
+                {"type": "message", "subtype": "bot_message", "ts": "1609459200.000000"},
+            ],
+            "has_more": False,
+            "response_metadata": {"next_cursor": ""},
+        }
+        respx.get("https://slack.com/api/conversations.history").mock(
+            return_value=httpx.Response(200, json=history)
+        )
+        respx.get("https://slack.com/api/conversations.info").mock(
+            return_value=httpx.Response(200, json={"ok": True, "channel": {"name": "dev"}})
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(channel_ids=[channel_id], max_age_days=365)
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {"bot_token": _SLACK_TOKEN}):
+            refs.append(ref)
+
+        assert refs == []
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_handles_api_error_gracefully(self) -> None:
+        respx.get("https://slack.com/api/conversations.history").mock(
+            return_value=httpx.Response(200, json={"ok": False, "error": "channel_not_found"})
+        )
+        respx.get("https://slack.com/api/conversations.info").mock(
+            return_value=httpx.Response(200, json={"ok": True, "channel": {"name": "gone"}})
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(channel_ids=["C_GONE"], max_age_days=365)
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, {"bot_token": _SLACK_TOKEN}):
+            refs.append(ref)
+        assert refs == []
+
+
+class TestSlackFetch:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_thread_with_replies(self) -> None:
+        channel_id = "C789"
+        thread_ts = "1609459200.000000"
+        root_message = {
+            "ok": True,
+            "messages": [
+                {"user": "U1", "ts": thread_ts, "text": "Root message"}
+            ],
+        }
+        replies = {
+            "ok": True,
+            "messages": [
+                {"user": "U1", "ts": thread_ts, "text": "Root message"},
+                {"user": "U2", "ts": "1609459260.000000", "text": "Reply here"},
+            ],
+            "has_more": False,
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        respx.get("https://slack.com/api/conversations.history").mock(
+            return_value=httpx.Response(200, json=root_message)
+        )
+        respx.get("https://slack.com/api/conversations.replies").mock(
+            return_value=httpx.Response(200, json=replies)
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(include_threads=True)
+        secrets = {"bot_token": _SLACK_TOKEN}
+        ref = DocumentRef(
+            external_id="sha1xyz",
+            uri=f"slack://channel/{channel_id}/thread/{thread_ts}",
+            metadata={
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "channel_name": "general",
+            },
+        )
+
+        result = await connector.fetch(config, secrets, ref)
+
+        assert result.content_type == "text/markdown"
+        decoded = result.content_bytes.decode()
+        assert "Root message" in decoded
+        assert "Reply here" in decoded
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_channel_raises(self) -> None:
+        connector = SlackConnector()
+        config = SlackConfig()
+        ref = DocumentRef(external_id="x", uri="slack://x", metadata={})
+        with pytest.raises(ValueError, match="channel_id"):
+            await connector.fetch(config, {"bot_token": _SLACK_TOKEN}, ref)
+
+
+class TestSlackWebhook:
+    def _make_sig(self, secret: str, ts: int, body: bytes) -> str:
+        base = f"v0:{ts}:{body.decode()}".encode()
+        return "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+
+    async def test_verify_signature_valid(self) -> None:
+        handler = SlackWebhookHandler()
+        secret = "slack-secret"
+        ts = int(time.time())
+        payload = b'{"type": "event_callback"}'
+        sig = self._make_sig(secret, ts, payload)
+        headers = {
+            "x-slack-signature": sig,
+            "x-slack-request-timestamp": str(ts),
+        }
+        result = await handler.verify_signature(payload, headers, secret)
+        assert result is True
+
+    async def test_verify_signature_stale_timestamp(self) -> None:
+        handler = SlackWebhookHandler()
+        secret = "slack-secret"
+        ts = int(time.time()) - 600  # 10 minutes ago
+        payload = b'{"type": "event_callback"}'
+        sig = self._make_sig(secret, ts, payload)
+        headers = {
+            "x-slack-signature": sig,
+            "x-slack-request-timestamp": str(ts),
+        }
+        result = await handler.verify_signature(payload, headers, secret)
+        assert result is False
+
+    async def test_verify_signature_bad_hash(self) -> None:
+        handler = SlackWebhookHandler()
+        headers = {
+            "x-slack-signature": "v0=badhash",
+            "x-slack-request-timestamp": str(int(time.time())),
+        }
+        result = await handler.verify_signature(b"payload", headers, "secret")
+        assert result is False
+
+    async def test_parse_message_event(self) -> None:
+        handler = SlackWebhookHandler()
+        payload = json.dumps({
+            "type": "event_callback",
+            "event": {
+                "type": "message",
+                "channel": "C123",
+                "ts": "1609459200.000000",
+                "thread_ts": "1609459200.000000",
+            },
+        }).encode()
+        result = await handler.parse_payload(payload, {})
+        assert result.source_name == "slack"
+        assert len(result.affected_refs) == 1
+        assert "C123" in result.affected_refs[0].uri
+
+    async def test_parse_url_verification(self) -> None:
+        handler = SlackWebhookHandler()
+        payload = json.dumps({"type": "url_verification", "challenge": "abc123"}).encode()
+        result = await handler.parse_payload(payload, {})
+        assert result.affected_refs == []
+
+    async def test_parse_invalid_json_raises(self) -> None:
+        handler = SlackWebhookHandler()
+        with pytest.raises(ValueError):
+            await handler.parse_payload(b"bad json", {})
+
+    def test_connector_returns_handler(self) -> None:
+        connector = SlackConnector()
+        assert connector.webhook_handler() is not None
+
+
+# ===========================================================================
+# JIRA
+# ===========================================================================
+
+
+class TestJiraJQL:
+    def test_jql_with_projects(self) -> None:
+        cfg = JiraConfig(base_url=_JIRA_BASE, project_keys=["PROJ", "API"])
+        jql = _build_jql(cfg)
+        assert 'project in ("PROJ", "API")' in jql
+
+    def test_jql_with_issue_types(self) -> None:
+        cfg = JiraConfig(base_url=_JIRA_BASE, issue_types=["Bug", "Story"])
+        jql = _build_jql(cfg)
+        assert 'issuetype in ("Bug", "Story")' in jql
+
+    def test_jql_with_custom_filter(self) -> None:
+        cfg = JiraConfig(base_url=_JIRA_BASE, jql_filter="priority = High")
+        jql = _build_jql(cfg)
+        assert "(priority = High)" in jql
+
+    def test_jql_empty_config(self) -> None:
+        cfg = JiraConfig(base_url=_JIRA_BASE)
+        jql = _build_jql(cfg)
+        assert "ORDER BY" in jql
+
+    def test_jql_combined(self) -> None:
+        cfg = JiraConfig(
+            base_url=_JIRA_BASE,
+            project_keys=["PROJ"],
+            issue_types=["Bug"],
+            jql_filter="status != Done",
+        )
+        jql = _build_jql(cfg)
+        assert "project" in jql
+        assert "issuetype" in jql
+        assert "status != Done" in jql
+
+
+class TestJiraAdfToMarkdown:
+    def test_plain_text(self) -> None:
+        node = {"type": "text", "text": "hello"}
+        assert _adf_to_markdown(node) == "hello"
+
+    def test_bold_text(self) -> None:
+        node = {
+            "type": "text",
+            "text": "bold",
+            "marks": [{"type": "strong"}],
+        }
+        result = _adf_to_markdown(node)
+        assert "**bold**" in result
+
+    def test_em_text(self) -> None:
+        node = {
+            "type": "text",
+            "text": "italic",
+            "marks": [{"type": "em"}],
+        }
+        result = _adf_to_markdown(node)
+        assert "_italic_" in result
+
+    def test_code_mark(self) -> None:
+        node = {
+            "type": "text",
+            "text": "fn()",
+            "marks": [{"type": "code"}],
+        }
+        result = _adf_to_markdown(node)
+        assert "`fn()`" in result
+
+    def test_link_mark(self) -> None:
+        node = {
+            "type": "text",
+            "text": "Click",
+            "marks": [{"type": "link", "attrs": {"href": "https://example.com"}}],
+        }
+        result = _adf_to_markdown(node)
+        assert "[Click](https://example.com)" in result
+
+    def test_paragraph(self) -> None:
+        node = {
+            "type": "paragraph",
+            "content": [{"type": "text", "text": "Paragraph text"}],
+        }
+        result = _adf_to_markdown(node)
+        assert "Paragraph text" in result
+
+    def test_heading(self) -> None:
+        node = {
+            "type": "heading",
+            "attrs": {"level": 2},
+            "content": [{"type": "text", "text": "Heading 2"}],
+        }
+        result = _adf_to_markdown(node)
+        assert "## Heading 2" in result
+
+    def test_code_block(self) -> None:
+        node = {
+            "type": "codeBlock",
+            "attrs": {"language": "python"},
+            "content": [{"type": "text", "text": "x = 1"}],
+        }
+        result = _adf_to_markdown(node)
+        assert "```python" in result
+        assert "x = 1" in result
+
+    def test_rule(self) -> None:
+        node = {"type": "rule"}
+        assert "---" in _adf_to_markdown(node)
+
+
+class TestJiraValidate:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_success(self) -> None:
+        respx.get(f"{_JIRA_BASE}/rest/api/3/myself").mock(
+            return_value=httpx.Response(200, json={"accountId": "uid"})
+        )
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE)
+        await connector.validate(config, {"email": "u@x.com", "api_token": "tok"})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_unauthorized_raises(self) -> None:
+        respx.get(f"{_JIRA_BASE}/rest/api/3/myself").mock(
+            return_value=httpx.Response(401)
+        )
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE)
+        with pytest.raises(PermissionError):
+            await connector.validate(config, {"email": "u@x.com", "api_token": "bad"})
+
+    @pytest.mark.asyncio
+    async def test_validate_missing_secrets_raises(self) -> None:
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE)
+        with pytest.raises(ValueError):
+            await connector.validate(config, {})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_validate_with_pat(self) -> None:
+        respx.get(f"{_JIRA_BASE}/rest/api/3/myself").mock(
+            return_value=httpx.Response(200, json={"accountId": "uid"})
+        )
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE)
+        await connector.validate(config, {"pat": "myPAT"})
+
+
+class TestJiraDiscover:
+    def _make_issue(self, issue_id: str = "10001", key: str = "PROJ-1") -> dict[str, Any]:
+        return {
+            "id": issue_id,
+            "key": key,
+            "fields": {
+                "summary": "Fix the bug",
+                "status": {"name": "Open"},
+                "priority": {"name": "High"},
+                "issuetype": {"name": "Bug"},
+                "assignee": {"displayName": "Alice"},
+                "reporter": {"displayName": "Bob"},
+                "labels": ["backend"],
+                "created": "2024-01-01T00:00:00.000+0000",
+                "updated": "2024-06-01T12:00:00.000+0000",
+            },
+        }
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_yields_issue_refs(self) -> None:
+        respx.get(f"{_JIRA_BASE}/rest/api/3/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={"issues": [self._make_issue()], "total": 1, "startAt": 0},
+            )
+        )
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE, project_keys=["PROJ"])
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, secrets):
+            refs.append(ref)
+
+        assert len(refs) == 1
+        assert refs[0].metadata["issue_key"] == "PROJ-1"
+        assert refs[0].metadata["summary"] == "Fix the bug"
+        assert refs[0].metadata["status"] == "Open"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discover_handles_api_error_gracefully(self) -> None:
+        respx.get(f"{_JIRA_BASE}/rest/api/3/search").mock(
+            return_value=httpx.Response(400, json={"errorMessages": ["bad jql"]})
+        )
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE)
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+
+        refs: list[DocumentRef] = []
+        async for ref in connector.discover(config, secrets):
+            refs.append(ref)
+        assert refs == []
+
+
+class TestJiraFetch:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_returns_markdown_with_comments(self) -> None:
+        issue_key = "PROJ-42"
+        issue_data = {
+            "id": "10042",
+            "key": issue_key,
+            "fields": {
+                "summary": "Critical bug in payment",
+                "status": {"name": "In Progress"},
+                "priority": {"name": "Critical"},
+                "issuetype": {"name": "Bug"},
+                "assignee": {"displayName": "Dev"},
+                "reporter": {"displayName": "PM"},
+                "labels": [],
+                "created": "2024-02-01T09:00:00.000+0000",
+                "updated": "2024-02-05T15:00:00.000+0000",
+                "description": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "Payment fails on checkout."}],
+                        }
+                    ],
+                },
+            },
+        }
+        comments_data = {
+            "comments": [
+                {
+                    "author": {"displayName": "Alice"},
+                    "created": "2024-02-02T10:00:00.000+0000",
+                    "body": {
+                        "type": "doc",
+                        "version": 1,
+                        "content": [
+                            {
+                                "type": "paragraph",
+                                "content": [{"type": "text", "text": "Can reproduce."}],
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+
+        respx.get(f"{_JIRA_BASE}/rest/api/3/issue/{issue_key}").mock(
+            return_value=httpx.Response(200, json=issue_data)
+        )
+        respx.get(f"{_JIRA_BASE}/rest/api/3/issue/{issue_key}/comment").mock(
+            return_value=httpx.Response(200, json=comments_data)
+        )
+
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE)
+        secrets = {"email": "u@x.com", "api_token": "tok"}
+        ref = DocumentRef(
+            external_id="sha1abc",
+            uri=f"{_JIRA_BASE}/browse/{issue_key}",
+            metadata={"issue_key": issue_key},
+        )
+
+        result = await connector.fetch(config, secrets, ref)
+
+        assert result.content_type == "text/markdown"
+        decoded = result.content_bytes.decode()
+        assert "PROJ-42" in decoded
+        assert "Critical bug in payment" in decoded
+        assert "Payment fails on checkout." in decoded
+        assert "Can reproduce." in decoded
+
+    @pytest.mark.asyncio
+    async def test_fetch_missing_issue_key_raises(self) -> None:
+        connector = JiraConnector()
+        config = JiraConfig(base_url=_JIRA_BASE)
+        ref = DocumentRef(external_id="x", uri="https://jira.example.com/browse/X", metadata={})
+        with pytest.raises(ValueError, match="issue_key"):
+            await connector.fetch(config, {"email": "u@x.com", "api_token": "tok"}, ref)
+
+
+class TestJiraWebhook:
+    async def test_verify_signature_valid(self) -> None:
+        handler = JiraWebhookHandler()
+        secret = "jira-secret"
+        payload = b'{"webhookEvent": "jira:issue_created"}'
+        sig = hmac.new(secret.encode(), payload, "sha256").hexdigest()
+        headers = {"x-hub-signature": f"sha256={sig}"}
+        result = await handler.verify_signature(payload, headers, secret)
+        assert result is True
+
+    async def test_verify_signature_no_header_no_secret(self) -> None:
+        handler = JiraWebhookHandler()
+        # No signature header and no configured secret = accept
+        result = await handler.verify_signature(b"payload", {}, "")
+        assert result is True
+
+    async def test_verify_signature_bad_hash(self) -> None:
+        handler = JiraWebhookHandler()
+        headers = {"x-hub-signature": "sha256=badhash"}
+        result = await handler.verify_signature(b"payload", headers, "secret")
+        assert result is False
+
+    async def test_parse_issue_created(self) -> None:
+        handler = JiraWebhookHandler()
+        payload = json.dumps({
+            "webhookEvent": "jira:issue_created",
+            "issue": {
+                "id": "10001",
+                "key": "PROJ-1",
+                "fields": {"updated": "2024-01-01T00:00:00.000+0000"},
+            },
+        }).encode()
+        result = await handler.parse_payload(payload, {})
+        assert result.source_name == "jira"
+        assert len(result.affected_refs) == 1
+        assert result.affected_refs[0].metadata["issue_key"] == "PROJ-1"
+
+    async def test_parse_invalid_json_raises(self) -> None:
+        handler = JiraWebhookHandler()
+        with pytest.raises(ValueError):
+            await handler.parse_payload(b"not json", {})
+
+    def test_connector_returns_handler(self) -> None:
+        connector = JiraConnector()
+        assert connector.webhook_handler() is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1144,6 +1144,7 @@ name = "omniscience-connectors"
 version = "0.1.0"
 source = { editable = "packages/connectors" }
 dependencies = [
+    { name = "httpx" },
     { name = "omniscience-core" },
     { name = "pydantic" },
     { name = "watchfiles" },
@@ -1151,6 +1152,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "omniscience-core", editable = "packages/core" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "watchfiles", specifier = ">=0.21.0" },


### PR DESCRIPTION
4 new connectors implementing the Connector protocol. Confluence (XHTML→markdown), Notion (blocks→markdown), Slack (threads+signing), Jira (ADF→markdown). All registered in default registry. 97 new tests. Closes #53, closes #54, closes #55, closes #56