### PR TITLE
feat: admin web UI with source, token, ingestion, and search management

### DIFF
--- a/apps/admin/.dockerignore
+++ b/apps/admin/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.DS_Store
+*.local

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: build
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+# Stage 2: serve with nginx
+FROM nginx:1.27-alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# SPA fallback: route all requests to index.html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Omniscience Admin</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/admin/nginx.conf
+++ b/apps/admin/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API calls to the backend
+    location /api/ {
+        proxy_pass http://app:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /health {
+        proxy_pass http://app:8000/health;
+        proxy_set_header Host $host;
+    }
+
+    # SPA: send all other requests to index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "omniscience-admin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.45",
+    "tailwindcss": "^3.4.11",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.3"
+  }
+}

--- a/apps/admin/postcss.config.js
+++ b/apps/admin/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,0 +1,57 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { TokenProvider, useTokenContext } from "./context/TokenContext";
+import { LoginScreen } from "./components/LoginScreen";
+import { Layout } from "./components/Layout";
+import { ToastContainer } from "./components/ToastContainer";
+import { useToast } from "./hooks/useToast";
+import { DashboardPage } from "./pages/DashboardPage";
+import { SourcesPage } from "./pages/SourcesPage";
+import { TokensPage } from "./pages/TokensPage";
+import { IngestionPage } from "./pages/IngestionPage";
+import { SearchPage } from "./pages/SearchPage";
+
+function AppInner() {
+  const { token } = useTokenContext();
+  const { toasts, addToast, removeToast } = useToast();
+
+  if (!token) {
+    return <LoginScreen />;
+  }
+
+  return (
+    <>
+      <BrowserRouter>
+        <Layout>
+          <Routes>
+            <Route path="/" element={<DashboardPage />} />
+            <Route
+              path="/sources"
+              element={<SourcesPage addToast={addToast} />}
+            />
+            <Route
+              path="/tokens"
+              element={<TokensPage addToast={addToast} />}
+            />
+            <Route
+              path="/ingestion"
+              element={<IngestionPage addToast={addToast} />}
+            />
+            <Route
+              path="/search"
+              element={<SearchPage addToast={addToast} />}
+            />
+          </Routes>
+        </Layout>
+      </BrowserRouter>
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
+    </>
+  );
+}
+
+export default function App() {
+  return (
+    <TokenProvider>
+      <AppInner />
+    </TokenProvider>
+  );
+}

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -1,0 +1,263 @@
+// API client wrapping fetch() with Bearer token auth.
+
+export type SourceType =
+  | "git"
+  | "fs"
+  | "confluence"
+  | "notion"
+  | "slack"
+  | "jira"
+  | "grafana"
+  | "k8s"
+  | "terraform";
+
+export type SourceStatus = "active" | "paused" | "error";
+
+export type IngestionRunStatus = "running" | "ok" | "partial" | "error";
+
+export interface Source {
+  id: string;
+  type: SourceType;
+  name: string;
+  config: Record<string, unknown>;
+  secrets_ref: string | null;
+  status: SourceStatus;
+  last_sync_at: string | null;
+  last_error: string | null;
+  last_error_at: string | null;
+  freshness_sla_seconds: number | null;
+  tenant_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SourceStats {
+  source_id: string;
+  total_documents: number;
+  active_documents: number;
+  total_chunks: number;
+  last_sync_at: string | null;
+  last_run_status: string | null;
+}
+
+export interface SourceCreate {
+  type: SourceType;
+  name: string;
+  config?: Record<string, unknown>;
+  secrets_ref?: string;
+  status?: SourceStatus;
+  freshness_sla_seconds?: number;
+}
+
+export interface IngestionRun {
+  id: string;
+  source_id: string;
+  started_at: string;
+  finished_at: string | null;
+  status: IngestionRunStatus;
+  docs_new: number;
+  docs_updated: number;
+  docs_removed: number;
+  errors: Record<string, unknown>;
+}
+
+export interface ApiToken {
+  id: string;
+  name: string;
+  token_prefix: string;
+  scopes: string[];
+  workspace_id: string | null;
+  created_at: string;
+  expires_at: string | null;
+  last_used_at: string | null;
+  is_active: boolean;
+}
+
+export interface TokenCreateRequest {
+  name: string;
+  scopes: string[];
+  expires_at?: string;
+}
+
+export interface TokenCreateResponse {
+  token: ApiToken;
+  secret: string;
+}
+
+export interface SearchRequest {
+  query: string;
+  top_k?: number;
+  sources?: string[];
+  retrieval_strategy?: "hybrid" | "keyword" | "structural" | "auto";
+}
+
+export interface SearchHit {
+  chunk_id: string;
+  document_id: string;
+  score: number;
+  text: string;
+  source: { id: string; name: string; type: string };
+  citation: {
+    uri: string;
+    title: string | null;
+    indexed_at: string;
+    doc_version: number;
+  };
+  lineage: {
+    ingestion_run_id: string | null;
+    embedding_model: string;
+    embedding_provider: string;
+    parser_version: string;
+    chunker_strategy: string;
+  };
+  metadata: Record<string, unknown>;
+}
+
+export interface SearchResult {
+  hits: SearchHit[];
+  query_stats: {
+    total_matches_before_filters: number;
+    vector_matches: number;
+    text_matches: number;
+    duration_ms: number;
+  };
+}
+
+export interface HealthResponse {
+  status: string;
+  version?: string;
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly detail: string
+  ) {
+    super(`API error ${status}: ${detail}`);
+    this.name = "ApiError";
+  }
+}
+
+export class ApiClient {
+  private token: string | null;
+
+  constructor(token: string | null = null) {
+    this.token = token;
+  }
+
+  setToken(token: string | null): void {
+    this.token = token;
+  }
+
+  private headers(): HeadersInit {
+    const h: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.token) {
+      h["Authorization"] = `Bearer ${this.token}`;
+    }
+    return h;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const res = await fetch(path, {
+      method,
+      headers: this.headers(),
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (res.status === 204) {
+      return undefined as T;
+    }
+
+    const data = await res.json().catch(() => ({ detail: res.statusText }));
+
+    if (!res.ok) {
+      const detail =
+        typeof data?.detail === "string"
+          ? data.detail
+          : typeof data?.detail?.message === "string"
+            ? data.detail.message
+            : JSON.stringify(data?.detail ?? data);
+      throw new ApiError(res.status, detail);
+    }
+
+    return data as T;
+  }
+
+  // Health
+  async health(): Promise<HealthResponse> {
+    return this.request<HealthResponse>("GET", "/health");
+  }
+
+  // Sources
+  async listSources(params?: {
+    source_type?: SourceType;
+    status?: SourceStatus;
+  }): Promise<Source[]> {
+    const qs = new URLSearchParams();
+    if (params?.source_type) qs.set("source_type", params.source_type);
+    if (params?.status) qs.set("status", params.status);
+    const suffix = qs.toString() ? `?${qs}` : "";
+    return this.request<Source[]>("GET", `/api/v1/sources${suffix}`);
+  }
+
+  async getSource(id: string): Promise<Source> {
+    return this.request<Source>("GET", `/api/v1/sources/${id}`);
+  }
+
+  async createSource(payload: SourceCreate): Promise<Source> {
+    return this.request<Source>("POST", "/api/v1/sources", payload);
+  }
+
+  async deleteSource(id: string): Promise<void> {
+    return this.request<void>("DELETE", `/api/v1/sources/${id}`);
+  }
+
+  async triggerSync(id: string): Promise<{ run_id: string }> {
+    return this.request<{ run_id: string }>(
+      "POST",
+      `/api/v1/sources/${id}/sync`
+    );
+  }
+
+  async sourceStats(id: string): Promise<SourceStats> {
+    return this.request<SourceStats>("GET", `/api/v1/sources/${id}/stats`);
+  }
+
+  // Ingestion runs
+  async listIngestionRuns(params?: {
+    source_id?: string;
+    status?: IngestionRunStatus;
+    limit?: number;
+  }): Promise<IngestionRun[]> {
+    const qs = new URLSearchParams();
+    if (params?.source_id) qs.set("source_id", params.source_id);
+    if (params?.status) qs.set("status", params.status);
+    if (params?.limit) qs.set("limit", String(params.limit));
+    const suffix = qs.toString() ? `?${qs}` : "";
+    return this.request<IngestionRun[]>("GET", `/api/v1/ingestion-runs${suffix}`);
+  }
+
+  // Tokens
+  async listTokens(): Promise<ApiToken[]> {
+    return this.request<ApiToken[]>("GET", "/api/v1/tokens");
+  }
+
+  async createToken(payload: TokenCreateRequest): Promise<TokenCreateResponse> {
+    return this.request<TokenCreateResponse>("POST", "/api/v1/tokens", payload);
+  }
+
+  async deleteToken(id: string): Promise<void> {
+    return this.request<void>("DELETE", `/api/v1/tokens/${id}`);
+  }
+
+  // Search
+  async search(payload: SearchRequest): Promise<SearchResult> {
+    return this.request<SearchResult>("POST", "/api/v1/search", payload);
+  }
+}

--- a/apps/admin/src/components/ConfirmDialog.tsx
+++ b/apps/admin/src/components/ConfirmDialog.tsx
@@ -1,0 +1,29 @@
+interface Props {
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({ message, onConfirm, onCancel }: Props) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-sm px-6 py-6">
+        <p className="text-sm text-gray-800 mb-6">{message}</p>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 text-sm rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors"
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -1,0 +1,66 @@
+import { ReactNode } from "react";
+import { NavLink } from "react-router-dom";
+import { useTokenContext } from "../context/TokenContext";
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const NAV_ITEMS = [
+  { to: "/", label: "Dashboard", end: true },
+  { to: "/sources", label: "Sources" },
+  { to: "/tokens", label: "Tokens" },
+  { to: "/ingestion", label: "Ingestion" },
+  { to: "/search", label: "Search Playground" },
+];
+
+export function Layout({ children }: LayoutProps) {
+  const { logout } = useTokenContext();
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      {/* Sidebar */}
+      <aside className="w-56 flex-shrink-0 bg-gray-900 text-gray-200 flex flex-col">
+        <div className="px-5 py-5 border-b border-gray-700">
+          <span className="text-white font-semibold text-lg tracking-tight">
+            Omniscience
+          </span>
+          <span className="ml-2 text-xs text-gray-400 font-mono">admin</span>
+        </div>
+
+        <nav className="flex-1 py-4 px-2 flex flex-col gap-1">
+          {NAV_ITEMS.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.end}
+              className={({ isActive }) =>
+                `rounded px-3 py-2 text-sm transition-colors ${
+                  isActive
+                    ? "bg-indigo-600 text-white"
+                    : "text-gray-300 hover:bg-gray-700 hover:text-white"
+                }`
+              }
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="px-4 py-4 border-t border-gray-700">
+          <button
+            onClick={logout}
+            className="w-full text-left text-xs text-gray-400 hover:text-gray-200 transition-colors"
+          >
+            Sign out
+          </button>
+        </div>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 overflow-auto">
+        <div className="max-w-6xl mx-auto px-6 py-8">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/apps/admin/src/components/LoginScreen.tsx
+++ b/apps/admin/src/components/LoginScreen.tsx
@@ -1,0 +1,61 @@
+import { useState, FormEvent } from "react";
+import { useTokenContext } from "../context/TokenContext";
+
+export function LoginScreen() {
+  const { setToken } = useTokenContext();
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setError("Please enter an API token.");
+      return;
+    }
+    setError(null);
+    setToken(trimmed);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="bg-white rounded-xl shadow-md w-full max-w-sm px-8 py-10">
+        <h1 className="text-2xl font-semibold text-gray-900 mb-1">
+          Omniscience Admin
+        </h1>
+        <p className="text-sm text-gray-500 mb-8">
+          Enter your API token to continue.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="token"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              API Token
+            </label>
+            <input
+              id="token"
+              type="password"
+              autoComplete="current-password"
+              placeholder="omni_dev_..."
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <button
+            type="submit"
+            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-lg px-4 py-2 text-sm transition-colors"
+          >
+            Sign in
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/StatusBadge.tsx
+++ b/apps/admin/src/components/StatusBadge.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  value: string;
+}
+
+const COLOR: Record<string, string> = {
+  active: "bg-green-100 text-green-800",
+  ok: "bg-green-100 text-green-800",
+  paused: "bg-yellow-100 text-yellow-800",
+  partial: "bg-yellow-100 text-yellow-800",
+  error: "bg-red-100 text-red-800",
+  running: "bg-blue-100 text-blue-800",
+};
+
+export function StatusBadge({ value }: Props) {
+  const cls = COLOR[value] ?? "bg-gray-100 text-gray-700";
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}>
+      {value}
+    </span>
+  );
+}

