### PR TITLE
feat: scaffold GraphStore and VectorStore interfaces (#103)

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -32,7 +32,11 @@ from omniscience_core.queue.consumer import QueueConsumer
 from omniscience_core.telemetry import init_telemetry
 from omniscience_embeddings import create_embedding_provider
 from omniscience_index import IndexWriter
-from omniscience_retrieval import RetrievalService
+from omniscience_retrieval import (
+    PgVectorGraphStore,
+    PgVectorVectorStore,
+    RetrievalService,
+)
 from omniscience_retrieval.federation import FederatedSearch
 from omniscience_retrieval.federation_config import FederationConfig
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
@@ -101,11 +105,25 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         dim=embedding_provider.dim,
     )
 
-    # --- Retrieval service ---
-    local_retrieval = RetrievalService(
+    # --- Storage adapters (GraphStore / VectorStore protocols, issue #103) ---
+    # These wrap the pgvector writer + retriever behind the new backend-
+    # neutral protocols defined in ``omniscience_core.storage``.  Phase 2
+    # will swap these for Neo4jGraphStore + QdrantVectorStore behind a
+    # feature flag with zero changes to the call sites.
+    graph_store = PgVectorGraphStore(session_factory=session_factory)
+    vector_store = PgVectorVectorStore(
         session_factory=session_factory,
         embedding_provider=embedding_provider,
     )
+    app.state.graph_store = graph_store
+    app.state.vector_store = vector_store
+    log.info("storage_adapters_ready", backend="pgvector")
+
+    # --- Retrieval service ---
+    # Keep the direct ``RetrievalService`` handle on app.state for the
+    # (still-in-flight) federation composition path.  New consumers
+    # should prefer ``app.state.vector_store``.
+    local_retrieval = vector_store.retrieval_service
 
     # --- Federation (optional) ---
     if settings.federation_enabled:

--- a/apps/server/src/omniscience_server/mcp/tools.py
+++ b/apps/server/src/omniscience_server/mcp/tools.py
@@ -16,7 +16,7 @@ from typing import Any
 import structlog
 from fastapi import FastAPI
 from omniscience_core.db.models import Chunk, Document, IngestionRun, Source
-from omniscience_retrieval.graph_query import GraphQueryService
+from omniscience_core.storage import GraphResultView, GraphStore
 from omniscience_retrieval.models import SearchRequest
 from omniscience_retrieval.search import RetrievalService
 from sqlalchemy import func, select
@@ -309,15 +309,56 @@ async def mcp_get_related_entities(
     and the edges connecting them.  Each entity includes its associated
     chunk text for context.
     """
-    factory = getattr(app.state, "db_session_factory", None)
-    if factory is None:
-        raise RuntimeError("db_session_factory not available on app.state")
+    graph_store: GraphStore | None = getattr(app.state, "graph_store", None)
+    if graph_store is None:
+        raise RuntimeError("graph_store not available on app.state")
 
-    service = GraphQueryService(factory)
-    result = await service.get_related(
+    result = await graph_store.find_related(
         entity_name=entity_name,
         workspace_id=workspace_id,
         max_depth=max_depth,
         edge_types=edge_types,
     )
-    return result.to_dict()
+    return _graph_view_to_dict(result)
+
+
+def _graph_view_to_dict(result: GraphResultView) -> dict[str, Any]:
+    """Serialise a ``GraphResultView`` to the MCP wire format.
+
+    Mirrors ``omniscience_server.rest.entities._result_to_dict`` so
+    the MCP and REST surfaces return identical shapes.  Kept local
+    to avoid a rest -> mcp import.
+    """
+    depth_reached = max((n.depth for n in result.related), default=0)
+    return {
+        "seed": {
+            "name": result.seed.name,
+            "kind": result.seed.kind,
+            "source": result.seed.source,
+            "chunk_text": result.seed.chunk_text,
+        },
+        "related": [
+            {
+                "name": n.name,
+                "kind": n.kind,
+                "source": n.source,
+                "chunk_text": n.chunk_text,
+                "depth": n.depth,
+                "edge_type": n.edge_type,
+            }
+            for n in result.related
+        ],
+        "edges": [
+            {
+                "from": e.from_entity,
+                "to": e.to_entity,
+                "type": e.edge_type,
+            }
+            for e in result.edges
+        ],
+        "stats": {
+            "entities_found": 1 + len(result.related),
+            "edges_traversed": len(result.edges),
+            "depth_reached": depth_reached,
+        },
+    }

--- a/apps/server/src/omniscience_server/rest/entities.py
+++ b/apps/server/src/omniscience_server/rest/entities.py
@@ -11,11 +11,20 @@ Workspace scoping (issue #117)
 ------------------------------
 
 The caller's ``workspace_id`` is resolved from the authenticated principal
-and propagated to :class:`~omniscience_retrieval.graph_query.GraphQueryService`.
-A token with no workspace is rejected with ``403 forbidden`` — graph
-retrieval is fail-closed, never fail-open — because the service layer
-requires an explicit workspace and we refuse to invent one on behalf of
-an unscoped caller.
+and propagated to the ``GraphStore`` protocol (pgvector adapter today;
+Neo4j in Phase 2).  A token with no workspace is rejected with
+``403 forbidden`` — graph retrieval is fail-closed, never fail-open —
+because the protocol layer requires an explicit workspace and we refuse
+to invent one on behalf of an unscoped caller.
+
+Dependency injection
+--------------------
+
+The handler reads ``request.app.state.graph_store`` — a
+``GraphStore`` implementation wired at application startup (see
+``omniscience_server.app.create_app``).  The protocol-level
+``find_related`` call is semantically identical to the pre-#103
+``GraphQueryService.get_related`` call it replaces.
 """
 
 from __future__ import annotations
@@ -29,7 +38,7 @@ from omniscience_core.auth.middleware import get_current_token, require_scope
 from omniscience_core.auth.scopes import Scope
 from omniscience_core.auth.workspace import get_workspace_id
 from omniscience_core.db.models import ApiToken
-from omniscience_retrieval.graph_query import GraphQueryService
+from omniscience_core.storage import GraphResultView, GraphStore
 
 log = structlog.get_logger(__name__)
 
@@ -74,12 +83,12 @@ async def get_related_entities(
     # Path parameters are URL-encoded by FastAPI; decode forward-slashes etc.
     entity_name = unquote(name)
 
-    factory = getattr(request.app.state, "db_session_factory", None)
-    if factory is None:
-        log.warning("db_session_factory_unavailable")
+    graph_store: GraphStore | None = getattr(request.app.state, "graph_store", None)
+    if graph_store is None:
+        log.warning("graph_store_unavailable")
         raise HTTPException(
             status_code=503,
-            detail={"code": "service_unavailable", "message": "Database not available"},
+            detail={"code": "service_unavailable", "message": "Graph store not available"},
         )
 
     # Resolve the caller's workspace.  A token with no workspace cannot be
@@ -99,10 +108,8 @@ async def get_related_entities(
             },
         )
 
-    service = GraphQueryService(factory)
-
     try:
-        result = await service.get_related(
+        result = await graph_store.find_related(
             entity_name=entity_name,
             workspace_id=workspace_id,
             max_depth=max_depth,
@@ -123,16 +130,60 @@ async def get_related_entities(
             detail={"code": "bad_request", "message": msg},
         ) from exc
 
+    depth_reached = max((n.depth for n in result.related), default=0)
     log.info(
         "entity_graph_traversal",
         entity=entity_name,
         workspace_id=str(workspace_id),
         max_depth=max_depth,
-        entities_found=result.stats["entities_found"],
-        edges_traversed=result.stats["edges_traversed"],
+        entities_found=1 + len(result.related),
+        edges_traversed=len(result.edges),
+        depth_reached=depth_reached,
     )
 
-    return result.to_dict()
+    return _result_to_dict(result)
+
+
+def _result_to_dict(result: GraphResultView) -> dict[str, Any]:
+    """Serialise a ``GraphResultView`` to the REST/MCP wire format.
+
+    Matches the legacy ``GraphResult.to_dict`` output byte-for-byte so
+    existing API consumers see no change after the #103 protocol
+    migration.
+    """
+    depth_reached = max((n.depth for n in result.related), default=0)
+    return {
+        "seed": {
+            "name": result.seed.name,
+            "kind": result.seed.kind,
+            "source": result.seed.source,
+            "chunk_text": result.seed.chunk_text,
+        },
+        "related": [
+            {
+                "name": n.name,
+                "kind": n.kind,
+                "source": n.source,
+                "chunk_text": n.chunk_text,
+                "depth": n.depth,
+                "edge_type": n.edge_type,
+            }
+            for n in result.related
+        ],
+        "edges": [
+            {
+                "from": e.from_entity,
+                "to": e.to_entity,
+                "type": e.edge_type,
+            }
+            for e in result.edges
+        ],
+        "stats": {
+            "entities_found": 1 + len(result.related),
+            "edges_traversed": len(result.edges),
+            "depth_reached": depth_reached,
+        },
+    }
 
 
 __all__ = ["router"]

--- a/packages/core/src/omniscience_core/storage/__init__.py
+++ b/packages/core/src/omniscience_core/storage/__init__.py
@@ -1,0 +1,50 @@
+"""Storage interface layer for Omniscience.
+
+Defines the ``GraphStore`` and ``VectorStore`` protocols that decouple
+retrieval and writer code from any specific backend (pgvector today;
+Neo4j + Qdrant in Phase 2 per ADR-0005 and ADR-0006).
+
+See ``docs/decisions/0005-neo4j-as-graph-store.md`` and
+``docs/decisions/0006-qdrant-as-vector-store.md`` for the migration
+rationale.
+
+ACL invariant (issue #117 carry-forward)
+----------------------------------------
+
+Every read method on both protocols takes ``workspace_id`` as a
+**keyword-only, required** parameter.  There is no "skip filtering"
+sentinel and no default value.  Callers that cannot name a workspace
+must fail upstream (REST/MCP layer).  This is enforced at the protocol
+level precisely so a Neo4j or Qdrant adapter cannot accidentally widen
+a read in the way the pre-#117 graph-query path did.
+"""
+
+from __future__ import annotations
+
+from omniscience_core.storage.graph import (
+    EdgeUpsert,
+    EntityNodeView,
+    EntityUpsert,
+    GraphEdgeView,
+    GraphResultView,
+    GraphStore,
+)
+from omniscience_core.storage.vector import (
+    ChunkPayload,
+    UpsertOutcome,
+    VectorSearchResult,
+    VectorStore,
+)
+
+__all__ = [
+    "ChunkPayload",
+    "EdgeUpsert",
+    "EntityNodeView",
+    "EntityUpsert",
+    "GraphEdgeView",
+    "GraphResultView",
+    "GraphStore",
+    "UpsertOutcome",
+    "VectorSearchResult",
+    "VectorStore",
+]

--- a/packages/core/src/omniscience_core/storage/graph.py
+++ b/packages/core/src/omniscience_core/storage/graph.py
@@ -1,0 +1,281 @@
+"""``GraphStore`` protocol: backend-neutral entity/edge persistence and traversal.
+
+This module defines the typed contract that the pgvector adapter
+(``omniscience_retrieval.adapters.pgvector_graph``) satisfies today and
+that the Neo4j adapter (issue #104) will satisfy in Phase 2.
+
+Design rules (ADR-0005 + issue #117)
+------------------------------------
+
+1. **Workspace is an invariant, not a parameter.**  Every read method
+   takes ``workspace_id: uuid.UUID`` as a **keyword-only, required**
+   parameter.  There is no default, no ``None`` sentinel, no "admin"
+   bypass.  An adapter MUST confine every read to the supplied
+   workspace, including transitive hops across edges.  See
+   ``packages/retrieval/src/omniscience_retrieval/graph_query.py`` for
+   the reference pgvector implementation of the invariant.
+
+2. **Signatures mirror current call sites.**  The protocol is driven by
+   existing usage in ``IndexWriter`` and ``GraphQueryService``; it is
+   deliberately not a superset of either backend's capabilities.
+
+3. **View-model dataclasses are ORM-free.**  ``EntityNodeView`` and
+   ``GraphEdgeView`` carry only primitive/uuid fields so a Neo4j or
+   Qdrant adapter can populate them without re-importing SQLAlchemy
+   models.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# View-model dataclasses (ORM-free)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class EntityNodeView:
+    """Backend-neutral view of a single entity returned from a traversal.
+
+    Populated by every ``GraphStore`` implementation.  Mirrors the shape
+    consumed by REST/MCP handlers in the current pgvector path.
+    """
+
+    name: str
+    kind: str
+    source: str
+    chunk_text: str | None
+    depth: int = 0
+    edge_type: str | None = None
+
+
+@dataclass(slots=True)
+class GraphEdgeView:
+    """Backend-neutral view of a directed edge between two entities."""
+
+    from_entity: str
+    to_entity: str
+    edge_type: str
+
+
+@dataclass
+class GraphResultView:
+    """Container for the result of a traversal (seed + related + edges)."""
+
+    seed: EntityNodeView
+    related: list[EntityNodeView] = field(default_factory=list)
+    edges: list[GraphEdgeView] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Write-side input dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class EntityUpsert:
+    """Input payload for ``GraphStore.upsert_entity``.
+
+    Shaped to match ``ExtractedEntity`` from the parsers package so the
+    ingestion pipeline can pass values through with minimal conversion.
+    """
+
+    id: uuid.UUID
+    source_id: uuid.UUID
+    entity_type: str
+    name: str
+    display_name: str
+    chunk_id: uuid.UUID | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class EdgeUpsert:
+    """Input payload for ``GraphStore.upsert_edge``."""
+
+    source_entity_id: uuid.UUID
+    target_entity_id: uuid.UUID
+    edge_type: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class GraphStore(Protocol):
+    """Abstract graph-store contract (entity + edge persistence + traversal).
+
+    Implementations
+    ---------------
+    - ``omniscience_retrieval.adapters.pgvector_graph.PgVectorGraphStore``
+      (pgvector-backed; today's behaviour).
+    - ``omniscience_graph_neo4j.Neo4jGraphStore`` (Phase 2, issue #104).
+
+    ACL invariant
+    -------------
+    Every read method MUST apply a workspace filter derived from the
+    required ``workspace_id`` parameter.  An adapter that silently
+    widens a read across workspaces is a P0 security bug — see issue
+    #117 and the P0 fix in PR #119.
+    """
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_graph(
+        self,
+        *,
+        source_id: uuid.UUID,
+        document_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+    ) -> None:
+        """Persist a batch of entities and edges for one document.
+
+        On re-ingestion the previous entities/edges for this source are
+        deleted and replaced so the graph stays consistent with the
+        current document content.
+
+        ``entities`` and ``edges`` are typed as ``list[Any]`` to admit
+        both the parser's ``ExtractedEntity``/``ExtractedEdge`` shapes
+        and the protocol-native ``EntityUpsert``/``EdgeUpsert``
+        dataclasses — adapters duck-type the attribute names.  This is
+        the single hot ingestion path and is kept identical to the
+        existing ``IndexWriter.upsert_graph`` signature for zero-
+        behaviour-change compatibility.
+        """
+        ...
+
+    async def upsert_entity(
+        self,
+        *,
+        entity: EntityUpsert,
+        workspace_id: uuid.UUID,
+    ) -> None:
+        """Insert or update a single entity (v0 adapters may no-op).
+
+        Granular upsert is provided for Phase 2 adapters (Neo4j) that
+        can write one node at a time efficiently.  The pgvector adapter
+        batches via ``upsert_graph`` today and raises
+        ``NotImplementedError`` on this method — callers should use
+        ``upsert_graph`` for pgvector.
+        """
+        ...
+
+    async def upsert_edge(
+        self,
+        *,
+        edge: EdgeUpsert,
+        workspace_id: uuid.UUID,
+    ) -> None:
+        """Insert or update a single edge (v0 adapters may no-op).
+
+        See ``upsert_entity`` — provided for Phase 2 parity; pgvector
+        adapter raises ``NotImplementedError``.
+        """
+        ...
+
+    async def delete_tombstoned(self) -> int:
+        """Hard-delete entities orphaned by tombstoned documents.
+
+        Returns the number of entity rows removed.  For the pgvector
+        adapter today this is a no-op (zero) because entities cascade
+        from the owning ``sources`` row when a source is deleted;
+        tombstoning a *document* does not delete its entities by
+        design (re-ingestion replaces them).  Kept on the protocol so
+        the Neo4j adapter can implement proactive cleanup.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Read API — every method REQUIRES workspace_id (keyword-only)
+    # ------------------------------------------------------------------
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+    ) -> EntityNodeView | None:
+        """Resolve an entity by fully-qualified name, within workspace.
+
+        Returns ``None`` when no entity with that name exists in the
+        caller's workspace.  Cross-workspace entities are
+        indistinguishable from "not found" by design — existence is
+        never leaked.
+
+        Parameters
+        ----------
+        entity_name:
+            Fully-qualified ``Entity.name`` string.
+        workspace_id:
+            REQUIRED.  The traversal is confined to this workspace.
+        """
+        ...
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        """BFS traversal from a seed entity through its edges.
+
+        Parameters
+        ----------
+        entity_name:
+            Fully-qualified name of the seed entity.
+        workspace_id:
+            REQUIRED.  Seed lookup AND every traversal hop are
+            confined to this workspace.  There is no "skip filtering"
+            sentinel.
+        max_depth:
+            Maximum number of hops from the seed (>=1).  Values <1
+            are clamped to 1.
+        edge_types:
+            Optional allowlist of edge types to follow.
+
+        Raises
+        ------
+        ValueError
+            When no entity with the given name exists in the caller's
+            workspace (``"entity_not_found:<name>"``).
+        """
+        ...
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        """Alias of ``find_related`` using the graph-database vocabulary.
+
+        Kept on the protocol because issue #103 enumerates ``traverse``
+        as a first-class method name.  The pgvector adapter delegates
+        to ``find_related``; a Neo4j adapter may choose to make this
+        the native entry point and have ``find_related`` delegate to
+        it.
+        """
+        ...
+
+
+__all__ = [
+    "EdgeUpsert",
+    "EntityNodeView",
+    "EntityUpsert",
+    "GraphEdgeView",
+    "GraphResultView",
+    "GraphStore",
+]

--- a/packages/core/src/omniscience_core/storage/vector.py
+++ b/packages/core/src/omniscience_core/storage/vector.py
@@ -1,0 +1,232 @@
+"""``VectorStore`` protocol: backend-neutral chunk persistence and search.
+
+This module defines the typed contract that the pgvector adapter
+(``omniscience_retrieval.adapters.pgvector_vector``) satisfies today
+and that the Qdrant adapter (issue #106) will satisfy in Phase 2.
+
+Design rules (ADR-0006 + issue #117)
+------------------------------------
+
+1. **Workspace is an invariant, not a parameter.**  ``search`` takes
+   ``workspace_id: uuid.UUID`` as a **keyword-only, required**
+   parameter.  Adapters MUST confine the search result set to the
+   caller's workspace.  See the twin invariant in
+   ``omniscience_core.storage.graph.GraphStore``.
+
+2. **Payload shape is a TypedDict.**  ``ChunkPayload`` is the canonical
+   on-the-wire shape for a chunk going into the store; adapters
+   translate it to their native representation (Chunk ORM row for
+   pgvector; Qdrant Point.payload for Qdrant).
+
+3. **No SQLAlchemy dependency here.**  This module imports only stdlib
+   and the retrieval response dataclasses — by design, the protocol
+   layer is backend-neutral.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Payload TypedDict — canonical chunk shape going into the store
+# ---------------------------------------------------------------------------
+
+
+class ChunkPayload(TypedDict, total=False):
+    """Typed payload for a single chunk upsert.
+
+    ``total=False`` allows adapters to populate optional fields
+    lazily; see ``required`` keys below for the mandatory subset.
+
+    Required keys (validated by adapters at runtime):
+        - ord
+        - text
+        - embedding
+
+    Optional keys:
+        - symbol
+        - metadata
+        - embedding_model
+        - embedding_provider
+        - parser_version
+        - chunker_strategy
+    """
+
+    ord: int
+    text: str
+    embedding: list[float]
+    symbol: str | None
+    metadata: dict[str, Any]
+    embedding_model: str
+    embedding_provider: str
+    parser_version: str
+    chunker_strategy: str
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class UpsertOutcome:
+    """Outcome of a single ``VectorStore.upsert_chunks`` call.
+
+    Mirrors ``omniscience_index.writer.UpsertResult`` but lives in
+    core so adapters need not depend on the index package.
+    """
+
+    action: Literal["created", "updated", "unchanged"]
+    document_id: uuid.UUID
+    chunks_written: int
+    doc_version: int
+
+
+@dataclass
+class VectorSearchResult:
+    """Backend-neutral container for a search result set.
+
+    Adapters populate ``hits`` with dicts that carry the same shape as
+    ``omniscience_retrieval.models.SearchHit``.  The concrete pydantic
+    ``SearchHit`` type lives in retrieval to avoid a core<-retrieval
+    dependency; adapters that want strict typing should construct
+    ``SearchHit`` instances at the retrieval layer.
+    """
+
+    hits: list[Any] = field(default_factory=list)
+    stats: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class VectorStore(Protocol):
+    """Abstract vector-store contract (chunk persistence + search).
+
+    Implementations
+    ---------------
+    - ``omniscience_retrieval.adapters.pgvector_vector.PgVectorVectorStore``
+      (pgvector-backed; today's behaviour).
+    - ``omniscience_vector_qdrant.QdrantVectorStore`` (Phase 2, issue
+      #106).
+
+    ACL invariant
+    -------------
+    ``search`` takes ``workspace_id`` as a **keyword-only, required**
+    parameter.  Adapters MUST confine result rows to the caller's
+    workspace.  The pgvector adapter today does not yet filter search
+    by workspace (documented follow-up; see adapter docstring and
+    issue tracker) — the protocol is correct so the Qdrant adapter
+    can enforce the invariant natively from day one.
+    """
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_chunks(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+        uri: str,
+        title: str | None,
+        content_hash: str,
+        metadata: dict[str, Any],
+        chunks: list[ChunkPayload],
+        ingestion_run_id: uuid.UUID | None = None,
+    ) -> UpsertOutcome:
+        """Atomically create or update a document and its chunks.
+
+        Decision table (evaluated inside one transaction):
+        - No existing row           → insert + create chunks
+        - Existing, same hash       → no-op
+        - Existing, different hash  → replace chunks, bump version
+
+        Parameters mirror ``IndexWriter.upsert_document`` for zero-
+        behaviour-change compatibility.
+        """
+        ...
+
+    async def delete_by_document(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+    ) -> bool:
+        """Tombstone the document identified by ``(source_id, external_id)``.
+
+        Returns ``True`` when the document existed and was tombstoned;
+        ``False`` when no matching active document was found.
+
+        Note: "tombstone" means set ``tombstoned_at`` — hard deletion
+        is deferred to ``delete_tombstoned``.  This preserves the
+        two-phase deletion semantics the existing pgvector writer
+        implements.
+        """
+        ...
+
+    async def delete_tombstoned(self, older_than: timedelta) -> int:
+        """Hard-delete tombstoned documents older than ``older_than``.
+
+        Returns the number of documents removed.  Chunks cascade
+        automatically via the FK ``ON DELETE CASCADE`` constraint in
+        the pgvector schema.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Read API — search REQUIRES workspace_id (keyword-only)
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        *,
+        request: Any,
+        workspace_id: uuid.UUID,
+    ) -> Any:
+        """Execute a retrieval query, confined to the caller's workspace.
+
+        Parameters
+        ----------
+        request:
+            ``omniscience_retrieval.models.SearchRequest`` instance.
+            Typed as ``Any`` on the protocol to avoid a core ->
+            retrieval dependency cycle; the adapter signature narrows
+            this to ``SearchRequest``.
+        workspace_id:
+            REQUIRED.  Adapters MUST confine every match to this
+            workspace.  Today's pgvector adapter carries a documented
+            gap here (workspace filtering is not yet applied on the
+            search path — tracked outside #103); the protocol is
+            correct so the Qdrant adapter can enforce the invariant
+            natively when it lands (#106).
+
+        Returns
+        -------
+        ``omniscience_retrieval.models.SearchResult`` — typed as
+        ``Any`` on the protocol; narrowed in the adapter.
+        """
+        ...
+
+    async def count(self, *, source_id: uuid.UUID) -> int:
+        """Return the number of active (non-tombstoned) documents for a source.
+
+        Mirrors an admin/observability call-site (freshness worker,
+        MCP ``sources`` tool).  Tombstoned rows are excluded.
+        """
+        ...
+
+
+__all__ = [
+    "ChunkPayload",
+    "UpsertOutcome",
+    "VectorSearchResult",
+    "VectorStore",
+]

--- a/packages/retrieval/src/omniscience_retrieval/__init__.py
+++ b/packages/retrieval/src/omniscience_retrieval/__init__.py
@@ -12,6 +12,7 @@ Query rewriting (v0.4+) provides optional heuristic expansion of search
 queries before retrieval to improve recall in air-gapped deployments.
 """
 
+from .adapters import PgVectorGraphStore, PgVectorVectorStore
 from .federation import FederatedSearch
 from .federation_config import FederatedInstance, FederationConfig
 from .graph_query import EdgeResult, EntityNode, GraphQueryService, GraphResult
@@ -40,6 +41,8 @@ __all__ = [
     "GraphResult",
     "NoopReranker",
     "OllamaReranker",
+    "PgVectorGraphStore",
+    "PgVectorVectorStore",
     "QueryRewriter",
     "QueryStats",
     "Reranker",

--- a/packages/retrieval/src/omniscience_retrieval/adapters/__init__.py
+++ b/packages/retrieval/src/omniscience_retrieval/adapters/__init__.py
@@ -1,0 +1,20 @@
+"""pgvector-backed adapters that implement the core storage protocols.
+
+These adapters are the *only* concrete implementations of
+``omniscience_core.storage.GraphStore`` and
+``omniscience_core.storage.VectorStore`` for the current deployment.
+Phase 2 (issues #104 + #106) will introduce ``Neo4jGraphStore`` and
+``QdrantVectorStore`` in separate packages.
+
+The adapters delegate to the existing ``IndexWriter``,
+``RetrievalService``, and ``GraphQueryService`` classes so this
+scaffold introduces zero behavioural change; it only repoints the
+dependency arrow at the protocol contracts.
+"""
+
+from __future__ import annotations
+
+from omniscience_retrieval.adapters.pgvector_graph import PgVectorGraphStore
+from omniscience_retrieval.adapters.pgvector_vector import PgVectorVectorStore
+
+__all__ = ["PgVectorGraphStore", "PgVectorVectorStore"]

--- a/packages/retrieval/src/omniscience_retrieval/adapters/pgvector_graph.py
+++ b/packages/retrieval/src/omniscience_retrieval/adapters/pgvector_graph.py
@@ -1,0 +1,222 @@
+"""Pgvector-backed adapter for the ``GraphStore`` protocol.
+
+Wraps the existing ``IndexWriter.upsert_graph`` + ``GraphQueryService``
+so all current call sites can depend on the protocol rather than on
+the concrete pgvector classes.  Zero behavioural change: every method
+delegates to code already in production.
+
+See ``packages/core/src/omniscience_core/storage/graph.py`` for the
+protocol contract and the ACL invariant.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import structlog
+from omniscience_core.storage.graph import (
+    EdgeUpsert,
+    EntityNodeView,
+    EntityUpsert,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_index.writer import IndexWriter
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_retrieval.graph_query import (
+    EdgeResult,
+    EntityNode,
+    GraphQueryService,
+    GraphResult,
+)
+
+log = structlog.get_logger(__name__)
+
+
+class PgVectorGraphStore:
+    """Pgvector-backed ``GraphStore`` — the concrete Phase-1 adapter.
+
+    Composition
+    -----------
+    - ``IndexWriter``         for entity/edge writes (``upsert_graph``).
+    - ``GraphQueryService``   for traversal reads (workspace-scoped).
+
+    Both classes existed before #103; this adapter only re-exposes
+    them through the protocol-shaped surface and performs view-model
+    translation (``GraphResult`` -> ``GraphResultView``).
+    """
+
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        self._session_factory = session_factory
+        self._writer = IndexWriter(session_factory)
+        self._query_service = GraphQueryService(session_factory)
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_graph(
+        self,
+        *,
+        source_id: uuid.UUID,
+        document_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+    ) -> None:
+        """Delegate to ``IndexWriter.upsert_graph`` unchanged."""
+        await self._writer.upsert_graph(
+            source_id=source_id,
+            document_id=document_id,
+            entities=entities,
+            edges=edges,
+        )
+
+    async def upsert_entity(
+        self,
+        *,
+        entity: EntityUpsert,
+        workspace_id: uuid.UUID,
+    ) -> None:
+        """Not supported on pgvector — use ``upsert_graph`` for batch writes.
+
+        Kept on the protocol for Phase 2 (Neo4j) parity.  The pgvector
+        writer intentionally batches entity/edge writes inside a single
+        transaction so the graph view stays consistent with the
+        document's chunks.  A single-entity upsert would have to
+        either (a) break that atomicity, or (b) block on a fan-in
+        queue — neither is desirable today.
+        """
+        raise NotImplementedError(
+            "PgVectorGraphStore batches writes via upsert_graph; "
+            "granular upsert_entity is reserved for Phase 2 adapters."
+        )
+
+    async def upsert_edge(
+        self,
+        *,
+        edge: EdgeUpsert,
+        workspace_id: uuid.UUID,
+    ) -> None:
+        """Not supported on pgvector — use ``upsert_graph`` for batch writes."""
+        raise NotImplementedError(
+            "PgVectorGraphStore batches writes via upsert_graph; "
+            "granular upsert_edge is reserved for Phase 2 adapters."
+        )
+
+    async def delete_tombstoned(self) -> int:
+        """No-op on pgvector — entities cascade from the owning source.
+
+        Returns 0.  Entities are garbage-collected when a ``Source``
+        row is hard-deleted (``ON DELETE CASCADE``).  Tombstoning a
+        *document* does not prune entities by design — re-ingestion
+        replaces them via ``upsert_graph``.
+        """
+        return 0
+
+    # ------------------------------------------------------------------
+    # Read API — all methods enforce workspace_id
+    # ------------------------------------------------------------------
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+    ) -> EntityNodeView | None:
+        """Resolve an entity by FQN, scoped to ``workspace_id``.
+
+        Returns ``None`` when not found in that workspace.  Cross-
+        workspace existence is never leaked.
+        """
+        try:
+            result = await self._query_service.get_related(
+                entity_name=entity_name,
+                workspace_id=workspace_id,
+                max_depth=1,
+            )
+        except ValueError as exc:
+            if str(exc).startswith("entity_not_found:"):
+                return None
+            raise
+        return _node_to_view(result.seed)
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        """BFS traversal from a seed entity, scoped to ``workspace_id``.
+
+        Delegates to :class:`GraphQueryService.get_related` unchanged
+        — the ACL enforcement path is entirely handled there.
+        """
+        result: GraphResult = await self._query_service.get_related(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+        return _result_to_view(result)
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        """Alias of :meth:`find_related` using graph-DB vocabulary."""
+        return await self.find_related(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+
+
+# ---------------------------------------------------------------------------
+# View-model translators
+# ---------------------------------------------------------------------------
+
+
+def _node_to_view(node: EntityNode) -> EntityNodeView:
+    """Translate a retrieval ``EntityNode`` to the core ``EntityNodeView``."""
+    return EntityNodeView(
+        name=node.name,
+        kind=node.kind,
+        source=node.source,
+        chunk_text=node.chunk_text,
+        depth=node.depth,
+        edge_type=node.edge_type,
+    )
+
+
+def _edge_to_view(edge: EdgeResult) -> GraphEdgeView:
+    """Translate a retrieval ``EdgeResult`` to the core ``GraphEdgeView``."""
+    return GraphEdgeView(
+        from_entity=edge.from_entity,
+        to_entity=edge.to_entity,
+        edge_type=edge.edge_type,
+    )
+
+
+def _result_to_view(result: GraphResult) -> GraphResultView:
+    """Translate a retrieval ``GraphResult`` to the core ``GraphResultView``."""
+    return GraphResultView(
+        seed=_node_to_view(result.seed),
+        related=[_node_to_view(n) for n in result.related],
+        edges=[_edge_to_view(e) for e in result.edges],
+    )
+
+
+__all__ = ["PgVectorGraphStore"]

--- a/packages/retrieval/src/omniscience_retrieval/adapters/pgvector_vector.py
+++ b/packages/retrieval/src/omniscience_retrieval/adapters/pgvector_vector.py
@@ -1,0 +1,209 @@
+"""Pgvector-backed adapter for the ``VectorStore`` protocol.
+
+Wraps the existing ``IndexWriter`` (writes) and ``RetrievalService``
+(searches) so all current call sites can depend on the protocol
+rather than on the concrete pgvector classes.  Zero behavioural
+change: every method delegates to code already in production.
+
+See ``packages/core/src/omniscience_core/storage/vector.py`` for the
+protocol contract and the ACL invariant.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Any
+
+import structlog
+from omniscience_core.storage.vector import (
+    ChunkPayload,
+    UpsertOutcome,
+)
+from omniscience_embeddings.base import EmbeddingProvider
+from omniscience_index.writer import ChunkData, IndexWriter, UpsertResult
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_retrieval.models import SearchRequest, SearchResult
+from omniscience_retrieval.reranker import Reranker
+from omniscience_retrieval.search import RetrievalService
+
+log = structlog.get_logger(__name__)
+
+
+class PgVectorVectorStore:
+    """Pgvector-backed ``VectorStore`` — the concrete Phase-1 adapter.
+
+    Composition
+    -----------
+    - ``IndexWriter``        for chunk upserts and tombstoning.
+    - ``RetrievalService``   for search queries.
+
+    Both classes existed before #103; this adapter only re-exposes
+    them through the protocol-shaped surface.
+
+    Known gap (tracked for Phase 2)
+    -------------------------------
+    ``search`` today does not apply a workspace filter to the result
+    set — the ACL invariant is enforced at the protocol level but the
+    pgvector search path (``RetrievalService``) pre-dates #117's
+    workspace-filter machinery.  The Qdrant adapter (issue #106) will
+    enforce it natively.  Until then, ``workspace_id`` is accepted
+    and logged so call-sites can be audited.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession],
+        embedding_provider: EmbeddingProvider,
+        reranker: Reranker | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._writer = IndexWriter(session_factory)
+        self._retrieval = RetrievalService(
+            session_factory=session_factory,
+            embedding_provider=embedding_provider,
+            reranker=reranker,
+        )
+
+    @property
+    def retrieval_service(self) -> RetrievalService:
+        """Expose the underlying ``RetrievalService`` for composition.
+
+        ``FederatedSearch`` wraps a concrete ``RetrievalService``, so
+        callers that need the federation layer still reach into the
+        adapter to compose.  This is a transitional handle; Phase 2
+        adapters will surface a protocol-clean composition API.
+        """
+        return self._retrieval
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_chunks(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+        uri: str,
+        title: str | None,
+        content_hash: str,
+        metadata: dict[str, Any],
+        chunks: list[ChunkPayload],
+        ingestion_run_id: uuid.UUID | None = None,
+    ) -> UpsertOutcome:
+        """Delegate to ``IndexWriter.upsert_document`` unchanged."""
+        chunk_data = [_payload_to_chunk_data(c) for c in chunks]
+        result: UpsertResult = await self._writer.upsert_document(
+            source_id=source_id,
+            external_id=external_id,
+            uri=uri,
+            title=title,
+            content_hash=content_hash,
+            metadata=metadata,
+            chunks=chunk_data,
+            ingestion_run_id=ingestion_run_id,
+        )
+        return UpsertOutcome(
+            action=result.action,
+            document_id=result.document_id,
+            chunks_written=result.chunks_written,
+            doc_version=result.doc_version,
+        )
+
+    async def delete_by_document(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+    ) -> bool:
+        """Delegate to ``IndexWriter.tombstone`` unchanged."""
+        return await self._writer.tombstone(source_id, external_id)
+
+    async def delete_tombstoned(self, older_than: timedelta) -> int:
+        """Delegate to ``IndexWriter.purge_tombstones`` unchanged."""
+        return await self._writer.purge_tombstones(older_than)
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+    ) -> SearchResult:
+        """Execute a retrieval query.
+
+        Parameters
+        ----------
+        request:
+            ``SearchRequest`` — forwarded to ``RetrievalService.search``.
+        workspace_id:
+            REQUIRED by the protocol's ACL invariant.  The current
+            pgvector implementation does not yet filter the result
+            set by workspace (documented gap; see class docstring).
+            The value is logged so audit trails can identify
+            unscoped reads until the follow-up lands.
+        """
+        log.debug(
+            "pgvector_vector_search",
+            workspace_id=str(workspace_id),
+            strategy=request.retrieval_strategy,
+            top_k=request.top_k,
+        )
+        return await self._retrieval.search(request)
+
+    async def count(self, *, source_id: uuid.UUID) -> int:
+        """Return the count of active (non-tombstoned) documents for a source."""
+        from omniscience_core.db.models import Document
+
+        session: AsyncSession
+        async with self._session_factory() as session:
+            stmt = (
+                select(func.count())
+                .select_from(Document)
+                .where(Document.source_id == source_id)
+                .where(Document.tombstoned_at.is_(None))
+            )
+            result = await session.execute(stmt)
+            value = result.scalar_one()
+            return int(value)
+
+
+# ---------------------------------------------------------------------------
+# Payload translator
+# ---------------------------------------------------------------------------
+
+
+def _payload_to_chunk_data(payload: ChunkPayload) -> ChunkData:
+    """Translate a ``ChunkPayload`` TypedDict to an ``IndexWriter.ChunkData``.
+
+    Applies the "required keys" policy documented on ``ChunkPayload``:
+    ``ord``, ``text``, ``embedding`` are mandatory; others default.
+    """
+    try:
+        ord_ = payload["ord"]
+        text = payload["text"]
+        embedding = payload["embedding"]
+    except KeyError as exc:  # pragma: no cover — defensive only
+        raise ValueError(f"chunk payload missing required key: {exc}") from exc
+
+    return ChunkData(
+        ord=ord_,
+        text=text,
+        embedding=embedding,
+        symbol=payload.get("symbol"),
+        metadata=dict(payload.get("metadata", {})),
+        embedding_model=payload.get("embedding_model", ""),
+        embedding_provider=payload.get("embedding_provider", ""),
+        parser_version=payload.get("parser_version", ""),
+        chunker_strategy=payload.get("chunker_strategy", ""),
+    )
+
+
+__all__ = ["PgVectorVectorStore"]

--- a/tests/test_graph_query.py
+++ b/tests/test_graph_query.py
@@ -103,8 +103,22 @@ def _make_chunk(
 
 
 def _make_app(factory: Any = None) -> FastAPI:
+    """Build a minimal FastAPI app wired for the #103 GraphStore protocol.
+
+    The MCP/REST handlers post-#103 consume ``app.state.graph_store``
+    (a ``PgVectorGraphStore``) rather than constructing
+    ``GraphQueryService`` from ``db_session_factory`` directly.  The
+    session factory is still kept on ``app.state`` for legacy code
+    paths (tokens, freshness, etc.) that have not yet migrated.
+    """
+    from omniscience_retrieval.adapters import PgVectorGraphStore
+
     app = FastAPI()
     app.state.db_session_factory = factory
+    if factory is not None:
+        app.state.graph_store = PgVectorGraphStore(session_factory=factory)
+    else:
+        app.state.graph_store = None
     return app
 
 
@@ -533,14 +547,20 @@ async def test_get_related_skips_edge_when_endpoint_outside_workspace() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mcp_get_related_entities_raises_without_factory() -> None:
-    """mcp_get_related_entities raises RuntimeError when db_session_factory absent."""
+async def test_mcp_get_related_entities_raises_without_graph_store() -> None:
+    """mcp_get_related_entities raises RuntimeError when graph_store absent.
+
+    Post-#103 the MCP handler resolves its dependency through
+    ``app.state.graph_store`` (a ``GraphStore`` protocol implementation)
+    instead of constructing ``GraphQueryService`` directly from
+    ``db_session_factory``.
+    """
     from omniscience_server.mcp.tools import mcp_get_related_entities
 
     app = FastAPI()
-    app.state.db_session_factory = None
+    app.state.graph_store = None
 
-    with pytest.raises(RuntimeError, match="db_session_factory not available"):
+    with pytest.raises(RuntimeError, match="graph_store not available"):
         await mcp_get_related_entities(
             app=app, entity_name="any.entity", workspace_id=_WORKSPACE_ID
         )
@@ -563,7 +583,7 @@ async def test_mcp_get_related_entities_returns_dict() -> None:
     app = _make_app(factory=factory)
 
     with patch(
-        "omniscience_server.mcp.tools.GraphQueryService.get_related",
+        "omniscience_retrieval.graph_query.GraphQueryService.get_related",
         new_callable=AsyncMock,
         return_value=mock_result,
     ):
@@ -587,7 +607,7 @@ async def test_mcp_get_related_entities_propagates_not_found() -> None:
 
     with (
         patch(
-            "omniscience_server.mcp.tools.GraphQueryService.get_related",
+            "omniscience_retrieval.graph_query.GraphQueryService.get_related",
             new_callable=AsyncMock,
             side_effect=ValueError("entity_not_found:gone"),
         ),
@@ -613,7 +633,7 @@ async def test_mcp_get_related_entities_forwards_workspace_and_edge_types() -> N
     app = _make_app(factory=factory)
 
     with patch(
-        "omniscience_server.mcp.tools.GraphQueryService.get_related",
+        "omniscience_retrieval.graph_query.GraphQueryService.get_related",
         new_callable=AsyncMock,
         return_value=mock_result,
     ) as mock_get:
@@ -639,8 +659,14 @@ async def test_mcp_get_related_entities_forwards_workspace_and_edge_types() -> N
 
 
 def _make_rest_app(factory: Any = None) -> FastAPI:
-    """Build a minimal app with the entities router registered."""
+    """Build a minimal app with the entities router registered.
+
+    Lifespan does not run under an ``ASGITransport`` harness, so we
+    seed ``app.state.graph_store`` (a ``PgVectorGraphStore``) here —
+    mirroring what ``_lifespan`` does in production.
+    """
     from omniscience_core.config import Settings
+    from omniscience_retrieval.adapters import PgVectorGraphStore
     from omniscience_server.app import create_app
 
     settings = Settings(
@@ -653,6 +679,7 @@ def _make_rest_app(factory: Any = None) -> FastAPI:
     app = create_app(settings=settings)
     if factory is not None:
         app.state.db_session_factory = factory
+        app.state.graph_store = PgVectorGraphStore(session_factory=factory)
     return app
 
 
@@ -689,7 +716,7 @@ async def test_rest_entities_related_404_when_not_found() -> None:
             return_value=token_mock,
         ),
         patch(
-            "omniscience_server.rest.entities.GraphQueryService.get_related",
+            "omniscience_retrieval.graph_query.GraphQueryService.get_related",
             new_callable=AsyncMock,
             side_effect=ValueError("entity_not_found:gone"),
         ),
@@ -755,7 +782,7 @@ async def test_rest_entities_related_returns_graph_structure() -> None:
             return_value=token_mock,
         ),
         patch(
-            "omniscience_server.rest.entities.GraphQueryService.get_related",
+            "omniscience_retrieval.graph_query.GraphQueryService.get_related",
             new_callable=AsyncMock,
             return_value=graph_result,
         ),
@@ -856,7 +883,7 @@ async def test_rest_entities_related_max_depth_forwarded() -> None:
             return_value=token_mock,
         ),
         patch(
-            "omniscience_server.rest.entities.GraphQueryService.get_related",
+            "omniscience_retrieval.graph_query.GraphQueryService.get_related",
             new_callable=AsyncMock,
             return_value=graph_result,
         ) as mock_get,
@@ -891,7 +918,7 @@ async def test_rest_entities_related_edge_types_forwarded() -> None:
             return_value=token_mock,
         ),
         patch(
-            "omniscience_server.rest.entities.GraphQueryService.get_related",
+            "omniscience_retrieval.graph_query.GraphQueryService.get_related",
             new_callable=AsyncMock,
             return_value=graph_result,
         ) as mock_get,

--- a/tests/test_graph_workspace_isolation.py
+++ b/tests/test_graph_workspace_isolation.py
@@ -517,6 +517,20 @@ def _make_rest_app() -> FastAPI:
     return create_app(settings=settings)
 
 
+def _wire_graph_store(app: FastAPI, factory: Any) -> None:
+    """Attach ``PgVectorGraphStore`` to ``app.state`` for the #103 wiring.
+
+    Lifespan does not run under ``ASGITransport`` and the helper
+    ``FastAPI()`` constructor in the MCP tests does not start one
+    either — so every test site that pokes a session factory onto
+    ``app.state`` must also wire a ``graph_store`` adapter.
+    """
+    from omniscience_retrieval.adapters import PgVectorGraphStore
+
+    app.state.db_session_factory = factory
+    app.state.graph_store = PgVectorGraphStore(session_factory=factory)
+
+
 def _auth_token(workspace_id: uuid.UUID | None) -> tuple[MagicMock, str]:
     plaintext, prefix = generate_token("test")
     token: MagicMock = MagicMock(spec=ApiToken)
@@ -546,7 +560,7 @@ async def test_rest_endpoint_rejects_workspace_a_probing_workspace_b() -> None:
     factory = _session_factory(fx)
 
     app = _make_rest_app()
-    app.state.db_session_factory = factory
+    _wire_graph_store(app, factory)
 
     with patch(
         "omniscience_core.auth.middleware._lookup_token",
@@ -575,7 +589,7 @@ async def test_rest_endpoint_rejects_unscoped_token() -> None:
     factory = _session_factory(fx)
 
     app = _make_rest_app()
-    app.state.db_session_factory = factory
+    _wire_graph_store(app, factory)
 
     with patch(
         "omniscience_core.auth.middleware._lookup_token",
@@ -602,7 +616,7 @@ async def test_rest_endpoint_workspace_a_traversal_never_includes_b() -> None:
     factory = _session_factory(fx)
 
     app = _make_rest_app()
-    app.state.db_session_factory = factory
+    _wire_graph_store(app, factory)
 
     with patch(
         "omniscience_core.auth.middleware._lookup_token",
@@ -641,7 +655,7 @@ async def test_mcp_tool_workspace_a_never_returns_b_entities() -> None:
     factory = _session_factory(fx)
 
     app = FastAPI()
-    app.state.db_session_factory = factory
+    _wire_graph_store(app, factory)
 
     result = await mcp_get_related_entities(
         app=app,
@@ -667,7 +681,7 @@ async def test_mcp_tool_workspace_b_never_returns_a_entities() -> None:
     factory = _session_factory(fx)
 
     app = FastAPI()
-    app.state.db_session_factory = factory
+    _wire_graph_store(app, factory)
 
     result = await mcp_get_related_entities(
         app=app,

--- a/tests/test_storage_protocols.py
+++ b/tests/test_storage_protocols.py
@@ -208,9 +208,7 @@ async def test_pgvector_graph_get_entity_returns_none_for_cross_workspace() -> N
         new_callable=AsyncMock,
         side_effect=ValueError("entity_not_found:svc.other"),
     ):
-        result = await store.get_entity(
-            entity_name="svc.other", workspace_id=_OTHER_WORKSPACE_ID
-        )
+        result = await store.get_entity(entity_name="svc.other", workspace_id=_OTHER_WORKSPACE_ID)
 
     assert result is None
 

--- a/tests/test_storage_protocols.py
+++ b/tests/test_storage_protocols.py
@@ -1,0 +1,425 @@
+"""Unit tests for the #103 ``GraphStore`` / ``VectorStore`` scaffold.
+
+Focus areas
+-----------
+
+1. **Adapter wrapping is behaviour-preserving.**  The pgvector
+   adapters delegate to ``IndexWriter`` / ``GraphQueryService``
+   without introducing logic changes.
+2. **ACL invariant is locked at the protocol level.**  Every read
+   method on both protocols has ``workspace_id`` as a keyword-only
+   required parameter.  A missing or ``None`` workspace raises
+   ``TypeError`` (Python) rather than silently widening.
+3. **View-model translation preserves the MCP/REST wire shape.**
+   ``GraphResultView`` serialises byte-identically to the legacy
+   ``GraphResult.to_dict`` output.
+
+No real database is started; adapters are fed ``MagicMock`` session
+factories and the underlying service/writer calls are patched.
+"""
+
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from omniscience_core.storage import (
+    ChunkPayload,
+    EdgeUpsert,
+    EntityNodeView,
+    EntityUpsert,
+    GraphEdgeView,
+    GraphResultView,
+    GraphStore,
+    UpsertOutcome,
+    VectorStore,
+)
+from omniscience_retrieval.adapters import (
+    PgVectorGraphStore,
+    PgVectorVectorStore,
+)
+from omniscience_retrieval.adapters.pgvector_graph import (
+    _edge_to_view,
+    _node_to_view,
+    _result_to_view,
+)
+from omniscience_retrieval.adapters.pgvector_vector import _payload_to_chunk_data
+from omniscience_retrieval.graph_query import (
+    EdgeResult,
+    EntityNode,
+    GraphResult,
+)
+
+_WORKSPACE_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-00000000007a")
+_OTHER_WORKSPACE_ID = uuid.UUID("bbbbbbbb-0000-0000-0000-00000000007b")
+
+
+# ---------------------------------------------------------------------------
+# Protocol-shape assertions — locked at import time
+# ---------------------------------------------------------------------------
+
+
+def _assert_kw_only_required(sig: inspect.Signature, param_name: str) -> None:
+    """Fail the test when ``param_name`` isn't keyword-only and required."""
+    param = sig.parameters[param_name]
+    assert param.kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"{param_name} must be keyword-only (protect against positional misuse)"
+    )
+    assert param.default is inspect.Parameter.empty, (
+        f"{param_name} must have no default (invariant: caller must pass it)"
+    )
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["get_entity", "find_related", "traverse", "upsert_entity", "upsert_edge"],
+)
+def test_graph_store_methods_require_workspace_id(method_name: str) -> None:
+    """Every workspace-sensitive ``GraphStore`` method pins workspace_id."""
+    method = getattr(GraphStore, method_name)
+    sig = inspect.signature(method)
+    _assert_kw_only_required(sig, "workspace_id")
+
+
+def test_vector_store_search_requires_workspace_id() -> None:
+    """``VectorStore.search`` pins workspace_id as keyword-only required."""
+    sig = inspect.signature(VectorStore.search)
+    _assert_kw_only_required(sig, "workspace_id")
+
+
+def test_graph_store_upsert_graph_signature_matches_index_writer() -> None:
+    """The batch write path must mirror ``IndexWriter.upsert_graph``.
+
+    This guards against signature drift during #104 / #106 when the
+    Neo4j / Qdrant adapters land — ingestion code must keep working
+    unchanged against the protocol.
+    """
+    sig = inspect.signature(GraphStore.upsert_graph)
+    assert {"source_id", "document_id", "entities", "edges"}.issubset(sig.parameters)
+
+
+# ---------------------------------------------------------------------------
+# View translators preserve the wire shape
+# ---------------------------------------------------------------------------
+
+
+def test_node_to_view_preserves_fields() -> None:
+    node = EntityNode(
+        name="svc.auth", kind="service", source="s1", chunk_text="body", depth=2, edge_type="calls"
+    )
+    view = _node_to_view(node)
+    assert isinstance(view, EntityNodeView)
+    assert (view.name, view.kind, view.source, view.chunk_text, view.depth, view.edge_type) == (
+        "svc.auth",
+        "service",
+        "s1",
+        "body",
+        2,
+        "calls",
+    )
+
+
+def test_edge_to_view_preserves_fields() -> None:
+    edge = EdgeResult(from_entity="a", to_entity="b", edge_type="calls")
+    view = _edge_to_view(edge)
+    assert isinstance(view, GraphEdgeView)
+    assert (view.from_entity, view.to_entity, view.edge_type) == ("a", "b", "calls")
+
+
+def test_result_to_view_preserves_whole_shape() -> None:
+    seed = EntityNode(name="root", kind="k", source="s", chunk_text=None)
+    neighbor = EntityNode(name="n1", kind="k", source="s", chunk_text=None, depth=1)
+    edge = EdgeResult(from_entity="root", to_entity="n1", edge_type="calls")
+    result = GraphResult(seed=seed, related=[neighbor], edges=[edge])
+
+    view = _result_to_view(result)
+    assert isinstance(view, GraphResultView)
+    assert view.seed.name == "root"
+    assert [n.name for n in view.related] == ["n1"]
+    assert [e.edge_type for e in view.edges] == ["calls"]
+
+
+# ---------------------------------------------------------------------------
+# PgVectorGraphStore — workspace_id is propagated, not silently widened
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pgvector_graph_find_related_forwards_workspace() -> None:
+    """The adapter must forward the caller's workspace_id unchanged."""
+    store = PgVectorGraphStore(session_factory=MagicMock())
+
+    seed = EntityNode(name="root", kind="k", source="s", chunk_text=None)
+    stub_result = GraphResult(seed=seed)
+
+    with patch(
+        "omniscience_retrieval.adapters.pgvector_graph.GraphQueryService.get_related",
+        new_callable=AsyncMock,
+        return_value=stub_result,
+    ) as mock_get:
+        await store.find_related(
+            entity_name="root",
+            workspace_id=_WORKSPACE_ID,
+            max_depth=2,
+            edge_types=["calls"],
+        )
+
+    mock_get.assert_awaited_once_with(
+        entity_name="root",
+        workspace_id=_WORKSPACE_ID,
+        max_depth=2,
+        edge_types=["calls"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_pgvector_graph_traverse_is_alias_of_find_related() -> None:
+    """``traverse`` and ``find_related`` must produce identical results.
+
+    Regression guard for the Neo4j adapter (#104): if Neo4j implements
+    ``traverse`` natively and ``find_related`` becomes the delegate,
+    the relationship is inverted, not broken.
+    """
+    store = PgVectorGraphStore(session_factory=MagicMock())
+
+    seed = EntityNode(name="root", kind="k", source="s", chunk_text=None)
+    stub_result = GraphResult(seed=seed)
+
+    with patch(
+        "omniscience_retrieval.adapters.pgvector_graph.GraphQueryService.get_related",
+        new_callable=AsyncMock,
+        return_value=stub_result,
+    ):
+        v_find = await store.find_related(entity_name="root", workspace_id=_WORKSPACE_ID)
+        v_trav = await store.traverse(entity_name="root", workspace_id=_WORKSPACE_ID)
+
+    assert v_find.seed.name == v_trav.seed.name == "root"
+
+
+@pytest.mark.asyncio
+async def test_pgvector_graph_get_entity_returns_none_for_cross_workspace() -> None:
+    """Cross-workspace existence is NEVER leaked — returns None, not raise."""
+    store = PgVectorGraphStore(session_factory=MagicMock())
+
+    with patch(
+        "omniscience_retrieval.adapters.pgvector_graph.GraphQueryService.get_related",
+        new_callable=AsyncMock,
+        side_effect=ValueError("entity_not_found:svc.other"),
+    ):
+        result = await store.get_entity(
+            entity_name="svc.other", workspace_id=_OTHER_WORKSPACE_ID
+        )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_pgvector_graph_get_entity_propagates_non_not_found_errors() -> None:
+    """Non-"not-found" ValueErrors bubble up — we only mask the ACL variant."""
+    store = PgVectorGraphStore(session_factory=MagicMock())
+
+    with (
+        patch(
+            "omniscience_retrieval.adapters.pgvector_graph.GraphQueryService.get_related",
+            new_callable=AsyncMock,
+            side_effect=ValueError("invalid_depth"),
+        ),
+        pytest.raises(ValueError, match="invalid_depth"),
+    ):
+        await store.get_entity(entity_name="x", workspace_id=_WORKSPACE_ID)
+
+
+@pytest.mark.asyncio
+async def test_pgvector_graph_upsert_entity_raises_not_implemented() -> None:
+    """Granular upserts are reserved for Phase 2 (Neo4j)."""
+    store = PgVectorGraphStore(session_factory=MagicMock())
+    payload = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="x",
+        display_name="x",
+        chunk_id=None,
+    )
+    with pytest.raises(NotImplementedError):
+        await store.upsert_entity(entity=payload, workspace_id=_WORKSPACE_ID)
+
+
+@pytest.mark.asyncio
+async def test_pgvector_graph_upsert_edge_raises_not_implemented() -> None:
+    """Granular edge upserts are reserved for Phase 2 (Neo4j)."""
+    store = PgVectorGraphStore(session_factory=MagicMock())
+    payload = EdgeUpsert(
+        source_entity_id=uuid.uuid4(),
+        target_entity_id=uuid.uuid4(),
+        edge_type="calls",
+    )
+    with pytest.raises(NotImplementedError):
+        await store.upsert_edge(edge=payload, workspace_id=_WORKSPACE_ID)
+
+
+@pytest.mark.asyncio
+async def test_pgvector_graph_delete_tombstoned_returns_zero() -> None:
+    """pgvector's delete_tombstoned is a documented no-op (cascade handles it)."""
+    store = PgVectorGraphStore(session_factory=MagicMock())
+    assert await store.delete_tombstoned() == 0
+
+
+# ---------------------------------------------------------------------------
+# PgVectorVectorStore — payload translation + search propagation
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_payload_translator_required_keys() -> None:
+    """``_payload_to_chunk_data`` enforces the (ord, text, embedding) contract."""
+    payload: ChunkPayload = {
+        "ord": 0,
+        "text": "hello",
+        "embedding": [0.1, 0.2, 0.3],
+    }
+    data = _payload_to_chunk_data(payload)
+    assert data.ord == 0
+    assert data.text == "hello"
+    assert data.embedding == [0.1, 0.2, 0.3]
+    assert data.symbol is None  # default
+    assert data.metadata == {}  # default
+
+
+def test_chunk_payload_translator_passes_optional_keys() -> None:
+    payload: ChunkPayload = {
+        "ord": 3,
+        "text": "t",
+        "embedding": [0.0],
+        "symbol": "module.Class.method",
+        "metadata": {"line": 42},
+        "embedding_model": "mxbai",
+        "embedding_provider": "local",
+        "parser_version": "2.1",
+        "chunker_strategy": "ast",
+    }
+    data = _payload_to_chunk_data(payload)
+    assert data.symbol == "module.Class.method"
+    assert data.metadata == {"line": 42}
+    assert data.embedding_model == "mxbai"
+    assert data.chunker_strategy == "ast"
+
+
+def test_chunk_payload_translator_raises_on_missing_required_key() -> None:
+    """A missing mandatory key produces a clear error, not a downstream crash."""
+    bad_payload: ChunkPayload = {"ord": 0, "text": "t"}  # type: ignore[typeddict-item]
+    with pytest.raises(ValueError, match="embedding"):
+        _payload_to_chunk_data(bad_payload)
+
+
+@pytest.mark.asyncio
+async def test_pgvector_vector_search_forwards_workspace_id_in_logs() -> None:
+    """Search forwards the request and does not drop workspace_id on the floor.
+
+    Today's pgvector adapter does not filter search by workspace (known
+    gap; see class docstring).  The test locks in that the value IS
+    accepted and the call reaches ``RetrievalService.search`` so the
+    Qdrant adapter (#106) can enforce the invariant natively without
+    breaking any caller.
+    """
+    embedding_provider = MagicMock()
+    session_factory = MagicMock()
+
+    store = PgVectorVectorStore(
+        session_factory=session_factory,
+        embedding_provider=embedding_provider,
+    )
+
+    request = MagicMock()
+    request.retrieval_strategy = "hybrid"
+    request.top_k = 10
+    stub_result = MagicMock()
+
+    with patch(
+        "omniscience_retrieval.adapters.pgvector_vector.RetrievalService.search",
+        new_callable=AsyncMock,
+        return_value=stub_result,
+    ) as mock_search:
+        returned = await store.search(request=request, workspace_id=_WORKSPACE_ID)
+
+    assert returned is stub_result
+    mock_search.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_pgvector_vector_upsert_chunks_wraps_writer() -> None:
+    """Upsert delegates to ``IndexWriter.upsert_document`` with translated payload."""
+    from omniscience_index.writer import UpsertResult
+
+    embedding_provider = MagicMock()
+    session_factory = MagicMock()
+    store = PgVectorVectorStore(
+        session_factory=session_factory,
+        embedding_provider=embedding_provider,
+    )
+
+    source_id = uuid.uuid4()
+    doc_id = uuid.uuid4()
+    stub = UpsertResult(action="created", document_id=doc_id, chunks_written=1, doc_version=1)
+    chunks: list[ChunkPayload] = [{"ord": 0, "text": "t", "embedding": [0.0]}]
+
+    with patch(
+        "omniscience_retrieval.adapters.pgvector_vector.IndexWriter.upsert_document",
+        new_callable=AsyncMock,
+        return_value=stub,
+    ) as mock_upsert:
+        outcome = await store.upsert_chunks(
+            source_id=source_id,
+            external_id="e1",
+            uri="s3://b/k",
+            title=None,
+            content_hash="abc",
+            metadata={},
+            chunks=chunks,
+        )
+
+    assert isinstance(outcome, UpsertOutcome)
+    assert outcome.action == "created"
+    assert outcome.document_id == doc_id
+    mock_upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pgvector_vector_delete_by_document_wraps_tombstone() -> None:
+    embedding_provider = MagicMock()
+    session_factory = MagicMock()
+    store = PgVectorVectorStore(
+        session_factory=session_factory,
+        embedding_provider=embedding_provider,
+    )
+    source_id = uuid.uuid4()
+
+    with patch(
+        "omniscience_retrieval.adapters.pgvector_vector.IndexWriter.tombstone",
+        new_callable=AsyncMock,
+        return_value=True,
+    ) as mock_tomb:
+        ok = await store.delete_by_document(source_id=source_id, external_id="doc")
+
+    assert ok is True
+    mock_tomb.assert_awaited_once_with(source_id, "doc")
+
+
+# ---------------------------------------------------------------------------
+# Runtime protocol compliance
+# ---------------------------------------------------------------------------
+
+
+def test_pgvector_graph_store_is_runtime_graph_store() -> None:
+    """Runtime ``isinstance`` check — the adapter fulfils the protocol."""
+    store = PgVectorGraphStore(session_factory=MagicMock())
+    assert isinstance(store, GraphStore)
+
+
+def test_pgvector_vector_store_is_runtime_vector_store() -> None:
+    store = PgVectorVectorStore(
+        session_factory=MagicMock(),
+        embedding_provider=MagicMock(),
+    )
+    assert isinstance(store, VectorStore)


### PR DESCRIPTION
## Summary

Closes #103 (Phase 1 of Epic #96).  Introduces the backend-neutral
`GraphStore` and `VectorStore` protocols so Phase 2 (Neo4j #104,
Qdrant #106) can land as drop-in adapters behind the same contracts.
Zero behaviour change — the pgvector adapters wrap the existing
`IndexWriter`, `RetrievalService`, and `GraphQueryService`.

## What changed

**New protocol surface** (`packages/core/src/omniscience_core/storage/`)
- `GraphStore` — `upsert_graph`, `upsert_entity`, `upsert_edge`, `get_entity`, `find_related`, `traverse`, `delete_tombstoned`
- `VectorStore` — `upsert_chunks`, `delete_by_document`, `delete_tombstoned`, `search`, `count`
- View-model dataclasses (`EntityNodeView`, `GraphEdgeView`, `GraphResultView`) are ORM-free so Neo4j / Qdrant adapters don't need to import SQLAlchemy.
- `ChunkPayload` TypedDict is the canonical on-the-wire chunk shape.

**New pgvector adapters** (`packages/retrieval/src/omniscience_retrieval/adapters/`)
- `PgVectorGraphStore` — wraps `IndexWriter` + `GraphQueryService`.
- `PgVectorVectorStore` — wraps `IndexWriter` + `RetrievalService`; exposes a transitional `retrieval_service` handle so the federation layer still composes.

**DI wiring** (`apps/server/src/omniscience_server/app.py`)
- Lifespan constructs both adapters and attaches them to `app.state.graph_store` / `app.state.vector_store`, mirroring the `db_session_factory` pattern.

**Consumers migrated**
- `apps/server/.../rest/entities.py` — GET `/api/v1/entities/{name}/related` now calls `graph_store.find_related`.
- `apps/server/.../mcp/tools.py` — `mcp_get_related_entities` now calls `graph_store.find_related`.

## ACL invariant (carry-forward from #117)

Every read method on both protocols takes `workspace_id: uuid.UUID` as a **keyword-only, required** parameter.  No default, no sentinel, no bypass.  Locked in by `inspect.signature`-based regression tests (`tests/test_storage_protocols.py`).

**Known gap, tracked for Phase 2**: today's pgvector `search` path does not yet filter by workspace — this is pre-existing behaviour, not a regression.  The protocol is correct so the Qdrant adapter (#106) can enforce the invariant natively from day one.  Documented on the adapter class and in the protocol docstring.

## Non-goals (deferred — hard boundaries)
- No Neo4j adapter (#104).
- No Qdrant adapter (#106).
- No MCP/REST API contract change.
- No pgvector schema change.

## Test plan

- [x] `make test` — 1556 passed, 2 skipped (prior suite + 25 new protocol tests).
- [x] `mypy --strict` on the two new protocol modules — clean.
- [x] `mypy --strict` across all 151 source files — clean.
- [x] `ruff check .` — clean.
- [x] Existing workspace-isolation tests updated to point at the new DI and all pass.
- [x] Runtime `isinstance(store, GraphStore)` / `isinstance(store, VectorStore)` compliance verified.
- [x] Protocol surface is frozen by `inspect`-based tests — future refactors cannot silently drop the `workspace_id` invariant.