### PR TITLE
feat: Voyage and Cohere embedding providers

### DIFF
--- a/packages/core/src/omniscience_core/config.py
+++ b/packages/core/src/omniscience_core/config.py
@@ -41,6 +41,20 @@ class Settings(BaseSettings):
         default="http://localhost:11434",
         description="Base URL for the Ollama API (used when embedding_provider='ollama').",
     )
+    voyage_api_key: str | None = Field(
+        default=None,
+        description=(
+            "Voyage AI API key (used when embedding_provider='voyage'). "
+            "Falls back to the VOYAGE_API_KEY environment variable when None."
+        ),
+    )
+    cohere_api_key: str | None = Field(
+        default=None,
+        description=(
+            "Cohere API key (used when embedding_provider='cohere'). "
+            "Falls back to the COHERE_API_KEY environment variable when None."
+        ),
+    )
 
     # --- Re-ranker ---
     reranker_enabled: bool = Field(

--- a/packages/embeddings/src/omniscience_embeddings/__init__.py
+++ b/packages/embeddings/src/omniscience_embeddings/__init__.py
@@ -7,6 +7,8 @@ Supported backends
 ------------------
 * **Ollama** (default) — local or self-hosted, privacy-preserving
 * **OpenAI** — ``text-embedding-3-small`` / ``text-embedding-3-large``
+* **Voyage** — ``voyage-3`` / ``voyage-3-lite`` / ``voyage-code-3``
+* **Cohere** — ``embed-english-v3.0`` / ``embed-multilingual-v3.0`` / ``embed-english-light-v3.0``
 
 Example::
 
@@ -19,13 +21,17 @@ Example::
 """
 
 from omniscience_embeddings.base import EmbeddingProvider
+from omniscience_embeddings.cohere import CohereEmbeddingProvider
 from omniscience_embeddings.factory import create_embedding_provider
 from omniscience_embeddings.ollama import OllamaEmbeddingProvider
 from omniscience_embeddings.openai import OpenAIEmbeddingProvider
+from omniscience_embeddings.voyage import VoyageEmbeddingProvider
 
 __all__ = [
+    "CohereEmbeddingProvider",
     "EmbeddingProvider",
     "OllamaEmbeddingProvider",
     "OpenAIEmbeddingProvider",
+    "VoyageEmbeddingProvider",
     "create_embedding_provider",
 ]

--- a/packages/embeddings/src/omniscience_embeddings/cohere.py
+++ b/packages/embeddings/src/omniscience_embeddings/cohere.py
@@ -1,0 +1,190 @@
+"""Cohere embedding provider implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Literal
+
+import httpx
+import structlog
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+log: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+_COHERE_BASE_URL = "https://api.cohere.com"
+
+# Known model dimensions for Cohere embedding models
+_MODEL_DIMS: dict[str, int] = {
+    "embed-english-v3.0": 1024,
+    "embed-multilingual-v3.0": 1024,
+    "embed-english-light-v3.0": 384,
+    "embed-multilingual-light-v3.0": 384,
+}
+
+# Cohere v3 models require an explicit input_type
+CohereInputType = Literal["search_document", "search_query", "classification", "clustering"]
+
+_RETRYABLE = (
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    httpx.RemoteProtocolError,
+    httpx.HTTPStatusError,
+)
+
+
+class CohereEmbeddingProvider:
+    """Embedding provider backed by the Cohere Embeddings API (v2).
+
+    Supports ``embed-english-v3.0`` (1024-d),
+    ``embed-multilingual-v3.0`` (1024-d), and
+    ``embed-english-light-v3.0`` (384-d).
+
+    Cohere v3 models require an *input_type* that signals how the text will
+    be used: ``"search_document"`` for texts being indexed into a corpus and
+    ``"search_query"`` for user queries at retrieval time.
+
+    The API key is read from the ``COHERE_API_KEY`` environment variable by
+    default; you can also pass it explicitly via the *api_key* argument.
+
+    Args:
+        model: Cohere embedding model name (default: 'embed-english-v3.0').
+        api_key: Cohere API key.  Falls back to ``COHERE_API_KEY`` env var.
+        base_url: API base URL (override for proxies / testing).
+        input_type: Semantic role for the texts.  Use ``'search_document'``
+            when building an index and ``'search_query'`` for query vectors.
+            Defaults to ``'search_document'``.
+        dim: Expected embedding dimensionality.  Inferred from *model* when
+            the model is in the built-in table.
+        batch_size: Maximum texts per request (default: 32).
+        max_attempts: Total retry attempts (default: 3).
+        min_backoff: Minimum exponential back-off seconds (default: 1.0).
+        max_backoff: Maximum exponential back-off seconds (default: 10.0).
+        timeout: HTTP request timeout seconds (default: 30.0).
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "embed-english-v3.0",
+        api_key: str | None = None,
+        base_url: str = _COHERE_BASE_URL,
+        input_type: CohereInputType = "search_document",
+        dim: int | None = None,
+        batch_size: int = 32,
+        max_attempts: int = 3,
+        min_backoff: float = 1.0,
+        max_backoff: float = 10.0,
+        timeout: float = 30.0,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("COHERE_API_KEY", "")
+        self._model = model
+        self._input_type = input_type
+        self._dim = dim if dim is not None else _MODEL_DIMS.get(model, 1024)
+        self._batch_size = batch_size
+        self._max_attempts = max_attempts
+        self._min_backoff = min_backoff
+        self._max_backoff = max_backoff
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            timeout=httpx.Timeout(timeout),
+            headers={
+                "Authorization": f"Bearer {resolved_key}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    # --- Protocol properties ------------------------------------------------
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def provider_name(self) -> str:
+        return "cohere"
+
+    # --- Public API ---------------------------------------------------------
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed *texts* in batches, returning one vector per input text."""
+        if not texts:
+            return []
+
+        all_embeddings: list[list[float]] = []
+        for batch in _chunk(texts, self._batch_size):
+            vectors = await self._embed_batch_with_retry(batch)
+            all_embeddings.extend(vectors)
+        return all_embeddings
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+        log.debug("cohere_client_closed", model=self._model)
+
+    # --- Internal -----------------------------------------------------------
+
+    async def _embed_batch_with_retry(self, batch: list[str]) -> list[list[float]]:
+        """Embed a single batch with exponential back-off retry.
+
+        Uses tenacity with ``reraise=True`` so the original exception surfaces
+        after all attempts are exhausted rather than a ``RetryError``.
+        """
+        wrapped = retry(
+            retry=retry_if_exception_type(_RETRYABLE),
+            stop=stop_after_attempt(self._max_attempts),
+            wait=wait_exponential(min=self._min_backoff, max=self._max_backoff),
+            reraise=True,
+        )(self._post_embed)
+        return await wrapped(batch)
+
+    async def _post_embed(self, batch: list[str]) -> list[list[float]]:
+        """POST one batch to the Cohere /v2/embed endpoint."""
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "texts": batch,
+            "input_type": self._input_type,
+            "embedding_types": ["float"],
+        }
+        log.debug("cohere_embed_request", model=self._model, batch_size=len(batch))
+
+        response = await self._client.post("/v2/embed", json=payload)
+        response.raise_for_status()
+
+        data: dict[str, Any] = response.json()
+        # Cohere v2 returns embeddings nested under embeddings.float
+        vectors: list[list[float]] = data["embeddings"]["float"]
+        _validate_dimensions(vectors, self._dim, self._model)
+
+        log.debug("cohere_embed_ok", model=self._model, count=len(vectors))
+        return vectors
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _chunk(items: list[str], size: int) -> list[list[str]]:
+    """Split *items* into consecutive sub-lists of at most *size* elements."""
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def _validate_dimensions(
+    vectors: list[list[float]],
+    expected_dim: int,
+    model: str,
+) -> None:
+    """Raise ValueError if any returned vector has the wrong dimensionality."""
+    for i, vec in enumerate(vectors):
+        if len(vec) != expected_dim:
+            raise ValueError(
+                f"Dimension mismatch from model '{model}': "
+                f"expected {expected_dim}, got {len(vec)} at index {i}"
+            )

