### PR TITLE
feat: cross-encoder re-ranker for retrieval precision

### DIFF
--- a/packages/core/src/omniscience_core/config.py
+++ b/packages/core/src/omniscience_core/config.py
@@ -42,6 +42,19 @@ class Settings(BaseSettings):
         description="Base URL for the Ollama API (used when embedding_provider='ollama').",
     )
 
+    # --- Re-ranker ---
+    reranker_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True, a cross-encoder re-ranker scores candidate chunks after "
+            "initial retrieval and re-orders them before the final top-k slice."
+        ),
+    )
+    reranker_model: str = Field(
+        default="nomic-embed-text",
+        description="Ollama model used by OllamaReranker for embedding-based scoring.",
+    )
+
     # --- Observability ---
     log_level: str = Field(
         default="INFO",

--- a/packages/retrieval/pyproject.toml
+++ b/packages/retrieval/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.30",
     "asyncpg>=0.29.0",
     "pgvector>=0.3.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.uv.sources]

--- a/packages/retrieval/src/omniscience_retrieval/__init__.py
+++ b/packages/retrieval/src/omniscience_retrieval/__init__.py
@@ -14,12 +14,16 @@ from .models import (
     SearchResult,
     SourceInfo,
 )
+from .reranker import NoopReranker, OllamaReranker, Reranker
 from .search import RetrievalService
 
 __all__ = [
     "ChunkLineage",
     "Citation",
+    "NoopReranker",
+    "OllamaReranker",
     "QueryStats",
+    "Reranker",
     "RetrievalService",
     "SearchHit",
     "SearchRequest",

--- a/packages/retrieval/src/omniscience_retrieval/reranker.py
+++ b/packages/retrieval/src/omniscience_retrieval/reranker.py
@@ -1,0 +1,214 @@
+"""Cross-encoder re-ranker implementations for retrieval precision.
+
+The re-ranker is an optional post-processing step that runs after the primary
+retrieval strategy produces a candidate set.  It scores each candidate against
+the query and re-orders the results before the final top-k slice is returned.
+
+Architecture:
+    - ``Reranker``       — structural Protocol; any conforming class can be used.
+    - ``OllamaReranker`` — uses Ollama's embedding API as a proxy for cross-encoder
+                           relevance: embeds the query and each candidate text,
+                           then returns cosine similarity scores.
+    - ``NoopReranker``   — pass-through; returns the original RRF scores unchanged.
+                           Used when re-ranking is disabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Reranker(Protocol):
+    """Structural protocol for all re-ranker backends.
+
+    A re-ranker receives a query string and the *text content* of candidate
+    chunks.  It returns a relevance score for each text, in the same order as
+    the input list.  Higher scores indicate higher relevance.
+
+    Implementations are responsible for closing any underlying network
+    resources via :meth:`close`.
+    """
+
+    async def rerank(self, query: str, texts: list[str]) -> list[float]:
+        """Score *texts* against *query*.
+
+        Args:
+            query: The user's search query.
+            texts: Candidate chunk texts to score, in retrieval order.
+
+        Returns:
+            A list of relevance scores (floats), one per input text, in the
+            same order as *texts*.  Scores need not be normalised to [0, 1].
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release underlying resources (HTTP client, connection pool, etc.)."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Ollama cross-encoder re-ranker (embedding-based cosine similarity)
+# ---------------------------------------------------------------------------
+
+
+class OllamaReranker:
+    """Cross-encoder scoring via Ollama embedding similarity.
+
+    Uses the Ollama ``/api/embed`` endpoint to produce dense vectors for both
+    the query and each candidate text, then returns the cosine similarity
+    between the query vector and each candidate vector.
+
+    This is a lightweight proxy for a true cross-encoder: it uses
+    bi-encoder embeddings but scores each candidate independently, giving a
+    reasonable precision lift over pure BM25/RRF scores at low latency.
+
+    Args:
+        base_url: Root URL of the Ollama server (default: http://localhost:11434).
+        model:    Embedding model to use (default: ``nomic-embed-text``).
+        timeout:  HTTP request timeout in seconds (default: 30.0).
+        batch_size: Number of texts per embedding request (default: 32).
+    """
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        model: str = "nomic-embed-text",
+        timeout: float = 30.0,
+        batch_size: int = 32,
+    ) -> None:
+        self._model = model
+        self._batch_size = batch_size
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            timeout=httpx.Timeout(timeout),
+        )
+
+    async def rerank(self, query: str, texts: list[str]) -> list[float]:
+        """Return cosine similarity scores between *query* and each text.
+
+        Args:
+            query: The user's search query.
+            texts: Candidate texts to score.
+
+        Returns:
+            A list of cosine similarity scores in ``[-1, 1]``, one per input
+            text.  Empty list when *texts* is empty.
+        """
+        if not texts:
+            return []
+
+        # Embed query and all candidate texts in one pass (query first).
+        all_inputs = [query, *texts]
+        all_vectors = await self._embed_all(all_inputs)
+
+        query_vec = all_vectors[0]
+        candidate_vecs = all_vectors[1:]
+
+        scores = [_cosine_similarity(query_vec, cv) for cv in candidate_vecs]
+        logger.debug(
+            "reranker scored %d candidates for query %r (model=%s)",
+            len(texts),
+            query[:60],
+            self._model,
+        )
+        return scores
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+        logger.debug("ollama_reranker_closed model=%s", self._model)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _embed_all(self, texts: list[str]) -> list[list[float]]:
+        """Embed *texts* in batches, concatenating results in order."""
+        all_vecs: list[list[float]] = []
+        for batch in _chunk(texts, self._batch_size):
+            vecs = await self._post_embed(batch)
+            all_vecs.extend(vecs)
+        return all_vecs
+
+    async def _post_embed(self, batch: list[str]) -> list[list[float]]:
+        """POST one batch to the Ollama /api/embed endpoint."""
+        payload = {"model": self._model, "input": batch}
+        response = await self._client.post("/api/embed", json=payload)
+        response.raise_for_status()
+        data: dict[str, list[list[float]]] = response.json()
+        return data["embeddings"]
+
+
+# ---------------------------------------------------------------------------
+# Noop re-ranker (pass-through)
+# ---------------------------------------------------------------------------
+
+
+class NoopReranker:
+    """Pass-through re-ranker that returns the original scores unchanged.
+
+    Used when re-ranking is disabled (``reranker_enabled=False`` in Settings)
+    so that callers do not need to branch on ``None``.  The scores returned are
+    sequential rank placeholders (``1.0 / (rank + 1)``), reflecting the
+    original retrieval order.
+    """
+
+    async def rerank(self, query: str, texts: list[str]) -> list[float]:
+        """Return placeholder scores that preserve the original order.
+
+        Args:
+            query: Ignored.
+            texts: Candidate texts (only the count matters).
+
+        Returns:
+            Decreasing scores ``[1.0, 0.5, 0.333, ...]``.
+        """
+        return [1.0 / (i + 1) for i in range(len(texts))]
+
+    async def close(self) -> None:
+        """No-op; nothing to release."""
+        return
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Return the cosine similarity between vectors *a* and *b*.
+
+    Returns 0.0 when either vector is zero-magnitude to avoid division by
+    zero.
+    """
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    mag_a = math.sqrt(sum(x * x for x in a))
+    mag_b = math.sqrt(sum(x * x for x in b))
+    if mag_a == 0.0 or mag_b == 0.0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def _chunk(items: list[str], size: int) -> list[list[str]]:
+    """Split *items* into consecutive sub-lists of at most *size* elements."""
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+__all__ = [
+    "NoopReranker",
+    "OllamaReranker",
+    "Reranker",
+]

--- a/packages/retrieval/src/omniscience_retrieval/search.py
+++ b/packages/retrieval/src/omniscience_retrieval/search.py
@@ -23,6 +23,7 @@ from .models import (
     SourceInfo,
 )
 from .ranking import reciprocal_rank_fusion
+from .reranker import NoopReranker, Reranker
 from .strategies.router import StrategyRouter
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,9 @@ logger = logging.getLogger(__name__)
 # A WARNING is still emitted during the transition period so existing callers
 # can update their log-monitoring expectations.
 _NON_HYBRID_STRATEGIES = frozenset({"keyword", "structural", "auto"})
+
+# Number of candidates forwarded to the re-ranker before slicing to top-k.
+_RERANK_CANDIDATE_LIMIT = 50
 
 
 class RetrievalService:
@@ -46,20 +50,34 @@ class RetrievalService:
 
     The hybrid path is implemented directly on this class and passed as a
     callable to ``StrategyRouter`` to avoid circular imports.
+
+    Optional re-ranking:
+        When *reranker* is supplied (and is not a :class:`~.reranker.NoopReranker`),
+        the service widens the initial candidate set to
+        ``_RERANK_CANDIDATE_LIMIT`` results, scores each candidate against the
+        query, and then returns the top-k by re-ranked score.  This improves
+        precision at the cost of one extra embedding round-trip.
     """
 
     def __init__(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         embedding_provider: EmbeddingProvider,
+        reranker: Reranker | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._embedding_provider = embedding_provider
+        self._reranker: Reranker = reranker if reranker is not None else NoopReranker()
         self._router = StrategyRouter(
             session_factory=session_factory,
             embedding_provider=embedding_provider,
             hybrid_fn=self._hybrid_search,
         )
+
+    @property
+    def _reranking_active(self) -> bool:
+        """True when an active (non-noop) reranker is configured."""
+        return not isinstance(self._reranker, NoopReranker)
 
     async def search(self, request: SearchRequest) -> SearchResult:
         """Execute the appropriate retrieval strategy and return top-k results."""
@@ -68,19 +86,66 @@ class RetrievalService:
                 "retrieval_strategy=%r dispatching to dedicated implementation",
                 request.retrieval_strategy,
             )
