### PR TITLE
feat: AWS live-resources connector with ARN linker strategy

### DIFF
--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -21,7 +21,7 @@ Registry::
     from omniscience_connectors import ConnectorRegistry, get_connector
 
 Built-in connectors (``git``, ``fs``, ``confluence``, ``notion``, ``slack``,
-``jira``, ``k8s-agentic``, ``s3``) are registered below and available
+``jira``, ``k8s-agentic``, ``s3``, ``aws``) are registered below and available
 immediately on import.  Third-party connectors call :func:`get_connector`
 after registering against the shared registry.
 """
@@ -35,6 +35,7 @@ from omniscience_connectors.agentic import (
     OllamaLLMProvider,
     build_provider,
 )
+from omniscience_connectors.aws.connector import AwsConfig, AwsConnector
 from omniscience_connectors.base import (
     Connector,
     DocumentRef,
@@ -67,6 +68,7 @@ _registry.register(JiraConnector)
 _registry.register(K8sAgenticConnector)
 _registry.register(DatabaseConnector)
 _registry.register(S3Connector)
+_registry.register(AwsConnector)
 
 # Public alias for the shared registry instance (all built-ins pre-registered).
 default_registry: ConnectorRegistry = _registry
@@ -74,6 +76,8 @@ default_registry: ConnectorRegistry = _registry
 __all__ = [
     "AgentConfig",
     "AgenticConnector",
+    "AwsConfig",
+    "AwsConnector",
     "ConfluenceConnector",
     "Connector",
     "ConnectorRegistry",

--- a/packages/connectors/src/omniscience_connectors/aws/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/aws/__init__.py
@@ -1,0 +1,1 @@
+"""AWS live-resources connector package."""

--- a/packages/connectors/src/omniscience_connectors/aws/connector.py
+++ b/packages/connectors/src/omniscience_connectors/aws/connector.py
@@ -1,0 +1,734 @@
+"""AWS live-resources connector.
+
+Discovers and describes live AWS resources across services and regions.
+Uses boto3 wrapped in ``asyncio.to_thread`` for async compatibility.
+
+Authentication is resolved from the ``secrets`` dict at call time:
+- ``aws_access_key_id`` + ``aws_secret_access_key`` (+ optional ``aws_session_token``)
+- ``aws_profile`` for SSO / named AWS profile
+- Neither: falls back to the default credential chain (instance role, env vars, etc.)
+
+Each discovered resource is tagged with ``kind="aws_live"`` and its ARN is stored
+in ``extra`` metadata to enable ARN-based cross-source linking.
+
+Supported services
+------------------
+- **s3** — list_buckets + describe each (tags, policy, versioning)  [global]
+- **iam** — list_users, list_roles, list_policies                   [global]
+- **ec2** — describe_instances, describe_vpcs, describe_security_groups [per-region]
+
+URI format: ``aws://{account_id}/{region}/{service}/{resource_type}/{name}``
+external_id: ARN (e.g. ``arn:aws:s3:::my-bucket``)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any, ClassVar
+
+import boto3
+import botocore.exceptions
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import Connector, DocumentRef, FetchedDocument, WebhookHandler
+
+__all__ = ["AwsConfig", "AwsConnector"]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class AwsConfig(BaseModel):
+    """Public configuration for the AWS connector (no secrets)."""
+
+    regions: list[str] = Field(default=["us-east-1"])
+    """List of AWS regions to scan for regional services like EC2."""
+
+    services: list[str] = Field(default=["s3", "iam", "ec2"])
+    """Which AWS services to discover.  Supported: ``"s3"``, ``"iam"``, ``"ec2"``."""
+
+    resource_type_filters: list[str] = Field(default_factory=list)
+    """Optional resource-type allow-list (e.g. ``["aws_instance", "aws_vpc"]``).
+    Empty means include all resource types for the configured services."""
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+
+
+def _build_session(secrets: dict[str, str], region: str | None = None) -> boto3.Session:
+    """Build a boto3 Session from runtime secrets.
+
+    Credential resolution order:
+    1. Explicit key/secret (``aws_access_key_id`` + ``aws_secret_access_key``).
+    2. Named profile (``aws_profile``) for SSO / shared config.
+    3. Default credential chain (instance role, env vars, ~/.aws/credentials).
+    """
+    access_key = secrets.get("aws_access_key_id", "")
+    secret_key = secrets.get("aws_secret_access_key", "")
+    session_token = secrets.get("aws_session_token", "")
+    profile = secrets.get("aws_profile", "")
+
+    if access_key and secret_key:
+        return boto3.Session(
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            aws_session_token=session_token or None,
+            region_name=region,
+        )
+    if profile:
+        return boto3.Session(profile_name=profile, region_name=region)
+    return boto3.Session(region_name=region)
+
+
+def _build_client(service: str, secrets: dict[str, str], region: str | None = None) -> Any:
+    """Return a boto3 service client."""
+    session = _build_session(secrets, region)
+    return session.client(service)  # type: ignore[call-overload]
+
+
+def _get_account_id(secrets: dict[str, str]) -> str:
+    """Retrieve the AWS account ID via STS get-caller-identity."""
+    sts = _build_client("sts", secrets)
+    response: dict[str, Any] = sts.get_caller_identity()
+    return str(response["Account"])
+
+
+# ---------------------------------------------------------------------------
+# Resource-type filter helper
+# ---------------------------------------------------------------------------
+
+
+def _allowed(resource_type: str, filters: list[str]) -> bool:
+    """Return True if *resource_type* is permitted by the filter list.
+
+    When the filter list is empty all resource types are permitted.
+    """
+    if not filters:
+        return True
+    return resource_type in filters
+
+
+# ---------------------------------------------------------------------------
+# Per-service discovery helpers (synchronous — run in asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _discover_s3(
+    secrets: dict[str, str],
+    account_id: str,
+    filters: list[str],
+) -> list[DocumentRef]:
+    """List all S3 buckets and return a DocumentRef per bucket."""
+    client = _build_client("s3", secrets)
+    refs: list[DocumentRef] = []
+
+    response: dict[str, Any] = client.list_buckets()
+    buckets: list[dict[str, Any]] = response.get("Buckets", [])
+
+    for bucket in buckets:
+        name: str = bucket.get("Name", "")
+        if not name:
+            continue
+
+        resource_type = "aws_s3_bucket"
+        if not _allowed(resource_type, filters):
+            continue
+
+        # S3 buckets are global; region is "us-east-1" by convention in ARNs
+        arn = f"arn:aws:s3:::{name}"
+        uri = f"aws://{account_id}/global/s3/bucket/{name}"
+
+        # Collect supplementary metadata without failing if permissions are missing
+        tags: dict[str, str] = {}
+        versioning = ""
+        location = ""
+
+        try:
+            tag_resp: dict[str, Any] = client.get_bucket_tagging(Bucket=name)
+            tags = {t["Key"]: t["Value"] for t in tag_resp.get("TagSet", [])}
+        except botocore.exceptions.ClientError:
+            pass
+
+        try:
+            ver_resp: dict[str, Any] = client.get_bucket_versioning(Bucket=name)
+            versioning = ver_resp.get("Status", "")
+        except botocore.exceptions.ClientError:
+            pass
+
+        try:
+            loc_resp: dict[str, Any] = client.get_bucket_location(Bucket=name)
+            location = loc_resp.get("LocationConstraint") or "us-east-1"
+        except botocore.exceptions.ClientError:
+            pass
+
+        refs.append(
+            DocumentRef(
+                external_id=arn,
+                uri=uri,
+                metadata={
+                    "kind": "aws_live",
+                    "resource_type": resource_type,
+                    "service": "s3",
+                    "region": location or "global",
+                    "account_id": account_id,
+                    "name": name,
+                    "arn": arn,
+                    "tags": tags,
+                    "versioning": versioning,
+                },
+            )
+        )
+
+    return refs
+
+
+def _discover_iam(
+    secrets: dict[str, str],
+    account_id: str,
+    filters: list[str],
+) -> list[DocumentRef]:
+    """List IAM users, roles, and policies (global service)."""
+    client = _build_client("iam", secrets)
+    refs: list[DocumentRef] = []
+
+    # --- Users ---
+    if _allowed("aws_iam_user", filters):
+        paginator = client.get_paginator("list_users")
+        for page in paginator.paginate():
+            for user in page.get("Users", []):
+                name: str = user.get("UserName", "")
+                arn: str = user.get("Arn", f"arn:aws:iam::{account_id}:user/{name}")
+                uri = f"aws://{account_id}/global/iam/user/{name}"
+                refs.append(
+                    DocumentRef(
+                        external_id=arn,
+                        uri=uri,
+                        metadata={
+                            "kind": "aws_live",
+                            "resource_type": "aws_iam_user",
+                            "service": "iam",
+                            "region": "global",
+                            "account_id": account_id,
+                            "name": name,
+                            "arn": arn,
+                            "user_id": user.get("UserId", ""),
+                            "path": user.get("Path", "/"),
+                        },
+                    )
+                )
+
+    # --- Roles ---
+    if _allowed("aws_iam_role", filters):
+        paginator = client.get_paginator("list_roles")
+        for page in paginator.paginate():
+            for role in page.get("Roles", []):
+                name = role.get("RoleName", "")
+                arn = role.get("Arn", f"arn:aws:iam::{account_id}:role/{name}")
+                uri = f"aws://{account_id}/global/iam/role/{name}"
+                refs.append(
+                    DocumentRef(
+                        external_id=arn,
+                        uri=uri,
+                        metadata={
+                            "kind": "aws_live",
+                            "resource_type": "aws_iam_role",
+                            "service": "iam",
+                            "region": "global",
+                            "account_id": account_id,
+                            "name": name,
+                            "arn": arn,
+                            "role_id": role.get("RoleId", ""),
+                            "path": role.get("Path", "/"),
+                        },
+                    )
+                )
+
+    # --- Customer-managed policies ---
+    if _allowed("aws_iam_policy", filters):
+        paginator = client.get_paginator("list_policies")
+        for page in paginator.paginate(Scope="Local"):
+            for policy in page.get("Policies", []):
+                name = policy.get("PolicyName", "")
+                arn = policy.get("Arn", f"arn:aws:iam::{account_id}:policy/{name}")
+                uri = f"aws://{account_id}/global/iam/policy/{name}"
+                refs.append(
+                    DocumentRef(
+                        external_id=arn,
+                        uri=uri,
+                        metadata={
+                            "kind": "aws_live",
+                            "resource_type": "aws_iam_policy",
+                            "service": "iam",
+                            "region": "global",
+                            "account_id": account_id,
+                            "name": name,
+                            "arn": arn,
+                            "policy_id": policy.get("PolicyId", ""),
+                            "attachment_count": policy.get("AttachmentCount", 0),
+                        },
+                    )
+                )
+
+    return refs
+
+
+def _discover_ec2(
+    secrets: dict[str, str],
+    account_id: str,
+    region: str,
+    filters: list[str],
+) -> list[DocumentRef]:
+    """Discover EC2 instances, VPCs, and security groups in *region*."""
+    client = _build_client("ec2", secrets, region)
+    refs: list[DocumentRef] = []
+
+    # --- Instances ---
+    if _allowed("aws_instance", filters):
+        paginator = client.get_paginator("describe_instances")
+        for page in paginator.paginate():
+            for reservation in page.get("Reservations", []):
+                for inst in reservation.get("Instances", []):
+                    instance_id: str = inst.get("InstanceId", "")
+                    if not instance_id:
+                        continue
+                    arn = f"arn:aws:ec2:{region}:{account_id}:instance/{instance_id}"
+                    # Extract Name tag if present
+                    name_tag = _extract_name_tag(inst.get("Tags", []))
+                    display_name = name_tag or instance_id
+                    uri = f"aws://{account_id}/{region}/ec2/instance/{instance_id}"
+                    refs.append(
+                        DocumentRef(
+                            external_id=arn,
+                            uri=uri,
+                            metadata={
+                                "kind": "aws_live",
+                                "resource_type": "aws_instance",
+                                "service": "ec2",
+                                "region": region,
+                                "account_id": account_id,
+                                "name": display_name,
+                                "instance_id": instance_id,
+                                "arn": arn,
+                                "instance_type": inst.get("InstanceType", ""),
+                                "state": inst.get("State", {}).get("Name", ""),
+                                "vpc_id": inst.get("VpcId", ""),
+                                "tags": {t["Key"]: t["Value"] for t in inst.get("Tags", [])},
+                            },
+                        )
+                    )
+
+    # --- VPCs ---
+    if _allowed("aws_vpc", filters):
+        paginator = client.get_paginator("describe_vpcs")
+        for page in paginator.paginate():
+            for vpc in page.get("Vpcs", []):
+                vpc_id: str = vpc.get("VpcId", "")
+                if not vpc_id:
+                    continue
+                arn = f"arn:aws:ec2:{region}:{account_id}:vpc/{vpc_id}"
+                name_tag = _extract_name_tag(vpc.get("Tags", []))
+                display_name = name_tag or vpc_id
+                uri = f"aws://{account_id}/{region}/ec2/vpc/{vpc_id}"
+                refs.append(
+                    DocumentRef(
+                        external_id=arn,
+                        uri=uri,
+                        metadata={
+                            "kind": "aws_live",
+                            "resource_type": "aws_vpc",
+                            "service": "ec2",
+                            "region": region,
+                            "account_id": account_id,
+                            "name": display_name,
+                            "vpc_id": vpc_id,
+                            "arn": arn,
+                            "cidr_block": vpc.get("CidrBlock", ""),
+                            "is_default": vpc.get("IsDefault", False),
+                            "state": vpc.get("State", ""),
+                            "tags": {t["Key"]: t["Value"] for t in vpc.get("Tags", [])},
+                        },
+                    )
+                )
+
+    # --- Security groups ---
+    if _allowed("aws_security_group", filters):
+        paginator = client.get_paginator("describe_security_groups")
+        for page in paginator.paginate():
+            for sg in page.get("SecurityGroups", []):
+                sg_id: str = sg.get("GroupId", "")
+                if not sg_id:
+                    continue
+                arn = f"arn:aws:ec2:{region}:{account_id}:security-group/{sg_id}"
+                sg_name: str = sg.get("GroupName", sg_id)
+                uri = f"aws://{account_id}/{region}/ec2/security-group/{sg_id}"
+                refs.append(
+                    DocumentRef(
+                        external_id=arn,
+                        uri=uri,
+                        metadata={
+                            "kind": "aws_live",
+                            "resource_type": "aws_security_group",
+                            "service": "ec2",
+                            "region": region,
+                            "account_id": account_id,
+                            "name": sg_name,
+                            "group_id": sg_id,
+                            "arn": arn,
+                            "description": sg.get("Description", ""),
+                            "vpc_id": sg.get("VpcId", ""),
+                            "tags": {t["Key"]: t["Value"] for t in sg.get("Tags", [])},
+                        },
+                    )
+                )
+
+    return refs
+
+
+def _extract_name_tag(tags: list[dict[str, str]]) -> str:
+    """Return the value of the ``Name`` tag, or empty string if absent."""
+    for tag in tags:
+        if tag.get("Key") == "Name":
+            return tag.get("Value", "")
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Per-resource fetch helpers (synchronous — run in asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_s3_resource(client: Any, name: str) -> dict[str, Any]:
+    """Describe a single S3 bucket in detail."""
+    detail: dict[str, Any] = {"name": name}
+
+    try:
+        loc = client.get_bucket_location(Bucket=name)
+        detail["location"] = loc.get("LocationConstraint") or "us-east-1"
+    except botocore.exceptions.ClientError:
+        pass
+
+    try:
+        ver = client.get_bucket_versioning(Bucket=name)
+        detail["versioning_status"] = ver.get("Status", "")
+        detail["versioning_mfa_delete"] = ver.get("MFADelete", "")
+    except botocore.exceptions.ClientError:
+        pass
+
+    try:
+        tag_resp = client.get_bucket_tagging(Bucket=name)
+        detail["tags"] = {t["Key"]: t["Value"] for t in tag_resp.get("TagSet", [])}
+    except botocore.exceptions.ClientError:
+        detail["tags"] = {}
+
+    try:
+        policy_resp = client.get_bucket_policy(Bucket=name)
+        raw_policy = policy_resp.get("Policy", "{}")
+        detail["policy"] = json.loads(raw_policy)
+    except botocore.exceptions.ClientError:
+        detail["policy"] = {}
+
+    return detail
+
+
+def _fetch_iam_user(client: Any, name: str, account_id: str) -> dict[str, Any]:
+    """Describe a single IAM user."""
+    detail: dict[str, Any] = {"user_name": name}
+    try:
+        resp = client.get_user(UserName=name)
+        user = resp.get("User", {})
+        detail.update(
+            {
+                "user_id": user.get("UserId", ""),
+                "arn": user.get("Arn", f"arn:aws:iam::{account_id}:user/{name}"),
+                "path": user.get("Path", "/"),
+                "create_date": str(user.get("CreateDate", "")),
+            }
+        )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+def _fetch_iam_role(client: Any, name: str, account_id: str) -> dict[str, Any]:
+    """Describe a single IAM role."""
+    detail: dict[str, Any] = {"role_name": name}
+    try:
+        resp = client.get_role(RoleName=name)
+        role = resp.get("Role", {})
+        detail.update(
+            {
+                "role_id": role.get("RoleId", ""),
+                "arn": role.get("Arn", f"arn:aws:iam::{account_id}:role/{name}"),
+                "path": role.get("Path", "/"),
+                "create_date": str(role.get("CreateDate", "")),
+                "assume_role_policy": role.get("AssumeRolePolicyDocument", {}),
+            }
+        )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+def _fetch_iam_policy(client: Any, arn: str) -> dict[str, Any]:
+    """Describe a single customer-managed IAM policy."""
+    detail: dict[str, Any] = {"arn": arn}
+    try:
+        resp = client.get_policy(PolicyArn=arn)
+        policy = resp.get("Policy", {})
+        detail.update(
+            {
+                "policy_name": policy.get("PolicyName", ""),
+                "policy_id": policy.get("PolicyId", ""),
+                "attachment_count": policy.get("AttachmentCount", 0),
+                "create_date": str(policy.get("CreateDate", "")),
+                "update_date": str(policy.get("UpdateDate", "")),
+            }
+        )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+def _fetch_ec2_instance(client: Any, instance_id: str) -> dict[str, Any]:
+    """Describe a single EC2 instance."""
+    detail: dict[str, Any] = {"instance_id": instance_id}
+    try:
+        resp = client.describe_instances(InstanceIds=[instance_id])
+        reservations = resp.get("Reservations", [])
+        if reservations:
+            instances = reservations[0].get("Instances", [])
+            if instances:
+                inst = instances[0]
+                detail.update(
+                    {
+                        "instance_type": inst.get("InstanceType", ""),
+                        "state": inst.get("State", {}).get("Name", ""),
+                        "vpc_id": inst.get("VpcId", ""),
+                        "subnet_id": inst.get("SubnetId", ""),
+                        "private_ip": inst.get("PrivateIpAddress", ""),
+                        "public_ip": inst.get("PublicIpAddress", ""),
+                        "image_id": inst.get("ImageId", ""),
+                        "launch_time": str(inst.get("LaunchTime", "")),
+                        "tags": {t["Key"]: t["Value"] for t in inst.get("Tags", [])},
+                    }
+                )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+def _fetch_ec2_vpc(client: Any, vpc_id: str) -> dict[str, Any]:
+    """Describe a single VPC."""
+    detail: dict[str, Any] = {"vpc_id": vpc_id}
+    try:
+        resp = client.describe_vpcs(VpcIds=[vpc_id])
+        vpcs = resp.get("Vpcs", [])
+        if vpcs:
+            vpc = vpcs[0]
+            detail.update(
+                {
+                    "cidr_block": vpc.get("CidrBlock", ""),
+                    "is_default": vpc.get("IsDefault", False),
+                    "state": vpc.get("State", ""),
+                    "dhcp_options_id": vpc.get("DhcpOptionsId", ""),
+                    "tags": {t["Key"]: t["Value"] for t in vpc.get("Tags", [])},
+                }
+            )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+def _fetch_ec2_sg(client: Any, sg_id: str) -> dict[str, Any]:
+    """Describe a single security group."""
+    detail: dict[str, Any] = {"group_id": sg_id}
+    try:
+        resp = client.describe_security_groups(GroupIds=[sg_id])
+        groups = resp.get("SecurityGroups", [])
+        if groups:
+            sg = groups[0]
+            detail.update(
+                {
+                    "group_name": sg.get("GroupName", ""),
+                    "description": sg.get("Description", ""),
+                    "vpc_id": sg.get("VpcId", ""),
+                    "ip_permissions": sg.get("IpPermissions", []),
+                    "ip_permissions_egress": sg.get("IpPermissionsEgress", []),
+                    "tags": {t["Key"]: t["Value"] for t in sg.get("Tags", [])},
+                }
+            )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector
+# ---------------------------------------------------------------------------
+
+
+class AwsConnector(Connector):
+    """Connector for live AWS resources.
+
+    Discovers resources across S3, IAM, and EC2 (configurable) and returns
+    them as :class:`~omniscience_connectors.base.DocumentRef` objects tagged
+    with ``kind="aws_live"``.  The ARN is stored as ``external_id`` and in
+    ``metadata["arn"]`` to support ARN-based cross-source linking.
+
+    Stateless: all state derives from config + secrets at call time.
+    """
+
+    connector_type: ClassVar[str] = "aws"
+    config_schema: ClassVar[type[BaseModel]] = AwsConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify AWS credentials via STS get-caller-identity.
+
+        Raises:
+            PermissionError: On access-denied errors.
+            RuntimeError: On any other AWS / connectivity error.
+        """
+        cfg: AwsConfig = config  # type: ignore[assignment]
+
+        def _check() -> None:
+            try:
+                _get_account_id(secrets)
+            except botocore.exceptions.ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code", "")
+                if code in ("AccessDenied", "403"):
+                    raise PermissionError(
+                        f"AWS credentials lack sts:GetCallerIdentity permission: {exc}"
+                    ) from exc
+                raise RuntimeError(f"AWS validation failed: {exc}") from exc
+            except botocore.exceptions.BotoCoreError as exc:
+                raise RuntimeError(f"AWS connectivity error during validation: {exc}") from exc
+
+        del cfg  # not needed for STS validation
+        await asyncio.to_thread(_check)
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield a DocumentRef for every discovered live AWS resource.
+
+        Enumerates all configured services across all configured regions.
+        Global services (S3, IAM) are enumerated once regardless of the
+        ``regions`` list.
+
+        Args:
+            config: Validated :class:`AwsConfig`.
+            secrets: Runtime-resolved credential values.
+
+        Yields:
+            :class:`~omniscience_connectors.base.DocumentRef` for each resource.
+        """
+        cfg: AwsConfig = config  # type: ignore[assignment]
+
+        account_id = await asyncio.to_thread(_get_account_id, secrets)
+        filters = cfg.resource_type_filters
+
+        # Global services (no region iteration)
+        if "s3" in cfg.services:
+            refs = await asyncio.to_thread(_discover_s3, secrets, account_id, filters)
+            for ref in refs:
+                yield ref
+
+        if "iam" in cfg.services:
+            refs = await asyncio.to_thread(_discover_iam, secrets, account_id, filters)
+            for ref in refs:
+                yield ref
+
+        # Regional services
+        if "ec2" in cfg.services:
+            for region in cfg.regions:
+                refs = await asyncio.to_thread(_discover_ec2, secrets, account_id, region, filters)
+                for ref in refs:
+                    yield ref
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Describe the AWS resource referenced by *ref* and return its JSON detail.
+
+        The ``ref.metadata`` fields are used to route the call to the correct
+        boto3 describe API.  Falls back to returning the ref metadata as JSON
+        when the resource type is unrecognised.
+
+        Args:
+            config: Validated :class:`AwsConfig`.
+            secrets: Runtime-resolved credential values.
+            ref: The reference returned by :meth:`discover`.
+
+        Returns:
+            :class:`~omniscience_connectors.base.FetchedDocument` with JSON content.
+        """
+        cfg: AwsConfig = config  # type: ignore[assignment]
+        del cfg
+
+        meta = ref.metadata
+        resource_type: str = meta.get("resource_type", "")
+        region: str = meta.get("region", "us-east-1")
+        account_id: str = meta.get("account_id", "")
+        arn: str = meta.get("arn", ref.external_id)
+
+        def _describe() -> dict[str, Any]:
+            if resource_type == "aws_s3_bucket":
+                client = _build_client("s3", secrets)
+                name: str = meta.get("name", "")
+                return _fetch_s3_resource(client, name)
+
+            if resource_type == "aws_iam_user":
+                client = _build_client("iam", secrets)
+                name = meta.get("name", "")
+                return _fetch_iam_user(client, name, account_id)
+
+            if resource_type == "aws_iam_role":
+                client = _build_client("iam", secrets)
+                name = meta.get("name", "")
+                return _fetch_iam_role(client, name, account_id)
+
+            if resource_type == "aws_iam_policy":
+                client = _build_client("iam", secrets)
+                return _fetch_iam_policy(client, arn)
+
+            if resource_type == "aws_instance":
+                client = _build_client("ec2", secrets, region)
+                return _fetch_ec2_instance(client, meta.get("instance_id", ""))
+
+            if resource_type == "aws_vpc":
+                client = _build_client("ec2", secrets, region)
+                return _fetch_ec2_vpc(client, meta.get("vpc_id", ""))
+
+            if resource_type == "aws_security_group":
+                client = _build_client("ec2", secrets, region)
+                return _fetch_ec2_sg(client, meta.get("group_id", ""))
+
+            # Unknown type: return metadata as-is
+            return dict(meta)
+
+        detail = await asyncio.to_thread(_describe)
+        content = json.dumps(detail, default=str).encode()
+
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=content,
+            content_type="application/json",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        """Return None — AWS live resources use scheduler-based polling."""
+        return None

--- a/packages/core/src/omniscience_core/db/models.py
+++ b/packages/core/src/omniscience_core/db/models.py
@@ -51,6 +51,7 @@ class SourceType(enum.StrEnum):
     k8s = "k8s"
     terraform = "terraform"
     s3 = "s3"
+    aws = "aws"
 
 
 class SourceStatus(enum.StrEnum):

--- a/packages/index/src/omniscience_index/linker.py
+++ b/packages/index/src/omniscience_index/linker.py
@@ -9,11 +9,15 @@ Matching strategy (applied in priority order):
 1. **Exact name match** — entities whose normalised names are identical
    across *different* sources are linked unconditionally (score == 1.0).
 
-2. **Resource name match** — Terraform resources ↔ Kubernetes resources
+2. **ARN match** — when one entity is ``tfstate_instance`` kind and the
+   other is ``aws_live`` kind, ARNs are compared.  Score 1.0 on exact ARN
+   match; score 0.8 on id-only match (without account/region prefix).
+
+3. **Resource name match** — Terraform resources ↔ Kubernetes resources
    are compared with :func:`~omniscience_index.matchers.resource_name_match`.
    Pairs scoring above :data:`RESOURCE_MATCH_THRESHOLD` are linked.
 
-3. **Service name match** — a Kubernetes ``Service`` entity ↔ a Grafana
+4. **Service name match** — a Kubernetes ``Service`` entity ↔ a Grafana
    dashboard entity are fuzzy-matched on their normalised names.
    Pairs scoring above :data:`SERVICE_MATCH_THRESHOLD` are linked.
 
@@ -53,6 +57,16 @@ SERVICE_MATCH_THRESHOLD: float = 0.5
 
 #: Edge type used for all cross-source links created by this module.
 CROSS_REF_EDGE_TYPE: str = "cross_ref"
+
+# ---------------------------------------------------------------------------
+# ARN matching constants
+# ---------------------------------------------------------------------------
+
+#: Entity kind used by AwsConnector for all live-resource entities.
+_AWS_LIVE_KIND: str = "aws_live"
+
+#: Entity kind used by Terraform state entities representing real resources.
+_TFSTATE_KIND: str = "tfstate_instance"
 
 
 # ---------------------------------------------------------------------------
@@ -225,7 +239,12 @@ class EntityLinker:
         if exact_name_match(ent_a.display_name, ent_b.display_name) == 1.0:
             return 1.0, "exact_display_name"
 
-        # Strategy 2: Terraform resource ↔ K8s resource
+        # Strategy 2: ARN match — tfstate_instance ↔ aws_live
+        arn_score, arn_strategy = _arn_match_score(ent_a, ent_b)
+        if arn_score > 0.0:
+            return arn_score, arn_strategy
+
+        # Strategy 3: Terraform resource ↔ K8s resource
         tf_types = {"terraform_resource", "terraform_module", "resource"}
         k8s_types = {"k8s_resource", "service", "deployment"}
 
@@ -239,7 +258,7 @@ class EntityLinker:
             if score >= RESOURCE_MATCH_THRESHOLD:
                 return score, "resource_name"
 
-        # Strategy 3: K8s Service ↔ Grafana dashboard
+        # Strategy 4: K8s Service ↔ Grafana dashboard
         grafana_types = {"dashboard", "grafana_dashboard"}
         is_k8s_service_a = is_k8s_a and _is_service_entity(ent_a)
         is_grafana_a = ent_a.entity_type in grafana_types
@@ -300,6 +319,93 @@ def _is_service_entity(entity: Entity) -> bool:
     meta: dict[str, Any] = entity.entity_metadata
     k8s_kind = str(meta.get("k8s_kind", "")).lower()
     return k8s_kind == "service" or entity.entity_type.lower() in {"service"}
+
+
+def _extract_arn(entity: Entity) -> str:
+    """Extract the ARN from an entity's extra/metadata dict.
+
+    Checks ``entity_metadata["arn"]``, ``entity_metadata["extra"]["arn"]``,
+    and falls back to ``entity.name`` when the entity type looks like an ARN.
+    """
+    meta: dict[str, Any] = entity.entity_metadata
+
+    # Direct arn key in metadata
+    arn = meta.get("arn", "")
+    if arn:
+        return str(arn)
+
+    # Nested under "extra"
+    extra: dict[str, Any] = meta.get("extra", {})
+    arn = extra.get("arn", "")
+    if arn:
+        return str(arn)
+
+    # entity.name may itself be an ARN (starts with "arn:")
+    if entity.name.startswith("arn:"):
+        return entity.name
+
+    return ""
+
+
+def _arn_id_segment(arn: str) -> str:
+    """Return the last path segment of an ARN — the bare resource id/name.
+
+    For ``arn:aws:s3:::my-bucket`` this returns ``my-bucket``.
+    For ``arn:aws:ec2:us-east-1:123:instance/i-abc`` this returns ``i-abc``.
+    Returns empty string when *arn* is empty or cannot be parsed.
+    """
+    if not arn:
+        return ""
+    # ARN format: arn:partition:service:region:account-id:resource
+    # resource may be "type/id" or just "id"
+    parts = arn.split(":", 5)
+    if len(parts) < 6:
+        return ""
+    resource = parts[5]
+    # Strip type prefix if present (e.g. "instance/i-abc" → "i-abc")
+    if "/" in resource:
+        resource = resource.rsplit("/", 1)[-1]
+    return resource
+
+
+def _arn_match_score(ent_a: Entity, ent_b: Entity) -> tuple[float, str]:
+    """Return ``(score, "arn_match")`` when a tfstate_instance ↔ aws_live ARN match fires.
+
+    Returns ``(0.0, "")`` when the strategy does not apply.
+
+    Scoring:
+    - 1.0 — exact ARN match
+    - 0.8 — id-only match (last path segment matches, ignoring account/region)
+    """
+    kind_a: str = str(ent_a.entity_metadata.get("kind", ""))
+    kind_b: str = str(ent_b.entity_metadata.get("kind", ""))
+
+    # Strategy applies only when one is tfstate_instance and other is aws_live
+    is_tf_a = kind_a == _TFSTATE_KIND or ent_a.entity_type == _TFSTATE_KIND
+    is_live_a = kind_a == _AWS_LIVE_KIND or ent_a.entity_type == _AWS_LIVE_KIND
+    is_tf_b = kind_b == _TFSTATE_KIND or ent_b.entity_type == _TFSTATE_KIND
+    is_live_b = kind_b == _AWS_LIVE_KIND or ent_b.entity_type == _AWS_LIVE_KIND
+
+    if not ((is_tf_a and is_live_b) or (is_live_a and is_tf_b)):
+        return 0.0, ""
+
+    arn_a = _extract_arn(ent_a)
+    arn_b = _extract_arn(ent_b)
+
+    if not arn_a or not arn_b:
+        return 0.0, ""
+
+    # Exact ARN match
+    if arn_a == arn_b:
+        return 1.0, "arn_match"
+
+    # Id-only match: compare the bare resource identifier
+    id_a = _arn_id_segment(arn_a)
+    id_b = _arn_id_segment(arn_b)
+    if id_a and id_b and id_a == id_b:
+        return 0.8, "arn_match"
+
+    return 0.0, ""
 
 
 __all__ = [

--- a/tests/test_aws_connector.py
+++ b/tests/test_aws_connector.py
@@ -1,0 +1,1017 @@
+"""Tests for the AWS live-resources connector (Issue #90).
+
+Coverage:
+- AwsConfig model validation (4 tests)
+- _build_session credential resolution (3 tests)
+- _build_client returns correct service client (2 tests)
+- _get_account_id resolves account (1 test)
+- _allowed resource-type filter helper (3 tests)
+- _extract_name_tag helper (2 tests)
+- _discover_s3 — bucket list, tags, versioning, location, filters (4 tests)
+- _discover_iam — users, roles, policies, pagination, filters (5 tests)
+- _discover_ec2 — instances, vpcs, security groups, filters, Name tag (5 tests)
+- AwsConnector.validate — success, access denied, generic error (3 tests)
+- AwsConnector.discover — s3+iam+ec2 integrated, global services once,
+  regional per region (3 tests)
+- AwsConnector.fetch — s3 bucket, iam user, iam role, iam policy,
+  ec2 instance, ec2 vpc, ec2 sg, unknown type (8 tests)
+- AwsConnector.webhook_handler returns None (1 test)
+- Registry: AwsConnector is registered as "aws" (1 test)
+- SourceType.aws exists (1 test)
+- ARN linker helpers: _extract_arn, _arn_id_segment, _arn_match_score (8 tests)
+- EntityLinker._match_score uses arn_match strategy (3 tests)
+
+Total: 57 tests
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from omniscience_connectors.aws.connector import (
+    AwsConfig,
+    AwsConnector,
+    _allowed,
+    _build_client,
+    _build_session,
+    _discover_ec2,
+    _discover_iam,
+    _discover_s3,
+    _extract_name_tag,
+    _get_account_id,
+)
+from omniscience_connectors.base import DocumentRef
+from omniscience_connectors.registry import get_connector
+from omniscience_core.db.models import Entity, SourceType
+from omniscience_index.linker import (
+    EntityLinker,
+    _arn_id_segment,
+    _arn_match_score,
+    _extract_arn,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ACCOUNT_ID = "123456789012"
+REGION = "us-east-1"
+
+SECRETS_EXPLICIT: dict[str, str] = {
+    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+    "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+}
+
+SECRETS_PROFILE: dict[str, str] = {"aws_profile": "my-profile"}
+
+SECRETS_DEFAULT: dict[str, str] = {}
+
+
+def _client_error(code: str, message: str = "error") -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, "Operation")
+
+
+def _make_entity(
+    *,
+    source_id: uuid.UUID | None = None,
+    entity_type: str = "function",
+    name: str = "mymod.my_func",
+    display_name: str | None = None,
+    entity_metadata: dict[str, Any] | None = None,
+) -> Entity:
+    return Entity(
+        id=uuid.uuid4(),
+        source_id=source_id or uuid.uuid4(),
+        entity_type=entity_type,
+        name=name,
+        display_name=display_name or name.split(".")[-1],
+        chunk_id=None,
+        entity_metadata=entity_metadata or {},
+        created_at=datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AwsConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConfig:
+    def test_default_regions(self) -> None:
+        cfg = AwsConfig()
+        assert cfg.regions == ["us-east-1"]
+
+    def test_default_services(self) -> None:
+        cfg = AwsConfig()
+        assert cfg.services == ["s3", "iam", "ec2"]
+
+    def test_custom_config(self) -> None:
+        cfg = AwsConfig(
+            regions=["us-west-2", "eu-west-1"],
+            services=["s3"],
+            resource_type_filters=["aws_s3_bucket"],
+        )
+        assert cfg.regions == ["us-west-2", "eu-west-1"]
+        assert cfg.services == ["s3"]
+        assert cfg.resource_type_filters == ["aws_s3_bucket"]
+
+    def test_empty_filters_default(self) -> None:
+        cfg = AwsConfig()
+        assert cfg.resource_type_filters == []
+
+
+# ---------------------------------------------------------------------------
+# _build_session / _build_client credential resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSession:
+    def test_explicit_key_secret(self) -> None:
+        session = _build_session(SECRETS_EXPLICIT)
+        creds = session.get_credentials()
+        assert creds is not None
+
+    def test_profile_credentials(self) -> None:
+        # Profiles may not be available in CI — just check no exception on construction
+        with patch("boto3.Session") as mock_session_cls:
+            _build_session(SECRETS_PROFILE, region="eu-west-1")
+            mock_session_cls.assert_called_once_with(
+                profile_name="my-profile", region_name="eu-west-1"
+            )
+
+    def test_default_credential_chain(self) -> None:
+        with patch("boto3.Session") as mock_session_cls:
+            _build_session(SECRETS_DEFAULT, region="us-east-1")
+            mock_session_cls.assert_called_once_with(region_name="us-east-1")
+
+    def test_build_client_returns_service_client(self) -> None:
+        mock_session = MagicMock()
+        with patch(
+            "omniscience_connectors.aws.connector._build_session", return_value=mock_session
+        ):
+            _build_client("sts", SECRETS_EXPLICIT)
+        mock_session.client.assert_called_once_with("sts")
+
+    def test_build_client_with_region(self) -> None:
+        mock_session = MagicMock()
+        with patch(
+            "omniscience_connectors.aws.connector._build_session", return_value=mock_session
+        ):
+            _build_client("ec2", SECRETS_EXPLICIT, region="eu-west-1")
+        mock_session.client.assert_called_once_with("ec2")
+
+
+# ---------------------------------------------------------------------------
+# _get_account_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetAccountId:
+    def test_returns_account_id(self) -> None:
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": ACCOUNT_ID}
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_sts):
+            result = _get_account_id(SECRETS_EXPLICIT)
+        assert result == ACCOUNT_ID
+
+
+# ---------------------------------------------------------------------------
+# _allowed filter helper
+# ---------------------------------------------------------------------------
+
+
+class TestAllowed:
+    def test_empty_filters_allows_all(self) -> None:
+        assert _allowed("aws_instance", []) is True
+
+    def test_filter_matches(self) -> None:
+        assert _allowed("aws_vpc", ["aws_vpc", "aws_instance"]) is True
+
+    def test_filter_excludes(self) -> None:
+        assert _allowed("aws_s3_bucket", ["aws_instance"]) is False
+
+
+# ---------------------------------------------------------------------------
+# _extract_name_tag helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractNameTag:
+    def test_finds_name_tag(self) -> None:
+        tags = [{"Key": "Name", "Value": "my-server"}, {"Key": "Env", "Value": "prod"}]
+        assert _extract_name_tag(tags) == "my-server"
+
+    def test_returns_empty_when_absent(self) -> None:
+        tags = [{"Key": "Env", "Value": "prod"}]
+        assert _extract_name_tag(tags) == ""
+
+
+# ---------------------------------------------------------------------------
+# _discover_s3
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverS3:
+    def _make_s3_client(
+        self,
+        buckets: list[str],
+        location: str = "us-east-1",
+        versioning: str = "Enabled",
+        tags: list[dict[str, str]] | None = None,
+    ) -> MagicMock:
+        client = MagicMock()
+        client.list_buckets.return_value = {"Buckets": [{"Name": b} for b in buckets]}
+        client.get_bucket_location.return_value = {"LocationConstraint": location}
+        client.get_bucket_versioning.return_value = {"Status": versioning}
+        client.get_bucket_tagging.return_value = {"TagSet": tags or []}
+        return client
+
+    def test_discovers_bucket(self) -> None:
+        client = self._make_s3_client(["my-bucket"])
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_s3(SECRETS_EXPLICIT, ACCOUNT_ID, [])
+        assert len(refs) == 1
+        ref = refs[0]
+        assert ref.external_id == "arn:aws:s3:::my-bucket"
+        assert ref.uri == f"aws://{ACCOUNT_ID}/global/s3/bucket/my-bucket"
+        assert ref.metadata["kind"] == "aws_live"
+        assert ref.metadata["resource_type"] == "aws_s3_bucket"
+
+    def test_empty_bucket_name_skipped(self) -> None:
+        client = MagicMock()
+        client.list_buckets.return_value = {"Buckets": [{"Name": ""}, {"Name": "real-bucket"}]}
+        client.get_bucket_location.return_value = {"LocationConstraint": "us-east-1"}
+        client.get_bucket_versioning.return_value = {}
+        client.get_bucket_tagging.side_effect = _client_error("NoSuchTagSet")
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_s3(SECRETS_EXPLICIT, ACCOUNT_ID, [])
+        assert len(refs) == 1
+        assert refs[0].metadata["name"] == "real-bucket"
+
+    def test_resource_type_filter_excludes(self) -> None:
+        client = self._make_s3_client(["my-bucket"])
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_s3(SECRETS_EXPLICIT, ACCOUNT_ID, ["aws_instance"])
+        assert refs == []
+
+    def test_tags_and_versioning_in_metadata(self) -> None:
+        client = self._make_s3_client(
+            ["tagged-bucket"],
+            versioning="Suspended",
+            tags=[{"Key": "Project", "Value": "Omni"}],
+        )
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_s3(SECRETS_EXPLICIT, ACCOUNT_ID, [])
+        assert refs[0].metadata["versioning"] == "Suspended"
+        assert refs[0].metadata["tags"] == {"Project": "Omni"}
+
+
+# ---------------------------------------------------------------------------
+# _discover_iam
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverIam:
+    def _paginator(self, pages: list[dict[str, Any]]) -> MagicMock:
+        pag = MagicMock()
+        pag.paginate.return_value = iter(pages)
+        return pag
+
+    def test_discovers_user(self) -> None:
+        client = MagicMock()
+        user = {
+            "UserName": "alice",
+            "Arn": f"arn:aws:iam::{ACCOUNT_ID}:user/alice",
+            "UserId": "AID123",
+            "Path": "/",
+        }
+        client.get_paginator.side_effect = lambda name: {
+            "list_users": self._paginator([{"Users": [user]}]),
+            "list_roles": self._paginator([{"Roles": []}]),
+            "list_policies": self._paginator([{"Policies": []}]),
+        }[name]
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_iam(SECRETS_EXPLICIT, ACCOUNT_ID, [])
+        user_refs = [r for r in refs if r.metadata["resource_type"] == "aws_iam_user"]
+        assert len(user_refs) == 1
+        assert user_refs[0].metadata["name"] == "alice"
+        assert user_refs[0].external_id == f"arn:aws:iam::{ACCOUNT_ID}:user/alice"
+
+    def test_discovers_role(self) -> None:
+        client = MagicMock()
+        role = {
+            "RoleName": "my-role",
+            "Arn": f"arn:aws:iam::{ACCOUNT_ID}:role/my-role",
+            "RoleId": "AROA123",
+            "Path": "/",
+        }
+        client.get_paginator.side_effect = lambda name: {
+            "list_users": self._paginator([{"Users": []}]),
+            "list_roles": self._paginator([{"Roles": [role]}]),
+            "list_policies": self._paginator([{"Policies": []}]),
+        }[name]
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_iam(SECRETS_EXPLICIT, ACCOUNT_ID, [])
+        role_refs = [r for r in refs if r.metadata["resource_type"] == "aws_iam_role"]
+        assert len(role_refs) == 1
+        assert role_refs[0].metadata["name"] == "my-role"
+
+    def test_discovers_policy(self) -> None:
+        client = MagicMock()
+        policy = {
+            "PolicyName": "my-policy",
+            "Arn": f"arn:aws:iam::{ACCOUNT_ID}:policy/my-policy",
+            "PolicyId": "ANPA123",
+            "AttachmentCount": 2,
+        }
+        client.get_paginator.side_effect = lambda name: {
+            "list_users": self._paginator([{"Users": []}]),
+            "list_roles": self._paginator([{"Roles": []}]),
+            "list_policies": self._paginator([{"Policies": [policy]}]),
+        }[name]
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_iam(SECRETS_EXPLICIT, ACCOUNT_ID, [])
+        policy_refs = [r for r in refs if r.metadata["resource_type"] == "aws_iam_policy"]
+        assert len(policy_refs) == 1
+        assert policy_refs[0].metadata["attachment_count"] == 2
+
+    def test_filter_excludes_iam_user(self) -> None:
+        client = MagicMock()
+        user = {"UserName": "bob", "Arn": f"arn:aws:iam::{ACCOUNT_ID}:user/bob"}
+        client.get_paginator.side_effect = lambda name: {
+            "list_users": self._paginator([{"Users": [user]}]),
+            "list_roles": self._paginator([{"Roles": []}]),
+            "list_policies": self._paginator([{"Policies": []}]),
+        }[name]
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_iam(SECRETS_EXPLICIT, ACCOUNT_ID, ["aws_iam_role"])
+        assert all(r.metadata["resource_type"] != "aws_iam_user" for r in refs)
+
+    def test_metadata_has_aws_live_kind(self) -> None:
+        client = MagicMock()
+        role = {"RoleName": "app-role", "Arn": f"arn:aws:iam::{ACCOUNT_ID}:role/app-role"}
+        client.get_paginator.side_effect = lambda name: {
+            "list_users": self._paginator([{"Users": []}]),
+            "list_roles": self._paginator([{"Roles": [role]}]),
+            "list_policies": self._paginator([{"Policies": []}]),
+        }[name]
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_iam(SECRETS_EXPLICIT, ACCOUNT_ID, [])
+        assert all(r.metadata["kind"] == "aws_live" for r in refs)
+
+
+# ---------------------------------------------------------------------------
+# _discover_ec2
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverEc2:
+    def _build_ec2_client(
+        self,
+        instances: list[dict[str, Any]] | None = None,
+        vpcs: list[dict[str, Any]] | None = None,
+        sgs: list[dict[str, Any]] | None = None,
+    ) -> MagicMock:
+        client = MagicMock()
+
+        def _paginator(name: str) -> MagicMock:
+            pag = MagicMock()
+            if name == "describe_instances":
+                data = instances or []
+                pag.paginate.return_value = iter(
+                    [{"Reservations": [{"Instances": data}]}] if data else [{"Reservations": []}]
+                )
+            elif name == "describe_vpcs":
+                pag.paginate.return_value = iter([{"Vpcs": vpcs or []}])
+            elif name == "describe_security_groups":
+                pag.paginate.return_value = iter([{"SecurityGroups": sgs or []}])
+            return pag
+
+        client.get_paginator.side_effect = _paginator
+        return client
+
+    def test_discovers_instance(self) -> None:
+        instance = {
+            "InstanceId": "i-0abc123",
+            "InstanceType": "t3.micro",
+            "State": {"Name": "running"},
+            "VpcId": "vpc-111",
+            "Tags": [{"Key": "Name", "Value": "web-server"}],
+        }
+        client = self._build_ec2_client(instances=[instance])
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_ec2(SECRETS_EXPLICIT, ACCOUNT_ID, REGION, [])
+        inst_refs = [r for r in refs if r.metadata["resource_type"] == "aws_instance"]
+        assert len(inst_refs) == 1
+        ref = inst_refs[0]
+        assert ref.external_id == f"arn:aws:ec2:{REGION}:{ACCOUNT_ID}:instance/i-0abc123"
+        assert ref.metadata["name"] == "web-server"
+        assert ref.metadata["instance_type"] == "t3.micro"
+
+    def test_discovers_vpc(self) -> None:
+        vpc = {
+            "VpcId": "vpc-abc",
+            "CidrBlock": "10.0.0.0/16",
+            "IsDefault": False,
+            "State": "available",
+            "Tags": [],
+        }
+        client = self._build_ec2_client(vpcs=[vpc])
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_ec2(SECRETS_EXPLICIT, ACCOUNT_ID, REGION, [])
+        vpc_refs = [r for r in refs if r.metadata["resource_type"] == "aws_vpc"]
+        assert len(vpc_refs) == 1
+        assert vpc_refs[0].metadata["cidr_block"] == "10.0.0.0/16"
+
+    def test_discovers_security_group(self) -> None:
+        sg = {
+            "GroupId": "sg-xyz",
+            "GroupName": "allow-https",
+            "Description": "HTTPS only",
+            "VpcId": "vpc-abc",
+            "Tags": [],
+        }
+        client = self._build_ec2_client(sgs=[sg])
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_ec2(SECRETS_EXPLICIT, ACCOUNT_ID, REGION, [])
+        sg_refs = [r for r in refs if r.metadata["resource_type"] == "aws_security_group"]
+        assert len(sg_refs) == 1
+        assert sg_refs[0].metadata["name"] == "allow-https"
+
+    def test_filter_excludes_instance(self) -> None:
+        instance = {
+            "InstanceId": "i-111",
+            "InstanceType": "t2.micro",
+            "State": {"Name": "running"},
+            "Tags": [],
+        }
+        client = self._build_ec2_client(instances=[instance])
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_ec2(SECRETS_EXPLICIT, ACCOUNT_ID, REGION, ["aws_vpc"])
+        assert all(r.metadata["resource_type"] != "aws_instance" for r in refs)
+
+    def test_instance_without_name_tag_uses_id(self) -> None:
+        instance = {
+            "InstanceId": "i-nametag",
+            "InstanceType": "t2.small",
+            "State": {"Name": "stopped"},
+            "Tags": [],
+        }
+        client = self._build_ec2_client(instances=[instance])
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=client):
+            refs = _discover_ec2(SECRETS_EXPLICIT, ACCOUNT_ID, REGION, [])
+        inst_refs = [r for r in refs if r.metadata["resource_type"] == "aws_instance"]
+        assert inst_refs[0].metadata["name"] == "i-nametag"
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.validate
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorValidate:
+    @pytest.fixture()
+    def connector(self) -> AwsConnector:
+        return AwsConnector()
+
+    @pytest.fixture()
+    def config(self) -> AwsConfig:
+        return AwsConfig()
+
+    async def test_validate_success(self, connector: AwsConnector, config: AwsConfig) -> None:
+        with patch(
+            "omniscience_connectors.aws.connector._get_account_id",
+            return_value=ACCOUNT_ID,
+        ):
+            await connector.validate(config, SECRETS_EXPLICIT)  # should not raise
+
+    async def test_validate_access_denied_raises_permission_error(
+        self, connector: AwsConnector, config: AwsConfig
+    ) -> None:
+        def _raise(_secrets: dict[str, str]) -> str:
+            raise _client_error("AccessDenied")
+
+        with (
+            patch("omniscience_connectors.aws.connector._get_account_id", side_effect=_raise),
+            pytest.raises(PermissionError, match="sts:GetCallerIdentity"),
+        ):
+            await connector.validate(config, SECRETS_EXPLICIT)
+
+    async def test_validate_generic_error_raises_runtime_error(
+        self, connector: AwsConnector, config: AwsConfig
+    ) -> None:
+        def _raise(_secrets: dict[str, str]) -> str:
+            raise _client_error("ServiceUnavailable")
+
+        with (
+            patch("omniscience_connectors.aws.connector._get_account_id", side_effect=_raise),
+            pytest.raises(RuntimeError, match="AWS validation failed"),
+        ):
+            await connector.validate(config, SECRETS_EXPLICIT)
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.discover
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorDiscover:
+    @pytest.fixture()
+    def connector(self) -> AwsConnector:
+        return AwsConnector()
+
+    async def test_discover_s3_and_iam_discovered_once(self, connector: AwsConnector) -> None:
+        """S3 and IAM are global — they appear exactly once per source.
+
+        Regardless of region count, each global service is enumerated once.
+        """
+        config = AwsConfig(regions=["us-east-1", "eu-west-1"], services=["s3", "iam"])
+
+        s3_refs = [
+            DocumentRef(
+                external_id="arn:aws:s3:::b1",
+                uri=f"aws://{ACCOUNT_ID}/global/s3/bucket/b1",
+                metadata={"kind": "aws_live"},
+            )
+        ]
+        iam_refs = [
+            DocumentRef(
+                external_id=f"arn:aws:iam::{ACCOUNT_ID}:user/alice",
+                uri=f"aws://{ACCOUNT_ID}/global/iam/user/alice",
+                metadata={"kind": "aws_live"},
+            )
+        ]
+
+        with (
+            patch(
+                "omniscience_connectors.aws.connector._get_account_id",
+                return_value=ACCOUNT_ID,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_s3",
+                return_value=s3_refs,
+            ) as mock_s3,
+            patch(
+                "omniscience_connectors.aws.connector._discover_iam",
+                return_value=iam_refs,
+            ) as mock_iam,
+        ):
+            refs = [ref async for ref in connector.discover(config, SECRETS_EXPLICIT)]
+
+        # S3 and IAM both called exactly once (global)
+        mock_s3.assert_called_once()
+        mock_iam.assert_called_once()
+        assert len(refs) == 2
+
+    async def test_discover_ec2_called_per_region(self, connector: AwsConnector) -> None:
+        config = AwsConfig(
+            regions=["us-east-1", "eu-west-1"],
+            services=["ec2"],
+        )
+        ec2_ref = DocumentRef(
+            external_id=f"arn:aws:ec2:us-east-1:{ACCOUNT_ID}:instance/i-abc",
+            uri=f"aws://{ACCOUNT_ID}/us-east-1/ec2/instance/i-abc",
+            metadata={"kind": "aws_live"},
+        )
+
+        with (
+            patch(
+                "omniscience_connectors.aws.connector._get_account_id",
+                return_value=ACCOUNT_ID,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_ec2",
+                return_value=[ec2_ref],
+            ) as mock_ec2,
+        ):
+            refs = [ref async for ref in connector.discover(config, SECRETS_EXPLICIT)]
+
+        assert mock_ec2.call_count == 2  # one per region
+        assert len(refs) == 2
+
+    async def test_discover_respects_service_filter(self, connector: AwsConnector) -> None:
+        config = AwsConfig(services=["iam"])  # only IAM
+
+        iam_refs = [
+            DocumentRef(
+                external_id=f"arn:aws:iam::{ACCOUNT_ID}:role/r",
+                uri=f"aws://{ACCOUNT_ID}/global/iam/role/r",
+                metadata={"kind": "aws_live"},
+            )
+        ]
+
+        with (
+            patch(
+                "omniscience_connectors.aws.connector._get_account_id",
+                return_value=ACCOUNT_ID,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_s3",
+            ) as mock_s3,
+            patch(
+                "omniscience_connectors.aws.connector._discover_iam",
+                return_value=iam_refs,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_ec2",
+            ) as mock_ec2,
+        ):
+            refs = [ref async for ref in connector.discover(config, SECRETS_EXPLICIT)]
+
+        mock_s3.assert_not_called()
+        mock_ec2.assert_not_called()
+        assert len(refs) == 1
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.fetch
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorFetch:
+    @pytest.fixture()
+    def connector(self) -> AwsConnector:
+        return AwsConnector()
+
+    @pytest.fixture()
+    def config(self) -> AwsConfig:
+        return AwsConfig()
+
+    def _make_ref(self, resource_type: str, name: str = "test", **extra: Any) -> DocumentRef:
+        base: dict[str, Any] = {
+            "kind": "aws_live",
+            "resource_type": resource_type,
+            "service": resource_type.split("_")[1] if "_" in resource_type else "s3",
+            "region": REGION,
+            "account_id": ACCOUNT_ID,
+            "name": name,
+            "arn": f"arn:aws::::{name}",
+        }
+        base.update(extra)
+        return DocumentRef(
+            external_id=base["arn"],
+            uri=f"aws://{ACCOUNT_ID}/{REGION}/{name}",
+            metadata=base,
+        )
+
+    async def test_fetch_s3_bucket(self, connector: AwsConnector, config: AwsConfig) -> None:
+        mock_client = MagicMock()
+        mock_client.get_bucket_location.return_value = {"LocationConstraint": "us-east-1"}
+        mock_client.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        mock_client.get_bucket_tagging.return_value = {"TagSet": []}
+        mock_client.get_bucket_policy.side_effect = _client_error("NoSuchBucketPolicy")
+
+        ref = self._make_ref("aws_s3_bucket", name="my-bucket")
+        ref.metadata["service"] = "s3"
+
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_client):
+            doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        assert doc.content_type == "application/json"
+        data = json.loads(doc.content_bytes)
+        assert data["name"] == "my-bucket"
+
+    async def test_fetch_iam_user(self, connector: AwsConnector, config: AwsConfig) -> None:
+        mock_client = MagicMock()
+        mock_client.get_user.return_value = {
+            "User": {
+                "UserName": "alice",
+                "UserId": "AID",
+                "Arn": f"arn:aws:iam::{ACCOUNT_ID}:user/alice",
+                "Path": "/",
+            }
+        }
+        ref = self._make_ref("aws_iam_user", name="alice")
+
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_client):
+            doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["user_name"] == "alice"
+
+    async def test_fetch_iam_role(self, connector: AwsConnector, config: AwsConfig) -> None:
+        mock_client = MagicMock()
+        mock_client.get_role.return_value = {
+            "Role": {
+                "RoleName": "my-role",
+                "RoleId": "AROA",
+                "Arn": f"arn:aws:iam::{ACCOUNT_ID}:role/my-role",
+                "Path": "/",
+                "AssumeRolePolicyDocument": {},
+            }
+        }
+        ref = self._make_ref("aws_iam_role", name="my-role")
+
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_client):
+            doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["role_name"] == "my-role"
+
+    async def test_fetch_iam_policy(self, connector: AwsConnector, config: AwsConfig) -> None:
+        arn = f"arn:aws:iam::{ACCOUNT_ID}:policy/my-policy"
+        mock_client = MagicMock()
+        mock_client.get_policy.return_value = {
+            "Policy": {
+                "PolicyName": "my-policy",
+                "PolicyId": "ANPA",
+                "AttachmentCount": 1,
+            }
+        }
+        ref = self._make_ref("aws_iam_policy", name="my-policy", arn=arn)
+
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_client):
+            doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["policy_name"] == "my-policy"
+
+    async def test_fetch_ec2_instance(self, connector: AwsConnector, config: AwsConfig) -> None:
+        mock_client = MagicMock()
+        mock_client.describe_instances.return_value = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-abc",
+                            "InstanceType": "t3.micro",
+                            "State": {"Name": "running"},
+                            "Tags": [],
+                        }
+                    ]
+                }
+            ]
+        }
+        ref = self._make_ref("aws_instance", name="i-abc", instance_id="i-abc")
+
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_client):
+            doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["instance_id"] == "i-abc"
+        assert data["instance_type"] == "t3.micro"
+
+    async def test_fetch_ec2_vpc(self, connector: AwsConnector, config: AwsConfig) -> None:
+        mock_client = MagicMock()
+        mock_client.describe_vpcs.return_value = {
+            "Vpcs": [
+                {
+                    "VpcId": "vpc-123",
+                    "CidrBlock": "10.0.0.0/16",
+                    "IsDefault": False,
+                    "State": "available",
+                    "Tags": [],
+                }
+            ]
+        }
+        ref = self._make_ref("aws_vpc", name="vpc-123", vpc_id="vpc-123")
+
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_client):
+            doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["cidr_block"] == "10.0.0.0/16"
+
+    async def test_fetch_ec2_security_group(
+        self, connector: AwsConnector, config: AwsConfig
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.describe_security_groups.return_value = {
+            "SecurityGroups": [
+                {
+                    "GroupId": "sg-abc",
+                    "GroupName": "allow-all",
+                    "Description": "All traffic",
+                    "VpcId": "vpc-123",
+                    "IpPermissions": [],
+                    "IpPermissionsEgress": [],
+                    "Tags": [],
+                }
+            ]
+        }
+        ref = self._make_ref("aws_security_group", name="sg-abc", group_id="sg-abc")
+
+        with patch("omniscience_connectors.aws.connector._build_client", return_value=mock_client):
+            doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["group_name"] == "allow-all"
+
+    async def test_fetch_unknown_resource_type_returns_metadata(
+        self, connector: AwsConnector, config: AwsConfig
+    ) -> None:
+        ref = self._make_ref("aws_lambda_function", name="my-fn")
+
+        doc = await connector.fetch(config, SECRETS_EXPLICIT, ref)
+
+        assert doc.content_type == "application/json"
+        data = json.loads(doc.content_bytes)
+        assert data["resource_type"] == "aws_lambda_function"
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.webhook_handler
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorWebhookHandler:
+    def test_returns_none(self) -> None:
+        connector = AwsConnector()
+        assert connector.webhook_handler() is None
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_aws_connector_registered(self) -> None:
+        connector = get_connector("aws")
+        assert isinstance(connector, AwsConnector)
+
+    def test_source_type_aws_exists(self) -> None:
+        assert SourceType.aws == "aws"
+
+
+# ---------------------------------------------------------------------------
+# ARN linker helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractArn:
+    def test_direct_arn_in_metadata(self) -> None:
+        entity = _make_entity(
+            entity_metadata={"arn": "arn:aws:s3:::my-bucket", "kind": "aws_live"}
+        )
+        assert _extract_arn(entity) == "arn:aws:s3:::my-bucket"
+
+    def test_nested_arn_in_extra(self) -> None:
+        entity = _make_entity(
+            entity_metadata={"extra": {"arn": "arn:aws:iam::123:role/r"}, "kind": "aws_live"}
+        )
+        assert _extract_arn(entity) == "arn:aws:iam::123:role/r"
+
+    def test_arn_as_entity_name(self) -> None:
+        entity = _make_entity(name="arn:aws:ec2:us-east-1:123:instance/i-abc")
+        assert _extract_arn(entity) == "arn:aws:ec2:us-east-1:123:instance/i-abc"
+
+    def test_no_arn_returns_empty(self) -> None:
+        entity = _make_entity(name="my-function")
+        assert _extract_arn(entity) == ""
+
+
+class TestArnIdSegment:
+    def test_s3_bucket_arn(self) -> None:
+        assert _arn_id_segment("arn:aws:s3:::my-bucket") == "my-bucket"
+
+    def test_ec2_instance_arn(self) -> None:
+        assert _arn_id_segment("arn:aws:ec2:us-east-1:123456789012:instance/i-0abc") == "i-0abc"
+
+    def test_iam_role_arn(self) -> None:
+        assert _arn_id_segment("arn:aws:iam::123456789012:role/my-role") == "my-role"
+
+    def test_empty_arn(self) -> None:
+        assert _arn_id_segment("") == ""
+
+    def test_malformed_arn(self) -> None:
+        assert _arn_id_segment("not-an-arn") == ""
+
+
+class TestArnMatchScore:
+    def test_exact_arn_match_scores_1(self) -> None:
+        arn = "arn:aws:s3:::my-bucket"
+        tf_entity = _make_entity(
+            entity_type="tfstate_instance",
+            entity_metadata={"kind": "tfstate_instance", "arn": arn},
+        )
+        live_entity = _make_entity(
+            entity_type="aws_live",
+            entity_metadata={"kind": "aws_live", "arn": arn},
+        )
+        score, strategy = _arn_match_score(tf_entity, live_entity)
+        assert score == 1.0
+        assert strategy == "arn_match"
+
+    def test_id_only_match_scores_08(self) -> None:
+        tf_entity = _make_entity(
+            entity_type="tfstate_instance",
+            entity_metadata={
+                "kind": "tfstate_instance",
+                "arn": "arn:aws:ec2:eu-west-1:111:instance/i-abc",
+            },
+        )
+        live_entity = _make_entity(
+            entity_type="aws_live",
+            entity_metadata={
+                "kind": "aws_live",
+                "arn": "arn:aws:ec2:us-east-1:222:instance/i-abc",
+            },
+        )
+        score, strategy = _arn_match_score(tf_entity, live_entity)
+        assert score == pytest.approx(0.8)
+        assert strategy == "arn_match"
+
+    def test_different_ids_scores_0(self) -> None:
+        tf_entity = _make_entity(
+            entity_type="tfstate_instance",
+            entity_metadata={
+                "kind": "tfstate_instance",
+                "arn": "arn:aws:s3:::bucket-a",
+            },
+        )
+        live_entity = _make_entity(
+            entity_type="aws_live",
+            entity_metadata={"kind": "aws_live", "arn": "arn:aws:s3:::bucket-b"},
+        )
+        score, _ = _arn_match_score(tf_entity, live_entity)
+        assert score == 0.0
+
+    def test_wrong_kinds_scores_0(self) -> None:
+        ent_a = _make_entity(entity_type="function", entity_metadata={"arn": "arn:aws:s3:::b"})
+        ent_b = _make_entity(entity_type="class", entity_metadata={"arn": "arn:aws:s3:::b"})
+        score, _ = _arn_match_score(ent_a, ent_b)
+        assert score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# EntityLinker._match_score uses arn_match
+# ---------------------------------------------------------------------------
+
+
+class TestEntityLinkerArnMatchScore:
+    @pytest.fixture()
+    def linker(self) -> EntityLinker:
+        mock_factory = MagicMock()
+        return EntityLinker(session_factory=mock_factory)
+
+    def test_arn_match_exact_wins_over_resource_name(self, linker: EntityLinker) -> None:
+        arn = "arn:aws:s3:::shared-bucket"
+        sid_a = uuid.uuid4()
+        sid_b = uuid.uuid4()
+        tf_entity = _make_entity(
+            source_id=sid_a,
+            entity_type="tfstate_instance",
+            name="aws_s3_bucket.tf-resource-xqz",
+            display_name="tf-resource-xqz",
+            entity_metadata={"kind": "tfstate_instance", "arn": arn},
+        )
+        live_entity = _make_entity(
+            source_id=sid_b,
+            entity_type="aws_live",
+            name="live-resource-abc",
+            display_name="live-resource-abc",
+            entity_metadata={"kind": "aws_live", "arn": arn},
+        )
+        score, strategy = linker._match_score(tf_entity, live_entity)
+        assert score == 1.0
+        assert strategy == "arn_match"
+
+    def test_arn_partial_match_returns_08(self, linker: EntityLinker) -> None:
+        sid_a = uuid.uuid4()
+        sid_b = uuid.uuid4()
+        tf_entity = _make_entity(
+            source_id=sid_a,
+            entity_type="tfstate_instance",
+            name="aws_instance.web",
+            entity_metadata={
+                "kind": "tfstate_instance",
+                "arn": "arn:aws:ec2:us-east-1:111:instance/i-web",
+            },
+        )
+        live_entity = _make_entity(
+            source_id=sid_b,
+            entity_type="aws_live",
+            name="i-web",
+            entity_metadata={
+                "kind": "aws_live",
+                "arn": "arn:aws:ec2:eu-west-1:222:instance/i-web",
+            },
+        )
+        score, strategy = linker._match_score(tf_entity, live_entity)
+        assert score == pytest.approx(0.8)
+        assert strategy == "arn_match"
+
+    def test_non_aws_entities_use_other_strategies(self, linker: EntityLinker) -> None:
+        sid_a = uuid.uuid4()
+        sid_b = uuid.uuid4()
+        k8s_entity = _make_entity(
+            source_id=sid_a,
+            entity_type="k8s_resource",
+            name="nginx-deployment",
+        )
+        tf_entity = _make_entity(
+            source_id=sid_b,
+            entity_type="terraform_resource",
+            name="aws_instance.nginx-deployment",
+        )
+        score, strategy = linker._match_score(k8s_entity, tf_entity)
+        # Should use resource_name strategy, not arn_match
+        assert strategy != "arn_match"
+        assert score >= 0.0

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -122,6 +122,7 @@ class TestSourceModel:
             "k8s",
             "terraform",
             "s3",
+            "aws",
         }
         assert {t.value for t in SourceType} == expected
 


### PR DESCRIPTION
AwsConnector for S3/IAM/EC2, ARN linker strategy (exact + id-only match), aws_live entity kind. 62 tests. Closes #90