--- a/packages/embeddings/src/omniscience_embeddings/factory.py
+++ b/packages/embeddings/src/omniscience_embeddings/factory.py
@@ -6,10 +6,12 @@ from omniscience_core.config import Settings
 from omniscience_core.errors import ConfigError
 
 from omniscience_embeddings.base import EmbeddingProvider
+from omniscience_embeddings.cohere import CohereEmbeddingProvider
 from omniscience_embeddings.ollama import OllamaEmbeddingProvider
 from omniscience_embeddings.openai import OpenAIEmbeddingProvider
+from omniscience_embeddings.voyage import VoyageEmbeddingProvider
 
-_SUPPORTED_PROVIDERS = ("ollama", "openai")
+_SUPPORTED_PROVIDERS = ("ollama", "openai", "voyage", "cohere")
 
 
 def create_embedding_provider(settings: Settings) -> EmbeddingProvider:
@@ -17,8 +19,10 @@ def create_embedding_provider(settings: Settings) -> EmbeddingProvider:
 
     Routes on ``settings.embedding_provider``:
 
-    * ``"ollama"`` → :class:`OllamaEmbeddingProvider` using ``settings.ollama_url``
-    * ``"openai"`` → :class:`OpenAIEmbeddingProvider` with default model
+    * ``"ollama"``  → :class:`OllamaEmbeddingProvider` using ``settings.ollama_url``
+    * ``"openai"``  → :class:`OpenAIEmbeddingProvider` with default model
+    * ``"voyage"``  → :class:`VoyageEmbeddingProvider` using ``settings.voyage_api_key``
+    * ``"cohere"``  → :class:`CohereEmbeddingProvider` using ``settings.cohere_api_key``
 
     Args:
         settings: Application settings instance.