-        return await self._router.execute(request)
+
+        result = await self._router.execute(request)
+
+        # Re-rank if a non-noop reranker is configured.
+        if self._reranking_active:
+            result = await self._apply_reranker(request, result)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Re-ranking
+    # ------------------------------------------------------------------
+
+    async def _apply_reranker(self, request: SearchRequest, result: SearchResult) -> SearchResult:
+        """Re-score *result.hits* against *request.query* and return top-k."""
+        candidates = result.hits[:_RERANK_CANDIDATE_LIMIT]
+        if not candidates:
+            return result
+
+        texts = [hit.text for hit in candidates]
+        scores = await self._reranker.rerank(request.query, texts)
+
+        # Pair each hit with its new score and sort descending.
+        rescored = sorted(
+            zip(scores, candidates, strict=True),
+            key=lambda pair: pair[0],
+            reverse=True,
+        )
+
+        top_k_hits = [
+            hit.model_copy(update={"score": score}) for score, hit in rescored[: request.top_k]
+        ]
+
+        logger.debug(
+            "reranker applied: candidates=%d top_k=%d",
+            len(candidates),
+            len(top_k_hits),
+        )
+        return SearchResult(hits=top_k_hits, query_stats=result.query_stats)
 
     # ------------------------------------------------------------------
     # Hybrid search (vector + BM25 + RRF)
     # ------------------------------------------------------------------
 
     async def _hybrid_search(self, request: SearchRequest) -> SearchResult:
-        """Run hybrid retrieval: pgvector HNSW + tsvector BM25, merged via RRF."""
+        """Run hybrid retrieval: pgvector HNSW + tsvector BM25, merged via RRF.
+
+        When a reranker is active, the initial hit set is widened to
+        ``_RERANK_CANDIDATE_LIMIT`` so the reranker has enough candidates to
+        work with before the final top-k slice.
+        """
         start = time.monotonic()
         query_vector = await self._embed_query(request.query)
 
+        # When reranking is active, widen the candidate pool so the reranker
+        # has enough hits to re-order meaningfully before the top-k slice.
+        hit_limit = _RERANK_CANDIDATE_LIMIT if self._reranking_active else request.top_k
+
         async with self._session_factory() as session:
-            oversample = request.top_k * 2
+            oversample = hit_limit * 2
 
             vector_rows = await self._vector_search(session, query_vector, oversample)
             text_rows = await self._text_search(session, request.query, oversample)
@@ -96,7 +161,7 @@ class RetrievalService:
 
             rows = await self._fetch_enriched(session, request, chunk_ids)
 
-        hits = self._build_hits(rows, scores, request.top_k)
+        hits = self._build_hits(rows, scores, hit_limit)
         duration_ms = (time.monotonic() - start) * 1000.0
 
         return SearchResult(

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,596 @@
+"""Tests for Issue #59 — Cross-encoder re-ranker.
+
+Coverage:
+- Reranker Protocol: OllamaReranker and NoopReranker are runtime-checkable
+- OllamaReranker.rerank: returns one score per text
+- OllamaReranker.rerank: empty texts returns empty list
+- OllamaReranker.rerank: scores are floats in [-1, 1]
+- OllamaReranker.rerank: identical query and text yields high similarity
+- OllamaReranker.rerank: orthogonal vectors yield zero similarity
+- OllamaReranker.rerank: batching splits large input across multiple requests
+- OllamaReranker.rerank: HTTP error propagates as httpx.HTTPStatusError
+- OllamaReranker.close: calls aclose on the underlying client
+- OllamaReranker: custom model is sent in POST payload
+- OllamaReranker: default model is nomic-embed-text
+- NoopReranker.rerank: returns decreasing placeholder scores
+- NoopReranker.rerank: length matches input texts
+- NoopReranker.rerank: empty texts returns empty list
+- NoopReranker.rerank: first score is always 1.0
+- NoopReranker.close: completes without error
+- _cosine_similarity: zero vector returns 0.0
+- _cosine_similarity: unit vectors return correct value
+- RetrievalService: no reranker -> NoopReranker assigned internally
+- RetrievalService: OllamaReranker wired -> re-scores hits after retrieval
+- RetrievalService: re-ranking re-orders hits by new scores
+- RetrievalService: re-ranking respects top_k slice
+- RetrievalService: NoopReranker does not trigger _apply_reranker
+- RetrievalService: reranker sees at most _RERANK_CANDIDATE_LIMIT candidates
+- Settings: reranker_enabled default is False
+- Settings: reranker_model default is nomic-embed-text
+- Settings: reranker_enabled can be set to True via env
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from omniscience_core.config import Settings
+from omniscience_retrieval import (
+    NoopReranker,
+    OllamaReranker,
+    QueryStats,
+    Reranker,
+    RetrievalService,
+    SearchHit,
+    SearchRequest,
+)
+from omniscience_retrieval.reranker import _cosine_similarity
+from omniscience_retrieval.search import _RERANK_CANDIDATE_LIMIT
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
+_EMBED_DIM = 768
+
+
+def _make_chunk(
+    chunk_id: uuid.UUID | None = None,
+    text: str = "sample chunk text",
+) -> MagicMock:
+    c = MagicMock()
+    c.id = chunk_id or uuid.uuid4()
+    c.document_id = uuid.uuid4()
+    c.text = text
+    c.ingestion_run_id = uuid.uuid4()
+    c.embedding_model = "text-embedding-004"
+    c.embedding_provider = "google-ai"
+    c.parser_version = "treesitter-python-0.21+oms-0.4.2"
+    c.chunker_strategy = "code_symbol"
+    c.chunk_metadata = {"language": "python"}
+    return c
+
+
+def _make_document(
+    doc_id: uuid.UUID | None = None,
+) -> MagicMock:
+    d = MagicMock()
+    d.id = doc_id or uuid.uuid4()
+    d.source_id = uuid.uuid4()
+    d.uri = "https://github.com/org/repo/blob/main/auth.py"
+    d.title = "auth.py"
+    d.indexed_at = _NOW
+    d.tombstoned_at = None
+    d.doc_version = 1
+    return d
+
+
+def _make_source() -> MagicMock:
+    s = MagicMock()
+    s.id = uuid.uuid4()
+    s.name = "main-repo"
+    s.type = "git"
+    return s
+
+
+def _make_embedding_provider(dim: int = _EMBED_DIM) -> AsyncMock:
+    provider = AsyncMock()
+    provider.dim = dim
+    provider.model_name = "text-embedding-004"
+    provider.provider_name = "google-ai"
+    provider.embed = AsyncMock(return_value=[[0.1] * dim])
+    return provider
+
+
+def _make_query_stats() -> QueryStats:
+    return QueryStats(
+        total_matches_before_filters=5,
+        vector_matches=3,
+        text_matches=4,
+        duration_ms=12.3,
+    )
+
+
+def _make_search_hit(
+    chunk_id: uuid.UUID | None = None,
+    score: float = 0.5,
+    text: str = "some text",
+) -> SearchHit:
+    cid = chunk_id or uuid.uuid4()
+    from omniscience_retrieval import ChunkLineage, Citation, SourceInfo
+
+    return SearchHit(
+        chunk_id=cid,
+        document_id=uuid.uuid4(),
+        score=score,
+        text=text,
+        source=SourceInfo(id=uuid.uuid4(), name="src", type="git"),
+        citation=Citation(
+            uri="https://example.com/file.py",
+            title="file.py",
+            indexed_at=_NOW,
+            doc_version=1,
+        ),
+        lineage=ChunkLineage(
+            ingestion_run_id=uuid.uuid4(),
+            embedding_model="nomic-embed-text",
+            embedding_provider="ollama",
+            parser_version="1.0",
+            chunker_strategy="fixed",
+        ),
+        metadata={},
+    )
+
+
+def _build_ollama_response(vectors: list[list[float]]) -> dict[str, Any]:
+    return {"embeddings": vectors}
+
+
+# ---------------------------------------------------------------------------
+# Mock HTTPX client factory
+# ---------------------------------------------------------------------------
+
+
+def _mock_httpx_client(responses: list[dict[str, Any]]) -> MagicMock:
+    """Return a mock httpx.AsyncClient that returns JSON responses in order."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    mock_responses = []
+    for payload in responses:
+        resp = MagicMock(spec=httpx.Response)
+        resp.json.return_value = payload
+        resp.raise_for_status = MagicMock()
+        mock_responses.append(resp)
+    client.post = AsyncMock(side_effect=mock_responses)
+    client.aclose = AsyncMock()
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Reranker Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerProtocol:
+    def test_ollama_reranker_satisfies_protocol(self) -> None:
+        """OllamaReranker is a runtime-checkable Reranker."""
+        assert isinstance(OllamaReranker(), Reranker)
+
+    def test_noop_reranker_satisfies_protocol(self) -> None:
+        """NoopReranker is a runtime-checkable Reranker."""
+        assert isinstance(NoopReranker(), Reranker)
+
+
+# ---------------------------------------------------------------------------
+# OllamaReranker tests
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaReranker:
+    @pytest.mark.asyncio
+    async def test_rerank_returns_one_score_per_text(self) -> None:
+        """rerank() must return exactly len(texts) scores."""
+        texts = ["alpha chunk", "beta chunk", "gamma chunk"]
+        # 4 vectors: query + 3 texts
+        vecs = [[1.0] + [0.0] * (_EMBED_DIM - 1)] * (len(texts) + 1)
+        reranker = OllamaReranker()
+        reranker._client = _mock_httpx_client([_build_ollama_response(vecs)])
+
+        scores = await reranker.rerank("query", texts)
+
+        assert len(scores) == len(texts)
+
+    @pytest.mark.asyncio
+    async def test_rerank_empty_texts_returns_empty(self) -> None:
+        """rerank() short-circuits on empty input, no HTTP call made."""
+        reranker = OllamaReranker()
+        reranker._client = _mock_httpx_client([])
+
+        scores = await reranker.rerank("query", [])
+
+        assert scores == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_scores_are_floats(self) -> None:
+        """All returned scores must be plain Python floats."""
+        # query: [1, 0, 0, 0], text: [0, 1, 0, 0] -> cosine = 0.0
+        vecs = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+        reranker = OllamaReranker()
+        reranker._client = _mock_httpx_client([_build_ollama_response(vecs)])
+
+        scores = await reranker.rerank("q", ["some text"])
+
+        assert all(isinstance(s, float) for s in scores)
+
+    @pytest.mark.asyncio
+    async def test_identical_query_and_text_yields_high_similarity(self) -> None:
+        """Same vector for query and text should produce similarity close to 1.0."""
+        vec = [0.5] * 4
+        vecs = [vec, vec]  # query + 1 candidate with same vector
+        reranker = OllamaReranker()
+        reranker._client = _mock_httpx_client([_build_ollama_response(vecs)])
+
+        scores = await reranker.rerank("q", ["same"])
+
+        assert scores[0] == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_orthogonal_vectors_yield_zero_similarity(self) -> None:
+        """Orthogonal query and text vectors should produce similarity of 0.0."""
+        vecs = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+        reranker = OllamaReranker()
+        reranker._client = _mock_httpx_client([_build_ollama_response(vecs)])
+
+        scores = await reranker.rerank("q", ["orthogonal"])
+
+        assert scores[0] == pytest.approx(0.0, abs=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_batching_splits_large_input(self) -> None:
+        """With batch_size=2 and 3 texts (+ query = 4), two HTTP calls are made."""
+        batch1_vecs = [[1.0, 0.0], [0.5, 0.5]]  # query + text[0]
+        batch2_vecs = [[0.3, 0.7], [0.9, 0.1]]  # text[1] + text[2]
+        reranker = OllamaReranker(batch_size=2)
+        reranker._client = _mock_httpx_client(
+            [
+                _build_ollama_response(batch1_vecs),
+                _build_ollama_response(batch2_vecs),
+            ]
+        )
+
+        scores = await reranker.rerank("q", ["a", "b", "c"])
+
+        # 2 batches posted
+        assert reranker._client.post.call_count == 2
+        assert len(scores) == 3
+
+    @pytest.mark.asyncio
+    async def test_http_error_propagates(self) -> None:
+        """An HTTP 500 from Ollama surfaces as httpx.HTTPStatusError."""
+        client = AsyncMock(spec=httpx.AsyncClient)
+        resp = MagicMock(spec=httpx.Response)
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500",
+            request=MagicMock(),
+            response=resp,
+        )
+        client.post = AsyncMock(return_value=resp)
+        reranker = OllamaReranker()
+        reranker._client = client
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await reranker.rerank("q", ["text"])
+
+    @pytest.mark.asyncio
+    async def test_close_calls_aclose(self) -> None:
+        """close() must delegate to the underlying client's aclose()."""
+        reranker = OllamaReranker()
+        reranker._client = AsyncMock(spec=httpx.AsyncClient)
+
+        await reranker.close()
+
+        reranker._client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_custom_model_sent_in_payload(self) -> None:
+        """The configured model name is forwarded in each POST payload."""
+        vec = [1.0, 0.0]
+        reranker = OllamaReranker(model="bge-large-en-v1.5")
+        reranker._client = _mock_httpx_client([_build_ollama_response([vec, vec])])
+
+        await reranker.rerank("q", ["text"])
+
+        call_kwargs = reranker._client.post.call_args
+        payload = call_kwargs[1]["json"]
+        assert payload["model"] == "bge-large-en-v1.5"
+
+    def test_default_model_is_nomic_embed_text(self) -> None:
+        """OllamaReranker defaults to nomic-embed-text."""
+        reranker = OllamaReranker()
+        assert reranker._model == "nomic-embed-text"
+
+    @pytest.mark.asyncio
+    async def test_rerank_multiple_texts_scores_ordered_by_similarity(self) -> None:
+        """Higher cosine similarity texts appear with higher scores."""
+        # query vec [1,0], text0 vec [1,0] (sim=1.0), text1 vec [0,1] (sim=0.0)
+        vecs = [
+            [1.0, 0.0],  # query
+            [1.0, 0.0],  # text0 -- identical to query
+            [0.0, 1.0],  # text1 -- orthogonal
+        ]
+        reranker = OllamaReranker()
+        reranker._client = _mock_httpx_client([_build_ollama_response(vecs)])
+
+        scores = await reranker.rerank("q", ["identical", "orthogonal"])
+
+        assert scores[0] > scores[1]
+
+
+# ---------------------------------------------------------------------------
+# NoopReranker tests
+# ---------------------------------------------------------------------------
+
+
+class TestNoopReranker:
+    @pytest.mark.asyncio
+    async def test_returns_decreasing_placeholder_scores(self) -> None:
+        """NoopReranker scores must strictly decrease."""
+        reranker = NoopReranker()
+        scores = await reranker.rerank("q", ["a", "b", "c"])
+        assert scores == sorted(scores, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_length_matches_input(self) -> None:
+        reranker = NoopReranker()
+        texts = ["x"] * 7
+        scores = await reranker.rerank("q", texts)
+        assert len(scores) == 7
+
+    @pytest.mark.asyncio
+    async def test_empty_texts_returns_empty(self) -> None:
+        reranker = NoopReranker()
+        scores = await reranker.rerank("q", [])
+        assert scores == []
+
+    @pytest.mark.asyncio
+    async def test_first_score_is_1(self) -> None:
+        reranker = NoopReranker()
+        scores = await reranker.rerank("q", ["first", "second"])
+        assert scores[0] == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_close_completes_without_error(self) -> None:
+        reranker = NoopReranker()
+        await reranker.close()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _cosine_similarity unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCosineSimilarity:
+    def test_zero_vector_a_returns_zero(self) -> None:
+        assert _cosine_similarity([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+    def test_zero_vector_b_returns_zero(self) -> None:
+        assert _cosine_similarity([1.0, 0.0], [0.0, 0.0]) == 0.0
+
+    def test_both_zero_vectors_returns_zero(self) -> None:
+        assert _cosine_similarity([0.0, 0.0], [0.0, 0.0]) == 0.0
+
+    def test_identical_unit_vectors(self) -> None:
+        assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+
+    def test_opposite_unit_vectors(self) -> None:
+        assert _cosine_similarity([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+    def test_orthogonal_vectors(self) -> None:
+        assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# RetrievalService + reranker integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_session_for_reranker(
+    chunk_ids: list[uuid.UUID],
+    texts: list[str],
+) -> MagicMock:
+    """Return a mock session that yields chunks as vector/text and enriched results."""
+    session = AsyncMock()
+
+    # Vector search result
+    vec_result = MagicMock()
+    vec_rows = []
+    for i, cid in enumerate(chunk_ids):
+        row = MagicMock()
+        row.id = cid
+        row.dist = 0.1 * i  # ascending distance -> descending similarity
+        vec_rows.append(row)
+    vec_result.all.return_value = vec_rows
+
+    # Text search result (empty to keep test simple)
+    txt_result = MagicMock()
+    txt_result.all.return_value = []
+
+    # Enriched fetch result
+    doc = _make_document()
+    src = _make_source()
+    enriched_rows = [
+        (_make_chunk(chunk_id=cid, text=t), doc, src)
+        for cid, t in zip(chunk_ids, texts, strict=True)
+    ]
+    enriched_result = MagicMock()
+    enriched_result.all.return_value = enriched_rows
+
+    session.execute = AsyncMock(side_effect=[vec_result, txt_result, enriched_result])
+    return session
+
+
+def _make_service_with_reranker(
+    chunk_ids: list[uuid.UUID],
+    texts: list[str],
+    reranker: Reranker | None,
+) -> RetrievalService:
+    session = _make_session_for_reranker(chunk_ids, texts)
+    session_factory = MagicMock()
+    session_factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    provider = _make_embedding_provider()
+    return RetrievalService(
+        session_factory=session_factory,
+        embedding_provider=provider,
+        reranker=reranker,
+    )
+
+
+class TestRetrievalServiceReranker:
+    @pytest.mark.asyncio
+    async def test_no_reranker_assigns_noop_internally(self) -> None:
+        """When reranker=None, service falls back to NoopReranker."""
+        from omniscience_retrieval.reranker import NoopReranker as _NoopReranker
+
+        cid = uuid.uuid4()
+        service = _make_service_with_reranker([cid], ["text"], reranker=None)
+        assert isinstance(service._reranker, _NoopReranker)
+
+    @pytest.mark.asyncio
+    async def test_noop_reranker_does_not_trigger_apply_reranker(self) -> None:
+        """When NoopReranker is in use, _apply_reranker must not be called."""
+        cid = uuid.uuid4()
+        service = _make_service_with_reranker([cid], ["text"], reranker=None)
+
+        with patch.object(service, "_apply_reranker", new_callable=AsyncMock) as mock_apply:
+            await service.search(SearchRequest(query="anything"))
+            mock_apply.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ollama_reranker_wired_rescores_hits(self) -> None:
+        """When a real OllamaReranker is supplied, hits are re-scored."""
+        chunk_ids = [uuid.uuid4(), uuid.uuid4()]
+        texts = ["unrelated text", "highly relevant text"]
+
+        # Simulate reranker: text[1] gets higher score than text[0]
+        mock_reranker = AsyncMock(spec=OllamaReranker)
+        mock_reranker.rerank = AsyncMock(return_value=[0.1, 0.9])
+
+        service = _make_service_with_reranker(chunk_ids, texts, reranker=mock_reranker)
+        result = await service.search(SearchRequest(query="relevant", top_k=2))
+
+        # The hit with score 0.9 should appear first
+        assert result.hits[0].score == pytest.approx(0.9)
+        assert result.hits[1].score == pytest.approx(0.1)
+
+    @pytest.mark.asyncio
+    async def test_reranking_reorders_hits_by_new_scores(self) -> None:
+        """Re-ranking must override the original RRF order."""
+        chunk_ids = [uuid.uuid4(), uuid.uuid4(), uuid.uuid4()]
+        texts = ["low", "medium", "high"]
+
+        # Reverse order: RRF has texts[0] first, reranker says texts[2] is best
+        mock_reranker = AsyncMock(spec=OllamaReranker)
+        mock_reranker.rerank = AsyncMock(return_value=[0.1, 0.5, 0.95])
+
+        service = _make_service_with_reranker(chunk_ids, texts, reranker=mock_reranker)
+        result = await service.search(SearchRequest(query="q", top_k=3))
+
+        scores = [h.score for h in result.hits]
+        assert scores == sorted(scores, reverse=True)
+        assert result.hits[0].text == "high"
+
+    @pytest.mark.asyncio
+    async def test_reranking_respects_top_k(self) -> None:
+        """After re-ranking, only top_k hits are returned."""
+        chunk_ids = [uuid.uuid4() for _ in range(5)]
+        texts = [f"text {i}" for i in range(5)]
+
+        mock_reranker = AsyncMock(spec=OllamaReranker)
+        mock_reranker.rerank = AsyncMock(return_value=[0.5, 0.4, 0.9, 0.2, 0.7])
+
+        service = _make_service_with_reranker(chunk_ids, texts, reranker=mock_reranker)
+        result = await service.search(SearchRequest(query="q", top_k=3))
+
+        assert len(result.hits) == 3
+
+    @pytest.mark.asyncio
+    async def test_reranker_receives_at_most_candidate_limit_texts(self) -> None:
+        """rerank() is called with at most _RERANK_CANDIDATE_LIMIT texts."""
+        # Build more candidates than the limit
+        n = _RERANK_CANDIDATE_LIMIT + 10
+        chunk_ids = [uuid.uuid4() for _ in range(n)]
+        texts = [f"text {i}" for i in range(n)]
+
+        captured_texts: list[str] = []
+
+        async def _capture_rerank(query: str, t: list[str]) -> list[float]:
+            captured_texts.extend(t)
+            return [1.0 / (i + 1) for i in range(len(t))]
+
+        mock_reranker = AsyncMock(spec=OllamaReranker)
+        mock_reranker.rerank = AsyncMock(side_effect=_capture_rerank)
+
+        # Build a bigger session mock for n chunks
+        session = AsyncMock()
+
+        vec_result = MagicMock()
+        vec_rows = [MagicMock(id=cid, dist=0.0) for cid in chunk_ids]
+        vec_result.all.return_value = vec_rows
+
+        txt_result = MagicMock()
+        txt_result.all.return_value = []
+
+        doc = _make_document()
+        src = _make_source()
+        enriched_result = MagicMock()
+        enriched_result.all.return_value = [
+            (_make_chunk(chunk_id=cid, text=t), doc, src)
+            for cid, t in zip(chunk_ids, texts, strict=True)
+        ]
+
+        session.execute = AsyncMock(side_effect=[vec_result, txt_result, enriched_result])
+        session_factory = MagicMock()
+        session_factory.return_value.__aenter__ = AsyncMock(return_value=session)
+        session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        provider = _make_embedding_provider()
+        service = RetrievalService(
+            session_factory=session_factory,
+            embedding_provider=provider,
+            reranker=mock_reranker,
+        )
+
+        await service.search(SearchRequest(query="q", top_k=5))
+
+        assert len(captured_texts) <= _RERANK_CANDIDATE_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# Settings tests
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerSettings:
+    def test_reranker_enabled_default_is_false(self) -> None:
+        settings = Settings()
+        assert settings.reranker_enabled is False
+
+    def test_reranker_model_default(self) -> None:
+        settings = Settings()
+        assert settings.reranker_model == "nomic-embed-text"
+
+    def test_reranker_enabled_can_be_overridden(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RERANKER_ENABLED", "true")
+        settings = Settings()
+        assert settings.reranker_enabled is True
+
+    def test_reranker_model_can_be_overridden(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RERANKER_MODEL", "bge-large-en-v1.5")
+        settings = Settings()
+        assert settings.reranker_model == "bge-large-en-v1.5"


### PR DESCRIPTION
Reranker protocol + OllamaReranker (cosine similarity), wired into RetrievalService with configurable top-N candidate pool. Opt-in via settings. 34 new tests. Closes #59