### PR TITLE
fix: P0 — enforce workspace_filter in graph retrieval

### DIFF
--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -3,7 +3,7 @@
 Registers five tools:
 - search              (requires scope: search)
 - get_document        (requires scope: search)
-- get_related_entities (requires scope: search)
+- get_related_entities (requires scope: search + workspace-scoped token)
 - list_sources        (requires scope: sources:read)
 - source_stats        (requires scope: sources:read)
 
@@ -26,6 +26,7 @@ from fastapi import FastAPI
 from mcp.server.fastmcp import Context, FastMCP
 from omniscience_core.auth.middleware import _lookup_token
 from omniscience_core.auth.scopes import Scope, check_scopes
+from omniscience_core.auth.workspace import get_workspace_id
 from omniscience_core.db.models import ApiToken
 
 from omniscience_server.mcp.tools import (
@@ -180,7 +181,8 @@ async def get_document(
     description=(
         "Traverse the entity graph from a named entity. "
         "Returns the seed entity, related entities up to max_depth hops, "
-        "and the edges that connect them. Each entity includes chunk text for context."
+        "and the edges that connect them. Each entity includes chunk text for context. "
+        "Requires a workspace-scoped token."
     ),
 )
 async def get_related_entities(
@@ -189,14 +191,30 @@ async def get_related_entities(
     max_depth: int = 1,
     edge_types: list[str] | None = None,
 ) -> dict[str, Any]:
-    """get_related_entities tool — requires scope 'search'."""
+    """get_related_entities tool — requires scope 'search' AND a workspace-scoped token.
+
+    The graph is workspace-scoped.  A token that is not bound to any
+    workspace cannot silently traverse the global graph (issue #117);
+    it is rejected with a ``forbidden:`` error.
+    """
     token = await _resolve_token(ctx)
     _require_scope(token, Scope.search)
+    # _require_scope raised if token is None, so it is non-None here.
+    assert token is not None  # noqa: S101 — narrows type for mypy
+
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "mcp_graph_request_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
 
     try:
         return await mcp_get_related_entities(
             app=_get_app(),
             entity_name=entity_name,
+            workspace_id=workspace_id,
             max_depth=max_depth,
             edge_types=edge_types,
         )

--- a/apps/server/src/omniscience_server/mcp/tools.py
+++ b/apps/server/src/omniscience_server/mcp/tools.py
@@ -294,13 +294,19 @@ async def mcp_source_stats(app: FastAPI, source_id: str) -> dict[str, Any]:
 async def mcp_get_related_entities(
     app: FastAPI,
     entity_name: str,
+    workspace_id: uuid.UUID,
     max_depth: int = 1,
     edge_types: list[str] | None = None,
 ) -> dict[str, Any]:
     """Traverse the entity graph starting from a named entity.
 
+    The caller MUST supply ``workspace_id`` — the traversal is confined to
+    entities and edges owned by that workspace.  See issue #117 for the
+    background: graph retrieval used to bypass workspace scoping and leak
+    cross-tenant entities.
+
     Returns the seed entity, related entities (up to max_depth hops),
-    and the edges connecting them. Each entity includes its associated
+    and the edges connecting them.  Each entity includes its associated
     chunk text for context.
     """
     factory = getattr(app.state, "db_session_factory", None)
@@ -310,6 +316,7 @@ async def mcp_get_related_entities(
     service = GraphQueryService(factory)
     result = await service.get_related(
         entity_name=entity_name,
+        workspace_id=workspace_id,
         max_depth=max_depth,
         edge_types=edge_types,
     )

--- a/apps/server/src/omniscience_server/rest/entities.py
+++ b/apps/server/src/omniscience_server/rest/entities.py
@@ -6,6 +6,16 @@ GET /api/v1/entities/{name}/related
         edge_types  (list[str])       — comma-separated edge type filter
 
 Requires the ``search`` scope.
+
+Workspace scoping (issue #117)
+------------------------------
+
+The caller's ``workspace_id`` is resolved from the authenticated principal
+and propagated to :class:`~omniscience_retrieval.graph_query.GraphQueryService`.
+A token with no workspace is rejected with ``403 forbidden`` — graph
+retrieval is fail-closed, never fail-open — because the service layer
+requires an explicit workspace and we refuse to invent one on behalf of
+an unscoped caller.
 """
 
 from __future__ import annotations
@@ -15,16 +25,19 @@ from urllib.parse import unquote
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from omniscience_core.auth.middleware import require_scope
+from omniscience_core.auth.middleware import get_current_token, require_scope
 from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken
 from omniscience_retrieval.graph_query import GraphQueryService
 
 log = structlog.get_logger(__name__)
 
 router = APIRouter(tags=["entities"])
 
-# Module-level Depends singleton — avoids ruff B008
+# Module-level Depends singletons — avoids ruff B008
 _search_scope_dep: Any = Depends(require_scope(Scope.search))
+_current_token_dep: Any = Depends(get_current_token)
 
 # Query parameter annotations — avoids ruff B008 (no function calls in defaults)
 _MaxDepthQuery = Annotated[
@@ -47,6 +60,7 @@ async def get_related_entities(
     request: Request,
     max_depth: _MaxDepthQuery = 1,
     edge_types: _EdgeTypesQuery = None,
+    token: ApiToken = _current_token_dep,
 ) -> dict[str, Any]:
     """Traverse the entity graph starting from the named entity.
 
@@ -55,6 +69,7 @@ async def get_related_entities(
     associated chunk text for context.
 
     Requires scope: ``search``
+    Requires: token scoped to a workspace (fails closed with 403 otherwise).
     """
     # Path parameters are URL-encoded by FastAPI; decode forward-slashes etc.
     entity_name = unquote(name)
@@ -67,11 +82,29 @@ async def get_related_entities(
             detail={"code": "service_unavailable", "message": "Database not available"},
         )
 
+    # Resolve the caller's workspace.  A token with no workspace cannot be
+    # silently widened to the global graph — that is the exact bug in
+    # issue #117.  Fail closed.
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "graph_request_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Graph retrieval requires a workspace-scoped token",
+            },
+        )
+
     service = GraphQueryService(factory)
 
     try:
         result = await service.get_related(
             entity_name=entity_name,
+            workspace_id=workspace_id,
             max_depth=max_depth,
             edge_types=edge_types if edge_types else None,
         )
@@ -93,6 +126,7 @@ async def get_related_entities(
     log.info(
         "entity_graph_traversal",
         entity=entity_name,
+        workspace_id=str(workspace_id),
         max_depth=max_depth,
         entities_found=result.stats["entities_found"],
         edges_traversed=result.stats["edges_traversed"],

--- a/packages/retrieval/src/omniscience_retrieval/graph_query.py
+++ b/packages/retrieval/src/omniscience_retrieval/graph_query.py
@@ -3,17 +3,43 @@
 Provides :class:`GraphQueryService` which traverses the entity/edge graph
 starting from a named seed entity, up to a configurable depth, with optional
 edge-type filtering.
+
+Workspace isolation (see issue #117)
+------------------------------------
+
+Every public method requires an explicit ``workspace_id`` and confines both
+the seed lookup and the BFS expansion to entities whose owning
+``sources.tenant_id`` matches that workspace.  ``NULL`` tenant rows (legacy
+data that predates multi-tenancy) are admitted alongside the caller's own
+workspace — this mirrors the backward-compat semantics of
+:func:`omniscience_core.auth.workspace.workspace_filter`.
+
+The ``workspace_id`` parameter is keyword-only and required — there is no
+default — so a caller without a workspace cannot silently widen the
+traversal.  Callers that lack a workspace must fail upstream (REST/MCP
+layer) before reaching this service.
+
+Scoping is applied at three points to be transitively complete:
+
+1. Seed lookup (``_fetch_entity_by_name``).
+2. BFS expansion (``_fetch_adjacent``) — the NEIGHBOUR entity must also
+   belong to the workspace, so a planted cross-tenant edge cannot leak.
+3. Edge-endpoint resolution (``_fetch_entity_by_id``) used to populate
+   the ``from``/``to`` names on result edges.  Any endpoint outside the
+   workspace causes the edge to be dropped entirely rather than surfaced
+   with partial information.
 """
 
 from __future__ import annotations
 
+import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
-from omniscience_core.db.models import Chunk, Edge, Entity
-from sqlalchemy import select
+from omniscience_core.db.models import Chunk, Edge, Entity, Source
+from sqlalchemy import ColumnElement, Select, null, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = structlog.get_logger(__name__)
@@ -102,8 +128,26 @@ class GraphResult:
 # ---------------------------------------------------------------------------
 
 
+def _workspace_predicate(workspace_id: uuid.UUID) -> ColumnElement[bool]:
+    """Return the WHERE predicate that confines a query to *workspace_id*.
+
+    Entities and edges do not carry workspace metadata directly — ownership
+    is inherited from the owning :class:`Source` via its ``tenant_id``
+    column.  Every query that applies this predicate MUST join
+    ``Entity.source_id == Source.id`` first.
+
+    ``NULL`` tenant_id rows are always included for backward compatibility
+    with legacy data that predates multi-tenancy.
+    """
+    return or_(Source.tenant_id == workspace_id, Source.tenant_id == null())
+
+
 class GraphQueryService:
     """Traverse the entity graph using BFS from a named seed entity.
+
+    All queries are workspace-scoped.  Callers supply an explicit
+    ``workspace_id`` on every invocation; there is no way to ask for a
+    cross-workspace view (by design — see issue #117).
 
     Parameters
     ----------
@@ -116,7 +160,9 @@ class GraphQueryService:
 
     async def get_related(
         self,
+        *,
         entity_name: str,
+        workspace_id: uuid.UUID,
         max_depth: int = 1,
         edge_types: list[str] | None = None,
     ) -> GraphResult:
@@ -126,8 +172,13 @@ class GraphQueryService:
         ----------
         entity_name:
             FQN (``name`` column) of the seed entity.
+        workspace_id:
+            REQUIRED workspace UUID.  Seed lookup AND every traversal hop
+            are confined to this workspace.  There is no "skip filtering"
+            sentinel value — a caller that cannot name a workspace must
+            fail upstream.
         max_depth:
-            Maximum number of hops from the seed (≥1).  Values <1 are
+            Maximum number of hops from the seed (>=1).  Values <1 are
             clamped to 1.
         edge_types:
             Optional allowlist of edge types to follow.  When ``None``,
@@ -142,14 +193,18 @@ class GraphQueryService:
         Raises
         ------
         ValueError
-            When no entity with the given name exists in the DB.
+            When no entity with the given name exists in the caller's
+            workspace.  Cross-workspace entities are indistinguishable
+            from "not found" by design — we never leak existence.
         """
         max_depth = max(1, max_depth)
 
         session: AsyncSession
         async with self._factory() as session:
-            # Resolve seed entity
-            seed_entity = await self._fetch_entity_by_name(session, entity_name)
+            # 1. Resolve seed entity within the caller's workspace only.
+            seed_entity = await self._fetch_entity_by_name(
+                session, entity_name, workspace_id=workspace_id
+            )
             if seed_entity is None:
                 raise ValueError(f"entity_not_found:{entity_name}")
 
@@ -178,32 +233,37 @@ class GraphQueryService:
                 if current_depth >= max_depth:
                     continue
 
-                # Fetch all edges originating from (outgoing) OR targeting
-                # (incoming) the current entity so the traversal is undirected.
-                next_hops = await self._fetch_adjacent(session, current_id, edge_types=edge_types)
+                # 2. Expand — only neighbours in the same workspace are
+                # returned.  A planted cross-tenant edge is invisible here.
+                next_hops = await self._fetch_adjacent(
+                    session,
+                    current_id,
+                    edge_types=edge_types,
+                    workspace_id=workspace_id,
+                )
 
                 for edge, neighbor_entity in next_hops:
                     neighbor_id = str(neighbor_entity.id)
-                    # Record the edge regardless of whether neighbor is new
-                    # (we add the edge only once per direction though).
-                    from_name = (
-                        seed_entity.name
-                        if edge.source_entity_id == seed_entity.id
-                        else neighbor_entity.name
-                    )
-                    # Determine proper from/to from the edge itself.
+                    # 3. Resolve the canonical from/to names for the edge,
+                    # re-applying the workspace predicate on both endpoints.
+                    # If either endpoint is outside the workspace, skip the
+                    # edge entirely — do not surface partial/mixed data.
                     from_entity_result = await self._fetch_entity_by_id(
-                        session, str(edge.source_entity_id)
+                        session,
+                        str(edge.source_entity_id),
+                        workspace_id=workspace_id,
                     )
                     to_entity_result = await self._fetch_entity_by_id(
-                        session, str(edge.target_entity_id)
+                        session,
+                        str(edge.target_entity_id),
+                        workspace_id=workspace_id,
                     )
-                    from_name = from_entity_result.name if from_entity_result else from_name
-                    to_name = to_entity_result.name if to_entity_result else neighbor_entity.name
+                    if from_entity_result is None or to_entity_result is None:
+                        continue
 
                     edge_result = EdgeResult(
-                        from_entity=from_name,
-                        to_entity=to_name,
+                        from_entity=from_entity_result.name,
+                        to_entity=to_entity_result.name,
                         edge_type=edge.edge_type,
                     )
                     # Deduplicate edges
@@ -230,6 +290,7 @@ class GraphQueryService:
         log.info(
             "graph_traversal_complete",
             seed=entity_name,
+            workspace_id=str(workspace_id),
             max_depth=max_depth,
             entities_found=1 + len(related_nodes),
             edges_traversed=len(result_edges),
@@ -238,27 +299,56 @@ class GraphQueryService:
         return GraphResult(seed=seed_node, related=related_nodes, edges=result_edges)
 
     # ------------------------------------------------------------------
-    # Private helpers
+    # Private helpers — every read pipes through the workspace predicate
     # ------------------------------------------------------------------
 
-    async def _fetch_entity_by_name(self, session: AsyncSession, name: str) -> Entity | None:
-        """Return the first Entity whose ``name`` matches exactly."""
-        result = await session.execute(select(Entity).where(Entity.name == name).limit(1))
+    async def _fetch_entity_by_name(
+        self,
+        session: AsyncSession,
+        name: str,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> Entity | None:
+        """Return the first matching Entity scoped to *workspace_id*."""
+        stmt: Select[Any] = (
+            select(Entity)
+            .join(Source, Entity.source_id == Source.id)
+            .where(Entity.name == name)
+            .where(_workspace_predicate(workspace_id))
+            .limit(1)
+        )
+        result = await session.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def _fetch_entity_by_id(self, session: AsyncSession, entity_id: str) -> Entity | None:
-        """Return an Entity by its primary key."""
-        from uuid import UUID
-
-        return await session.get(Entity, UUID(entity_id))
+    async def _fetch_entity_by_id(
+        self,
+        session: AsyncSession,
+        entity_id: str,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> Entity | None:
+        """Return an Entity by PK, constrained to *workspace_id*."""
+        stmt: Select[Any] = (
+            select(Entity)
+            .join(Source, Entity.source_id == Source.id)
+            .where(Entity.id == uuid.UUID(entity_id))
+            .where(_workspace_predicate(workspace_id))
+            .limit(1)
+        )
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
 
     async def _fetch_chunk_text(self, session: AsyncSession, chunk_id: object) -> str | None:
-        """Return the first chunk's text for an entity, or None."""
+        """Return the chunk's text, or None.
+
+        Chunks do not carry workspace metadata directly; they are reached
+        only via entities we have already authorised, so fetching by PK
+        is safe once the owning entity has passed the workspace filter.
+        """
         if chunk_id is None:
             return None
-        from uuid import UUID
 
-        chunk = await session.get(Chunk, UUID(str(chunk_id)))
+        chunk = await session.get(Chunk, uuid.UUID(str(chunk_id)))
         return chunk.text if chunk is not None else None
 
     async def _fetch_adjacent(
@@ -266,29 +356,33 @@ class GraphQueryService:
         session: AsyncSession,
         entity_id: str,
         edge_types: list[str] | None,
+        *,
+        workspace_id: uuid.UUID,
     ) -> list[tuple[Edge, Entity]]:
-        """Return (edge, neighbor_entity) pairs for all adjacent edges.
+        """Return (edge, neighbor_entity) pairs whose NEIGHBOUR is in *workspace_id*.
 
         Traversal is bidirectional: we look at both outgoing
         (source_entity_id == entity_id) and incoming
-        (target_entity_id == entity_id) edges.
+        (target_entity_id == entity_id) edges.  For every hop, the
+        neighbour entity (and therefore its owning source) must itself
+        belong to the workspace — this closes the transitive leak path.
         """
-        from uuid import UUID
+        eid = uuid.UUID(entity_id)
 
-        eid = UUID(entity_id)
-
-        # Outgoing edges
-        outgoing_query = (
+        outgoing_query: Select[Any] = (
             select(Edge, Entity)
             .join(Entity, Edge.target_entity_id == Entity.id)
+            .join(Source, Entity.source_id == Source.id)
             .where(Edge.source_entity_id == eid)
+            .where(_workspace_predicate(workspace_id))
         )
 
-        # Incoming edges
-        incoming_query = (
+        incoming_query: Select[Any] = (
             select(Edge, Entity)
             .join(Entity, Edge.source_entity_id == Entity.id)
+            .join(Source, Entity.source_id == Source.id)
             .where(Edge.target_entity_id == eid)
+            .where(_workspace_predicate(workspace_id))
         )
 
         if edge_types:

--- a/tests/test_graph_query.py
+++ b/tests/test_graph_query.py
@@ -10,6 +10,7 @@ Covers:
 - GraphQueryService.get_related: max_depth clamped to minimum 1
 - GraphQueryService.get_related: chunk_text populated when chunk exists
 - GraphQueryService.get_related: chunk_text is None when chunk_id is None
+- GraphQueryService.get_related: workspace_id is required (keyword-only, no default)
 - GraphResult.stats: entities_found, edges_traversed, depth_reached
 - GraphResult.to_dict: correct wire format structure
 - GraphResult.to_dict: empty related list
@@ -18,6 +19,7 @@ Covers:
 - mcp_get_related_entities: raises RuntimeError when no factory on app.state
 - mcp_get_related_entities: delegates to GraphQueryService and returns dict
 - mcp_get_related_entities: propagates ValueError from service
+- mcp_get_related_entities: forwards workspace_id to the service
 - MCP server tool: entity_not_found propagated as ValueError
 - REST GET /api/v1/entities/{name}/related: 404 when entity not found
 - REST GET /api/v1/entities/{name}/related: 503 when DB unavailable
@@ -26,6 +28,7 @@ Covers:
 - REST GET /api/v1/entities/{name}/related: edge_types query param forwarded
 - REST GET /api/v1/entities/{name}/related: requires search scope (401)
 - REST GET /api/v1/entities/{name}/related: requires search scope (403)
+- REST GET /api/v1/entities/{name}/related: 403 when token has no workspace (#117)
 - GraphQueryService._fetch_entity_by_name: returns None for missing entity
 - GraphQueryService._fetch_chunk_text: returns None when chunk_id is None
 """
@@ -54,6 +57,10 @@ _NEIGHBOR_ID = uuid.uuid4()
 _CHUNK_ID = uuid.uuid4()
 _SRC_ID = uuid.uuid4()
 _EDGE_ID = uuid.uuid4()
+# Workspace used for all unit-test queries.  The unit-test DB is fully
+# mocked so this value never actually filters any row; it exists only to
+# satisfy the required ``workspace_id`` parameter introduced for #117.
+_WORKSPACE_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000042")
 
 
 def _make_entity(
@@ -107,6 +114,20 @@ def _build_service_with_session(session: AsyncMock) -> GraphQueryService:
     factory.return_value.__aenter__ = AsyncMock(return_value=session)
     factory.return_value.__aexit__ = AsyncMock(return_value=False)
     return GraphQueryService(factory)
+
+
+def _scalar_result(value: Any) -> MagicMock:
+    """Build an execute() return whose scalar_one_or_none() == value."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    return r
+
+
+def _iter_result(rows: list[Any]) -> MagicMock:
+    """Build an execute() return that iterates over *rows*."""
+    r = MagicMock()
+    r.__iter__ = MagicMock(return_value=iter(rows))
+    return r
 
 
 # ---------------------------------------------------------------------------
@@ -200,14 +221,29 @@ def test_entity_node_defaults() -> None:
 async def test_get_related_raises_when_seed_not_found() -> None:
     """get_related raises ValueError with entity_not_found: prefix."""
     session = AsyncMock()
-    # scalar_one_or_none returns None → entity not found
-    result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None
-    session.execute = AsyncMock(return_value=result_mock)
+    session.execute = AsyncMock(return_value=_scalar_result(None))
 
     service = _build_service_with_session(session)
     with pytest.raises(ValueError, match=r"entity_not_found:missing\.entity"):
-        await service.get_related("missing.entity")
+        await service.get_related(entity_name="missing.entity", workspace_id=_WORKSPACE_ID)
+
+
+@pytest.mark.asyncio
+async def test_get_related_requires_workspace_id_keyword_only() -> None:
+    """workspace_id is keyword-only — passing it positionally fails.
+
+    Regression guard for issue #117: we never want a caller to silently
+    omit the workspace filter by mis-ordering arguments.
+    """
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_scalar_result(None))
+    service = _build_service_with_session(session)
+
+    # Positional call is a TypeError at call time because the only
+    # allowed positional argument is self.
+    with pytest.raises(TypeError):
+        # Intentional misuse — ignore type checker.
+        await service.get_related("missing.entity", _WORKSPACE_ID)  # type: ignore[misc]
 
 
 @pytest.mark.asyncio
@@ -216,21 +252,19 @@ async def test_get_related_returns_seed_only_when_no_edges() -> None:
     seed = _make_entity(chunk_id=None)
     session = AsyncMock()
 
-    # _fetch_entity_by_name → returns seed
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-
-    # _fetch_adjacent → no edges (outgoing + incoming both empty)
-    empty_out = MagicMock()
-    empty_out.__iter__ = MagicMock(return_value=iter([]))
-    empty_in = MagicMock()
-    empty_in.__iter__ = MagicMock(return_value=iter([]))
-
-    session.execute = AsyncMock(side_effect=[name_result, empty_out, empty_in])
-    session.get = AsyncMock(return_value=None)  # chunk lookup → None
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),  # _fetch_entity_by_name
+            _iter_result([]),  # outgoing
+            _iter_result([]),  # incoming
+        ]
+    )
+    session.get = AsyncMock(return_value=None)  # chunk lookup
 
     service = _build_service_with_session(session)
-    result = await service.get_related("aws_s3_bucket.logs")
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID
+    )
 
     assert result.seed.name == "aws_s3_bucket.logs"
     assert result.related == []
@@ -254,31 +288,27 @@ async def test_get_related_depth1_returns_immediate_neighbor() -> None:
     )
 
     session = AsyncMock()
-
-    # execute calls:
-    # 1. _fetch_entity_by_name (SELECT Entity WHERE name=...)
-    # 2. outgoing edges (SELECT Edge JOIN Entity WHERE source=seed)
-    # 3. incoming edges (SELECT Edge JOIN Entity WHERE target=seed)
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-
-    out_result = MagicMock()
-    out_result.__iter__ = MagicMock(return_value=iter([(edge, neighbor)]))
-
-    in_result = MagicMock()
-    in_result.__iter__ = MagicMock(return_value=iter([]))
-
-    session.execute = AsyncMock(side_effect=[name_result, out_result, in_result])
-
-    # session.get calls:
-    # 1. _fetch_chunk_text for seed (chunk_id=None → returns None)
-    # 2. _fetch_entity_by_id for edge.source_entity_id
-    # 3. _fetch_entity_by_id for edge.target_entity_id
-    # 4. _fetch_chunk_text for neighbor (chunk_id=None → returns None)
-    session.get = AsyncMock(side_effect=[None, seed, neighbor, None])
+    # execute calls (in order):
+    # 1. _fetch_entity_by_name (SELECT Entity JOIN Source WHERE name=...)
+    # 2. outgoing edges
+    # 3. incoming edges
+    # 4. _fetch_entity_by_id for edge.source_entity_id (workspace-scoped)
+    # 5. _fetch_entity_by_id for edge.target_entity_id (workspace-scoped)
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([(edge, neighbor)]),
+            _iter_result([]),
+            _scalar_result(seed),  # source_entity resolve
+            _scalar_result(neighbor),  # target_entity resolve
+        ]
+    )
+    session.get = AsyncMock(return_value=None)  # chunk lookups
 
     service = _build_service_with_session(session)
-    result = await service.get_related("aws_s3_bucket.logs", max_depth=1)
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID, max_depth=1
+    )
 
     assert len(result.related) == 1
     assert result.related[0].name == "resource.aws_s3_bucket.logs"
@@ -295,21 +325,19 @@ async def test_get_related_chunk_text_populated() -> None:
     seed = _make_entity(chunk_id=_CHUNK_ID)
 
     session = AsyncMock()
-
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-
-    out_result = MagicMock()
-    out_result.__iter__ = MagicMock(return_value=iter([]))
-    in_result = MagicMock()
-    in_result.__iter__ = MagicMock(return_value=iter([]))
-
-    session.execute = AsyncMock(side_effect=[name_result, out_result, in_result])
-    # session.get → chunk
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([]),
+            _iter_result([]),
+        ]
+    )
     session.get = AsyncMock(return_value=chunk)
 
     service = _build_service_with_session(session)
-    result = await service.get_related("aws_s3_bucket.logs")
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID
+    )
 
     assert result.seed.chunk_text == "resource aws_s3_bucket logs {}"
 
@@ -320,18 +348,19 @@ async def test_get_related_chunk_text_none_when_no_chunk_id() -> None:
     seed = _make_entity(chunk_id=None)
 
     session = AsyncMock()
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-    out_result = MagicMock()
-    out_result.__iter__ = MagicMock(return_value=iter([]))
-    in_result = MagicMock()
-    in_result.__iter__ = MagicMock(return_value=iter([]))
-
-    session.execute = AsyncMock(side_effect=[name_result, out_result, in_result])
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([]),
+            _iter_result([]),
+        ]
+    )
     session.get = AsyncMock(return_value=None)
 
     service = _build_service_with_session(session)
-    result = await service.get_related("aws_s3_bucket.logs")
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID
+    )
 
     assert result.seed.chunk_text is None
 
@@ -342,19 +371,19 @@ async def test_get_related_max_depth_clamped_to_1() -> None:
     seed = _make_entity(chunk_id=None)
 
     session = AsyncMock()
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-    out_result = MagicMock()
-    out_result.__iter__ = MagicMock(return_value=iter([]))
-    in_result = MagicMock()
-    in_result.__iter__ = MagicMock(return_value=iter([]))
-
-    session.execute = AsyncMock(side_effect=[name_result, out_result, in_result])
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([]),
+            _iter_result([]),
+        ]
+    )
     session.get = AsyncMock(return_value=None)
 
     service = _build_service_with_session(session)
-    # max_depth=0 should be clamped to 1 — no crash
-    result = await service.get_related("aws_s3_bucket.logs", max_depth=0)
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID, max_depth=0
+    )
     assert result.seed.name == "aws_s3_bucket.logs"
 
 
@@ -364,23 +393,24 @@ async def test_get_related_edge_type_filter_applied() -> None:
     seed = _make_entity(chunk_id=None)
 
     session = AsyncMock()
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-    # No edges returned because filter restricts them
-    out_result = MagicMock()
-    out_result.__iter__ = MagicMock(return_value=iter([]))
-    in_result = MagicMock()
-    in_result.__iter__ = MagicMock(return_value=iter([]))
-
-    session.execute = AsyncMock(side_effect=[name_result, out_result, in_result])
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([]),
+            _iter_result([]),
+        ]
+    )
     session.get = AsyncMock(return_value=None)
 
     service = _build_service_with_session(session)
-    result = await service.get_related("aws_s3_bucket.logs", edge_types=["cross_ref"])
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs",
+        workspace_id=_WORKSPACE_ID,
+        edge_types=["cross_ref"],
+    )
 
-    # The edge_types filter should have been passed to the query — no neighbors
     assert result.related == []
-    # Verify the execute was called at least once for the name lookup
+    # Name lookup at minimum triggers one execute.
     assert session.execute.call_count >= 1
 
 
@@ -394,7 +424,6 @@ async def test_get_related_bidirectional_incoming_edge() -> None:
         entity_type="module",
         chunk_id=None,
     )
-    # edge points from upstream TO seed (incoming from seed's perspective)
     edge = _make_edge(
         source_entity_id=_NEIGHBOR_ID,
         target_entity_id=_SEED_ID,
@@ -402,22 +431,21 @@ async def test_get_related_bidirectional_incoming_edge() -> None:
     )
 
     session = AsyncMock()
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-
-    out_result = MagicMock()
-    out_result.__iter__ = MagicMock(return_value=iter([]))
-
-    in_result = MagicMock()
-    # For incoming edges: the JOIN is on source_entity_id, so we get (edge, upstream)
-    in_result.__iter__ = MagicMock(return_value=iter([(edge, upstream)]))
-
-    session.execute = AsyncMock(side_effect=[name_result, out_result, in_result])
-    # get calls: chunk for seed, edge entity lookups (source/target), chunk for upstream
-    session.get = AsyncMock(side_effect=[None, upstream, seed, None])
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([]),  # outgoing
+            _iter_result([(edge, upstream)]),  # incoming
+            _scalar_result(upstream),  # source_entity resolve
+            _scalar_result(seed),  # target_entity resolve
+        ]
+    )
+    session.get = AsyncMock(return_value=None)
 
     service = _build_service_with_session(session)
-    result = await service.get_related("aws_s3_bucket.logs", max_depth=1)
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID, max_depth=1
+    )
 
     assert len(result.related) == 1
     assert result.related[0].name == "upstream.module"
@@ -442,26 +470,61 @@ async def test_get_related_deduplicates_visited_nodes() -> None:
     )
 
     session = AsyncMock()
-    name_result = MagicMock()
-    name_result.scalar_one_or_none.return_value = seed
-
-    out_result = MagicMock()
-    out_result.__iter__ = MagicMock(return_value=iter([(edge1, neighbor), (edge2, neighbor)]))
-
-    in_result = MagicMock()
-    in_result.__iter__ = MagicMock(return_value=iter([]))
-
-    # Accommodate multiple session.get calls
-    session.execute = AsyncMock(side_effect=[name_result, out_result, in_result])
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([(edge1, neighbor), (edge2, neighbor)]),
+            _iter_result([]),
+            # edge1 endpoint resolves
+            _scalar_result(seed),
+            _scalar_result(neighbor),
+            # edge2 endpoint resolves
+            _scalar_result(seed),
+            _scalar_result(neighbor),
+        ]
+    )
     session.get = AsyncMock(return_value=None)
 
     service = _build_service_with_session(session)
-    result = await service.get_related("aws_s3_bucket.logs", max_depth=1)
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID, max_depth=1
+    )
 
-    # Even though edge1 and edge2 both point to the same neighbor,
-    # the neighbor should appear only once in related.
     neighbor_names = [n.name for n in result.related]
     assert neighbor_names.count("shared.entity") == 1
+
+
+@pytest.mark.asyncio
+async def test_get_related_skips_edge_when_endpoint_outside_workspace() -> None:
+    """If one edge endpoint is outside the workspace, the edge is dropped.
+
+    Direct regression test for #117 at the unit level: even if an edge row
+    slips through (e.g. via a planted cross-tenant entity), the endpoint
+    resolution MUST re-check the workspace and refuse to surface it.
+    """
+    seed = _make_entity(entity_id=_SEED_ID, chunk_id=None)
+    neighbor = _make_entity(entity_id=_NEIGHBOR_ID, name="other.ws.entity", chunk_id=None)
+    edge = _make_edge(source_entity_id=_SEED_ID, target_entity_id=_NEIGHBOR_ID)
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(seed),
+            _iter_result([(edge, neighbor)]),
+            _iter_result([]),
+            _scalar_result(seed),  # from-endpoint in-workspace
+            _scalar_result(None),  # to-endpoint OUTSIDE workspace → drop edge
+        ]
+    )
+    session.get = AsyncMock(return_value=None)
+
+    service = _build_service_with_session(session)
+    result = await service.get_related(
+        entity_name="aws_s3_bucket.logs", workspace_id=_WORKSPACE_ID, max_depth=1
+    )
+
+    assert result.edges == []
+    assert result.related == []
 
 
 # ---------------------------------------------------------------------------
@@ -478,7 +541,9 @@ async def test_mcp_get_related_entities_raises_without_factory() -> None:
     app.state.db_session_factory = None
 
     with pytest.raises(RuntimeError, match="db_session_factory not available"):
-        await mcp_get_related_entities(app=app, entity_name="any.entity")
+        await mcp_get_related_entities(
+            app=app, entity_name="any.entity", workspace_id=_WORKSPACE_ID
+        )
 
 
 @pytest.mark.asyncio
@@ -502,7 +567,9 @@ async def test_mcp_get_related_entities_returns_dict() -> None:
         new_callable=AsyncMock,
         return_value=mock_result,
     ):
-        result = await mcp_get_related_entities(app=app, entity_name="e")
+        result = await mcp_get_related_entities(
+            app=app, entity_name="e", workspace_id=_WORKSPACE_ID
+        )
 
     assert "seed" in result
     assert "related" in result
@@ -526,12 +593,12 @@ async def test_mcp_get_related_entities_propagates_not_found() -> None:
         ),
         pytest.raises(ValueError, match="entity_not_found"),
     ):
-        await mcp_get_related_entities(app=app, entity_name="gone")
+        await mcp_get_related_entities(app=app, entity_name="gone", workspace_id=_WORKSPACE_ID)
 
 
 @pytest.mark.asyncio
-async def test_mcp_get_related_entities_passes_edge_types() -> None:
-    """mcp_get_related_entities forwards edge_types to GraphQueryService."""
+async def test_mcp_get_related_entities_forwards_workspace_and_edge_types() -> None:
+    """mcp_get_related_entities forwards workspace_id and edge_types to the service."""
     from omniscience_server.mcp.tools import mcp_get_related_entities
 
     mock_result = MagicMock()
@@ -553,12 +620,14 @@ async def test_mcp_get_related_entities_passes_edge_types() -> None:
         await mcp_get_related_entities(
             app=app,
             entity_name="e",
+            workspace_id=_WORKSPACE_ID,
             max_depth=2,
             edge_types=["cross_ref", "tfstate_of"],
         )
 
     mock_get.assert_called_once_with(
         entity_name="e",
+        workspace_id=_WORKSPACE_ID,
         max_depth=2,
         edge_types=["cross_ref", "tfstate_of"],
     )
@@ -587,20 +656,31 @@ def _make_rest_app(factory: Any = None) -> FastAPI:
     return app
 
 
+def _make_auth_token(
+    scopes: list[str] | None = None,
+    workspace_id: uuid.UUID | None = _WORKSPACE_ID,
+) -> tuple[MagicMock, str]:
+    """Build a mock ApiToken + generate a matching plaintext bearer string."""
+    from omniscience_core.auth.tokens import generate_token, hash_token
+    from omniscience_core.db.models import ApiToken
+
+    plaintext, prefix = generate_token("test")
+    token: MagicMock = MagicMock(spec=ApiToken)
+    token.hashed_token = hash_token(plaintext)
+    token.token_prefix = prefix
+    token.scopes = scopes or ["search"]
+    token.expires_at = None
+    token.is_active = True
+    token.workspace_id = workspace_id
+    return token, plaintext
+
+
 @pytest.mark.asyncio
 async def test_rest_entities_related_404_when_not_found() -> None:
     """GET /api/v1/entities/{name}/related returns 404 when entity absent."""
     from httpx import ASGITransport, AsyncClient
-    from omniscience_core.auth.tokens import generate_token, hash_token
-    from omniscience_core.db.models import ApiToken
 
-    token_mock: ApiToken = MagicMock(spec=ApiToken)
-    plaintext, prefix = generate_token("test")
-    token_mock.hashed_token = hash_token(plaintext)
-    token_mock.token_prefix = prefix
-    token_mock.scopes = ["search"]
-    token_mock.expires_at = None
-    token_mock.is_active = True
+    token_mock, plaintext = _make_auth_token()
 
     with (
         patch(
@@ -631,19 +711,9 @@ async def test_rest_entities_related_404_when_not_found() -> None:
 async def test_rest_entities_related_503_when_no_db() -> None:
     """GET /api/v1/entities/{name}/related returns 503 when DB unavailable."""
     from httpx import ASGITransport, AsyncClient
-    from omniscience_core.auth.tokens import generate_token, hash_token
-    from omniscience_core.db.models import ApiToken
 
-    token_mock: ApiToken = MagicMock(spec=ApiToken)
-    plaintext, prefix = generate_token("test")
-    token_mock.hashed_token = hash_token(plaintext)
-    token_mock.token_prefix = prefix
-    token_mock.scopes = ["search"]
-    token_mock.expires_at = None
-    token_mock.is_active = True
+    token_mock, plaintext = _make_auth_token()
 
-    # Provide a factory for auth, but make the entities endpoint see None
-    # by patching getattr inside the entities module.
     with (
         patch(
             "omniscience_core.auth.middleware._lookup_token",
@@ -670,17 +740,8 @@ async def test_rest_entities_related_503_when_no_db() -> None:
 async def test_rest_entities_related_returns_graph_structure() -> None:
     """GET /api/v1/entities/{name}/related returns the GraphResult dict."""
     from httpx import ASGITransport, AsyncClient
-    from omniscience_core.auth.tokens import generate_token, hash_token
-    from omniscience_core.db.models import ApiToken
-    from omniscience_retrieval.graph_query import EntityNode, GraphResult
 
-    token_mock: ApiToken = MagicMock(spec=ApiToken)
-    plaintext, prefix = generate_token("test")
-    token_mock.hashed_token = hash_token(plaintext)
-    token_mock.token_prefix = prefix
-    token_mock.scopes = ["search"]
-    token_mock.expires_at = None
-    token_mock.is_active = True
+    token_mock, plaintext = _make_auth_token()
 
     seed = EntityNode(
         name="aws_s3_bucket.logs", kind="tfstate_instance", source="s", chunk_text=None
@@ -733,16 +794,8 @@ async def test_rest_entities_related_401_without_token() -> None:
 async def test_rest_entities_related_403_wrong_scope() -> None:
     """GET /api/v1/entities/{name}/related returns 403 for insufficient scope."""
     from httpx import ASGITransport, AsyncClient
-    from omniscience_core.auth.tokens import generate_token, hash_token
-    from omniscience_core.db.models import ApiToken
 
-    token_mock: ApiToken = MagicMock(spec=ApiToken)
-    plaintext, prefix = generate_token("test")
-    token_mock.hashed_token = hash_token(plaintext)
-    token_mock.token_prefix = prefix
-    token_mock.scopes = ["sources:read"]  # wrong scope
-    token_mock.expires_at = None
-    token_mock.is_active = True
+    token_mock, plaintext = _make_auth_token(scopes=["sources:read"])
 
     with patch(
         "omniscience_core.auth.middleware._lookup_token",
@@ -761,20 +814,37 @@ async def test_rest_entities_related_403_wrong_scope() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rest_entities_related_403_when_token_has_no_workspace() -> None:
+    """A token without a workspace is rejected — fail-closed for #117."""
+    from httpx import ASGITransport, AsyncClient
+
+    token_mock, plaintext = _make_auth_token(workspace_id=None)
+
+    with patch(
+        "omniscience_core.auth.middleware._lookup_token",
+        new_callable=AsyncMock,
+        return_value=token_mock,
+    ):
+        app = _make_rest_app(factory=MagicMock())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/api/v1/entities/some.entity/related",
+                headers={"Authorization": f"Bearer {plaintext}"},
+            )
+
+    assert response.status_code == 403
+    data = response.json()
+    assert data["error"]["code"] == "forbidden"
+    assert "workspace" in data["error"]["message"].lower()
+
+
+@pytest.mark.asyncio
 async def test_rest_entities_related_max_depth_forwarded() -> None:
     """max_depth query parameter is forwarded to GraphQueryService."""
     from httpx import ASGITransport, AsyncClient
-    from omniscience_core.auth.tokens import generate_token, hash_token
-    from omniscience_core.db.models import ApiToken
-    from omniscience_retrieval.graph_query import EntityNode, GraphResult
 
-    token_mock: ApiToken = MagicMock(spec=ApiToken)
-    plaintext, prefix = generate_token("test")
-    token_mock.hashed_token = hash_token(plaintext)
-    token_mock.token_prefix = prefix
-    token_mock.scopes = ["search"]
-    token_mock.expires_at = None
-    token_mock.is_active = True
+    token_mock, plaintext = _make_auth_token()
 
     seed = EntityNode(name="e", kind="k", source="s", chunk_text=None)
     graph_result = GraphResult(seed=seed)
@@ -801,23 +871,15 @@ async def test_rest_entities_related_max_depth_forwarded() -> None:
 
     call_kwargs = mock_get.call_args.kwargs
     assert call_kwargs["max_depth"] == 3
+    assert call_kwargs["workspace_id"] == _WORKSPACE_ID
 
 
 @pytest.mark.asyncio
 async def test_rest_entities_related_edge_types_forwarded() -> None:
     """edge_types query parameter is forwarded to GraphQueryService."""
     from httpx import ASGITransport, AsyncClient
-    from omniscience_core.auth.tokens import generate_token, hash_token
-    from omniscience_core.db.models import ApiToken
-    from omniscience_retrieval.graph_query import EntityNode, GraphResult
 
-    token_mock: ApiToken = MagicMock(spec=ApiToken)
-    plaintext, prefix = generate_token("test")
-    token_mock.hashed_token = hash_token(plaintext)
-    token_mock.token_prefix = prefix
-    token_mock.scopes = ["search"]
-    token_mock.expires_at = None
-    token_mock.is_active = True
+    token_mock, plaintext = _make_auth_token()
 
     seed = EntityNode(name="e", kind="k", source="s", chunk_text=None)
     graph_result = GraphResult(seed=seed)
@@ -868,13 +930,13 @@ def test_mcp_server_has_get_related_entities_tool() -> None:
 async def test_fetch_entity_by_name_returns_none_when_missing() -> None:
     """_fetch_entity_by_name returns None when no entity matches."""
     session = AsyncMock()
-    result_mock = MagicMock()
-    result_mock.scalar_one_or_none.return_value = None
-    session.execute = AsyncMock(return_value=result_mock)
+    session.execute = AsyncMock(return_value=_scalar_result(None))
 
     factory = MagicMock()
     service = GraphQueryService(factory)
-    entity = await service._fetch_entity_by_name(session, "nonexistent")
+    entity = await service._fetch_entity_by_name(
+        session, "nonexistent", workspace_id=_WORKSPACE_ID
+    )
     assert entity is None
 
 
@@ -887,7 +949,6 @@ async def test_fetch_chunk_text_returns_none_when_chunk_id_none() -> None:
 
     text = await service._fetch_chunk_text(session, None)
     assert text is None
-    # session.get should NOT have been called
     session.get.assert_not_called()
 
 

--- a/tests/test_graph_workspace_isolation.py
+++ b/tests/test_graph_workspace_isolation.py
@@ -1,0 +1,681 @@
+"""Cross-workspace isolation tests for graph retrieval — regression for issue #117.
+
+Problem
+-------
+
+Before this fix, ``GraphQueryService.get_related`` and its REST/MCP
+callers did not apply the workspace filter.  A token scoped to workspace
+A could retrieve entities and edges from workspace B by traversing the
+graph.
+
+Strategy
+--------
+
+We exercise three layers in one test file:
+
+1. **Service layer** — a fake AsyncSession applies the workspace predicate
+   exactly as Postgres would (it checks that the compiled SQL includes
+   ``sources.tenant_id`` and it filters an in-memory fixture by that
+   tenant).  This proves the SQL-level guarantee.
+2. **SQL shape** — we compile the service's SELECT statements and assert
+   the workspace predicate is present on EVERY read path (seed lookup,
+   adjacency, endpoint resolve).  This is the "defence-in-depth" grep-like
+   regression guard: future refactors cannot silently drop it.
+3. **REST endpoint** — an end-to-end call through the FastAPI app proves
+   the token→workspace resolution wires into the service correctly and
+   that a cross-workspace request returns 404 (never a B-entity payload).
+4. **MCP tool** — same check through the MCP tool path.
+
+No real database is started; Postgres-specific column types (pgvector,
+tsvector) prevent an in-memory SQLite fallback.  The fake session below
+is a deliberate middle ground: it parses the compiled SQL parameters to
+emulate workspace scoping and serves from an in-memory row set.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.db.models import ApiToken
+from omniscience_retrieval.graph_query import GraphQueryService
+from sqlalchemy.sql import Select
+
+# ---------------------------------------------------------------------------
+# Fixtures: two workspaces with deliberately crossing entity names
+# ---------------------------------------------------------------------------
+
+_WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-0000000000a1")
+_WS_B = uuid.UUID("bbbbbbbb-0000-0000-0000-0000000000b2")
+
+
+@dataclass
+class _FakeEntity:
+    """Minimal duck-typed stand-in for :class:`omniscience_core.db.models.Entity`."""
+
+    id: uuid.UUID
+    name: str
+    entity_type: str
+    source_id: uuid.UUID
+    chunk_id: uuid.UUID | None = None
+
+
+@dataclass
+class _FakeEdge:
+    """Minimal duck-typed stand-in for :class:`omniscience_core.db.models.Edge`."""
+
+    id: uuid.UUID
+    source_entity_id: uuid.UUID
+    target_entity_id: uuid.UUID
+    edge_type: str
+
+
+@dataclass
+class _FakeSource:
+    """Minimal duck-typed stand-in for :class:`omniscience_core.db.models.Source`."""
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID | None
+
+
+@dataclass
+class _Fixture:
+    """Two-workspace fixture with entities, edges, and crossing names."""
+
+    sources: dict[uuid.UUID, _FakeSource] = field(default_factory=dict)
+    entities: dict[uuid.UUID, _FakeEntity] = field(default_factory=dict)
+    edges: list[_FakeEdge] = field(default_factory=list)
+
+    def entities_by_name(self, name: str) -> Iterable[_FakeEntity]:
+        return (e for e in self.entities.values() if e.name == name)
+
+    def workspace_of(self, entity: _FakeEntity) -> uuid.UUID | None:
+        return self.sources[entity.source_id].tenant_id
+
+
+def _build_fixture() -> _Fixture:
+    """Build a two-workspace fixture with two entities named ``svc.shared``.
+
+    Workspace A:
+        svc.shared   (entity A1)   --calls-->   svc.internal-a   (entity A2)
+    Workspace B:
+        svc.shared   (entity B1)   --calls-->   svc.internal-b   (entity B2)
+
+    The name ``svc.shared`` crosses both workspaces on purpose.  A
+    correctly-scoped query from A must return only A1/A2 and never
+    acknowledge B1/B2's existence.
+    """
+    src_a = _FakeSource(id=uuid.uuid4(), tenant_id=_WS_A)
+    src_b = _FakeSource(id=uuid.uuid4(), tenant_id=_WS_B)
+
+    a1 = _FakeEntity(id=uuid.uuid4(), name="svc.shared", entity_type="service", source_id=src_a.id)
+    a2 = _FakeEntity(
+        id=uuid.uuid4(), name="svc.internal-a", entity_type="service", source_id=src_a.id
+    )
+    b1 = _FakeEntity(id=uuid.uuid4(), name="svc.shared", entity_type="service", source_id=src_b.id)
+    b2 = _FakeEntity(
+        id=uuid.uuid4(), name="svc.internal-b", entity_type="service", source_id=src_b.id
+    )
+
+    edge_a = _FakeEdge(
+        id=uuid.uuid4(), source_entity_id=a1.id, target_entity_id=a2.id, edge_type="calls"
+    )
+    edge_b = _FakeEdge(
+        id=uuid.uuid4(), source_entity_id=b1.id, target_entity_id=b2.id, edge_type="calls"
+    )
+    # Planted cross-tenant edge — simulates a poisoned row that references an
+    # entity in the other workspace.  A correct implementation must NOT
+    # traverse it.
+    cross_edge = _FakeEdge(
+        id=uuid.uuid4(),
+        source_entity_id=a1.id,
+        target_entity_id=b1.id,
+        edge_type="calls",
+    )
+
+    fx = _Fixture()
+    fx.sources = {src_a.id: src_a, src_b.id: src_b}
+    fx.entities = {e.id: e for e in (a1, a2, b1, b2)}
+    fx.edges = [edge_a, edge_b, cross_edge]
+    return fx
+
+
+# ---------------------------------------------------------------------------
+# Fake session that interprets workspace scoping
+# ---------------------------------------------------------------------------
+
+
+def _extract_workspace_id_param(stmt: Select[Any]) -> uuid.UUID | None:
+    """Return the workspace UUID bound into the compiled statement, if any.
+
+    The predicate produced by ``graph_query._workspace_predicate`` is
+    ``or_(Source.tenant_id == :tenant_id_1, Source.tenant_id IS NULL)``,
+    so the bound param name always starts with ``tenant_id``.  We match
+    by name to avoid confusing the workspace UUID with a pivot entity id.
+    """
+    params = stmt.compile().params
+    for key, value in params.items():
+        if key.startswith("tenant_id") and isinstance(value, uuid.UUID):
+            return value
+    return None
+
+
+def _extract_name_param(stmt: Select[Any]) -> str | None:
+    """Return the first string param bound into the statement."""
+    params = stmt.compile().params
+    for value in params.values():
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _extract_non_workspace_uuid_params(stmt: Select[Any]) -> list[uuid.UUID]:
+    """Return every UUID param that is NOT the workspace predicate's tenant_id."""
+    params = stmt.compile().params
+    return [
+        v for k, v in params.items() if isinstance(v, uuid.UUID) and not k.startswith("tenant_id")
+    ]
+
+
+class _FakeResult:
+    """Matches the slice of AsyncSession.execute()'s return type we use."""
+
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def scalar_one_or_none(self) -> Any | None:
+        return self._rows[0] if self._rows else None
+
+    def __iter__(self) -> Any:
+        return iter(self._rows)
+
+
+class _FakeSession:
+    """An AsyncSession stand-in that enforces workspace scoping.
+
+    It inspects the compiled SQL of each incoming ``Select`` and routes it
+    to one of the fixture helpers.  The helpers apply the workspace
+    predicate before returning rows — exactly mirroring what Postgres
+    would do for the real query.
+    """
+
+    def __init__(self, fixture: _Fixture) -> None:
+        self._fx = fixture
+
+    async def execute(self, stmt: Select[Any]) -> _FakeResult:
+        non_ws_params = _extract_non_workspace_uuid_params(stmt)
+        workspace_id = _extract_workspace_id_param(stmt)
+
+        # Seed lookup: SELECT entities … JOIN sources … WHERE entities.name = ?
+        # Discriminate on the bound param name rather than SELECT-list
+        # substrings (adjacency's SELECT also mentions entities.name).
+        param_names = list(stmt.compile().params.keys())
+        has_name_where = any(k.startswith("name") for k in param_names)
+        has_entity_id_where = any(k.startswith("id_") or k == "id" for k in param_names)
+        has_edge_pivot_where = any(
+            k.startswith("source_entity_id") or k.startswith("target_entity_id")
+            for k in param_names
+        )
+
+        if has_name_where:
+            name = _extract_name_param(stmt)
+            if name is None or workspace_id is None:
+                return _FakeResult([])
+            matches = [
+                e
+                for e in self._fx.entities_by_name(name)
+                if self._fx.workspace_of(e) in (workspace_id, None)
+            ]
+            return _FakeResult(matches[:1])
+
+        # Entity-by-id lookup used to resolve edge endpoints.
+        if has_entity_id_where and not has_edge_pivot_where:
+            if workspace_id is None or not non_ws_params:
+                return _FakeResult([])
+            target_id = next(
+                (p for p in non_ws_params),
+                None,
+            )
+            if target_id is None:
+                return _FakeResult([])
+            ent = self._fx.entities.get(target_id)
+            if ent is None:
+                return _FakeResult([])
+            if self._fx.workspace_of(ent) not in (workspace_id, None):
+                return _FakeResult([])
+            return _FakeResult([ent])
+
+        # Adjacency lookup: SELECT edges, entities … WHERE edges.source_entity_id = ?
+        # OR WHERE edges.target_entity_id = ?.  The bound param name tells us
+        # which side is the pivot (source_entity_id vs target_entity_id).
+        if has_edge_pivot_where:
+            if workspace_id is None or not non_ws_params:
+                return _FakeResult([])
+            param_dict = stmt.compile().params
+            is_outgoing = any(k.startswith("source_entity_id") for k in param_dict)
+            pivot_key = "source_entity_id" if is_outgoing else "target_entity_id"
+            pivot = next(
+                (v for k, v in param_dict.items() if k.startswith(pivot_key)),
+                None,
+            )
+            if pivot is None:
+                return _FakeResult([])
+            pairs: list[tuple[_FakeEdge, _FakeEntity]] = []
+            for edge in self._fx.edges:
+                if is_outgoing:
+                    if edge.source_entity_id != pivot:
+                        continue
+                    neighbour = self._fx.entities.get(edge.target_entity_id)
+                else:
+                    if edge.target_entity_id != pivot:
+                        continue
+                    neighbour = self._fx.entities.get(edge.source_entity_id)
+                if neighbour is None:
+                    continue
+                if self._fx.workspace_of(neighbour) not in (workspace_id, None):
+                    # Neighbour is in another workspace: simulate the SQL
+                    # WHERE (source.tenant_id = ws OR source.tenant_id IS NULL)
+                    # filtering it out at the DB level.
+                    continue
+                pairs.append((edge, neighbour))
+            return _FakeResult(pairs)
+
+        return _FakeResult([])
+
+    async def get(self, model_cls: Any, pk: uuid.UUID) -> Any | None:
+        # Only called for Chunk lookups in graph_query.  Tests use chunk_id=None,
+        # so this should never actually be called — return None defensively.
+        return None
+
+    # The auth middleware calls flush/commit on the shared session while it
+    # updates ``last_used_at``.  We stub them out as no-ops so the fake session
+    # is a drop-in replacement.
+    async def flush(self) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+    async def rollback(self) -> None:
+        return None
+
+
+def _session_factory(fixture: _Fixture) -> Any:
+    """Build a factory returning an async context-manager wrapping _FakeSession."""
+    session = _FakeSession(fixture)
+
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# 1. Service-layer isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_scoped_to_workspace_a_never_returns_workspace_b_entities() -> None:
+    """Cross-workspace regression for #117 at the service level.
+
+    Token scoped to workspace A asks for ``svc.shared``.  The entity
+    ``svc.shared`` exists in both A and B, and a cross-tenant edge is
+    planted pointing from A1 to B1.  The result MUST contain only A2 and
+    must never mention any B-entity by name.
+    """
+    fx = _build_fixture()
+    service = GraphQueryService(_session_factory(fx))
+
+    result = await service.get_related(
+        entity_name="svc.shared",
+        workspace_id=_WS_A,
+        max_depth=2,
+    )
+
+    names_in_result = {result.seed.name, *(n.name for n in result.related)}
+    assert "svc.internal-a" in names_in_result
+    # The B-side names MUST NOT appear.
+    assert "svc.internal-b" not in names_in_result
+    # Edges must not leak the cross-tenant B1 endpoint.
+    for e in result.edges:
+        assert "svc.internal-b" not in (e.from_entity, e.to_entity)
+
+
+@pytest.mark.asyncio
+async def test_service_scoped_to_workspace_b_never_returns_workspace_a_entities() -> None:
+    """Symmetric check: B must not see any A-side entities."""
+    fx = _build_fixture()
+    service = GraphQueryService(_session_factory(fx))
+
+    result = await service.get_related(
+        entity_name="svc.shared",
+        workspace_id=_WS_B,
+        max_depth=2,
+    )
+
+    names_in_result = {result.seed.name, *(n.name for n in result.related)}
+    assert "svc.internal-b" in names_in_result
+    assert "svc.internal-a" not in names_in_result
+    for e in result.edges:
+        assert "svc.internal-a" not in (e.from_entity, e.to_entity)
+
+
+@pytest.mark.asyncio
+async def test_service_raises_not_found_for_entity_in_other_workspace() -> None:
+    """An entity that exists only in workspace B looks like 404 to workspace A.
+
+    We never leak existence of cross-tenant rows — "not found" is the
+    only legal signal.
+    """
+    fx = _build_fixture()
+    # Remove the A-side svc.shared so that svc.shared only exists in B.
+    a1_id = next(
+        e.id
+        for e in fx.entities.values()
+        if e.name == "svc.shared" and fx.workspace_of(e) == _WS_A
+    )
+    del fx.entities[a1_id]
+    fx.edges = [e for e in fx.edges if e.source_entity_id != a1_id]
+
+    service = GraphQueryService(_session_factory(fx))
+
+    with pytest.raises(ValueError, match=r"entity_not_found:svc\.shared"):
+        await service.get_related(
+            entity_name="svc.shared",
+            workspace_id=_WS_A,
+            max_depth=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. SQL-shape regression guards — prevent silent re-introduction of the bug
+# ---------------------------------------------------------------------------
+
+
+def test_seed_lookup_sql_includes_workspace_predicate() -> None:
+    """The seed-lookup SELECT must reference sources.tenant_id."""
+
+    # Build a Service instance without calling __init__ side effects on a real factory.
+    service = GraphQueryService(session_factory=MagicMock())
+
+    # Monkey-patch execute to capture the compiled statement.
+    captured: dict[str, Select[Any]] = {}
+
+    async def _capture(stmt: Select[Any]) -> Any:
+        captured["stmt"] = stmt
+
+        class _Empty:
+            def scalar_one_or_none(self) -> Any | None:
+                return None
+
+        return _Empty()
+
+    sess = AsyncMock()
+    sess.execute = AsyncMock(side_effect=_capture)
+
+    import asyncio
+
+    asyncio.run(service._fetch_entity_by_name(sess, "whatever", workspace_id=_WS_A))
+
+    sql = str(captured["stmt"].compile()).lower()
+    assert "sources.tenant_id" in sql, (
+        "Seed lookup lost the workspace predicate — graph retrieval would "
+        "leak cross-tenant entities (regression of issue #117)"
+    )
+
+
+def test_adjacency_sql_includes_workspace_predicate() -> None:
+    """Both outgoing and incoming adjacency SELECTs must reference sources.tenant_id."""
+
+    service = GraphQueryService(session_factory=MagicMock())
+
+    captured: list[Select[Any]] = []
+
+    async def _capture(stmt: Select[Any]) -> Any:
+        captured.append(stmt)
+
+        class _Empty:
+            def __iter__(self) -> Any:
+                return iter([])
+
+        return _Empty()
+
+    sess = AsyncMock()
+    sess.execute = AsyncMock(side_effect=_capture)
+
+    import asyncio
+
+    asyncio.run(
+        service._fetch_adjacent(
+            sess,
+            str(uuid.uuid4()),
+            edge_types=None,
+            workspace_id=_WS_A,
+        )
+    )
+
+    assert len(captured) == 2, "adjacency should issue one outgoing + one incoming query"
+    for stmt in captured:
+        sql = str(stmt.compile()).lower()
+        assert "sources.tenant_id" in sql, (
+            "Adjacency query lost the workspace predicate — transitive graph "
+            "leaks possible (regression of issue #117)"
+        )
+
+
+def test_entity_by_id_sql_includes_workspace_predicate() -> None:
+    """Endpoint resolve query must reference sources.tenant_id."""
+
+    service = GraphQueryService(session_factory=MagicMock())
+
+    captured: dict[str, Select[Any]] = {}
+
+    async def _capture(stmt: Select[Any]) -> Any:
+        captured["stmt"] = stmt
+
+        class _Empty:
+            def scalar_one_or_none(self) -> Any | None:
+                return None
+
+        return _Empty()
+
+    sess = AsyncMock()
+    sess.execute = AsyncMock(side_effect=_capture)
+
+    import asyncio
+
+    asyncio.run(service._fetch_entity_by_id(sess, str(uuid.uuid4()), workspace_id=_WS_A))
+
+    sql = str(captured["stmt"].compile()).lower()
+    assert "sources.tenant_id" in sql
+
+
+# ---------------------------------------------------------------------------
+# 3. REST endpoint — end-to-end isolation
+# ---------------------------------------------------------------------------
+
+
+def _make_rest_app() -> FastAPI:
+    from omniscience_core.config import Settings
+    from omniscience_server.app import create_app
+
+    settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+    return create_app(settings=settings)
+
+
+def _auth_token(workspace_id: uuid.UUID | None) -> tuple[MagicMock, str]:
+    plaintext, prefix = generate_token("test")
+    token: MagicMock = MagicMock(spec=ApiToken)
+    token.hashed_token = hash_token(plaintext)
+    token.token_prefix = prefix
+    token.scopes = ["search"]
+    token.expires_at = None
+    token.is_active = True
+    token.workspace_id = workspace_id
+    return token, plaintext
+
+
+@pytest.mark.asyncio
+async def test_rest_endpoint_rejects_workspace_a_probing_workspace_b() -> None:
+    """End-to-end: A-scoped caller cannot fetch B-only entities via REST."""
+    fx = _build_fixture()
+    # Drop the A-side ``svc.shared`` so only B owns that name.
+    a1_id = next(
+        e.id
+        for e in fx.entities.values()
+        if e.name == "svc.shared" and fx.workspace_of(e) == _WS_A
+    )
+    del fx.entities[a1_id]
+    fx.edges = [e for e in fx.edges if e.source_entity_id != a1_id]
+
+    token_a, plaintext = _auth_token(workspace_id=_WS_A)
+    factory = _session_factory(fx)
+
+    app = _make_rest_app()
+    app.state.db_session_factory = factory
+
+    with patch(
+        "omniscience_core.auth.middleware._lookup_token",
+        new_callable=AsyncMock,
+        return_value=token_a,
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/api/v1/entities/svc.shared/related",
+                headers={"Authorization": f"Bearer {plaintext}"},
+            )
+
+    assert response.status_code == 404, response.text
+    body = response.json()
+    assert body["error"]["code"] == "entity_not_found"
+    # Sanity: response body must NOT contain any B-side internal names.
+    assert "svc.internal-b" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_rest_endpoint_rejects_unscoped_token() -> None:
+    """Tokens without a workspace are rejected with 403 (fail-closed)."""
+    fx = _build_fixture()
+    token, plaintext = _auth_token(workspace_id=None)
+    factory = _session_factory(fx)
+
+    app = _make_rest_app()
+    app.state.db_session_factory = factory
+
+    with patch(
+        "omniscience_core.auth.middleware._lookup_token",
+        new_callable=AsyncMock,
+        return_value=token,
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/api/v1/entities/svc.shared/related",
+                headers={"Authorization": f"Bearer {plaintext}"},
+            )
+
+    assert response.status_code == 403, response.text
+    body = response.json()
+    assert body["error"]["code"] == "forbidden"
+
+
+@pytest.mark.asyncio
+async def test_rest_endpoint_workspace_a_traversal_never_includes_b() -> None:
+    """End-to-end traversal returns only workspace-A entities."""
+    fx = _build_fixture()
+    token_a, plaintext = _auth_token(workspace_id=_WS_A)
+    factory = _session_factory(fx)
+
+    app = _make_rest_app()
+    app.state.db_session_factory = factory
+
+    with patch(
+        "omniscience_core.auth.middleware._lookup_token",
+        new_callable=AsyncMock,
+        return_value=token_a,
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get(
+                "/api/v1/entities/svc.shared/related?max_depth=2",
+                headers={"Authorization": f"Bearer {plaintext}"},
+            )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+
+    related_names = {n["name"] for n in data["related"]}
+    assert "svc.internal-a" in related_names
+    assert "svc.internal-b" not in related_names
+    for edge in data["edges"]:
+        assert edge["from"] != "svc.internal-b"
+        assert edge["to"] != "svc.internal-b"
+
+
+# ---------------------------------------------------------------------------
+# 4. MCP tool — end-to-end isolation at the tool helper level
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_workspace_a_never_returns_b_entities() -> None:
+    """The MCP ``get_related_entities`` helper enforces workspace scoping."""
+    from omniscience_server.mcp.tools import mcp_get_related_entities
+
+    fx = _build_fixture()
+    factory = _session_factory(fx)
+
+    app = FastAPI()
+    app.state.db_session_factory = factory
+
+    result = await mcp_get_related_entities(
+        app=app,
+        entity_name="svc.shared",
+        workspace_id=_WS_A,
+        max_depth=2,
+    )
+
+    related_names = {n["name"] for n in result["related"]}
+    assert "svc.internal-a" in related_names
+    assert "svc.internal-b" not in related_names
+    for edge in result["edges"]:
+        assert edge["from"] != "svc.internal-b"
+        assert edge["to"] != "svc.internal-b"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_workspace_b_never_returns_a_entities() -> None:
+    """Symmetric MCP-layer check for workspace B."""
+    from omniscience_server.mcp.tools import mcp_get_related_entities
+
+    fx = _build_fixture()
+    factory = _session_factory(fx)
+
+    app = FastAPI()
+    app.state.db_session_factory = factory
+
+    result = await mcp_get_related_entities(
+        app=app,
+        entity_name="svc.shared",
+        workspace_id=_WS_B,
+        max_depth=2,
+    )
+
+    related_names = {n["name"] for n in result["related"]}
+    assert "svc.internal-b" in related_names
+    assert "svc.internal-a" not in related_names


### PR DESCRIPTION
## Summary

P0 security fix for cross-tenant entity disclosure via graph retrieval. Closes #117.

`GraphQueryService.get_related` and its REST/MCP callers were applying zero workspace scoping. A workspace-A-scoped token could read workspace-B entities and edges via:

- `GET /api/v1/entities/{name}/related`
- MCP tool `get_related_entities`

This is a regression against the multi-tenant ACL guarantees established by #57 and was explicitly flagged in ADR-0005 (#116) as a carry-forward requirement for the upcoming Neo4j adapter (#104).

## The fix

### Before
```python
# graph_query.py
async def get_related(
    self,
    entity_name: str,
    max_depth: int = 1,
    edge_types: list[str] | None = None,
) -> GraphResult:
    ...
    seed_entity = await self._fetch_entity_by_name(session, entity_name)
```

No workspace_id parameter anywhere. No `workspace_filter()` call anywhere in `packages/retrieval/`.

### After
```python
# graph_query.py
async def get_related(
    self,
    *,
    entity_name: str,
    workspace_id: uuid.UUID,   # required, keyword-only, no default
    max_depth: int = 1,
    edge_types: list[str] | None = None,
) -> GraphResult:
    ...
    seed_entity = await self._fetch_entity_by_name(
        session, entity_name, workspace_id=workspace_id
    )
```

The predicate `(source.tenant_id = :ws OR source.tenant_id IS NULL)` is applied at three points to be transitively complete:

1. **Seed lookup** — `_fetch_entity_by_name` joins `Entity → Source` and filters by `sources.tenant_id`.
2. **BFS expansion** — `_fetch_adjacent` joins the neighbour entity's source and filters; a planted cross-tenant edge is invisible because its neighbour is excluded.
3. **Edge-endpoint resolution** — `_fetch_entity_by_id` applies the same predicate on both `from` and `to` endpoints; if either is outside the workspace the edge is dropped entirely (no partial/mixed surface).

Entities and edges do not carry `workspace_id` columns directly — ownership is inherited from `Source.tenant_id`, following the existing `workspace_filter` helper convention for tables that predate multi-tenancy. `NULL` tenant rows are admitted alongside the caller's workspace for backward-compat with pre-migration data.

### Fail-closed on the principal side

REST handler and MCP tool wrapper resolve `workspace_id` from the authenticated principal (`get_workspace_id(token)`). A token with no workspace is rejected with **403 `forbidden`** — graph retrieval never falls back to a global view. This matches the service-layer contract (`workspace_id` required, no sentinel).

## Tests

### New file: `tests/test_graph_workspace_isolation.py`

Four layers of coverage:

1. **Service layer** — fake AsyncSession that enforces the workspace predicate by parsing compiled SQL and filtering an in-memory fixture. The fixture seeds `svc.shared` into **both** workspaces A and B plus a planted cross-tenant edge; an A-scoped traversal from `svc.shared` returns only A-entities, and B-entity names never appear (symmetric test for B).
2. **SQL-shape regression guards** — assert `sources.tenant_id` appears in every SELECT emitted by `_fetch_entity_by_name`, `_fetch_adjacent` (both outgoing and incoming), and `_fetch_entity_by_id`. Grep-like guard: future refactors cannot silently drop the predicate.
3. **REST endpoint** — end-to-end `GET /api/v1/entities/{name}/related` with an A-scoped token against a fixture owned only by B returns 404 (never 200 with a B payload). Unscoped token → 403. A-scoped traversal response body is asserted to contain no B names anywhere.
4. **MCP tool** — same guarantee through `mcp_get_related_entities`.

### Updated: `tests/test_graph_query.py`

Every existing call to `service.get_related(...)` now passes `workspace_id`. New unit tests:

- `test_get_related_requires_workspace_id_keyword_only` — positional misuse raises `TypeError`, preventing silent arg-order mistakes.
- `test_get_related_skips_edge_when_endpoint_outside_workspace` — explicit unit-level check that the endpoint-drop path works.
- `test_rest_entities_related_403_when_token_has_no_workspace` — fail-closed path through REST.

### Results

```
1531 passed, 2 skipped in 7.14s
ruff check: all checks passed
ruff format: 6 files already formatted
mypy apps/ packages/: Success: no issues found in 145 source files
mypy on touched files: Success: no issues found in 4 source files
```

Coverage of `graph_query.py`: **100%**.

## Additional findings (audit of sibling endpoints)

Per the issue's step 5, I audited the rest of `apps/server/src/omniscience_server/rest/` and `packages/retrieval/src/omniscience_retrieval/` for the same pattern. **Several other code paths have the same class of bug and are NOT addressed in this PR** — the issue scope is explicitly the graph path, and fixing more here would widen the blast radius of a P0 hotfix. Each should get its own issue:

| Endpoint / path | Workspace-scoped? | Impact |
|---|---|---|
| `packages/retrieval/src/omniscience_retrieval/search.py` — hybrid `_vector_search` / `_text_search` / `_fetch_enriched` | **No** | `POST /api/v1/search` returns chunks from all workspaces. The issue text asserts direct search is "correctly scoped" — by code inspection it is not. |
| `packages/retrieval/src/omniscience_retrieval/strategies/structural.py` — `select(Entity)` on name/display_name plus edge/chunk fan-outs | **No** | `POST /api/v1/search?retrieval_strategy=structural` (and `auto` when it dispatches there) hits the same graph tables without scoping. Same leak class as this issue. |
| `apps/server/src/omniscience_server/rest/sources.py` — `GET /sources`, `GET /sources/{id}`, `GET /sources/{id}/stats`, etc. | **No** | Cross-tenant source metadata is readable. |
| `apps/server/src/omniscience_server/rest/documents.py` | **No** | Same — document metadata and chunks by document id. |
| `apps/server/src/omniscience_server/rest/ingestion_runs.py` | **No** | Run history cross-tenant. |
| `apps/server/src/omniscience_server/rest/freshness.py` | **No** | Freshness metadata cross-tenant. |
| `apps/server/src/omniscience_server/mcp/tools.py` — `mcp_get_document`, `mcp_list_sources`, `mcp_source_stats`, `mcp_search` | **No** | MCP equivalents of the REST gaps above. |

`workspace_filter()` in `packages/core/src/omniscience_core/auth/workspace.py` is defined but has **zero call sites** across the app/retrieval layers prior to this PR. The helper is essentially dead code today. I recommend opening a follow-up epic to thread `workspace_id` through every read surface, with CI lint that rejects `session.execute(select(Entity|Edge|Source|Document|Chunk|IngestionRun)...)` not guarded by a `workspace_*` predicate — mirroring the "lint rule against raw Cypher strings omitting the predicate" that ADR-0005 already commits to for the Neo4j path.

Happy to file a tracking issue for the epic + a P1 issue for the `/search` structural strategy as an immediate follow-up if useful.

## Links

- Closes #117
- Related #57 (multi-tenant workspaces — original ACL work)
- Related #88 (`get_related_entities` MCP tool)
- Related #116 / ADR-0005 (mandates workspace predicate on Neo4j adapter)

## Deployment notes

- **Breaking change on the Python API surface of `GraphQueryService.get_related`**: the signature is now keyword-only with a required `workspace_id`. Only in-tree callers exist (`rest/entities.py`, `mcp/tools.py`); both updated in this PR. The REST/MCP wire contract is unchanged except that unscoped tokens now receive 403 instead of a 200 payload.
- **No DB migration required**. Scoping reuses the existing `sources.tenant_id` column.
- **Fail-closed posture** means any existing token with `workspace_id IS NULL` will start getting 403 on graph retrieval. If there are legacy unscoped tokens in production that must keep working, they need to be re-issued against a workspace before rollout.

## Test plan

- [x] Unit + integration tests pass locally (`make test` — 1531 passed, 2 skipped)
- [x] `ruff check`, `ruff format --check`, `mypy apps/ packages/` clean
- [ ] Reviewer: verify A→B leak is closed on a real two-workspace deployment
- [ ] Security Engineer sign-off