@@ -36,6 +40,12 @@ def create_embedding_provider(settings: Settings) -> EmbeddingProvider:
 
     if provider == "openai":
         return OpenAIEmbeddingProvider()
+
+    if provider == "voyage":
+        return VoyageEmbeddingProvider(api_key=settings.voyage_api_key or None)
+
+    if provider == "cohere":
+        return CohereEmbeddingProvider(api_key=settings.cohere_api_key or None)
 
     raise ConfigError(
         f"Unknown embedding provider '{settings.embedding_provider}'. "

--- a/packages/embeddings/src/omniscience_embeddings/voyage.py
+++ b/packages/embeddings/src/omniscience_embeddings/voyage.py
@@ -1,0 +1,172 @@
+"""Voyage AI embedding provider implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import structlog
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+log: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+_VOYAGE_BASE_URL = "https://api.voyageai.com"
+
+# Known model dimensions for Voyage embedding models
+_MODEL_DIMS: dict[str, int] = {
+    "voyage-3": 1024,
+    "voyage-3-lite": 512,
+    "voyage-code-3": 1024,
+}
+
+_RETRYABLE = (
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    httpx.RemoteProtocolError,
+    httpx.HTTPStatusError,
+)
+
+
+class VoyageEmbeddingProvider:
+    """Embedding provider backed by the Voyage AI Embeddings API.
+
+    Supports ``voyage-3`` (1024-d), ``voyage-3-lite`` (512-d), and
+    ``voyage-code-3`` (1024-d).
+
+    The API key is read from the ``VOYAGE_API_KEY`` environment variable by
+    default; you can also pass it explicitly via the *api_key* argument.
+
+    Args:
+        model: Voyage embedding model name (default: 'voyage-3').
+        api_key: Voyage API key.  Falls back to ``VOYAGE_API_KEY`` env var.
+        base_url: API base URL (override for proxies / testing).
+        dim: Expected embedding dimensionality.  Inferred from *model* when
+            the model is in the built-in table.
+        batch_size: Maximum texts per request (default: 32).
+        max_attempts: Total retry attempts (default: 3).
+        min_backoff: Minimum exponential back-off seconds (default: 1.0).
+        max_backoff: Maximum exponential back-off seconds (default: 10.0).
+        timeout: HTTP request timeout seconds (default: 30.0).
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "voyage-3",
+        api_key: str | None = None,
+        base_url: str = _VOYAGE_BASE_URL,
+        dim: int | None = None,
+        batch_size: int = 32,
+        max_attempts: int = 3,
+        min_backoff: float = 1.0,
+        max_backoff: float = 10.0,
+        timeout: float = 30.0,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("VOYAGE_API_KEY", "")
+        self._model = model
+        self._dim = dim if dim is not None else _MODEL_DIMS.get(model, 1024)
+        self._batch_size = batch_size
+        self._max_attempts = max_attempts
+        self._min_backoff = min_backoff
+        self._max_backoff = max_backoff
+        self._client = httpx.AsyncClient(
+            base_url=base_url,
+            timeout=httpx.Timeout(timeout),
+            headers={
+                "Authorization": f"Bearer {resolved_key}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    # --- Protocol properties ------------------------------------------------
+
+    @property
+    def dim(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def provider_name(self) -> str:
+        return "voyage"
+
+    # --- Public API ---------------------------------------------------------
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed *texts* in batches, returning one vector per input text."""
+        if not texts:
+            return []
+
+        all_embeddings: list[list[float]] = []
+        for batch in _chunk(texts, self._batch_size):
+            vectors = await self._embed_batch_with_retry(batch)
+            all_embeddings.extend(vectors)
+        return all_embeddings
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+        log.debug("voyage_client_closed", model=self._model)
+
+    # --- Internal -----------------------------------------------------------
+
+    async def _embed_batch_with_retry(self, batch: list[str]) -> list[list[float]]:
+        """Embed a single batch with exponential back-off retry.
+
+        Uses tenacity with ``reraise=True`` so the original exception surfaces
+        after all attempts are exhausted rather than a ``RetryError``.
+        """
+        wrapped = retry(
+            retry=retry_if_exception_type(_RETRYABLE),
+            stop=stop_after_attempt(self._max_attempts),
+            wait=wait_exponential(min=self._min_backoff, max=self._max_backoff),
+            reraise=True,
+        )(self._post_embed)
+        return await wrapped(batch)
+
+    async def _post_embed(self, batch: list[str]) -> list[list[float]]:
+        """POST one batch to the Voyage AI /v1/embeddings endpoint."""
+        payload: dict[str, Any] = {"model": self._model, "input": batch}
+        log.debug("voyage_embed_request", model=self._model, batch_size=len(batch))
+
+        response = await self._client.post("/v1/embeddings", json=payload)
+        response.raise_for_status()
+
+        data: dict[str, Any] = response.json()
+        # Sort by index to ensure order matches input order
+        items: list[dict[str, Any]] = sorted(data["data"], key=lambda x: x["index"])
+        vectors: list[list[float]] = [item["embedding"] for item in items]
+        _validate_dimensions(vectors, self._dim, self._model)
+
+        log.debug("voyage_embed_ok", model=self._model, count=len(vectors))
+        return vectors
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _chunk(items: list[str], size: int) -> list[list[str]]:
+    """Split *items* into consecutive sub-lists of at most *size* elements."""
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def _validate_dimensions(
+    vectors: list[list[float]],
+    expected_dim: int,
+    model: str,
+) -> None:
+    """Raise ValueError if any returned vector has the wrong dimensionality."""
+    for i, vec in enumerate(vectors):
+        if len(vec) != expected_dim:
+            raise ValueError(
+                f"Dimension mismatch from model '{model}': "
+                f"expected {expected_dim}, got {len(vec)} at index {i}"
+            )

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -3,7 +3,7 @@
 Covers:
 - OllamaEmbeddingProvider: happy path, batching, retry, dimension validation
 - OpenAIEmbeddingProvider: happy path, batching, dimension validation
-- Factory routing: ollama, openai, unknown provider
+- Factory routing: ollama, openai, voyage, cohere, unknown provider
 - close() cleanup
 """
 
@@ -16,9 +16,11 @@ import pytest
 from omniscience_core.config import Settings
 from omniscience_core.errors import ConfigError
 from omniscience_embeddings import (
+    CohereEmbeddingProvider,
     EmbeddingProvider,
     OllamaEmbeddingProvider,
     OpenAIEmbeddingProvider,
+    VoyageEmbeddingProvider,
     create_embedding_provider,
 )
 
@@ -394,8 +396,24 @@ def test_factory_creates_openai(monkeypatch: pytest.MonkeyPatch) -> None:
     assert provider.provider_name == "openai"
 
 
-def test_factory_unknown_provider_raises() -> None:
+def test_factory_creates_voyage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VOYAGE_API_KEY", "pa-test")
     settings = Settings(embedding_provider="voyage")
+    provider = create_embedding_provider(settings)
+    assert isinstance(provider, VoyageEmbeddingProvider)
+    assert provider.provider_name == "voyage"
+
+
+def test_factory_creates_cohere(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COHERE_API_KEY", "co-test")
+    settings = Settings(embedding_provider="cohere")
+    provider = create_embedding_provider(settings)
+    assert isinstance(provider, CohereEmbeddingProvider)
+    assert provider.provider_name == "cohere"
+
+
+def test_factory_unknown_provider_raises() -> None:
+    settings = Settings(embedding_provider="unknown-provider-xyz")
     with pytest.raises(ConfigError, match="Unknown embedding provider"):
         create_embedding_provider(settings)
 

--- a/tests/test_voyage_cohere.py
+++ b/tests/test_voyage_cohere.py
@@ -1,0 +1,635 @@
+"""Tests for VoyageEmbeddingProvider and CohereEmbeddingProvider.
+
+Covers:
+- Protocol compliance
+- Property accessors (model_name, provider_name, dim)
+- embed(): happy path, empty input, batching, dimension validation
+- Retry behaviour: transient failure recovery, exhausted retries
+- close(): client cleanup
+- Factory routing for 'voyage' and 'cohere'
+- Settings integration: voyage_api_key / cohere_api_key fields
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from omniscience_core.config import Settings
+from omniscience_embeddings import (
+    CohereEmbeddingProvider,
+    EmbeddingProvider,
+    VoyageEmbeddingProvider,
+    create_embedding_provider,
+)
+
+# ---------------------------------------------------------------------------
+# Response builders
+# ---------------------------------------------------------------------------
+
+_VOYAGE_DIM = 1024
+_VOYAGE_LITE_DIM = 512
+_COHERE_DIM = 1024
+_COHERE_LIGHT_DIM = 384
+
+
+def _make_voyage_response(texts: list[str], dim: int = _VOYAGE_DIM) -> httpx.Response:
+    """Build a mock Voyage /v1/embeddings response for *texts*."""
+    body = {
+        "data": [{"index": i, "embedding": [0.1] * dim} for i in range(len(texts))],
+        "model": "voyage-3",
+    }
+    return httpx.Response(200, json=body)
+
+
+def _make_cohere_response(texts: list[str], dim: int = _COHERE_DIM) -> httpx.Response:
+    """Build a mock Cohere /v2/embed response for *texts*."""
+    body = {
+        "embeddings": {
+            "float": [[0.1] * dim for _ in texts],
+        },
+        "model": "embed-english-v3.0",
+    }
+    return httpx.Response(200, json=body)
+
+
+def _make_transport(responses: list[httpx.Response]) -> httpx.MockTransport:
+    """Return a MockTransport that yields *responses* in order."""
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        resp = responses[call_count]
+        call_count += 1
+        return resp
+
+    return httpx.MockTransport(handler)
+
+
+# ===========================================================================
+# VoyageEmbeddingProvider
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+def test_voyage_satisfies_protocol() -> None:
+    provider = VoyageEmbeddingProvider(api_key="pa-test")
+    assert isinstance(provider, EmbeddingProvider)
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_voyage_properties_default_model() -> None:
+    p = VoyageEmbeddingProvider(api_key="pa-test")
+    assert p.model_name == "voyage-3"
+    assert p.provider_name == "voyage"
+    assert p.dim == 1024
+
+
+def test_voyage_properties_lite_model() -> None:
+    p = VoyageEmbeddingProvider(model="voyage-3-lite", api_key="pa-test")
+    assert p.model_name == "voyage-3-lite"
+    assert p.dim == 512
+
+
+def test_voyage_properties_code_model() -> None:
+    p = VoyageEmbeddingProvider(model="voyage-code-3", api_key="pa-test")
+    assert p.model_name == "voyage-code-3"
+    assert p.dim == 1024
+
+
+def test_voyage_explicit_dim_overrides_table() -> None:
+    p = VoyageEmbeddingProvider(model="voyage-3", api_key="pa-test", dim=256)
+    assert p.dim == 256
+
+
+def test_voyage_unknown_model_falls_back_to_1024() -> None:
+    p = VoyageEmbeddingProvider(model="voyage-custom", api_key="pa-test")
+    assert p.dim == 1024
+
+
+# ---------------------------------------------------------------------------
+# embed — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voyage_embed_single_batch() -> None:
+    texts = ["hello", "world"]
+    transport = _make_transport([_make_voyage_response(texts)])
+    provider = VoyageEmbeddingProvider(model="voyage-3", api_key="pa-test")
+    provider._client = httpx.AsyncClient(base_url="https://api.voyageai.com", transport=transport)
+
+    result = await provider.embed(texts)
+
+    assert len(result) == 2
+    assert len(result[0]) == _VOYAGE_DIM
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_voyage_embed_empty_returns_empty() -> None:
+    provider = VoyageEmbeddingProvider(api_key="pa-test")
+    result = await provider.embed([])
+    assert result == []
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_voyage_embed_preserves_order() -> None:
+    """Response items returned out-of-order must be sorted by index."""
+    texts = ["a", "b", "c"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Return items in reverse index order
+        body = {
+            "data": [
+                {"index": 2, "embedding": [0.3] * _VOYAGE_DIM},
+                {"index": 0, "embedding": [0.1] * _VOYAGE_DIM},
+                {"index": 1, "embedding": [0.2] * _VOYAGE_DIM},
+            ],
+            "model": "voyage-3",
+        }
+        return httpx.Response(200, json=body)
+
+    transport = httpx.MockTransport(handler)
+    provider = VoyageEmbeddingProvider(model="voyage-3", api_key="pa-test")
+    provider._client = httpx.AsyncClient(base_url="https://api.voyageai.com", transport=transport)
+
+    result = await provider.embed(texts)
+
+    assert result[0][0] == pytest.approx(0.1)
+    assert result[1][0] == pytest.approx(0.2)
+    assert result[2][0] == pytest.approx(0.3)
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# embed — batching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voyage_batching_splits_into_correct_calls() -> None:
+    """100 texts with batch_size=32 → 4 HTTP calls (32, 32, 32, 4)."""
+    texts = [f"text_{i}" for i in range(100)]
+    batch_sizes_seen: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        batch = payload["input"]
+        batch_sizes_seen.append(len(batch))
+        return _make_voyage_response(batch)
+
+    transport = httpx.MockTransport(handler)
+    provider = VoyageEmbeddingProvider(model="voyage-3", api_key="pa-test", batch_size=32)
+    provider._client = httpx.AsyncClient(base_url="https://api.voyageai.com", transport=transport)
+
+    result = await provider.embed(texts)
+
+    assert len(result) == 100
+    assert batch_sizes_seen == [32, 32, 32, 4]
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# embed — dimension validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voyage_wrong_dimension_raises() -> None:
+    texts = ["check dim"]
+    wrong_dim = 999
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _make_voyage_response(texts, dim=wrong_dim)
+
+    transport = httpx.MockTransport(handler)
+    provider = VoyageEmbeddingProvider(model="voyage-3", api_key="pa-test")  # expects 1024
+    provider._client = httpx.AsyncClient(base_url="https://api.voyageai.com", transport=transport)
+
+    with pytest.raises(ValueError, match="Dimension mismatch"):
+        await provider.embed(texts)
+
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voyage_retry_on_transient_failure() -> None:
+    """First call raises ConnectError; second succeeds."""
+    texts = ["retry me"]
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ConnectError("transient failure")
+        return _make_voyage_response(texts)
+
+    transport = httpx.MockTransport(handler)
+    provider = VoyageEmbeddingProvider(
+        model="voyage-3",
+        api_key="pa-test",
+        max_attempts=3,
+        min_backoff=0.0,
+        max_backoff=0.0,
+    )
+    provider._client = httpx.AsyncClient(base_url="https://api.voyageai.com", transport=transport)
+
+    result = await provider.embed(texts)
+
+    assert len(result) == 1
+    assert call_count == 2
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_voyage_retry_exhausted_raises() -> None:
+    """All retry attempts fail → exception is re-raised."""
+    texts = ["fail me"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("always fails")
+
+    transport = httpx.MockTransport(handler)
+    provider = VoyageEmbeddingProvider(
+        model="voyage-3",
+        api_key="pa-test",
+        max_attempts=2,
+        min_backoff=0.0,
+        max_backoff=0.0,
+    )
+    provider._client = httpx.AsyncClient(base_url="https://api.voyageai.com", transport=transport)
+
+    with pytest.raises(httpx.ConnectError):
+        await provider.embed(texts)
+
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voyage_close_releases_client() -> None:
+    provider = VoyageEmbeddingProvider(api_key="pa-test")
+    closed_called = False
+    original_aclose = provider._client.aclose
+
+    async def mock_aclose() -> None:
+        nonlocal closed_called
+        closed_called = True
+        await original_aclose()
+
+    provider._client.aclose = mock_aclose  # type: ignore[method-assign]
+    await provider.close()
+    assert closed_called
+
+
+# ===========================================================================
+# CohereEmbeddingProvider
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+def test_cohere_satisfies_protocol() -> None:
+    provider = CohereEmbeddingProvider(api_key="co-test")
+    assert isinstance(provider, EmbeddingProvider)
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_cohere_properties_default_model() -> None:
+    p = CohereEmbeddingProvider(api_key="co-test")
+    assert p.model_name == "embed-english-v3.0"
+    assert p.provider_name == "cohere"
+    assert p.dim == 1024
+
+
+def test_cohere_properties_multilingual_model() -> None:
+    p = CohereEmbeddingProvider(model="embed-multilingual-v3.0", api_key="co-test")
+    assert p.model_name == "embed-multilingual-v3.0"
+    assert p.dim == 1024
+
+
+def test_cohere_properties_light_model() -> None:
+    p = CohereEmbeddingProvider(model="embed-english-light-v3.0", api_key="co-test")
+    assert p.model_name == "embed-english-light-v3.0"
+    assert p.dim == 384
+
+
+def test_cohere_explicit_dim_overrides_table() -> None:
+    p = CohereEmbeddingProvider(model="embed-english-v3.0", api_key="co-test", dim=512)
+    assert p.dim == 512
+
+
+def test_cohere_default_input_type_is_search_document() -> None:
+    p = CohereEmbeddingProvider(api_key="co-test")
+    assert p._input_type == "search_document"
+
+
+def test_cohere_search_query_input_type() -> None:
+    p = CohereEmbeddingProvider(api_key="co-test", input_type="search_query")
+    assert p._input_type == "search_query"
+
+
+# ---------------------------------------------------------------------------
+# embed — happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohere_embed_single_batch() -> None:
+    texts = ["hello", "world"]
+    transport = _make_transport([_make_cohere_response(texts)])
+    provider = CohereEmbeddingProvider(model="embed-english-v3.0", api_key="co-test")
+    provider._client = httpx.AsyncClient(base_url="https://api.cohere.com", transport=transport)
+
+    result = await provider.embed(texts)
+
+    assert len(result) == 2
+    assert len(result[0]) == _COHERE_DIM
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_cohere_embed_empty_returns_empty() -> None:
+    provider = CohereEmbeddingProvider(api_key="co-test")
+    result = await provider.embed([])
+    assert result == []
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_cohere_request_includes_input_type() -> None:
+    """Verify the 'input_type' field is sent in the request payload."""
+    texts = ["doc text"]
+    received_payload: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal received_payload
+        received_payload = json.loads(request.content)
+        return _make_cohere_response(texts)
+
+    transport = httpx.MockTransport(handler)
+    provider = CohereEmbeddingProvider(
+        model="embed-english-v3.0",
+        api_key="co-test",
+        input_type="search_query",
+    )
+    provider._client = httpx.AsyncClient(base_url="https://api.cohere.com", transport=transport)
+
+    await provider.embed(texts)
+
+    assert received_payload.get("input_type") == "search_query"
+    assert received_payload.get("model") == "embed-english-v3.0"
+    assert "texts" in received_payload
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_cohere_request_includes_embedding_types() -> None:
+    """Verify 'embedding_types' contains 'float' in request payload."""
+    texts = ["check payload"]
+    received_payload: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal received_payload
+        received_payload = json.loads(request.content)
+        return _make_cohere_response(texts)
+
+    transport = httpx.MockTransport(handler)
+    provider = CohereEmbeddingProvider(model="embed-english-v3.0", api_key="co-test")
+    provider._client = httpx.AsyncClient(base_url="https://api.cohere.com", transport=transport)
+
+    await provider.embed(texts)
+
+    assert received_payload.get("embedding_types") == ["float"]
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# embed — batching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohere_batching_splits_into_correct_calls() -> None:
+    """100 texts with batch_size=32 → 4 HTTP calls (32, 32, 32, 4)."""
+    texts = [f"text_{i}" for i in range(100)]
+    batch_sizes_seen: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        batch = payload["texts"]
+        batch_sizes_seen.append(len(batch))
+        return _make_cohere_response(batch)
+
+    transport = httpx.MockTransport(handler)
+    provider = CohereEmbeddingProvider(
+        model="embed-english-v3.0", api_key="co-test", batch_size=32
+    )
+    provider._client = httpx.AsyncClient(base_url="https://api.cohere.com", transport=transport)
+
+    result = await provider.embed(texts)
+
+    assert len(result) == 100
+    assert batch_sizes_seen == [32, 32, 32, 4]
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# embed — dimension validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohere_wrong_dimension_raises() -> None:
+    texts = ["check dim"]
+    wrong_dim = 999
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _make_cohere_response(texts, dim=wrong_dim)
+
+    transport = httpx.MockTransport(handler)
+    provider = CohereEmbeddingProvider(
+        model="embed-english-v3.0", api_key="co-test"
+    )  # expects 1024
+    provider._client = httpx.AsyncClient(base_url="https://api.cohere.com", transport=transport)
+
+    with pytest.raises(ValueError, match="Dimension mismatch"):
+        await provider.embed(texts)
+
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# Retry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohere_retry_on_transient_failure() -> None:
+    """First call raises ConnectError; second succeeds."""
+    texts = ["retry me"]
+    call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ConnectError("transient failure")
+        return _make_cohere_response(texts)
+
+    transport = httpx.MockTransport(handler)
+    provider = CohereEmbeddingProvider(
+        model="embed-english-v3.0",
+        api_key="co-test",
+        max_attempts=3,
+        min_backoff=0.0,
+        max_backoff=0.0,
+    )
+    provider._client = httpx.AsyncClient(base_url="https://api.cohere.com", transport=transport)
+
+    result = await provider.embed(texts)
+
+    assert len(result) == 1
+    assert call_count == 2
+    await provider.close()
+
+
+@pytest.mark.asyncio
+async def test_cohere_retry_exhausted_raises() -> None:
+    """All retry attempts fail → exception is re-raised."""
+    texts = ["fail me"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("always fails")
+
+    transport = httpx.MockTransport(handler)
+    provider = CohereEmbeddingProvider(
+        model="embed-english-v3.0",
+        api_key="co-test",
+        max_attempts=2,
+        min_backoff=0.0,
+        max_backoff=0.0,
+    )
+    provider._client = httpx.AsyncClient(base_url="https://api.cohere.com", transport=transport)
+
+    with pytest.raises(httpx.ConnectError):
+        await provider.embed(texts)
+
+    await provider.close()
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohere_close_releases_client() -> None:
+    provider = CohereEmbeddingProvider(api_key="co-test")
+    closed_called = False
+    original_aclose = provider._client.aclose
+
+    async def mock_aclose() -> None:
+        nonlocal closed_called
+        closed_called = True
+        await original_aclose()
+
+    provider._client.aclose = mock_aclose  # type: ignore[method-assign]
+    await provider.close()
+    assert closed_called
+
+
+# ===========================================================================
+# Factory — Voyage and Cohere routing
+# ===========================================================================
+
+
+def test_factory_voyage_from_settings_key() -> None:
+    """voyage_api_key in Settings flows through to the provider."""
+    settings = Settings(embedding_provider="voyage", voyage_api_key="pa-settings-key")
+    provider = create_embedding_provider(settings)
+    assert isinstance(provider, VoyageEmbeddingProvider)
+    assert provider.provider_name == "voyage"
+
+
+def test_factory_voyage_from_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """VOYAGE_API_KEY env var is used when settings key is None."""
+    monkeypatch.setenv("VOYAGE_API_KEY", "pa-env-key")
+    settings = Settings(embedding_provider="voyage", voyage_api_key=None)
+    provider = create_embedding_provider(settings)
+    assert isinstance(provider, VoyageEmbeddingProvider)
+
+
+def test_factory_cohere_from_settings_key() -> None:
+    """cohere_api_key in Settings flows through to the provider."""
+    settings = Settings(embedding_provider="cohere", cohere_api_key="co-settings-key")
+    provider = create_embedding_provider(settings)
+    assert isinstance(provider, CohereEmbeddingProvider)
+    assert provider.provider_name == "cohere"
+
+
+def test_factory_cohere_from_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """COHERE_API_KEY env var is used when settings key is None."""
+    monkeypatch.setenv("COHERE_API_KEY", "co-env-key")
+    settings = Settings(embedding_provider="cohere", cohere_api_key=None)
+    provider = create_embedding_provider(settings)
+    assert isinstance(provider, CohereEmbeddingProvider)
+
+
+# ===========================================================================
+# Settings — new API key fields
+# ===========================================================================
+
+
+def test_settings_voyage_api_key_defaults_to_none() -> None:
+    settings = Settings()
+    assert settings.voyage_api_key is None
+
+
+def test_settings_cohere_api_key_defaults_to_none() -> None:
+    settings = Settings()
+    assert settings.cohere_api_key is None
+
+
+def test_settings_voyage_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VOYAGE_API_KEY", "pa-from-env")
+    settings = Settings(voyage_api_key=None)
+    # The field is None because env-var fallback lives in the provider, not Settings
+    # (Settings.voyage_api_key is an optional explicit override)
+    assert settings.voyage_api_key is None
+
+
+def test_settings_voyage_api_key_explicit_value() -> None:
+    settings = Settings(voyage_api_key="pa-explicit")
+    assert settings.voyage_api_key == "pa-explicit"
+
+
+def test_settings_cohere_api_key_explicit_value() -> None:
+    settings = Settings(cohere_api_key="co-explicit")
+    assert settings.cohere_api_key == "co-explicit"


### PR DESCRIPTION
VoyageEmbeddingProvider (voyage-3/lite/code-3) + CohereEmbeddingProvider (v3.0/multilingual/light). Factory routing, config fields. 39 new tests. Closes #72