--- a/apps/admin/src/components/ToastContainer.tsx
+++ b/apps/admin/src/components/ToastContainer.tsx
@@ -1,0 +1,36 @@
+import { Toast } from "../hooks/useToast";
+
+interface Props {
+  toasts: Toast[];
+  onRemove: (id: number) => void;
+}
+
+export function ToastContainer({ toasts, onRemove }: Props) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={`flex items-start gap-3 rounded-lg px-4 py-3 shadow-lg text-sm text-white max-w-sm ${
+            t.type === "error"
+              ? "bg-red-600"
+              : t.type === "success"
+                ? "bg-green-600"
+                : "bg-gray-800"
+          }`}
+        >
+          <span className="flex-1">{t.message}</span>
+          <button
+            onClick={() => onRemove(t.id)}
+            className="ml-2 opacity-70 hover:opacity-100 leading-none"
+            aria-label="Dismiss"
+          >
+            &times;
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/src/context/TokenContext.tsx
+++ b/apps/admin/src/context/TokenContext.tsx
@@ -1,0 +1,51 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from "react";
+import { ApiClient } from "../api/client";
+
+const STORAGE_KEY = "omniscience_admin_token";
+
+interface TokenContextValue {
+  token: string | null;
+  client: ApiClient;
+  setToken: (t: string | null) => void;
+  logout: () => void;
+}
+
+const TokenContext = createContext<TokenContextValue | null>(null);
+
+const client = new ApiClient(null);
+
+export function TokenProvider({ children }: { children: ReactNode }) {
+  const [token, setTokenState] = useState<string | null>(() =>
+    localStorage.getItem(STORAGE_KEY)
+  );
+
+  useEffect(() => {
+    client.setToken(token);
+    if (token) {
+      localStorage.setItem(STORAGE_KEY, token);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [token]);
+
+  const setToken = (t: string | null) => setTokenState(t);
+  const logout = () => setTokenState(null);
+
+  return (
+    <TokenContext.Provider value={{ token, client, setToken, logout }}>
+      {children}
+    </TokenContext.Provider>
+  );
+}
+
+export function useTokenContext(): TokenContextValue {
+  const ctx = useContext(TokenContext);
+  if (!ctx) throw new Error("useTokenContext must be used within TokenProvider");
+  return ctx;
+}

--- a/apps/admin/src/hooks/useToast.ts
+++ b/apps/admin/src/hooks/useToast.ts
@@ -1,0 +1,30 @@
+import { useState, useCallback } from "react";
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: "success" | "error" | "info";
+}
+
+let _id = 0;
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = useCallback(
+    (message: string, type: Toast["type"] = "info") => {
+      const id = ++_id;
+      setToasts((prev) => [...prev, { id, message, type }]);
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id));
+      }, 4000);
+    },
+    []
+  );
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return { toasts, addToast, removeToast };
+}

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("Root element not found");
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/admin/src/pages/DashboardPage.tsx
+++ b/apps/admin/src/pages/DashboardPage.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTokenContext } from "../context/TokenContext";
+import { Source, IngestionRun } from "../api/client";
+import { StatusBadge } from "../components/StatusBadge";
+
+function StatCard({
+  label,
+  value,
+  to,
+}: {
+  label: string;
+  value: string | number;
+  to: string;
+}) {
+  return (
+    <Link
+      to={to}
+      className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-5 hover:shadow-md transition-shadow"
+    >
+      <p className="text-sm text-gray-500">{label}</p>
+      <p className="text-3xl font-semibold text-gray-900 mt-1">{value}</p>
+    </Link>
+  );
+}
+
+export function DashboardPage() {
+  const { client } = useTokenContext();
+  const [sources, setSources] = useState<Source[]>([]);
+  const [runs, setRuns] = useState<IngestionRun[]>([]);
+  const [health, setHealth] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const [s, r, h] = await Promise.allSettled([
+          client.listSources(),
+          client.listIngestionRuns({ limit: 10 }),
+          client.health(),
+        ]);
+        if (cancelled) return;
+
+        if (s.status === "fulfilled") setSources(s.value);
+        if (r.status === "fulfilled") setRuns(r.value);
+        if (h.status === "fulfilled") setHealth(h.value.status);
+      } catch (e) {
+        if (!cancelled) setError(String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  if (loading) {
+    return (
+      <div className="text-sm text-gray-500 py-12 text-center">Loading...</div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-red-600 py-12 text-center">{error}</div>
+    );
+  }
+
+  const runningCount = sources.filter((s) => s.status === "active").length;
+  const errorCount = sources.filter((s) => s.status === "error").length;
+  const recentRuns = runs.slice(0, 5);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-2xl font-semibold text-gray-900">Dashboard</h1>
+        {health && (
+          <span
+            className={`inline-flex items-center gap-1.5 text-sm font-medium ${
+              health === "ok" ? "text-green-600" : "text-red-600"
+            }`}
+          >
+            <span
+              className={`h-2 w-2 rounded-full ${
+                health === "ok" ? "bg-green-500" : "bg-red-500"
+              }`}
+            />
+            API {health}
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mb-10">
+        <StatCard label="Total sources" value={sources.length} to="/sources" />
+        <StatCard label="Active sources" value={runningCount} to="/sources" />
+        <StatCard
+          label="Sources with errors"
+          value={errorCount}
+          to="/sources"
+        />
+      </div>
+
+      <section>
+        <h2 className="text-base font-medium text-gray-700 mb-4">
+          Recent ingestion runs
+        </h2>
+        {recentRuns.length === 0 ? (
+          <p className="text-sm text-gray-400">No ingestion runs yet.</p>
+        ) : (
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">
+                    Source
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">
+                    Status
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">
+                    Docs new
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-600">
+                    Started
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {recentRuns.map((run) => {
+                  const src = sources.find((s) => s.id === run.source_id);
+                  return (
+                    <tr key={run.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 font-mono text-xs text-gray-600">
+                        {src?.name ?? run.source_id.slice(0, 8)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusBadge value={run.status} />
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        {run.docs_new}
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 tabular-nums">
+                        {new Date(run.started_at).toLocaleString()}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {runs.length > 5 && (
+          <div className="mt-3">
+            <Link
+              to="/ingestion"
+              className="text-sm text-indigo-600 hover:underline"
+            >
+              View all runs
+            </Link>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/admin/src/pages/IngestionPage.tsx
+++ b/apps/admin/src/pages/IngestionPage.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useState, FormEvent } from "react";
+import { useTokenContext } from "../context/TokenContext";
+import {
+  IngestionRun,
+  IngestionRunStatus,
+  Source,
+  ApiError,
+} from "../api/client";
+import { StatusBadge } from "../components/StatusBadge";
+
+interface ToastFn {
+  (msg: string, type?: "success" | "error" | "info"): void;
+}
+
+interface Props {
+  addToast: ToastFn;
+}
+
+const STATUS_OPTIONS: IngestionRunStatus[] = [
+  "running",
+  "ok",
+  "partial",
+  "error",
+];
+
+export function IngestionPage({ addToast }: Props) {
+  const { client } = useTokenContext();
+  const [runs, setRuns] = useState<IngestionRun[]>([]);
+  const [sources, setSources] = useState<Source[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sourceFilter, setSourceFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+
+  const loadRuns = async (params?: {
+    source_id?: string;
+    status?: IngestionRunStatus;
+  }) => {
+    setLoading(true);
+    try {
+      const [r, s] = await Promise.all([
+        client.listIngestionRuns({ ...params, limit: 100 }),
+        client.listSources(),
+      ]);
+      setRuns(r);
+      setSources(s);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Failed to load ingestion runs: ${msg}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadRuns();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleFilter = (e: FormEvent) => {
+    e.preventDefault();
+    loadRuns({
+      source_id: sourceFilter || undefined,
+      status: (statusFilter as IngestionRunStatus) || undefined,
+    });
+  };
+
+  const sourceMap = Object.fromEntries(sources.map((s) => [s.id, s.name]));
+
+  const duration = (run: IngestionRun): string => {
+    if (!run.finished_at) return "—";
+    const ms =
+      new Date(run.finished_at).getTime() -
+      new Date(run.started_at).getTime();
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">Ingestion Runs</h1>
+
+      {/* Filters */}
+      <form
+        onSubmit={handleFilter}
+        className="bg-white rounded-xl border border-gray-200 shadow-sm px-4 py-4 mb-6 flex flex-wrap items-end gap-4"
+      >
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Source
+          </label>
+          <select
+            value={sourceFilter}
+            onChange={(e) => setSourceFilter(e.target.value)}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 min-w-40"
+          >
+            <option value="">All sources</option>
+            {sources.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Status
+          </label>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="">All statuses</option>
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="submit"
+          className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+        >
+          Apply
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setSourceFilter("");
+            setStatusFilter("");
+            loadRuns();
+          }}
+          className="px-4 py-2 text-sm border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          Reset
+        </button>
+      </form>
+
+      {loading ? (
+        <p className="text-sm text-gray-500 py-12 text-center">Loading...</p>
+      ) : runs.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-12 text-center text-sm text-gray-400">
+          No ingestion runs found.
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Source
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  New
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Updated
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Removed
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Duration
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Started
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {runs.map((run) => (
+                <tr key={run.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 text-gray-900">
+                    {sourceMap[run.source_id] ?? (
+                      <span className="font-mono text-xs text-gray-500">
+                        {run.source_id.slice(0, 8)}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusBadge value={run.status} />
+                    {run.status === "error" &&
+                      Object.keys(run.errors).length > 0 && (
+                        <details className="mt-1">
+                          <summary className="text-xs text-red-500 cursor-pointer">
+                            Errors
+                          </summary>
+                          <pre className="text-xs text-red-600 bg-red-50 rounded p-2 mt-1 max-w-xs overflow-auto">
+                            {JSON.stringify(run.errors, null, 2)}
+                          </pre>
+                        </details>
+                      )}
+                  </td>
+                  <td className="px-4 py-3 text-gray-700 tabular-nums">
+                    {run.docs_new}
+                  </td>
+                  <td className="px-4 py-3 text-gray-700 tabular-nums">
+                    {run.docs_updated}
+                  </td>
+                  <td className="px-4 py-3 text-gray-700 tabular-nums">
+                    {run.docs_removed}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500 tabular-nums text-xs">
+                    {duration(run)}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500 text-xs tabular-nums">
+                    {new Date(run.started_at).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/pages/SearchPage.tsx
+++ b/apps/admin/src/pages/SearchPage.tsx
@@ -1,0 +1,201 @@
+import { useState, FormEvent } from "react";
+import { useTokenContext } from "../context/TokenContext";
+import { SearchResult, SearchHit, ApiError, Source } from "../api/client";
+import { useEffect } from "react";
+
+interface ToastFn {
+  (msg: string, type?: "success" | "error" | "info"): void;
+}
+
+interface Props {
+  addToast: ToastFn;
+}
+
+function HitCard({ hit }: { hit: SearchHit }) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-5">
+      <div className="flex items-start justify-between gap-4 mb-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-gray-900 truncate">
+            {hit.citation.title ?? hit.citation.uri}
+          </p>
+          <a
+            href={hit.citation.uri}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-indigo-600 hover:underline truncate block"
+          >
+            {hit.citation.uri}
+          </a>
+        </div>
+        <div className="flex-shrink-0 text-right">
+          <span className="text-sm font-semibold text-gray-900 tabular-nums">
+            {(hit.score * 100).toFixed(1)}
+          </span>
+          <p className="text-xs text-gray-400">score</p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 mb-3 text-xs text-gray-500">
+        <span className="font-mono bg-gray-100 rounded px-1.5 py-0.5">
+          {hit.source.type}
+        </span>
+        <span>{hit.source.name}</span>
+        <span>v{hit.citation.doc_version}</span>
+      </div>
+
+      <p className="text-sm text-gray-700 leading-relaxed line-clamp-4">
+        {hit.text}
+      </p>
+    </div>
+  );
+}
+
+export function SearchPage({ addToast }: Props) {
+  const { client } = useTokenContext();
+  const [query, setQuery] = useState("");
+  const [topK, setTopK] = useState(10);
+  const [sourceFilter, setSourceFilter] = useState("");
+  const [strategy, setStrategy] = useState<"hybrid" | "keyword" | "structural" | "auto">("hybrid");
+  const [result, setResult] = useState<SearchResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [sources, setSources] = useState<Source[]>([]);
+
+  useEffect(() => {
+    client.listSources().then(setSources).catch(() => {});
+  }, [client]);
+
+  const handleSearch = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) return;
+    setLoading(true);
+    try {
+      const r = await client.search({
+        query: query.trim(),
+        top_k: topK,
+        sources: sourceFilter ? [sourceFilter] : undefined,
+        retrieval_strategy: strategy,
+      });
+      setResult(r);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Search failed: ${msg}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-gray-900 mb-6">
+        Search Playground
+      </h1>
+
+      <form
+        onSubmit={handleSearch}
+        className="bg-white rounded-xl border border-gray-200 shadow-sm p-5 mb-6 space-y-4"
+      >
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Query
+          </label>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="How does authentication work?"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Top K: <span className="font-semibold">{topK}</span>
+            </label>
+            <input
+              type="range"
+              min={1}
+              max={50}
+              value={topK}
+              onChange={(e) => setTopK(Number(e.target.value))}
+              className="w-full accent-indigo-600"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Strategy
+            </label>
+            <select
+              value={strategy}
+              onChange={(e) => setStrategy(e.target.value as typeof strategy)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="hybrid">hybrid</option>
+              <option value="keyword">keyword</option>
+              <option value="structural">structural</option>
+              <option value="auto">auto</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Source filter
+            </label>
+            <select
+              value={sourceFilter}
+              onChange={(e) => setSourceFilter(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="">All sources</option>
+              {sources.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading || !query.trim()}
+          className="px-5 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+        >
+          {loading ? "Searching..." : "Search"}
+        </button>
+      </form>
+
+      {result && (
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-sm text-gray-600">
+              <span className="font-semibold text-gray-900">
+                {result.hits.length}
+              </span>{" "}
+              hits &middot;{" "}
+              <span className="tabular-nums">
+                {result.query_stats.duration_ms.toFixed(0)}ms
+              </span>{" "}
+              &middot; {result.query_stats.vector_matches} vector /{" "}
+              {result.query_stats.text_matches} text matches
+            </p>
+          </div>
+
+          {result.hits.length === 0 ? (
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-12 text-center text-sm text-gray-400">
+              No results found.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {result.hits.map((hit) => (
+                <HitCard key={hit.chunk_id} hit={hit} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/pages/SourcesPage.tsx
+++ b/apps/admin/src/pages/SourcesPage.tsx
@@ -1,0 +1,301 @@
+import { useEffect, useState, FormEvent } from "react";
+import { useTokenContext } from "../context/TokenContext";
+import { Source, SourceCreate, SourceType, ApiError } from "../api/client";
+import { StatusBadge } from "../components/StatusBadge";
+import { ConfirmDialog } from "../components/ConfirmDialog";
+
+const SOURCE_TYPES: SourceType[] = [
+  "git",
+  "fs",
+  "confluence",
+  "notion",
+  "slack",
+  "jira",
+  "grafana",
+  "k8s",
+  "terraform",
+];
+
+interface ToastFn {
+  (msg: string, type?: "success" | "error" | "info"): void;
+}
+
+interface Props {
+  addToast: ToastFn;
+}
+
+function AddSourceForm({
+  onCreated,
+  addToast,
+}: {
+  onCreated: (s: Source) => void;
+  addToast: ToastFn;
+}) {
+  const { client } = useTokenContext();
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<SourceType>("git");
+  const [name, setName] = useState("");
+  const [configRaw, setConfigRaw] = useState("{}");
+  const [submitting, setSubmitting] = useState(false);
+  const [configError, setConfigError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setConfigError(null);
+
+    let config: Record<string, unknown>;
+    try {
+      config = JSON.parse(configRaw);
+    } catch {
+      setConfigError("Config must be valid JSON.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const payload: SourceCreate = { type, name: name.trim(), config };
+      const created = await client.createSource(payload);
+      onCreated(created);
+      addToast(`Source "${created.name}" created.`, "success");
+      setName("");
+      setConfigRaw("{}");
+      setOpen(false);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Failed to create source: ${msg}`, "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+      >
+        Add source
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6 mb-6">
+      <h2 className="text-base font-medium text-gray-900 mb-4">Add source</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Type
+            </label>
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value as SourceType)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              {SOURCE_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-repo"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Config (JSON)
+          </label>
+          <textarea
+            value={configRaw}
+            onChange={(e) => setConfigRaw(e.target.value)}
+            rows={5}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            placeholder='{"repo_url": "https://github.com/..."}'
+          />
+          {configError && (
+            <p className="text-xs text-red-600 mt-1">{configError}</p>
+          )}
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+          >
+            {submitting ? "Creating..." : "Create"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export function SourcesPage({ addToast }: Props) {
+  const { client } = useTokenContext();
+  const [sources, setSources] = useState<Source[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<Source | null>(null);
+  const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .listSources()
+      .then((s) => {
+        if (!cancelled) setSources(s);
+      })
+      .catch((e) => addToast(String(e), "error"))
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, addToast]);
+
+  const handleCreated = (s: Source) => setSources((prev) => [s, ...prev]);
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await client.deleteSource(deleteTarget.id);
+      setSources((prev) => prev.filter((s) => s.id !== deleteTarget.id));
+      addToast(`Source "${deleteTarget.name}" deleted.`, "success");
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Delete failed: ${msg}`, "error");
+    } finally {
+      setDeleteTarget(null);
+    }
+  };
+
+  const handleSync = async (source: Source) => {
+    setSyncingIds((prev) => new Set(prev).add(source.id));
+    try {
+      const { run_id } = await client.triggerSync(source.id);
+      addToast(`Sync triggered (run ${run_id.slice(0, 8)}).`, "success");
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Sync failed: ${msg}`, "error");
+    } finally {
+      setSyncingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(source.id);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">Sources</h1>
+        <AddSourceForm onCreated={handleCreated} addToast={addToast} />
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-gray-500 py-12 text-center">Loading...</p>
+      ) : sources.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-12 text-center text-sm text-gray-400">
+          No sources configured yet.
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Type
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Last sync
+                </th>
+                <th className="px-4 py-3 text-right font-medium text-gray-600">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {sources.map((src) => (
+                <tr key={src.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 font-medium text-gray-900">
+                    {src.name}
+                    {src.last_error && (
+                      <p className="text-xs text-red-500 mt-0.5 truncate max-w-xs">
+                        {src.last_error}
+                      </p>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-600">
+                    {src.type}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StatusBadge value={src.status} />
+                  </td>
+                  <td className="px-4 py-3 text-gray-500 tabular-nums text-xs">
+                    {src.last_sync_at
+                      ? new Date(src.last_sync_at).toLocaleString()
+                      : "Never"}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <div className="flex justify-end gap-2">
+                      <button
+                        onClick={() => handleSync(src)}
+                        disabled={syncingIds.has(src.id)}
+                        className="px-3 py-1.5 text-xs border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-100 disabled:opacity-50 transition-colors"
+                      >
+                        {syncingIds.has(src.id) ? "Syncing..." : "Sync"}
+                      </button>
+                      <button
+                        onClick={() => setDeleteTarget(src)}
+                        className="px-3 py-1.5 text-xs border border-red-200 text-red-600 rounded-lg hover:bg-red-50 transition-colors"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {deleteTarget && (
+        <ConfirmDialog
+          message={`Delete source "${deleteTarget.name}"? This action cannot be undone.`}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/pages/TokensPage.tsx
+++ b/apps/admin/src/pages/TokensPage.tsx
@@ -1,0 +1,314 @@
+import { useEffect, useState, FormEvent } from "react";
+import { useTokenContext } from "../context/TokenContext";
+import { ApiToken, ApiError } from "../api/client";
+import { ConfirmDialog } from "../components/ConfirmDialog";
+
+const AVAILABLE_SCOPES = ["search", "sources:read", "sources:write", "admin"];
+
+interface ToastFn {
+  (msg: string, type?: "success" | "error" | "info"): void;
+}
+
+interface Props {
+  addToast: ToastFn;
+}
+
+function CreateTokenForm({
+  onCreated,
+  addToast,
+}: {
+  onCreated: (token: ApiToken, secret: string) => void;
+  addToast: ToastFn;
+}) {
+  const { client } = useTokenContext();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [scopes, setScopes] = useState<string[]>(["search"]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const toggleScope = (scope: string) => {
+    setScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]
+    );
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      addToast("Name is required.", "error");
+      return;
+    }
+    if (scopes.length === 0) {
+      addToast("Select at least one scope.", "error");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const resp = await client.createToken({
+        name: name.trim(),
+        scopes,
+      });
+      onCreated(resp.token, resp.secret);
+      setName("");
+      setScopes(["search"]);
+      setOpen(false);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Failed to create token: ${msg}`, "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+      >
+        Create token
+      </button>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6 mb-6">
+      <h2 className="text-base font-medium text-gray-900 mb-4">Create token</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Name
+          </label>
+          <input
+            type="text"
+            required
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="my-service-token"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        <div>
+          <p className="block text-sm font-medium text-gray-700 mb-2">
+            Scopes
+          </p>
+          <div className="flex flex-wrap gap-3">
+            {AVAILABLE_SCOPES.map((scope) => (
+              <label key={scope} className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={scopes.includes(scope)}
+                  onChange={() => toggleScope(scope)}
+                  className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span className="font-mono text-xs">{scope}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+          >
+            {submitting ? "Creating..." : "Create"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function SecretReveal({
+  secret,
+  onDismiss,
+}: {
+  secret: string;
+  onDismiss: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(secret).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="bg-yellow-50 border border-yellow-300 rounded-xl p-4 mb-6">
+      <p className="text-sm font-medium text-yellow-800 mb-2">
+        Copy this token now — it will not be shown again.
+      </p>
+      <div className="flex items-center gap-2">
+        <code className="flex-1 bg-white border border-yellow-200 rounded px-3 py-2 text-xs font-mono break-all">
+          {secret}
+        </code>
+        <button
+          onClick={copy}
+          className="px-3 py-2 text-xs bg-yellow-200 rounded hover:bg-yellow-300 transition-colors whitespace-nowrap"
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+      <button
+        onClick={onDismiss}
+        className="mt-3 text-xs text-yellow-700 hover:underline"
+      >
+        I have saved it
+      </button>
+    </div>
+  );
+}
+
+export function TokensPage({ addToast }: Props) {
+  const { client } = useTokenContext();
+  const [tokens, setTokens] = useState<ApiToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [revokeTarget, setRevokeTarget] = useState<ApiToken | null>(null);
+  const [newSecret, setNewSecret] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .listTokens()
+      .then((t) => {
+        if (!cancelled) setTokens(t);
+      })
+      .catch((e) => addToast(String(e), "error"))
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, addToast]);
+
+  const handleCreated = (token: ApiToken, secret: string) => {
+    setTokens((prev) => [token, ...prev]);
+    setNewSecret(secret);
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    try {
+      await client.deleteToken(revokeTarget.id);
+      setTokens((prev) => prev.filter((t) => t.id !== revokeTarget.id));
+      addToast(`Token "${revokeTarget.name}" revoked.`, "success");
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Revoke failed: ${msg}`, "error");
+    } finally {
+      setRevokeTarget(null);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold text-gray-900">API Tokens</h1>
+        <CreateTokenForm onCreated={handleCreated} addToast={addToast} />
+      </div>
+
+      {newSecret && (
+        <SecretReveal
+          secret={newSecret}
+          onDismiss={() => setNewSecret(null)}
+        />
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-500 py-12 text-center">Loading...</p>
+      ) : tokens.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm px-6 py-12 text-center text-sm text-gray-400">
+          No active tokens.
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Prefix
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Scopes
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Created
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-600">
+                  Last used
+                </th>
+                <th className="px-4 py-3 text-right font-medium text-gray-600">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {tokens.map((tok) => (
+                <tr key={tok.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 font-medium text-gray-900">
+                    {tok.name}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-600">
+                    {tok.token_prefix}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {tok.scopes.map((s) => (
+                        <span
+                          key={s}
+                          className="inline-flex items-center rounded px-1.5 py-0.5 bg-indigo-50 text-indigo-700 text-xs font-mono"
+                        >
+                          {s}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-gray-500 text-xs tabular-nums">
+                    {new Date(tok.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500 text-xs tabular-nums">
+                    {tok.last_used_at
+                      ? new Date(tok.last_used_at).toLocaleString()
+                      : "Never"}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => setRevokeTarget(tok)}
+                      className="px-3 py-1.5 text-xs border border-red-200 text-red-600 rounded-lg hover:bg-red-50 transition-colors"
+                    >
+                      Revoke
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {revokeTarget && (
+        <ConfirmDialog
+          message={`Revoke token "${revokeTarget.name}"? Any services using this token will lose access.`}
+          onConfirm={handleRevoke}
+          onCancel={() => setRevokeTarget(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/tailwind.config.js
+++ b/apps/admin/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/admin/tsconfig.node.json
+++ b/apps/admin/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+      "/health": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,15 @@ services:
       start_period: 10s
     restart: unless-stopped
 
+  admin:
+    build: ./apps/admin
+    ports:
+      - "3001:80"
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped
+
   postgres:
     image: pgvector/pgvector:pg16
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.workspace]
+exclude = ["apps/admin"]
 members = [
     "apps/*",
     "packages/*",


### PR DESCRIPTION
## Summary

React + Vite + Tailwind admin dashboard at `apps/admin/`.

### Pages
- **Dashboard**: stat cards, health status, recent ingestion runs
- **Sources**: CRUD table, JSON config form, sync trigger
- **Tokens**: create with one-time secret reveal + clipboard copy, revoke
- **Ingestion**: filter by source/status, duration display
- **Search Playground**: query input, top_k slider, strategy select, hit cards with citations

### Infrastructure
- Multi-stage Dockerfile (node build → nginx serve)
- Added `admin` service to docker-compose.yml on port 3001
- Nginx proxies `/api` to the backend app

### Auth
- Token-only login (stored in localStorage)
- First token can be minted from the UI itself

27 new files, 2001 lines.

Closes #58