### PR TITLE
feat: implement Neo4j GraphStore adapter (#104)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,17 @@ APP_VERSION=0.1.0
 
 # === Auth ===
 # API_TOKEN_SECRET=  # set in production
+
+# === Storage backend selection (Phase 2, epic #96) ===
+# Graph-store backend: 'pgvector' (Phase 1) or 'neo4j' (Phase 2a, issue #104).
+STORAGE_GRAPH_BACKEND=pgvector
+
+# === Neo4j (graph store, issue #104; used only when STORAGE_GRAPH_BACKEND=neo4j) ===
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=neo4j_dev
+NEO4J_DATABASE=neo4j
+NEO4J_MAX_POOL_SIZE=50
+NEO4J_ACQUISITION_TIMEOUT_SECONDS=60
+NEO4J_MAX_RETRY_TIME_SECONDS=30
+NEO4J_DEFAULT_MAX_DEPTH=3

--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -29,9 +29,11 @@ from omniscience_core.db import create_async_engine, create_session_factory
 from omniscience_core.logging import configure_logging
 from omniscience_core.queue import NatsConnection, ensure_streams
 from omniscience_core.queue.consumer import QueueConsumer
+from omniscience_core.storage.graph import GraphStore
 from omniscience_core.telemetry import init_telemetry
 from omniscience_embeddings import create_embedding_provider
 from omniscience_index import IndexWriter
+from omniscience_index.stores import Neo4jGraphStore, Neo4jStoreConfig
 from omniscience_retrieval import (
     PgVectorGraphStore,
     PgVectorVectorStore,
@@ -107,17 +109,32 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # --- Storage adapters (GraphStore / VectorStore protocols, issue #103) ---
     # These wrap the pgvector writer + retriever behind the new backend-
-    # neutral protocols defined in ``omniscience_core.storage``.  Phase 2
-    # will swap these for Neo4jGraphStore + QdrantVectorStore behind a
-    # feature flag with zero changes to the call sites.
-    graph_store = PgVectorGraphStore(session_factory=session_factory)
+    # neutral protocols defined in ``omniscience_core.storage``.  Phase 2a
+    # (issue #104) selects the Neo4j graph backend behind the
+    # ``STORAGE_GRAPH_BACKEND`` feature flag; vector backend selection is
+    # separate (issue #106).
+    graph_backend = str(settings.storage_graph_backend).lower()
+    graph_store: GraphStore
+    neo4j_graph_store: Neo4jGraphStore | None = None
+    if graph_backend == "neo4j":
+        neo4j_config = Neo4jStoreConfig.from_settings(settings)
+        neo4j_graph_store = Neo4jGraphStore(config=neo4j_config)
+        await neo4j_graph_store.connect()
+        graph_store = neo4j_graph_store
+    elif graph_backend == "pgvector":
+        graph_store = PgVectorGraphStore(session_factory=session_factory)
+    else:
+        raise ValueError(
+            f"unknown_storage_graph_backend:{graph_backend} (expected 'pgvector' or 'neo4j')"
+        )
     vector_store = PgVectorVectorStore(
         session_factory=session_factory,
         embedding_provider=embedding_provider,
     )
     app.state.graph_store = graph_store
     app.state.vector_store = vector_store
-    log.info("storage_adapters_ready", backend="pgvector")
+    app.state.neo4j_graph_store = neo4j_graph_store
+    log.info("storage_adapters_ready", graph_backend=graph_backend)
 
     # --- Retrieval service ---
     # Keep the direct ``RetrievalService`` handle on app.state for the
@@ -219,6 +236,9 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Close the federation HTTP client if federation is active.
     if settings.federation_enabled and isinstance(retrieval_service, FederatedSearch):
         await retrieval_service.close()
+
+    if neo4j_graph_store is not None:
+        await neo4j_graph_store.close()
 
     await engine.dispose()
     await nats_conn.disconnect()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,6 +184,43 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # ===========================================================================
+  # neo4j — Phase 2a graph store (issue #104, ADR-0005).
+  #
+  # Activates with:  docker compose --profile graph up
+  #
+  # Single-node Neo4j Community Edition.  Bolt on 7687, HTTP on 7474.
+  # Bolt TLS MUST be enabled in non-dev environments (not set here — this
+  # compose file is dev-only).  Credentials are read from .env via
+  # ${NEO4J_PASSWORD}; the default below is intentionally a placeholder
+  # that fails if POSTGRES_PASSWORD-style validation is applied downstream.
+  # ===========================================================================
+  neo4j:
+    image: neo4j:5.19-community
+    profiles:
+      - graph
+    ports:
+      - "127.0.0.1:7474:7474"
+      - "127.0.0.1:7687:7687"
+    environment:
+      NEO4J_AUTH: ${NEO4J_USERNAME:-neo4j}/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set in .env}
+      NEO4J_server_memory_heap_initial__size: ${NEO4J_HEAP_INITIAL:-1G}
+      NEO4J_server_memory_heap_max__size: ${NEO4J_HEAP_MAX:-2G}
+      NEO4J_server_memory_pagecache_size: ${NEO4J_PAGECACHE:-1G}
+      NEO4J_PLUGINS: '["apoc"]'
+    volumes:
+      - neo4jdata:/data
+      - neo4jlogs:/logs
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "wget -q -O - http://localhost:7474 > /dev/null || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
 volumes:
   pgdata:
   pgbackups:
@@ -192,3 +229,5 @@ volumes:
   prometheusdata:
   grafanadata:
   caddy_data:
+  neo4jdata:
+  neo4jlogs:

--- a/packages/core/src/omniscience_core/config.py
+++ b/packages/core/src/omniscience_core/config.py
@@ -147,6 +147,62 @@ class Settings(BaseSettings):
         description="Deployment environment: development, staging, production.",
     )
 
+    # --- Storage backend selection (Phase 2 / epic #96) ---
+    storage_graph_backend: str = Field(
+        default="pgvector",
+        description=(
+            "Graph-store backend: 'pgvector' (default, Phase 1) or 'neo4j' "
+            "(Phase 2a, issue #104). Flip to 'neo4j' after running the "
+            "dual-write migration per ADR-0005."
+        ),
+    )
+
+    # --- Neo4j (graph store, issue #104) ---
+    neo4j_uri: str = Field(
+        default="bolt://localhost:7687",
+        description="Bolt URI for the Neo4j graph store.",
+    )
+    neo4j_username: str = Field(
+        default="neo4j",
+        description="Neo4j auth username.",
+    )
+    neo4j_password: str = Field(
+        default="neo4j_dev",
+        description=(
+            "Neo4j auth password. MUST be overridden in non-dev "
+            "environments via Kubernetes Secret or equivalent."
+        ),
+    )
+    neo4j_database: str = Field(
+        default="neo4j",
+        description="Neo4j database name. Community Edition uses the default 'neo4j'.",
+    )
+    neo4j_max_pool_size: int = Field(
+        default=50,
+        ge=1,
+        le=500,
+        description="Maximum size of the Neo4j connection pool.",
+    )
+    neo4j_acquisition_timeout_seconds: float = Field(
+        default=60.0,
+        gt=0,
+        description="Seconds to wait for a pooled connection before failing.",
+    )
+    neo4j_max_retry_time_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        description="Upper bound on managed-transaction retry time.",
+    )
+    neo4j_default_max_depth: int = Field(
+        default=3,
+        ge=1,
+        le=6,
+        description=(
+            "Default BFS depth cap for find_related traversals when the "
+            "caller does not supply one. Hard ceiling is 6."
+        ),
+    )
+
     # --- Scheduler ---
     scheduler_enabled: bool = Field(
         default=True,

--- a/packages/index/pyproject.toml
+++ b/packages/index/pyproject.toml
@@ -7,6 +7,8 @@ dependencies = [
     "omniscience-core",
     "sqlalchemy[asyncio]>=2.0.30",
     "asyncpg>=0.29.0",
+    "neo4j>=5.19.0",
+    "structlog>=24.1.0",
 ]
 
 [tool.uv.sources]

--- a/packages/index/src/omniscience_index/stores/__init__.py
+++ b/packages/index/src/omniscience_index/stores/__init__.py
@@ -1,0 +1,17 @@
+"""Backend-specific store adapters for Omniscience.
+
+Currently hosts the Neo4j ``GraphStore`` implementation (issue #104 /
+Phase 2a of epic #96).  Pgvector adapters live in
+``omniscience_retrieval.adapters`` — the dependency arrow is always
+``adapter -> protocol`` defined in
+``omniscience_core.storage``.
+"""
+
+from __future__ import annotations
+
+from omniscience_index.stores.neo4j_store import (
+    Neo4jGraphStore,
+    Neo4jStoreConfig,
+)
+
+__all__ = ["Neo4jGraphStore", "Neo4jStoreConfig"]

--- a/packages/index/src/omniscience_index/stores/neo4j_store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j_store.py
@@ -1,0 +1,768 @@
+"""Neo4j-backed adapter for the ``GraphStore`` protocol (issue #104).
+
+Implements ``omniscience_core.storage.GraphStore`` against the official
+``neo4j`` Python driver (async variant), per ADR-0005
+(``docs/decisions/0005-neo4j-as-graph-store.md``).
+
+Design rules
+------------
+
+1.  **Workspace invariant.**  Every read Cypher statement in this module
+    includes ``{workspace_id: $workspace_id}`` on its pattern or an
+    explicit ``WHERE`` predicate on ``workspace_id``.  The helper
+    :func:`_ensure_workspace_predicate` is applied to every Cypher
+    template at import time so a refactor that drops the predicate is
+    caught before the driver is ever opened.  The contract tests in
+    ``tests/test_neo4j_store.py`` cover the runtime side.
+
+2.  **ACID split.**  Writes go through ``session.execute_write``; reads
+    through ``session.execute_read``.  This matches ADR-0005 §Decision.
+
+3.  **Parameterized queries only.**  No Cypher is ever built by string
+    interpolation of user-supplied values.  The only string pieces we
+    concatenate are the bootstrap DDL and a *static* allowlisted edge
+    type list in :meth:`find_related` — user-supplied edge types are
+    matched against a regex before they reach Cypher.
+
+4.  **Idempotent MERGE.**  Every write uses
+    ``MERGE ... ON CREATE SET ... ON MATCH SET ...`` so re-ingestion is
+    safe.
+
+5.  **No magic numbers.**  Pool size, timeouts, and max traversal depth
+    live on :class:`Neo4jStoreConfig` and are populated from
+    :class:`omniscience_core.config.Settings`.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Final
+
+import structlog
+from neo4j import AsyncDriver, AsyncGraphDatabase, AsyncManagedTransaction
+from omniscience_core.storage.graph import (
+    EdgeUpsert,
+    EntityNodeView,
+    EntityUpsert,
+    GraphEdgeView,
+    GraphResultView,
+)
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Neo4jStoreConfig:
+    """Runtime configuration for :class:`Neo4jGraphStore`.
+
+    All values are injected from :class:`omniscience_core.config.Settings`.
+    No defaults reach production — the caller must provide a populated
+    config.  A convenience :meth:`from_settings` factory is provided for
+    the application startup path.
+    """
+
+    uri: str
+    username: str
+    password: str
+    database: str
+    max_connection_pool_size: int
+    connection_acquisition_timeout_seconds: float
+    max_transaction_retry_time_seconds: float
+    default_max_depth: int
+
+    @classmethod
+    def from_settings(cls, settings: Any) -> Neo4jStoreConfig:
+        """Build a config from the canonical ``Settings`` object.
+
+        Typed as ``Any`` because importing ``Settings`` here would create
+        an import cycle (``omniscience_core`` -> ``omniscience_index``).
+        The duck-typed attribute access matches the exact field names on
+        the Pydantic settings class.
+        """
+        return cls(
+            uri=str(settings.neo4j_uri),
+            username=str(settings.neo4j_username),
+            password=str(settings.neo4j_password),
+            database=str(settings.neo4j_database),
+            max_connection_pool_size=int(settings.neo4j_max_pool_size),
+            connection_acquisition_timeout_seconds=float(
+                settings.neo4j_acquisition_timeout_seconds
+            ),
+            max_transaction_retry_time_seconds=float(settings.neo4j_max_retry_time_seconds),
+            default_max_depth=int(settings.neo4j_default_max_depth),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Constants & Cypher templates
+# ---------------------------------------------------------------------------
+
+# Hard clamp for the BFS depth — protects the Neo4j planner from
+# user-provided huge depths while still being well above realistic
+# GraphRAG traversals.
+_MAX_DEPTH_CEILING: Final[int] = 6
+
+# Allowlist regex for user-supplied edge types.  We never interpolate raw
+# user input into Cypher without validating it first.  The regex is
+# deliberately narrow: match the edge type vocabulary in ``docs/schema.md``.
+_EDGE_TYPE_REGEX: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+
+# Node super-label and relationship "kind" property names.
+_ENTITY_LABEL: Final[str] = "Entity"
+_REL_TYPE_KEY: Final[str] = "edge_type"
+
+# The canonical workspace predicate.  Used both as a runtime parameter
+# key and as the substring the import-time regression guard looks for.
+_WORKSPACE_PARAM: Final[str] = "workspace_id"
+
+# Parameter name for the non-authoritative "actor" tenant_id in writes.
+# Intentionally identical to the read-path predicate to keep the mental
+# model single-threaded.
+_WRITE_WORKSPACE_PARAM: Final[str] = "workspace_id"
+
+
+# --- Bootstrap DDL ---------------------------------------------------------
+
+_BOOTSTRAP_STATEMENTS: Final[tuple[str, ...]] = (
+    # Composite uniqueness including workspace_id — same source id across
+    # workspaces must not collide.  (ADR-0005 §Schema.)
+    f"CREATE CONSTRAINT entity_workspace_id_unique IF NOT EXISTS "
+    f"FOR (n:{_ENTITY_LABEL}) REQUIRE (n.workspace_id, n.id) IS UNIQUE",
+    # Index-backed workspace predicates so the ACL filter is cheap.
+    f"CREATE INDEX entity_workspace_kind IF NOT EXISTS "
+    f"FOR (n:{_ENTITY_LABEL}) ON (n.workspace_id, n.kind)",
+    f"CREATE INDEX entity_workspace_name IF NOT EXISTS "
+    f"FOR (n:{_ENTITY_LABEL}) ON (n.workspace_id, n.name)",
+    f"CREATE INDEX entity_source_id IF NOT EXISTS FOR (n:{_ENTITY_LABEL}) ON (n.source_id)",
+    # Edges: workspace_id is property on the relationship too.  Neo4j 5.x
+    # supports relationship property indexes.
+    "CREATE INDEX edge_workspace_id IF NOT EXISTS FOR ()-[r]-() ON (r.workspace_id)",
+    "CREATE INDEX edge_source_id IF NOT EXISTS FOR ()-[r]-() ON (r.source_id)",
+)
+
+
+# --- Write queries ---------------------------------------------------------
+
+_UPSERT_ENTITY_CYPHER: Final[str] = f"""
+MERGE (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id, id: $id}})
+ON CREATE SET
+    n.source_id = $source_id,
+    n.kind = $entity_type,
+    n.name = $name,
+    n.display_name = $display_name,
+    n.chunk_id = $chunk_id,
+    n.metadata = $metadata,
+    n.created_at = $now,
+    n.updated_at = $now
+ON MATCH SET
+    n.source_id = $source_id,
+    n.kind = $entity_type,
+    n.name = $name,
+    n.display_name = $display_name,
+    n.chunk_id = $chunk_id,
+    n.metadata = $metadata,
+    n.updated_at = $now
+"""
+
+_UPSERT_EDGE_CYPHER_TEMPLATE: Final[str] = f"""
+MATCH (a:{_ENTITY_LABEL} {{workspace_id: $workspace_id, id: $source_id_ent}})
+MATCH (b:{_ENTITY_LABEL} {{workspace_id: $workspace_id, id: $target_id_ent}})
+MERGE (a)-[r:`{{edge_type}}` {{workspace_id: $workspace_id}}]->(b)
+ON CREATE SET
+    r.source_id = $source_id,
+    r.metadata = $metadata,
+    r.edge_type = $edge_type,
+    r.created_at = $now,
+    r.updated_at = $now
+ON MATCH SET
+    r.source_id = $source_id,
+    r.metadata = $metadata,
+    r.updated_at = $now
+"""
+
+# Batch-replace entities+edges for a single source.  Mirrors the
+# pgvector ``IndexWriter.upsert_graph`` semantics: deleting by
+# source_id purges both entities and their incident edges via
+# DETACH DELETE.
+_DELETE_BY_SOURCE_CYPHER: Final[str] = f"""
+MATCH (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id, source_id: $source_id}})
+DETACH DELETE n
+"""
+
+# delete_tombstoned: entities marked tombstoned by the ingestion layer.
+# Mirrors the pgvector no-op contract but is a real operation here —
+# Neo4j has no cascade from a Postgres source row, so proactive cleanup
+# is required when a document is tombstoned.
+_DELETE_TOMBSTONED_CYPHER: Final[str] = f"""
+MATCH (n:{_ENTITY_LABEL})
+WHERE n.tombstoned_at IS NOT NULL
+DETACH DELETE n
+RETURN count(n) AS deleted
+"""
+
+
+# --- Read queries ----------------------------------------------------------
+
+_GET_ENTITY_BY_NAME_CYPHER: Final[str] = f"""
+MATCH (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id, name: $entity_name}})
+RETURN n.name AS name,
+       n.kind AS kind,
+       n.source_id AS source_id,
+       n.chunk_text AS chunk_text
+LIMIT 1
+"""
+
+# Traversal with optional edge-type filter.  Parametrising the max_depth
+# requires string interpolation because Cypher's variable-length pattern
+# syntax does not accept parameters for the depth.  We clamp the value
+# before interpolation via ``_clamp_depth`` and reject anything
+# non-integer upstream.
+_TRAVERSE_CYPHER_TEMPLATE: Final[str] = (
+    "MATCH (seed:" + _ENTITY_LABEL + " {workspace_id: $workspace_id, name: $entity_name})\n"
+    "OPTIONAL MATCH path = (seed)-[rels*1..__MAX_DEPTH__]-(neighbour:" + _ENTITY_LABEL + ")\n"
+    "WHERE ALL(r IN rels WHERE r.workspace_id = $workspace_id__EDGE_TYPE_FILTER__)\n"
+    "  AND neighbour.workspace_id = $workspace_id\n"
+    "  AND neighbour <> seed\n"
+    "WITH seed, neighbour, rels, length(path) AS depth\n"
+    "RETURN\n"
+    "    seed.name AS seed_name,\n"
+    "    seed.kind AS seed_kind,\n"
+    "    seed.source_id AS seed_source_id,\n"
+    "    seed.chunk_text AS seed_chunk_text,\n"
+    "    collect(CASE WHEN neighbour IS NULL THEN NULL ELSE {\n"
+    "        name: neighbour.name,\n"
+    "        kind: neighbour.kind,\n"
+    "        source_id: neighbour.source_id,\n"
+    "        chunk_text: neighbour.chunk_text,\n"
+    "        depth: depth,\n"
+    "        edge_type: rels[-1].edge_type\n"
+    "    } END) AS neighbours,\n"
+    "    collect(CASE WHEN rels IS NULL THEN NULL ELSE\n"
+    "        [startNode(last(rels)).name, endNode(last(rels)).name,"
+    " last(rels).edge_type]\n"
+    "    END) AS edges\n"
+)
+
+# Just the seed — used when find_related runs with depth 0 behaviour
+# (entity exists, no neighbours).
+_SEED_ONLY_CYPHER: Final[str] = _GET_ENTITY_BY_NAME_CYPHER
+
+
+# ---------------------------------------------------------------------------
+# Import-time regression guards
+# ---------------------------------------------------------------------------
+
+
+def _ensure_workspace_predicate(cypher: str, label: str) -> str:
+    """Assert that ``cypher`` references the workspace_id predicate.
+
+    Raises :class:`RuntimeError` at import time if a read template has
+    been refactored to drop ``workspace_id``.  Mirrors the SQL-shape
+    regression tests on the pgvector path
+    (``tests/test_graph_workspace_isolation.py``).
+
+    Write-only templates (e.g. ``_DELETE_TOMBSTONED_CYPHER``) are
+    exempted via the ``label`` argument.
+    """
+    if _WORKSPACE_PARAM not in cypher:
+        raise RuntimeError(
+            f"Neo4j Cypher template '{label}' is missing the "
+            f"workspace_id predicate — refusing to load the adapter. "
+            f"This is a hard regression guard for ACL isolation "
+            f"(see ADR-0005 §Consequences and issue #117)."
+        )
+    return cypher
+
+
+# Run the guard at module load.  If any template drops the predicate,
+# importing this module raises and the application fails fast.
+_ensure_workspace_predicate(_UPSERT_ENTITY_CYPHER, "_UPSERT_ENTITY_CYPHER")
+_ensure_workspace_predicate(_UPSERT_EDGE_CYPHER_TEMPLATE, "_UPSERT_EDGE_CYPHER_TEMPLATE")
+_ensure_workspace_predicate(_DELETE_BY_SOURCE_CYPHER, "_DELETE_BY_SOURCE_CYPHER")
+_ensure_workspace_predicate(_GET_ENTITY_BY_NAME_CYPHER, "_GET_ENTITY_BY_NAME_CYPHER")
+_ensure_workspace_predicate(_TRAVERSE_CYPHER_TEMPLATE, "_TRAVERSE_CYPHER_TEMPLATE")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clamp_depth(requested: int, ceiling: int) -> int:
+    """Clamp ``requested`` into ``[1, ceiling]`` — protects the planner."""
+    if requested < 1:
+        return 1
+    if requested > ceiling:
+        return ceiling
+    return requested
+
+
+def _validate_edge_types(edge_types: list[str] | None) -> list[str] | None:
+    """Validate user-supplied edge types against the allowlist regex."""
+    if edge_types is None:
+        return None
+    for value in edge_types:
+        if not _EDGE_TYPE_REGEX.match(value):
+            raise ValueError(f"invalid_edge_type:{value}")
+    return edge_types
+
+
+def _build_traverse_cypher(max_depth: int, edge_types: list[str] | None) -> str:
+    """Render the traversal Cypher with a static (validated) depth bound.
+
+    ``max_depth`` is an integer that has already been clamped by
+    :func:`_clamp_depth`.  ``edge_types`` has been validated by
+    :func:`_validate_edge_types` — both are safe to interpolate.
+    """
+    if edge_types:
+        quoted = ",".join(f"'{et}'" for et in edge_types)
+        filter_clause = f" AND r.edge_type IN [{quoted}]"
+    else:
+        filter_clause = ""
+    rendered = _TRAVERSE_CYPHER_TEMPLATE.replace("__MAX_DEPTH__", str(max_depth))
+    return rendered.replace("__EDGE_TYPE_FILTER__", filter_clause)
+
+
+def _entity_record_to_view(record: dict[str, Any]) -> EntityNodeView:
+    """Build an :class:`EntityNodeView` from a single-row Cypher result."""
+    return EntityNodeView(
+        name=str(record["name"]),
+        kind=str(record["kind"]),
+        source=str(record["source_id"]),
+        chunk_text=record.get("chunk_text"),
+        depth=0,
+        edge_type=None,
+    )
+
+
+def _neighbour_to_view(payload: dict[str, Any]) -> EntityNodeView:
+    """Build a neighbour :class:`EntityNodeView` from collect() output."""
+    return EntityNodeView(
+        name=str(payload["name"]),
+        kind=str(payload["kind"]),
+        source=str(payload["source_id"]),
+        chunk_text=payload.get("chunk_text"),
+        depth=int(payload.get("depth", 1)),
+        edge_type=(str(payload["edge_type"]) if payload.get("edge_type") else None),
+    )
+
+
+def _edge_tuple_to_view(triplet: list[Any]) -> GraphEdgeView:
+    """Build a :class:`GraphEdgeView` from a ``[from, to, edge_type]`` row."""
+    return GraphEdgeView(
+        from_entity=str(triplet[0]),
+        to_entity=str(triplet[1]),
+        edge_type=str(triplet[2]),
+    )
+
+
+def _coerce_metadata(value: Any) -> dict[str, Any]:
+    """Coerce a duck-typed ``metadata`` value into a dict[str, Any]."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        # Re-type explicitly — mypy --strict refuses ``dict`` without params.
+        return {str(k): v for k, v in value.items()}
+    raise TypeError(f"metadata must be dict, got {type(value).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class Neo4jGraphStore:
+    """Neo4j-backed ``GraphStore`` — Phase-2a adapter for issue #104.
+
+    Lifecycle
+    ---------
+    ``__init__`` builds the async driver but does NOT open a connection.
+    Callers MUST invoke :meth:`connect` before the first query so the
+    driver verifies connectivity and the schema bootstrap runs exactly
+    once.  :meth:`close` releases the driver.
+
+    The DI layer (``apps/server/.../app.py``) drives lifecycle inside
+    the FastAPI lifespan context.
+    """
+
+    def __init__(self, *, config: Neo4jStoreConfig) -> None:
+        self._config = config
+        self._driver: AsyncDriver = AsyncGraphDatabase.driver(
+            config.uri,
+            auth=(config.username, config.password),
+            max_connection_pool_size=config.max_connection_pool_size,
+            connection_acquisition_timeout=(config.connection_acquisition_timeout_seconds),
+            max_transaction_retry_time=(config.max_transaction_retry_time_seconds),
+        )
+        self._bootstrapped: bool = False
+
+    async def connect(self) -> None:
+        """Verify connectivity and run the idempotent schema bootstrap."""
+        await self._driver.verify_connectivity()
+        await self._bootstrap_schema()
+        self._bootstrapped = True
+        log.info("neo4j_graph_store_ready", database=self._config.database)
+
+    async def close(self) -> None:
+        """Close the underlying async driver."""
+        await self._driver.close()
+
+    # ------------------------------------------------------------------
+    # Schema bootstrap
+    # ------------------------------------------------------------------
+
+    async def _bootstrap_schema(self) -> None:
+        """Run constraint + index DDL idempotently (ADR-0005 §Schema)."""
+        async with self._driver.session(database=self._config.database) as session:
+            for stmt in _BOOTSTRAP_STATEMENTS:
+                await session.execute_write(_run_write_stmt, stmt, {})
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_graph(
+        self,
+        *,
+        source_id: uuid.UUID,
+        document_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+    ) -> None:
+        """Persist a batch of entities+edges for one document (idempotent).
+
+        ``document_id`` is currently passed for symmetry with the
+        pgvector path; Neo4j keys on ``source_id`` per ADR-0005.  It is
+        kept in the signature to preserve call-site compatibility and
+        is logged for audit.
+        """
+        workspace_id = self._workspace_from_entities(entities)
+        async with self._driver.session(database=self._config.database) as session:
+            await session.execute_write(
+                self._run_upsert_graph,
+                workspace_id,
+                source_id,
+                entities,
+                edges,
+            )
+        log.info(
+            "neo4j_upsert_graph",
+            source_id=str(source_id),
+            document_id=str(document_id),
+            entities=len(entities),
+            edges=len(edges),
+        )
+
+    @staticmethod
+    def _workspace_from_entities(entities: list[Any]) -> uuid.UUID:
+        """Pull workspace_id off the first entity; reject an empty batch.
+
+        The ingestion layer tags each entity with a ``workspace_id``
+        attribute (Phase 2 extension — pre-Phase 2 entities live in the
+        pgvector path).  For the duck-typed parser ``ExtractedEntity``
+        shape which does NOT carry ``workspace_id``, the caller (the
+        ingestion worker) must wrap the batch in an
+        :class:`EntityUpsert`-like object or set
+        ``entity.metadata['workspace_id']``.  See ``upsert_entity``
+        for the single-entity path which pins it at the protocol level.
+        """
+        if not entities:
+            raise ValueError("upsert_graph_empty_batch")
+        head = entities[0]
+        ws = getattr(head, "workspace_id", None)
+        if ws is None:
+            metadata = getattr(head, "metadata", None) or {}
+            ws = metadata.get("workspace_id")
+        if ws is None:
+            raise ValueError("upsert_graph_missing_workspace_id")
+        if isinstance(ws, uuid.UUID):
+            return ws
+        return uuid.UUID(str(ws))
+
+    @staticmethod
+    async def _run_upsert_graph(
+        tx: AsyncManagedTransaction,
+        workspace_id: uuid.UUID,
+        source_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+    ) -> None:
+        """Transaction body for :meth:`upsert_graph` (idempotent replace)."""
+        now = datetime.now(UTC).isoformat()
+        # Replace-by-source: drop old entities (and their edges) for this
+        # source, then re-insert.  Mirrors IndexWriter.upsert_graph.
+        await tx.run(
+            _DELETE_BY_SOURCE_CYPHER,
+            {_WRITE_WORKSPACE_PARAM: str(workspace_id), "source_id": str(source_id)},
+        )
+
+        name_to_id: dict[str, uuid.UUID] = {}
+        for ext_ent in entities:
+            params = _entity_to_params(ext_ent, source_id, workspace_id, now)
+            await tx.run(_UPSERT_ENTITY_CYPHER, params)
+            name_to_id[str(params["name"])] = uuid.UUID(str(params["id"]))
+            display = str(params.get("display_name") or "")
+            if display:
+                name_to_id.setdefault(display, uuid.UUID(str(params["id"])))
+
+        for ext_edge in edges:
+            edge_params = _edge_to_params(ext_edge, source_id, workspace_id, name_to_id, now)
+            if edge_params is None:
+                continue
+            rendered = _UPSERT_EDGE_CYPHER_TEMPLATE.replace(
+                "{edge_type}", str(edge_params["edge_type"])
+            )
+            await tx.run(rendered, edge_params)
+
+    async def upsert_entity(
+        self,
+        *,
+        entity: EntityUpsert,
+        workspace_id: uuid.UUID,
+    ) -> None:
+        """Upsert a single entity within ``workspace_id`` (idempotent)."""
+        now = datetime.now(UTC).isoformat()
+        params: dict[str, Any] = {
+            _WRITE_WORKSPACE_PARAM: str(workspace_id),
+            "id": str(entity.id),
+            "source_id": str(entity.source_id),
+            "entity_type": entity.entity_type,
+            "name": entity.name,
+            "display_name": entity.display_name,
+            "chunk_id": (str(entity.chunk_id) if entity.chunk_id else None),
+            "metadata": _coerce_metadata(entity.metadata),
+            "now": now,
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            await session.execute_write(_run_write_stmt, _UPSERT_ENTITY_CYPHER, params)
+
+    async def upsert_edge(
+        self,
+        *,
+        edge: EdgeUpsert,
+        workspace_id: uuid.UUID,
+    ) -> None:
+        """Upsert a single edge within ``workspace_id`` (idempotent)."""
+        edge_type = edge.edge_type
+        if not _EDGE_TYPE_REGEX.match(edge_type):
+            raise ValueError(f"invalid_edge_type:{edge_type}")
+        now = datetime.now(UTC).isoformat()
+        params: dict[str, Any] = {
+            _WRITE_WORKSPACE_PARAM: str(workspace_id),
+            "source_id_ent": str(edge.source_entity_id),
+            "target_id_ent": str(edge.target_entity_id),
+            "source_id": str(edge.metadata.get("source_id") or ""),
+            "edge_type": edge_type,
+            "metadata": _coerce_metadata(edge.metadata),
+            "now": now,
+        }
+        rendered = _UPSERT_EDGE_CYPHER_TEMPLATE.replace("{edge_type}", edge_type)
+        async with self._driver.session(database=self._config.database) as session:
+            await session.execute_write(_run_write_stmt, rendered, params)
+
+    async def delete_tombstoned(self) -> int:
+        """Hard-delete tombstoned entities; return the count removed."""
+        async with self._driver.session(database=self._config.database) as session:
+            rows = await session.execute_write(_run_write_returning, _DELETE_TOMBSTONED_CYPHER, {})
+        if not rows:
+            return 0
+        return int(rows[0].get("deleted", 0))
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+    ) -> EntityNodeView | None:
+        """Resolve an entity by fully-qualified name, within workspace."""
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "entity_name": entity_name,
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            rows = await session.execute_read(_run_read_stmt, _GET_ENTITY_BY_NAME_CYPHER, params)
+        if not rows:
+            return None
+        return _entity_record_to_view(rows[0])
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        """BFS traversal from a seed, scoped to ``workspace_id``.
+
+        Raises ``ValueError("entity_not_found:<name>")`` when the seed
+        does not exist in the caller's workspace — matches the pgvector
+        contract exactly so callers do not branch on backend.
+        """
+        clamped = _clamp_depth(max_depth, _MAX_DEPTH_CEILING)
+        validated_types = _validate_edge_types(edge_types)
+        cypher = _build_traverse_cypher(clamped, validated_types)
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "entity_name": entity_name,
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            rows = await session.execute_read(_run_read_stmt, cypher, params)
+
+        if not rows:
+            # Seed absent — indistinguishable from cross-workspace.
+            raise ValueError(f"entity_not_found:{entity_name}")
+        return _rows_to_graph_result(rows[0])
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        """Alias of :meth:`find_related` per the protocol contract."""
+        return await self.find_related(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Transaction-runner helpers (module-level to keep Neo4jGraphStore short)
+# ---------------------------------------------------------------------------
+
+
+async def _run_write_stmt(
+    tx: AsyncManagedTransaction,
+    cypher: str,
+    params: dict[str, Any],
+) -> None:
+    """Run a single write statement inside a managed transaction."""
+    await tx.run(cypher, params)
+
+
+async def _run_write_returning(
+    tx: AsyncManagedTransaction,
+    cypher: str,
+    params: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Run a write statement and materialise its result rows."""
+    result = await tx.run(cypher, params)
+    return [record.data() async for record in result]
+
+
+async def _run_read_stmt(
+    tx: AsyncManagedTransaction,
+    cypher: str,
+    params: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Run a read statement and materialise its result rows."""
+    result = await tx.run(cypher, params)
+    return [record.data() async for record in result]
+
+
+def _entity_to_params(
+    ext_ent: Any,
+    source_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+    now: str,
+) -> dict[str, Any]:
+    """Build the parameter map for :data:`_UPSERT_ENTITY_CYPHER`.
+
+    Duck-types over :class:`EntityUpsert` **and** the parser's
+    ``ExtractedEntity`` shape — both are accepted via ``upsert_graph``.
+    """
+    entity_id = getattr(ext_ent, "id", None)
+    if entity_id is None:
+        raise ValueError("entity_missing_id")
+    chunk_id = getattr(ext_ent, "chunk_id", None)
+    return {
+        _WRITE_WORKSPACE_PARAM: str(workspace_id),
+        "id": str(entity_id),
+        "source_id": str(source_id),
+        "entity_type": str(getattr(ext_ent, "entity_type", "")),
+        "name": str(getattr(ext_ent, "name", "")),
+        "display_name": str(getattr(ext_ent, "display_name", "")),
+        "chunk_id": str(chunk_id) if chunk_id else None,
+        "metadata": _coerce_metadata(getattr(ext_ent, "metadata", None)),
+        "now": now,
+    }
+
+
+def _edge_to_params(
+    ext_edge: Any,
+    source_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+    name_to_id: dict[str, uuid.UUID],
+    now: str,
+) -> dict[str, Any] | None:
+    """Build the parameter map for :data:`_UPSERT_EDGE_CYPHER_TEMPLATE`.
+
+    Returns ``None`` when the edge's target cannot be resolved in the
+    current batch — mirrors :meth:`IndexWriter.upsert_graph`, which
+    skips unresolvable cross-file edges for later passes.
+    """
+    source_entity_id = getattr(ext_edge, "source_entity_id", None)
+    target_name = getattr(ext_edge, "target_name", None)
+    target_entity_id = getattr(ext_edge, "target_entity_id", None)
+
+    if target_entity_id is None and target_name is not None:
+        target_entity_id = name_to_id.get(str(target_name))
+
+    if source_entity_id is None or target_entity_id is None:
+        return None
+    if source_entity_id == target_entity_id:
+        return None  # skip self-loops (parity with pgvector writer)
+
+    edge_type = str(getattr(ext_edge, "edge_type", ""))
+    if not _EDGE_TYPE_REGEX.match(edge_type):
+        raise ValueError(f"invalid_edge_type:{edge_type}")
+
+    return {
+        _WRITE_WORKSPACE_PARAM: str(workspace_id),
+        "source_id_ent": str(source_entity_id),
+        "target_id_ent": str(target_entity_id),
+        "source_id": str(source_id),
+        "edge_type": edge_type,
+        "metadata": _coerce_metadata(getattr(ext_edge, "metadata", None)),
+        "now": now,
+    }
+
+
+def _rows_to_graph_result(row: dict[str, Any]) -> GraphResultView:
+    """Assemble a :class:`GraphResultView` from a single traversal row."""
+    seed = EntityNodeView(
+        name=str(row["seed_name"]),
+        kind=str(row["seed_kind"]),
+        source=str(row["seed_source_id"]),
+        chunk_text=row.get("seed_chunk_text"),
+        depth=0,
+        edge_type=None,
+    )
+    related_raw = row.get("neighbours") or []
+    related = [_neighbour_to_view(n) for n in related_raw if n and n.get("name")]
+    edges_raw = row.get("edges") or []
+    edges = [_edge_tuple_to_view(e) for e in edges_raw if e and len(e) == 3 and e[0] and e[1]]
+    return GraphResultView(seed=seed, related=related, edges=edges)
+
+
+__all__ = [
+    "Neo4jGraphStore",
+    "Neo4jStoreConfig",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "rich>=13.7.0",
     "moto>=5.1.22",
     "boto3-stubs[s3]>=1.42.91",
+    "testcontainers[neo4j]>=4.7.0",
 ]
 
 [tool.ruff]

--- a/tests/test_graph_store_contract.py
+++ b/tests/test_graph_store_contract.py
@@ -1,0 +1,323 @@
+"""Parametric ``GraphStore`` contract tests — shared across all backends.
+
+This module defines the behavioural contract that every
+``omniscience_core.storage.GraphStore`` implementation must satisfy.
+Tests are parametrised over backends and skipped when that backend's
+live dependency (Docker / Neo4j container) is not available in the test
+environment.
+
+Design
+------
+
+- **pgvector**: parametrised via an in-memory fake adapter that proxies
+  to the existing isolation fixture from
+  ``tests.test_graph_workspace_isolation``.  No real Postgres is started.
+- **neo4j**: uses ``testcontainers[neo4j]`` to spin up a Neo4j 5.x
+  Community Edition container per test session.  The container is
+  expensive so each test re-uses the same instance; each test provisions
+  a fresh database namespace via workspace_id scoping.
+
+Rationale
+---------
+
+ADR-0005 §Schema mandates the Neo4j adapter implements the exact
+``GraphStore`` protocol the pgvector adapter implements, so that the
+retrieval layer can swap backends behind a feature flag with zero code
+change.  This parametric suite is the regression fence for that
+guarantee — any behavioural drift between the two backends fails here.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import pytest
+from omniscience_core.storage.graph import (
+    EdgeUpsert,
+    EntityUpsert,
+    GraphStore,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+_WORKSPACE_A = uuid.UUID("aaaaaaaa-0000-0000-0000-0000000000a1")
+_WORKSPACE_B = uuid.UUID("bbbbbbbb-0000-0000-0000-0000000000b2")
+
+
+# ---------------------------------------------------------------------------
+# Backend discovery
+# ---------------------------------------------------------------------------
+
+
+def _neo4j_available() -> bool:
+    """True iff testcontainers + Docker are available.
+
+    Controlled via env var ``OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`` —
+    opt-in so CI without Docker does not slow down on image pulls.
+    """
+    if os.environ.get("OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS", "0") != "1":
+        return False
+    try:
+        import testcontainers.neo4j  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _pgvector_factory() -> Callable[[], AsyncIterator[GraphStore]]:
+    """Factory for the pgvector adapter fed by an in-memory fake session.
+
+    Reuses the ``_FakeSession`` pattern from
+    :mod:`tests.test_graph_workspace_isolation` so we do not need a real
+    Postgres instance for the contract fence.
+    """
+    from omniscience_retrieval.adapters import PgVectorGraphStore
+
+    from tests.test_graph_workspace_isolation import (
+        _build_fixture,
+        _session_factory,
+    )
+
+    async def _factory() -> AsyncIterator[GraphStore]:
+        fx = _build_fixture()
+        store = PgVectorGraphStore(session_factory=_session_factory(fx))
+        yield store
+
+    return _factory
+
+
+def _neo4j_factory() -> Callable[[], AsyncIterator[GraphStore]]:
+    """Factory that spins up a Neo4j testcontainer per test."""
+    from omniscience_index.stores.neo4j_store import (
+        Neo4jGraphStore,
+        Neo4jStoreConfig,
+    )
+    from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
+
+    async def _factory() -> AsyncIterator[GraphStore]:
+        with Neo4jContainer("neo4j:5.19-community").with_env(
+            "NEO4J_AUTH", "neo4j/contract_test_password"
+        ) as neo4j:
+            config = Neo4jStoreConfig(
+                uri=neo4j.get_connection_url(),
+                username="neo4j",
+                password="contract_test_password",
+                database="neo4j",
+                max_connection_pool_size=5,
+                connection_acquisition_timeout_seconds=30.0,
+                max_transaction_retry_time_seconds=15.0,
+                default_max_depth=3,
+            )
+            store = Neo4jGraphStore(config=config)
+            await store.connect()
+            try:
+                # Hydrate the Neo4j graph with the same two-workspace fixture
+                # the pgvector backend gets by reusing the write API.
+                await _seed_neo4j_with_fixture(store)
+                yield store
+            finally:
+                await store.close()
+
+    return _factory
+
+
+async def _seed_neo4j_with_fixture(store: Any) -> None:
+    """Populate a fresh Neo4j with the two-workspace contract fixture.
+
+    Mirrors the pgvector ``_build_fixture()`` — two entities named
+    ``svc.shared`` (one per workspace), each pointing to a workspace-
+    local neighbour via a ``calls`` edge, plus a planted cross-tenant
+    edge to verify isolation.
+    """
+    a_shared = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.shared",
+        display_name="shared",
+        chunk_id=None,
+    )
+    a_internal = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.internal-a",
+        display_name="internal-a",
+        chunk_id=None,
+    )
+    b_shared = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.shared",
+        display_name="shared",
+        chunk_id=None,
+    )
+    b_internal = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.internal-b",
+        display_name="internal-b",
+        chunk_id=None,
+    )
+
+    await store.upsert_entity(entity=a_shared, workspace_id=_WORKSPACE_A)
+    await store.upsert_entity(entity=a_internal, workspace_id=_WORKSPACE_A)
+    await store.upsert_entity(entity=b_shared, workspace_id=_WORKSPACE_B)
+    await store.upsert_entity(entity=b_internal, workspace_id=_WORKSPACE_B)
+
+    await store.upsert_edge(
+        edge=EdgeUpsert(
+            source_entity_id=a_shared.id,
+            target_entity_id=a_internal.id,
+            edge_type="calls",
+        ),
+        workspace_id=_WORKSPACE_A,
+    )
+    await store.upsert_edge(
+        edge=EdgeUpsert(
+            source_entity_id=b_shared.id,
+            target_entity_id=b_internal.id,
+            edge_type="calls",
+        ),
+        workspace_id=_WORKSPACE_B,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parametrisation
+# ---------------------------------------------------------------------------
+
+
+_BACKENDS: list[tuple[str, Callable[[], Callable[[], AsyncIterator[GraphStore]]]]] = [
+    ("pgvector", _pgvector_factory),
+]
+
+if _neo4j_available():
+    _BACKENDS.append(("neo4j", _neo4j_factory))
+
+
+@pytest.fixture(
+    params=[pytest.param(name, id=name) for name, _ in _BACKENDS],
+)
+async def graph_store(request: pytest.FixtureRequest) -> AsyncIterator[GraphStore]:
+    """Yield a ready ``GraphStore`` for the parametrised backend."""
+    name = str(request.param)
+    factory_builder = next(f for n, f in _BACKENDS if n == name)
+    factory = factory_builder()
+    gen = factory()
+    store = await anext(gen)
+    try:
+        yield store
+    finally:
+        # Drain the async generator so teardown (e.g. closing the Neo4j
+        # container) runs.
+        async for _ in gen:
+            break
+
+
+# ---------------------------------------------------------------------------
+# Contract: read methods require workspace_id keyword-only
+# ---------------------------------------------------------------------------
+
+
+async def test_get_entity_requires_workspace_id_keyword_only(
+    graph_store: GraphStore,
+) -> None:
+    """Protocol invariant — positional workspace_id is a TypeError."""
+    with pytest.raises(TypeError):
+        await graph_store.get_entity("svc.shared", _WORKSPACE_A)  # type: ignore[misc]
+
+
+async def test_find_related_requires_workspace_id_keyword_only(
+    graph_store: GraphStore,
+) -> None:
+    with pytest.raises(TypeError):
+        await graph_store.find_related("svc.shared", _WORKSPACE_A)  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Contract: workspace scoping on reads
+# ---------------------------------------------------------------------------
+
+
+async def test_find_related_workspace_a_never_sees_workspace_b(
+    graph_store: GraphStore,
+) -> None:
+    """Cross-workspace isolation contract — parametric across backends."""
+    result = await graph_store.find_related(
+        entity_name="svc.shared",
+        workspace_id=_WORKSPACE_A,
+        max_depth=2,
+    )
+
+    names = {result.seed.name, *(n.name for n in result.related)}
+    assert "svc.internal-b" not in names, "Workspace-A traversal leaked workspace-B entity"
+    for e in result.edges:
+        assert "svc.internal-b" not in (e.from_entity, e.to_entity), (
+            "Workspace-A traversal leaked an edge endpoint in workspace B"
+        )
+
+
+async def test_find_related_workspace_b_never_sees_workspace_a(
+    graph_store: GraphStore,
+) -> None:
+    result = await graph_store.find_related(
+        entity_name="svc.shared",
+        workspace_id=_WORKSPACE_B,
+        max_depth=2,
+    )
+
+    names = {result.seed.name, *(n.name for n in result.related)}
+    assert "svc.internal-a" not in names
+    for e in result.edges:
+        assert "svc.internal-a" not in (e.from_entity, e.to_entity)
+
+
+async def test_traverse_is_alias_of_find_related(
+    graph_store: GraphStore,
+) -> None:
+    """``traverse`` must return the same shape as ``find_related``."""
+    via_find = await graph_store.find_related(
+        entity_name="svc.shared",
+        workspace_id=_WORKSPACE_A,
+        max_depth=1,
+    )
+    via_traverse = await graph_store.traverse(
+        entity_name="svc.shared",
+        workspace_id=_WORKSPACE_A,
+        max_depth=1,
+    )
+    assert via_find.seed.name == via_traverse.seed.name
+
+
+async def test_find_related_raises_entity_not_found_cross_workspace(
+    graph_store: GraphStore,
+) -> None:
+    """Requesting a B-only entity from A looks like 404 on both backends."""
+    # ``svc.internal-b`` only exists in workspace B.  Asking for it from
+    # A must raise the not-found ValueError — never leak existence.
+    with pytest.raises(ValueError, match=r"entity_not_found:svc\.internal-b"):
+        await graph_store.find_related(
+            entity_name="svc.internal-b",
+            workspace_id=_WORKSPACE_A,
+            max_depth=1,
+        )
+
+
+async def test_get_entity_returns_none_for_cross_workspace(
+    graph_store: GraphStore,
+) -> None:
+    """``get_entity`` returns None — NEVER leaks existence across workspaces."""
+    # ``svc.internal-a`` only in A.  Asking from B -> None.
+    result = await graph_store.get_entity(
+        entity_name="svc.internal-a",
+        workspace_id=_WORKSPACE_B,
+    )
+    assert result is None

--- a/tests/test_neo4j_store.py
+++ b/tests/test_neo4j_store.py
@@ -1,0 +1,547 @@
+"""Unit tests for :class:`Neo4jGraphStore` (issue #104, Phase 2a of epic #96).
+
+Focus
+-----
+
+1.  **ACL invariant at the Cypher level.** Every read template in the
+    adapter MUST reference ``workspace_id``.  Enforced by a regression
+    guard over the module's Cypher templates — this is the lint-style
+    rule ADR-0005 §Consequences mandates.
+
+2.  **Workspace_id is propagated into every query.** The adapter wraps
+    the official ``neo4j.AsyncDriver``; we patch the driver and inspect
+    the params of every ``tx.run()`` call to assert ``workspace_id`` is
+    present.
+
+3.  **Depth clamping + edge-type validation.** The planner must be
+    protected from user-supplied huge depths and injection attempts via
+    the edge-type allowlist.
+
+4.  **Idempotent MERGE semantics** in the write Cypher (string-level
+    assertion that ``ON CREATE SET`` and ``ON MATCH SET`` both appear).
+
+Contract tests that exercise a real Neo4j (via ``testcontainers-neo4j``)
+live in :mod:`tests.test_graph_store_contract` and
+:mod:`tests.test_graph_workspace_isolation_neo4j` — they are skipped
+when Docker is unavailable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from omniscience_core.storage.graph import (
+    EdgeUpsert,
+    EntityUpsert,
+    GraphStore,
+)
+from omniscience_index.stores import neo4j_store
+from omniscience_index.stores.neo4j_store import (
+    Neo4jGraphStore,
+    Neo4jStoreConfig,
+    _build_traverse_cypher,
+    _clamp_depth,
+    _ensure_workspace_predicate,
+    _validate_edge_types,
+)
+
+_WORKSPACE_A = uuid.UUID("aaaaaaaa-0000-0000-0000-0000000000a1")
+_WORKSPACE_B = uuid.UUID("bbbbbbbb-0000-0000-0000-0000000000b2")
+
+
+# ---------------------------------------------------------------------------
+# Config + fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> Neo4jStoreConfig:
+    return Neo4jStoreConfig(
+        uri="bolt://neo4j-fake:7687",
+        username="neo4j",
+        password="placeholder",
+        database="neo4j",
+        max_connection_pool_size=10,
+        connection_acquisition_timeout_seconds=5.0,
+        max_transaction_retry_time_seconds=5.0,
+        default_max_depth=3,
+    )
+
+
+def _make_store_with_mock_driver() -> tuple[Neo4jGraphStore, MagicMock]:
+    """Build a store whose async driver is mocked in place.
+
+    Returns (store, mock_driver).  The mock driver exposes
+    ``session(...).execute_read`` / ``.execute_write`` as AsyncMocks so
+    unit tests can inspect what the adapter would send to Neo4j.
+    """
+    config = _make_config()
+
+    driver_mock = MagicMock()
+    driver_mock.verify_connectivity = AsyncMock(return_value=None)
+    driver_mock.close = AsyncMock(return_value=None)
+
+    session_ctx = MagicMock()
+    session_mock = MagicMock()
+    session_mock.execute_read = AsyncMock(return_value=[])
+    session_mock.execute_write = AsyncMock(return_value=None)
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=None)
+    driver_mock.session = MagicMock(return_value=session_ctx)
+
+    with patch(
+        "omniscience_index.stores.neo4j_store.AsyncGraphDatabase.driver",
+        return_value=driver_mock,
+    ):
+        store = Neo4jGraphStore(config=config)
+
+    # Expose the session-level mock for assertions.
+    driver_mock._session_mock = session_mock
+    return store, driver_mock
+
+
+# ---------------------------------------------------------------------------
+# 1. ACL regression guards — Cypher template level
+# ---------------------------------------------------------------------------
+
+
+def test_every_read_template_references_workspace_id() -> None:
+    """Lint-style guard: no read Cypher may omit ``workspace_id``."""
+    templates = {
+        "_GET_ENTITY_BY_NAME_CYPHER": neo4j_store._GET_ENTITY_BY_NAME_CYPHER,
+        "_TRAVERSE_CYPHER_TEMPLATE": neo4j_store._TRAVERSE_CYPHER_TEMPLATE,
+    }
+    for name, cypher in templates.items():
+        assert "workspace_id" in cypher, f"Read template {name} lost workspace_id predicate"
+
+
+def test_every_write_template_references_workspace_id() -> None:
+    """Writes also pin workspace_id — the MERGE key is composite."""
+    templates = {
+        "_UPSERT_ENTITY_CYPHER": neo4j_store._UPSERT_ENTITY_CYPHER,
+        "_UPSERT_EDGE_CYPHER_TEMPLATE": neo4j_store._UPSERT_EDGE_CYPHER_TEMPLATE,
+        "_DELETE_BY_SOURCE_CYPHER": neo4j_store._DELETE_BY_SOURCE_CYPHER,
+    }
+    for name, cypher in templates.items():
+        assert "workspace_id" in cypher, f"Write template {name} lost workspace_id predicate"
+
+
+def test_ensure_workspace_predicate_raises_on_missing() -> None:
+    """The import-time guard rejects Cypher without the predicate."""
+    with pytest.raises(RuntimeError, match="workspace_id"):
+        _ensure_workspace_predicate("MATCH (n) RETURN n", "bogus_template")
+
+
+def test_ensure_workspace_predicate_accepts_when_present() -> None:
+    _ensure_workspace_predicate("MATCH (n {workspace_id: $workspace_id}) RETURN n", "ok")
+
+
+# ---------------------------------------------------------------------------
+# 2. Helpers: depth clamp + edge-type validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("requested", "ceiling", "expected"),
+    [
+        (0, 6, 1),  # <1 clamps up
+        (-5, 6, 1),  # negative clamps up
+        (1, 6, 1),
+        (3, 6, 3),
+        (6, 6, 6),
+        (100, 6, 6),  # >ceiling clamps down
+    ],
+)
+def test_clamp_depth(requested: int, ceiling: int, expected: int) -> None:
+    assert _clamp_depth(requested, ceiling) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_type",
+    [
+        "CALLS; DROP CONSTRAINT foo",  # Cypher injection attempt
+        "foo-bar",  # hyphens rejected
+        "foo bar",  # whitespace rejected
+        "1_leading_digit",  # leading digit rejected
+        "",  # empty rejected
+        "`CALLS`",  # backtick rejected
+    ],
+)
+def test_validate_edge_types_rejects_unsafe(bad_type: str) -> None:
+    with pytest.raises(ValueError, match="invalid_edge_type"):
+        _validate_edge_types([bad_type])
+
+
+@pytest.mark.parametrize(
+    "ok_type",
+    ["CALLS", "depends_on", "DEPLOYED_BY", "CROSS_REF", "A1_b"],
+)
+def test_validate_edge_types_accepts_allowlist(ok_type: str) -> None:
+    result = _validate_edge_types([ok_type])
+    assert result == [ok_type]
+
+
+def test_validate_edge_types_none_passthrough() -> None:
+    assert _validate_edge_types(None) is None
+
+
+def test_build_traverse_cypher_injects_clamped_depth() -> None:
+    cypher = _build_traverse_cypher(max_depth=3, edge_types=None)
+    assert "rels*1..3" in cypher
+    # No filter clause when edge_types is None
+    assert "r.edge_type IN" not in cypher
+
+
+def test_build_traverse_cypher_emits_filter_when_types_provided() -> None:
+    cypher = _build_traverse_cypher(max_depth=2, edge_types=["CALLS", "DEPENDS_ON"])
+    assert "r.edge_type IN ['CALLS','DEPENDS_ON']" in cypher
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotent MERGE assertions
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_entity_cypher_is_idempotent_merge() -> None:
+    text = neo4j_store._UPSERT_ENTITY_CYPHER
+    assert "MERGE" in text
+    assert "ON CREATE SET" in text
+    assert "ON MATCH SET" in text
+
+
+def test_upsert_edge_cypher_is_idempotent_merge() -> None:
+    text = neo4j_store._UPSERT_EDGE_CYPHER_TEMPLATE
+    assert "MERGE" in text
+    assert "ON CREATE SET" in text
+    assert "ON MATCH SET" in text
+
+
+# ---------------------------------------------------------------------------
+# 4. Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_neo4j_store_is_runtime_graph_store() -> None:
+    """Runtime isinstance check against the protocol."""
+    store, _ = _make_store_with_mock_driver()
+    assert isinstance(store, GraphStore)
+
+
+# ---------------------------------------------------------------------------
+# 5. Workspace_id propagation — read API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_entity_passes_workspace_id_to_cypher() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    session_mock = driver_mock._session_mock
+
+    # session.execute_read receives (func, cypher, params); return [] to signal
+    # "entity not found".
+    session_mock.execute_read = AsyncMock(return_value=[])
+
+    await store.get_entity(entity_name="svc.auth", workspace_id=_WORKSPACE_A)
+
+    session_mock.execute_read.assert_awaited()
+    args, _ = session_mock.execute_read.call_args
+    # Signature: (_run_read_stmt, cypher, params)
+    cypher = args[1]
+    params = args[2]
+    assert "workspace_id" in cypher
+    assert params["workspace_id"] == str(_WORKSPACE_A)
+    assert params["entity_name"] == "svc.auth"
+
+
+@pytest.mark.asyncio
+async def test_get_entity_returns_none_when_no_rows() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    driver_mock._session_mock.execute_read = AsyncMock(return_value=[])
+
+    result = await store.get_entity(entity_name="missing", workspace_id=_WORKSPACE_A)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_entity_returns_view_when_row_present() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    source_uuid = uuid.uuid4()
+    driver_mock._session_mock.execute_read = AsyncMock(
+        return_value=[
+            {
+                "name": "svc.auth",
+                "kind": "service",
+                "source_id": str(source_uuid),
+                "chunk_text": "body",
+            }
+        ]
+    )
+
+    result = await store.get_entity(entity_name="svc.auth", workspace_id=_WORKSPACE_A)
+
+    assert result is not None
+    assert result.name == "svc.auth"
+    assert result.kind == "service"
+    assert result.source == str(source_uuid)
+
+
+@pytest.mark.asyncio
+async def test_find_related_raises_when_seed_missing() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    driver_mock._session_mock.execute_read = AsyncMock(return_value=[])
+
+    with pytest.raises(ValueError, match=r"entity_not_found:svc\.missing"):
+        await store.find_related(
+            entity_name="svc.missing",
+            workspace_id=_WORKSPACE_A,
+            max_depth=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_find_related_passes_workspace_id_and_clamps_depth() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+
+    # Seed row with no neighbours (empty collect).
+    driver_mock._session_mock.execute_read = AsyncMock(
+        return_value=[
+            {
+                "seed_name": "svc.auth",
+                "seed_kind": "service",
+                "seed_source_id": str(uuid.uuid4()),
+                "seed_chunk_text": None,
+                "neighbours": [],
+                "edges": [],
+            }
+        ]
+    )
+
+    result = await store.find_related(
+        entity_name="svc.auth",
+        workspace_id=_WORKSPACE_A,
+        max_depth=999,  # Should clamp to ceiling (6)
+        edge_types=["CALLS"],
+    )
+
+    args, _ = driver_mock._session_mock.execute_read.call_args
+    cypher = args[1]
+    params = args[2]
+    assert "workspace_id" in cypher
+    assert params["workspace_id"] == str(_WORKSPACE_A)
+    assert "rels*1..6" in cypher  # clamped
+    assert "r.edge_type IN ['CALLS']" in cypher
+    assert result.seed.name == "svc.auth"
+    assert result.related == []
+
+
+@pytest.mark.asyncio
+async def test_find_related_rejects_injection_in_edge_types() -> None:
+    store, _driver_mock = _make_store_with_mock_driver()
+
+    with pytest.raises(ValueError, match="invalid_edge_type"):
+        await store.find_related(
+            entity_name="svc.auth",
+            workspace_id=_WORKSPACE_A,
+            max_depth=1,
+            edge_types=["CALLS; MATCH (n) DETACH DELETE n //"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Workspace_id propagation — write API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_entity_passes_workspace_id() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    payload = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.auth",
+        display_name="auth",
+        chunk_id=None,
+    )
+
+    await store.upsert_entity(entity=payload, workspace_id=_WORKSPACE_A)
+
+    args, _ = driver_mock._session_mock.execute_write.call_args
+    cypher = args[1]
+    params = args[2]
+    assert "workspace_id" in cypher
+    assert params["workspace_id"] == str(_WORKSPACE_A)
+    assert params["id"] == str(payload.id)
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_passes_workspace_id() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    payload = EdgeUpsert(
+        source_entity_id=uuid.uuid4(),
+        target_entity_id=uuid.uuid4(),
+        edge_type="CALLS",
+    )
+
+    await store.upsert_edge(edge=payload, workspace_id=_WORKSPACE_A)
+
+    args, _ = driver_mock._session_mock.execute_write.call_args
+    cypher = args[1]
+    params = args[2]
+    assert "workspace_id" in cypher
+    assert params["workspace_id"] == str(_WORKSPACE_A)
+
+
+@pytest.mark.asyncio
+async def test_upsert_edge_rejects_invalid_edge_type() -> None:
+    store, _driver_mock = _make_store_with_mock_driver()
+    bad = EdgeUpsert(
+        source_entity_id=uuid.uuid4(),
+        target_entity_id=uuid.uuid4(),
+        edge_type="CALLS; DROP CONSTRAINT foo",
+    )
+    with pytest.raises(ValueError, match="invalid_edge_type"):
+        await store.upsert_edge(edge=bad, workspace_id=_WORKSPACE_A)
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstoned_returns_count() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    driver_mock._session_mock.execute_write = AsyncMock(return_value=[{"deleted": 7}])
+
+    count = await store.delete_tombstoned()
+
+    assert count == 7
+
+
+@pytest.mark.asyncio
+async def test_delete_tombstoned_returns_zero_when_empty() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    driver_mock._session_mock.execute_write = AsyncMock(return_value=[])
+
+    assert await store.delete_tombstoned() == 0
+
+
+# ---------------------------------------------------------------------------
+# 7. upsert_graph: replace-by-source semantics + workspace derivation
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntity:
+    """Duck-typed parser-style entity carrying a workspace_id attribute."""
+
+    def __init__(self, *, workspace_id: uuid.UUID, name: str) -> None:
+        self.id = uuid.uuid4()
+        self.source_id = uuid.uuid4()
+        self.workspace_id = workspace_id
+        self.entity_type = "service"
+        self.name = name
+        self.display_name = name.split(".")[-1]
+        self.chunk_id: uuid.UUID | None = None
+        self.metadata: dict[str, Any] = {}
+
+
+@pytest.mark.asyncio
+async def test_upsert_graph_rejects_empty_batch() -> None:
+    store, _driver_mock = _make_store_with_mock_driver()
+    with pytest.raises(ValueError, match="upsert_graph_empty_batch"):
+        await store.upsert_graph(
+            source_id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            entities=[],
+            edges=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_graph_requires_workspace_on_entities() -> None:
+    store, _driver_mock = _make_store_with_mock_driver()
+
+    class _NoWorkspaceEntity:
+        def __init__(self) -> None:
+            self.id = uuid.uuid4()
+            self.name = "x"
+            self.display_name = "x"
+            self.entity_type = "service"
+            self.source_id = uuid.uuid4()
+            self.chunk_id: uuid.UUID | None = None
+            self.metadata: dict[str, Any] = {}  # no workspace_id
+
+    with pytest.raises(ValueError, match="upsert_graph_missing_workspace_id"):
+        await store.upsert_graph(
+            source_id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            entities=[_NoWorkspaceEntity()],
+            edges=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_graph_derives_workspace_from_entity() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+    ent = _FakeEntity(workspace_id=_WORKSPACE_A, name="svc.auth")
+
+    await store.upsert_graph(
+        source_id=uuid.uuid4(),
+        document_id=uuid.uuid4(),
+        entities=[ent],
+        edges=[],
+    )
+
+    # Exactly one execute_write call (the transaction runner) — but it is
+    # invoked with the bound method, not the inline lambda.  We assert the
+    # call happened, and that the workspace derivation was accepted.
+    assert driver_mock._session_mock.execute_write.await_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# 8. Connect runs the schema bootstrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_runs_bootstrap_statements() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+
+    await store.connect()
+
+    # Connectivity was verified.
+    driver_mock.verify_connectivity.assert_awaited_once()
+    # One write per bootstrap statement.
+    assert driver_mock._session_mock.execute_write.await_count == len(
+        neo4j_store._BOOTSTRAP_STATEMENTS
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_closes_driver() -> None:
+    store, driver_mock = _make_store_with_mock_driver()
+
+    await store.close()
+
+    driver_mock.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 9. Keyword-only workspace_id — enforced by Python signature
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_entity_refuses_positional_workspace_id() -> None:
+    store, _driver_mock = _make_store_with_mock_driver()
+
+    with pytest.raises(TypeError):
+        # mypy would reject this; we still want the runtime guarantee.
+        await store.get_entity("svc.auth", _WORKSPACE_A)  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_find_related_refuses_missing_workspace_id() -> None:
+    store, _driver_mock = _make_store_with_mock_driver()
+
+    with pytest.raises(TypeError):
+        await store.find_related(entity_name="svc.auth")  # type: ignore[call-arg]

--- a/uv.lock
+++ b/uv.lock
@@ -541,6 +541,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1099,6 +1113,18 @@ wheels = [
 ]
 
 [[package]]
+name = "neo4j"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/01/d6ce65e4647f6cb2b9cca3b813978f7329b54b4e36660aaec1ddf0ccce7a/neo4j-6.1.0.tar.gz", hash = "sha256:b5dde8c0d8481e7b6ae3733569d990dd3e5befdc5d452f531ad1884ed3500b84", size = 239629, upload-time = "2026-01-12T11:27:34.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/5c/ee71e2dd955045425ef44283f40ba1da67673cf06404916ca2950ac0cd39/neo4j-6.1.0-py3-none-any.whl", hash = "sha256:3bd93941f3a3559af197031157220af9fd71f4f93a311db687bd69ffa417b67d", size = 325326, upload-time = "2026-01-12T11:27:33.196Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1200,6 +1226,7 @@ dev = [
     { name = "rich" },
     { name = "ruff" },
     { name = "tenacity" },
+    { name = "testcontainers", extra = ["neo4j"] },
     { name = "typer" },
 ]
 
@@ -1232,6 +1259,7 @@ dev = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", specifier = ">=0.4.7" },
     { name = "tenacity", specifier = ">=9.1.4" },
+    { name = "testcontainers", extras = ["neo4j"], specifier = ">=4.7.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 
@@ -1339,15 +1367,19 @@ version = "0.1.0"
 source = { editable = "packages/index" }
 dependencies = [
     { name = "asyncpg" },
+    { name = "neo4j" },
     { name = "omniscience-core" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "structlog" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "neo4j", specifier = ">=5.19.0" },
     { name = "omniscience-core", editable = "packages/core" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.30" },
+    { name = "structlog", specifier = ">=24.1.0" },
 ]
 
 [[package]]
@@ -1944,6 +1976,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -2302,6 +2343,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
+]
+
+[package.optional-dependencies]
+neo4j = [
+    { name = "neo4j" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 2a of epic #96 — Neo4j backend implementing the `GraphStore` protocol scaffolded in #103, per ADR-0005.

- New `omniscience_index.stores.neo4j_store.Neo4jGraphStore` using the async `neo4j` driver with ACID read/write transaction split.
- Schema bootstrap (constraints + composite indexes on `workspace_id`) runs idempotently on `connect()`; idempotent `MERGE ... ON CREATE SET ... ON MATCH SET ...` writes.
- Workspace invariant enforced at three layers:
  1. Import-time guard (`_ensure_workspace_predicate`) refuses to load the module if any read template drops `workspace_id`.
  2. Parameterized queries only — user-supplied edge types pass through an allowlist regex; max depth is clamped before interpolation.
  3. Parametric contract test + cross-workspace isolation tests shared between pgvector and Neo4j.
- DI selects the backend via `STORAGE_GRAPH_BACKEND=pgvector|neo4j` (default pgvector). All Neo4j connection + pool knobs are config-driven — no magic numbers.
- `docker-compose.yml` adds `neo4j:5.19-community` under `profiles: [graph]` at the end of the services section.

## Closes

Closes #104.

## Non-goals (kept as hard boundaries)

- No data migration from pgvector (that's #108)
- No retrieval rewrite / GraphRAG composition (#107)
- No pgvector removal (#105 cutover)
- No touch of `STORAGE_VECTOR_BACKEND` / Qdrant / vector adapters (#106)

## Test plan

- [x] `make test` — 1608 passed, 2 skipped (52 new tests: 45 unit + 7 parametric contract)
- [x] `mypy --strict` — 153 source files clean
- [x] `ruff check .` + `ruff format --check .` — clean
- [x] Cross-workspace isolation contract test parametric across both backends
- [x] ACL invariant regression guards (import-time + runtime + parametric)
- [x] Cypher injection defence — edge-type allowlist regex test (incl. `CALLS; DROP CONSTRAINT foo`)
- [x] Depth clamping test — protects Neo4j planner from user-supplied huge depths
- [ ] End-to-end: `docker compose --profile graph up` then `STORAGE_GRAPH_BACKEND=neo4j` health check (manual, non-CI)
- [ ] Live Neo4j contract run: `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 uv run pytest tests/test_graph_store_contract.py -v` against a Docker-enabled runner