### PR TITLE
feat: implement Qdrant VectorStore adapter (#106)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,10 @@ APP_VERSION=0.1.0
 # API_TOKEN_SECRET=  # set in production
 
 # === Storage backend selection (Phase 2, epic #96) ===
-# Graph-store backend: 'pgvector' (Phase 1) or 'neo4j' (Phase 2a, issue #104).
+# Graph-store backend: 'pgvector' (default) or 'neo4j' (Phase 2a, issue #104).
 STORAGE_GRAPH_BACKEND=pgvector
+# Vector-store backend: 'pgvector' (default) or 'qdrant' (Phase 2b, issue #106).
+STORAGE_VECTOR_BACKEND=pgvector
 
 # === Neo4j (graph store, issue #104; used only when STORAGE_GRAPH_BACKEND=neo4j) ===
 NEO4J_URI=bolt://neo4j:7687
@@ -35,3 +37,12 @@ NEO4J_MAX_POOL_SIZE=50
 NEO4J_ACQUISITION_TIMEOUT_SECONDS=60
 NEO4J_MAX_RETRY_TIME_SECONDS=30
 NEO4J_DEFAULT_MAX_DEPTH=3
+
+# === Qdrant (vector store, issue #106; used only when STORAGE_VECTOR_BACKEND=qdrant) ===
+# QDRANT_HOST=qdrant
+# QDRANT_GRPC_PORT=6334
+# QDRANT_HTTP_PORT=6333
+# QDRANT_API_KEY=        # required in every non-dev environment
+# QDRANT_HTTPS=false
+# QDRANT_PREFER_GRPC=true
+# QDRANT_TIMEOUT_SECONDS=10.0

--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -32,8 +32,11 @@ from omniscience_core.queue.consumer import QueueConsumer
 from omniscience_core.storage.graph import GraphStore
 from omniscience_core.telemetry import init_telemetry
 from omniscience_embeddings import create_embedding_provider
+from omniscience_embeddings.base import EmbeddingProvider
 from omniscience_index import IndexWriter
 from omniscience_index.stores import Neo4jGraphStore, Neo4jStoreConfig
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
 from omniscience_retrieval import (
     PgVectorGraphStore,
     PgVectorVectorStore,
@@ -111,8 +114,8 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # These wrap the pgvector writer + retriever behind the new backend-
     # neutral protocols defined in ``omniscience_core.storage``.  Phase 2a
     # (issue #104) selects the Neo4j graph backend behind the
-    # ``STORAGE_GRAPH_BACKEND`` feature flag; vector backend selection is
-    # separate (issue #106).
+    # ``STORAGE_GRAPH_BACKEND`` feature flag; Phase 2b (issue #106) selects
+    # the Qdrant vector backend behind ``STORAGE_VECTOR_BACKEND``.
     graph_backend = str(settings.storage_graph_backend).lower()
     graph_store: GraphStore
     neo4j_graph_store: Neo4jGraphStore | None = None
@@ -127,20 +130,49 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise ValueError(
             f"unknown_storage_graph_backend:{graph_backend} (expected 'pgvector' or 'neo4j')"
         )
-    vector_store = PgVectorVectorStore(
+    pgvector_store = PgVectorVectorStore(
         session_factory=session_factory,
         embedding_provider=embedding_provider,
     )
     app.state.graph_store = graph_store
-    app.state.vector_store = vector_store
+
+    # --- Vector backend selection (Epic #96, Phase 2b, issue #106) ---
+    # ``STORAGE_VECTOR_BACKEND`` toggles between the pgvector adapter
+    # (default) and the Qdrant adapter.  The pgvector retrieval service
+    # remains available on ``app.state`` for the hybrid/federation path
+    # until #107 (retrieval rewrite) composes over the new interface.
+    vector_backend = str(settings.storage_vector_backend).lower()
+    if vector_backend == "qdrant":
+        qdrant_store = await _build_qdrant_store(settings, embedding_provider)
+        app.state.vector_store = qdrant_store
+        app.state.qdrant_store = qdrant_store
+        log.info(
+            "storage_adapters_ready",
+            graph_backend=graph_backend,
+            vector_backend="qdrant",
+            collection=qdrant_store.collection_name,
+        )
+    elif vector_backend == "pgvector":
+        app.state.vector_store = pgvector_store
+        app.state.qdrant_store = None
+        log.info(
+            "storage_adapters_ready",
+            graph_backend=graph_backend,
+            vector_backend="pgvector",
+        )
+    else:
+        raise ValueError(
+            f"STORAGE_VECTOR_BACKEND must be 'pgvector' or 'qdrant' (got {vector_backend!r})"
+        )
     app.state.neo4j_graph_store = neo4j_graph_store
-    log.info("storage_adapters_ready", graph_backend=graph_backend)
 
     # --- Retrieval service ---
     # Keep the direct ``RetrievalService`` handle on app.state for the
     # (still-in-flight) federation composition path.  New consumers
-    # should prefer ``app.state.vector_store``.
-    local_retrieval = vector_store.retrieval_service
+    # should prefer ``app.state.vector_store``.  Retrieval is still
+    # pgvector-backed until #107 cuts over; the Qdrant store is wired
+    # in but not yet consulted by the hybrid search path.
+    local_retrieval = pgvector_store.retrieval_service
 
     # --- Federation (optional) ---
     if settings.federation_enabled:
@@ -233,6 +265,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     worker_task.cancel()
     await embedding_provider.close()
 
+    # Close the Qdrant client if the qdrant backend is active (#106).
+    qdrant_store_on_shutdown: QdrantVectorStore | None = getattr(app.state, "qdrant_store", None)
+    if qdrant_store_on_shutdown is not None:
+        await qdrant_store_on_shutdown.close()
+
     # Close the federation HTTP client if federation is active.
     if settings.federation_enabled and isinstance(retrieval_service, FederatedSearch):
         await retrieval_service.close()
@@ -242,6 +279,29 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     await engine.dispose()
     await nats_conn.disconnect()
+
+
+async def _build_qdrant_store(
+    settings: Settings, embedding_provider: EmbeddingProvider
+) -> QdrantVectorStore:
+    """Construct, connect, and bootstrap a ``QdrantVectorStore`` (#106).
+
+    Reads connection settings from ``Settings`` (including the API key
+    from ``QDRANT_API_KEY``) and returns a ready-to-use adapter with
+    the collection and payload indexes already ensured on the cluster.
+    """
+    config = QdrantConfig(
+        host=settings.qdrant_host,
+        grpc_port=settings.qdrant_grpc_port,
+        http_port=settings.qdrant_http_port,
+        api_key=settings.qdrant_api_key,
+        https=settings.qdrant_https,
+        prefer_grpc=settings.qdrant_prefer_grpc,
+        timeout_seconds=settings.qdrant_timeout_seconds,
+    )
+    store = QdrantVectorStore(config=config, embedding_provider=embedding_provider)
+    await store.connect()
+    return store
 
 
 async def _metrics_endpoint(request: Request) -> Response:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,6 +221,40 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  # ==========================================================================
+  # qdrant — Vector store (Epic #96, ADR-0006, issue #106)
+  # --------------------------------------------------------------------------
+  # Activates with:   docker compose --profile graph up
+  # gRPC primary:     6334  (ADR-0006 §Transport)
+  # HTTP fallback:    6333
+  # Storage volume:   /qdrant/storage  (bind-mounted for persistence)
+  # API key:          QDRANT__SERVICE__API_KEY env (unset in dev profile)
+  # ==========================================================================
+  qdrant:
+    image: qdrant/qdrant:v1.12.4
+    profiles:
+      - graph
+    ports:
+      - "127.0.0.1:6333:6333"
+      - "127.0.0.1:6334:6334"
+    environment:
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
+      QDRANT__SERVICE__GRPC_PORT: "6334"
+      QDRANT__SERVICE__HTTP_PORT: "6333"
+      QDRANT__LOG_LEVEL: ${QDRANT_LOG_LEVEL:-INFO}
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/6333' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    restart: unless-stopped
+  # ==========================================================================
+  # /qdrant
+  # ==========================================================================
+
 volumes:
   pgdata:
   pgbackups:
@@ -231,3 +265,4 @@ volumes:
   caddy_data:
   neo4jdata:
   neo4jlogs:
+  qdrant_data:

--- a/packages/core/src/omniscience_core/config.py
+++ b/packages/core/src/omniscience_core/config.py
@@ -99,6 +99,56 @@ class Settings(BaseSettings):
         description="Ollama model used by OllamaReranker for embedding-based scoring.",
     )
 
+    # --- Storage backends (Epic #96 — Neo4j + Qdrant migration) ---
+    storage_vector_backend: str = Field(
+        default="pgvector",
+        description=(
+            "Vector-store backend: 'pgvector' (default) or 'qdrant'. "
+            "Switches the VectorStore implementation wired into the DI "
+            "container. See ADR-0006. Pgvector remains the default until "
+            "the cutover (#105) completes."
+        ),
+    )
+    qdrant_host: str = Field(
+        default="localhost",
+        description="Qdrant server host (used when storage_vector_backend='qdrant').",
+    )
+    qdrant_grpc_port: int = Field(
+        default=6334,
+        ge=1,
+        le=65535,
+        description="Qdrant gRPC port (ADR-0006 §Transport — primary transport).",
+    )
+    qdrant_http_port: int = Field(
+        default=6333,
+        ge=1,
+        le=65535,
+        description="Qdrant HTTP port (ADR-0006 §Transport — fallback transport).",
+    )
+    qdrant_api_key: str | None = Field(
+        default=None,
+        description=(
+            "Qdrant API key. Required in every non-dev environment per "
+            "ADR-0006 §Deployment posture. Read from env QDRANT_API_KEY."
+        ),
+    )
+    qdrant_https: bool = Field(
+        default=False,
+        description="Enable TLS on Qdrant client connections (required in non-dev).",
+    )
+    qdrant_prefer_grpc: bool = Field(
+        default=True,
+        description=(
+            "Prefer gRPC over HTTP when talking to Qdrant. gRPC is the "
+            "primary transport per ADR-0006; HTTP is the fallback."
+        ),
+    )
+    qdrant_timeout_seconds: float = Field(
+        default=10.0,
+        gt=0,
+        description="Per-RPC timeout for Qdrant operations.",
+    )
+
     # --- Federation ---
     federation_enabled: bool = Field(
         default=False,

--- a/packages/index/pyproject.toml
+++ b/packages/index/pyproject.toml
@@ -1,18 +1,21 @@
 [project]
 name = "omniscience-index"
 version = "0.1.0"
-description = "PostgreSQL + pgvector index layer for Omniscience"
+description = "PostgreSQL + pgvector + Qdrant index layer for Omniscience"
 requires-python = ">=3.12"
 dependencies = [
     "omniscience-core",
+    "omniscience-embeddings",
     "sqlalchemy[asyncio]>=2.0.30",
     "asyncpg>=0.29.0",
     "neo4j>=5.19.0",
+    "qdrant-client>=1.12.0",
     "structlog>=24.1.0",
 ]
 
 [tool.uv.sources]
 omniscience-core = { workspace = true }
+omniscience-embeddings = { workspace = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/index/src/omniscience_index/stores/__init__.py
+++ b/packages/index/src/omniscience_index/stores/__init__.py
@@ -1,10 +1,16 @@
 """Backend-specific store adapters for Omniscience.
 
-Currently hosts the Neo4j ``GraphStore`` implementation (issue #104 /
-Phase 2a of epic #96).  Pgvector adapters live in
-``omniscience_retrieval.adapters`` — the dependency arrow is always
-``adapter -> protocol`` defined in
-``omniscience_core.storage``.
+Hosts the Neo4j ``GraphStore`` implementation (issue #104) and the
+Qdrant ``VectorStore`` implementation (issue #106).  Pgvector adapters
+live in ``omniscience_retrieval.adapters`` — the dependency arrow is
+always ``adapter -> protocol`` defined in ``omniscience_core.storage``.
+
+Concrete adapters are not re-exported from here to keep optional
+third-party dependencies off the import path of callers that only
+need the protocols.  Import the concrete adapter explicitly::
+
+    from omniscience_index.stores.neo4j_store import Neo4jGraphStore
+    from omniscience_index.stores.qdrant_store import QdrantVectorStore
 """
 
 from __future__ import annotations

--- a/packages/index/src/omniscience_index/stores/qdrant_config.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_config.py
@@ -1,0 +1,44 @@
+"""Configuration for the Qdrant vector-store adapter.
+
+Kept in its own module so the settings layer, tests, and the adapter
+all depend on a single source of truth for config shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omniscience_index.stores.qdrant_constants import (
+    DEFAULT_QDRANT_GRPC_PORT,
+    DEFAULT_QDRANT_HOST,
+    DEFAULT_QDRANT_HTTP_PORT,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QdrantConfig:
+    """Connection and TLS settings for the Qdrant adapter.
+
+    ``api_key`` is read from the environment at the application edge
+    (``omniscience_core.config.Settings``) and passed in.  It is
+    **never** read directly by the adapter — the adapter consumes
+    already-resolved config so secrets stay centralised.
+
+    ADR-0006 §Deployment posture mandates an API key in every
+    non-dev environment.  The dev profile passes ``api_key=None``.
+
+    ADR-0006 §Transport: gRPC on ``grpc_port`` (default 6334) is
+    tried first; HTTP on ``http_port`` (default 6333) is the fallback
+    transport used when gRPC is unreachable.
+    """
+
+    host: str = DEFAULT_QDRANT_HOST
+    grpc_port: int = DEFAULT_QDRANT_GRPC_PORT
+    http_port: int = DEFAULT_QDRANT_HTTP_PORT
+    api_key: str | None = None
+    https: bool = False
+    prefer_grpc: bool = True
+    timeout_seconds: float = 10.0
+
+
+__all__ = ["QdrantConfig"]

--- a/packages/index/src/omniscience_index/stores/qdrant_constants.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_constants.py
@@ -1,0 +1,134 @@
+"""Named constants for the Qdrant vector store adapter.
+
+Every value here is traced back to
+``docs/decisions/0006-qdrant-as-vector-store.md`` (ADR-0006).  No
+magic numbers are allowed in ``qdrant_store.py``; anything tunable
+that the ADR names explicitly lives here with a docstring that cites
+the ADR section.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# HNSW parameters — ADR-0006, Decision §Index
+# ---------------------------------------------------------------------------
+
+#: HNSW connection graph degree.  ADR-0006, Decision:
+#: "m=16, ef_construct=128 as baselines".  Memory is roughly linear in
+#: ``m`` per point; 16 is the community default for general-purpose
+#: retrieval workloads.
+HNSW_M: Final[int] = 16
+
+#: HNSW index-time candidate list size.  ADR-0006, Decision: "m=16,
+#: ef_construct=128 as baselines".  Higher values yield a denser graph
+#: at build time; 128 is the community default.
+HNSW_EF_CONSTRUCT: Final[int] = 128
+
+# ---------------------------------------------------------------------------
+# Collection layout — ADR-0006, Decision §Schema posture
+# ---------------------------------------------------------------------------
+
+#: Name of the single named vector inside every collection.  ADR-0006,
+#: Decision §Schema posture: "the more common pattern will be one named
+#: vector per collection and one collection per model".  The name is
+#: fixed so the retrieval side does not need to introspect the schema.
+NAMED_VECTOR_DENSE_PRIMARY: Final[str] = "dense_primary"
+
+#: Prefix applied to every Omniscience-managed collection.  Keeps our
+#: collections distinguishable from any that might be created by other
+#: tenants sharing the cluster.
+COLLECTION_NAME_PREFIX: Final[str] = "omniscience"
+
+# ---------------------------------------------------------------------------
+# Payload field names — ADR-0006, Decision §Schema posture §Required payload
+# ---------------------------------------------------------------------------
+
+PAYLOAD_WORKSPACE_ID: Final[str] = "workspace_id"
+PAYLOAD_SOURCE_ID: Final[str] = "source_id"
+PAYLOAD_DOCUMENT_ID: Final[str] = "document_id"
+PAYLOAD_EMBEDDING_MODEL: Final[str] = "embedding_model"
+PAYLOAD_EMBEDDING_PROVIDER: Final[str] = "embedding_provider"
+PAYLOAD_PARSER_VERSION: Final[str] = "parser_version"
+PAYLOAD_CHUNKER_STRATEGY: Final[str] = "chunker_strategy"
+PAYLOAD_CONTENT_TYPE: Final[str] = "content_type"
+PAYLOAD_TAGS: Final[str] = "tags"
+PAYLOAD_TEXT: Final[str] = "text"
+PAYLOAD_ORD: Final[str] = "ord"
+PAYLOAD_SYMBOL: Final[str] = "symbol"
+PAYLOAD_METADATA: Final[str] = "metadata"
+PAYLOAD_INGESTION_RUN_ID: Final[str] = "ingestion_run_id"
+PAYLOAD_EXTERNAL_ID: Final[str] = "external_id"
+PAYLOAD_URI: Final[str] = "uri"
+PAYLOAD_TITLE: Final[str] = "title"
+PAYLOAD_CONTENT_HASH: Final[str] = "content_hash"
+PAYLOAD_DOC_VERSION: Final[str] = "doc_version"
+PAYLOAD_TOMBSTONED_AT: Final[str] = "tombstoned_at"
+PAYLOAD_RECORDED_AT: Final[str] = "recorded_at"
+
+#: Fields that get a Qdrant payload index.  ADR-0006, Decision §Schema
+#: posture lists them explicitly — workspace_id is the mandatory one
+#: (§ACL carry-forward), the rest are performance-oriented for the
+#: filter-then-ANN pattern.
+INDEXED_PAYLOAD_FIELDS: Final[tuple[str, ...]] = (
+    PAYLOAD_WORKSPACE_ID,
+    PAYLOAD_SOURCE_ID,
+    PAYLOAD_DOCUMENT_ID,
+    PAYLOAD_EMBEDDING_MODEL,
+    PAYLOAD_EMBEDDING_PROVIDER,
+    PAYLOAD_PARSER_VERSION,
+    PAYLOAD_CHUNKER_STRATEGY,
+    PAYLOAD_CONTENT_TYPE,
+    PAYLOAD_TAGS,
+    PAYLOAD_TOMBSTONED_AT,
+    PAYLOAD_RECORDED_AT,
+)
+
+# ---------------------------------------------------------------------------
+# Client transport — ADR-0006, Decision §Transport
+# ---------------------------------------------------------------------------
+
+#: Default Qdrant host used when the config does not override it.
+DEFAULT_QDRANT_HOST: Final[str] = "localhost"
+
+#: gRPC port.  ADR-0006, Decision §Transport: "gRPC primary (port
+#: 6334)".
+DEFAULT_QDRANT_GRPC_PORT: Final[int] = 6334
+
+#: HTTP / REST port.  ADR-0006, Decision §Transport: "HTTP fallback
+#: (port 6333)".
+DEFAULT_QDRANT_HTTP_PORT: Final[int] = 6333
+
+
+__all__ = [
+    "COLLECTION_NAME_PREFIX",
+    "DEFAULT_QDRANT_GRPC_PORT",
+    "DEFAULT_QDRANT_HOST",
+    "DEFAULT_QDRANT_HTTP_PORT",
+    "HNSW_EF_CONSTRUCT",
+    "HNSW_M",
+    "INDEXED_PAYLOAD_FIELDS",
+    "NAMED_VECTOR_DENSE_PRIMARY",
+    "PAYLOAD_CHUNKER_STRATEGY",
+    "PAYLOAD_CONTENT_HASH",
+    "PAYLOAD_CONTENT_TYPE",
+    "PAYLOAD_DOCUMENT_ID",
+    "PAYLOAD_DOC_VERSION",
+    "PAYLOAD_EMBEDDING_MODEL",
+    "PAYLOAD_EMBEDDING_PROVIDER",
+    "PAYLOAD_EXTERNAL_ID",
+    "PAYLOAD_INGESTION_RUN_ID",
+    "PAYLOAD_METADATA",
+    "PAYLOAD_ORD",
+    "PAYLOAD_PARSER_VERSION",
+    "PAYLOAD_RECORDED_AT",
+    "PAYLOAD_SOURCE_ID",
+    "PAYLOAD_SYMBOL",
+    "PAYLOAD_TAGS",
+    "PAYLOAD_TEXT",
+    "PAYLOAD_TITLE",
+    "PAYLOAD_TOMBSTONED_AT",
+    "PAYLOAD_URI",
+    "PAYLOAD_WORKSPACE_ID",
+]

--- a/packages/index/src/omniscience_index/stores/qdrant_filters.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_filters.py
@@ -1,0 +1,149 @@
+"""Typed filter-builder for the Qdrant vector-store adapter.
+
+Rationale (ADR-0006 §ACL carry-forward, §Consequences §team)
+-----------------------------------------------------------
+
+The ADR mandates that every read against Qdrant apply a mandatory
+``must`` clause on ``workspace_id``.  Raw construction of
+``qdrant_client.models.Filter`` outside this module is a
+review-rejected pattern and enforced by a lint rule (see
+``tests/test_qdrant_filter_builder_lint.py``).  This module is the
+ONLY place in the codebase that imports ``Filter`` / ``FieldCondition``
+/ ``MatchValue`` directly.
+
+Construction model
+------------------
+
+- ``QdrantFilterBuilder(workspace_id=...)`` takes ``workspace_id``
+  as a **required** constructor argument.  There is no way to
+  instantiate the builder without it.
+- ``.with_source_ids([...])``, ``.with_document_ids([...])``,
+  ``.exclude_tombstoned()`` etc. return a new builder (immutable
+  pattern) so callers can compose safely.
+- ``.build()`` emits a ``qdrant_client.models.Filter`` with
+  ``workspace_id`` always present in ``must``.  A missing workspace
+  is impossible by construction.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, replace
+
+from qdrant_client import models as qm
+
+from omniscience_index.stores.qdrant_constants import (
+    PAYLOAD_DOCUMENT_ID,
+    PAYLOAD_EXTERNAL_ID,
+    PAYLOAD_SOURCE_ID,
+    PAYLOAD_TOMBSTONED_AT,
+    PAYLOAD_WORKSPACE_ID,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QdrantFilterBuilder:
+    """Immutable builder for a workspace-scoped Qdrant filter.
+
+    Every instance is born workspace-scoped; subsequent ``with_*``
+    calls narrow the filter further but can NEVER widen the workspace
+    boundary.  This class is the only sanctioned constructor of
+    ``qdrant_client.models.Filter`` in the codebase.
+    """
+
+    workspace_id: uuid.UUID
+    source_ids: tuple[uuid.UUID, ...] = field(default_factory=tuple)
+    document_ids: tuple[uuid.UUID, ...] = field(default_factory=tuple)
+    external_id: str | None = None
+    exclude_tombstoned_flag: bool = False
+
+    def with_source_ids(self, source_ids: list[uuid.UUID]) -> QdrantFilterBuilder:
+        """Return a new builder narrowed to the given sources."""
+        return replace(self, source_ids=tuple(source_ids))
+
+    def with_document_ids(self, document_ids: list[uuid.UUID]) -> QdrantFilterBuilder:
+        """Return a new builder narrowed to the given documents."""
+        return replace(self, document_ids=tuple(document_ids))
+
+    def with_external_id(self, external_id: str) -> QdrantFilterBuilder:
+        """Return a new builder narrowed to a single external document id."""
+        return replace(self, external_id=external_id)
+
+    def exclude_tombstoned(self) -> QdrantFilterBuilder:
+        """Return a new builder that excludes tombstoned points."""
+        return replace(self, exclude_tombstoned_flag=True)
+
+    def build(self) -> qm.Filter:
+        """Emit the concrete Qdrant filter.
+
+        Post-condition: ``workspace_id`` is always present in the
+        ``must`` clause.  This invariant is re-asserted in a unit
+        test to guard against future refactors.
+        """
+        # Type annotated as the full union Qdrant accepts so mypy
+        # --strict does not reject list invariance.
+        must: list[
+            qm.FieldCondition
+            | qm.IsEmptyCondition
+            | qm.IsNullCondition
+            | qm.HasIdCondition
+            | qm.HasVectorCondition
+            | qm.NestedCondition
+            | qm.Filter
+        ] = [
+            qm.FieldCondition(
+                key=PAYLOAD_WORKSPACE_ID,
+                match=qm.MatchValue(value=str(self.workspace_id)),
+            )
+        ]
+        if self.source_ids:
+            must.append(
+                qm.FieldCondition(
+                    key=PAYLOAD_SOURCE_ID,
+                    match=qm.MatchAny(any=[str(s) for s in self.source_ids]),
+                )
+            )
+        if self.document_ids:
+            must.append(
+                qm.FieldCondition(
+                    key=PAYLOAD_DOCUMENT_ID,
+                    match=qm.MatchAny(any=[str(d) for d in self.document_ids]),
+                )
+            )
+        if self.external_id is not None:
+            must.append(
+                qm.FieldCondition(
+                    key=PAYLOAD_EXTERNAL_ID,
+                    match=qm.MatchValue(value=self.external_id),
+                )
+            )
+        if self.exclude_tombstoned_flag:
+            # Non-tombstoned points have tombstoned_at == null; this
+            # clause keeps the selection tight rather than relying on
+            # must_not/not-matching semantics.
+            must.append(qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_TOMBSTONED_AT)))
+        return qm.Filter(must=must)
+
+
+def build_tombstone_sweep_filter(*, cutoff_iso: str) -> qm.Filter:
+    """Admin-only sweep filter for global tombstone purge.
+
+    This is the **only** read-like Qdrant filter that intentionally
+    omits ``workspace_id``: it is consumed exclusively by
+    ``QdrantVectorStore.delete_tombstoned``, a cron-style maintenance
+    sweep that hard-deletes tombstoned points older than a cutoff
+    across every tenant.  The filter is defined in this module so
+    the lint rule that forbids raw ``qm.Filter(...)`` elsewhere in
+    the codebase (ADR-0006 §ACL carry-forward) still holds.
+    """
+    return qm.Filter(
+        must=[
+            qm.FieldCondition(
+                key=PAYLOAD_TOMBSTONED_AT,
+                range=qm.DatetimeRange(lt=cutoff_iso),  # type: ignore[arg-type]
+            )
+        ]
+    )
+
+
+__all__ = ["QdrantFilterBuilder", "build_tombstone_sweep_filter"]

--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -1,0 +1,808 @@
+"""Qdrant-backed adapter for the ``VectorStore`` protocol.
+
+Implements issue #106 (Phase 2b of Epic #96) per ADR-0006.  See:
+
+- ``docs/decisions/0006-qdrant-as-vector-store.md`` for the
+  authoritative spec (collection layout, payload schema, deployment
+  posture, ACL carry-forward).
+- ``packages/core/src/omniscience_core/storage/vector.py`` for the
+  ``VectorStore`` protocol this class satisfies.
+- ``packages/retrieval/src/omniscience_retrieval/adapters/pgvector_vector.py``
+  for the parallel pgvector implementation this class must be
+  behaviour-compatible with on the contract-test surface.
+
+ACL invariant (non-negotiable, ADR-0006 §ACL carry-forward)
+-----------------------------------------------------------
+
+Every read path in this module composes filters through
+``QdrantFilterBuilder``, which takes ``workspace_id`` as a required
+constructor argument.  Raw ``qdrant_client.models.Filter`` construction
+is forbidden outside ``qdrant_filters.py`` and is enforced by a lint
+test (see ``tests/test_qdrant_filter_builder_lint.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+from omniscience_core.storage.vector import (
+    ChunkPayload,
+    UpsertOutcome,
+)
+from omniscience_embeddings.base import EmbeddingProvider
+from qdrant_client import AsyncQdrantClient
+from qdrant_client import models as qm
+from qdrant_client.http.exceptions import UnexpectedResponse
+
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_constants import (
+    COLLECTION_NAME_PREFIX,
+    HNSW_EF_CONSTRUCT,
+    HNSW_M,
+    INDEXED_PAYLOAD_FIELDS,
+    NAMED_VECTOR_DENSE_PRIMARY,
+    PAYLOAD_CHUNKER_STRATEGY,
+    PAYLOAD_CONTENT_HASH,
+    PAYLOAD_DOC_VERSION,
+    PAYLOAD_DOCUMENT_ID,
+    PAYLOAD_EMBEDDING_MODEL,
+    PAYLOAD_EMBEDDING_PROVIDER,
+    PAYLOAD_EXTERNAL_ID,
+    PAYLOAD_INGESTION_RUN_ID,
+    PAYLOAD_METADATA,
+    PAYLOAD_ORD,
+    PAYLOAD_PARSER_VERSION,
+    PAYLOAD_RECORDED_AT,
+    PAYLOAD_SOURCE_ID,
+    PAYLOAD_SYMBOL,
+    PAYLOAD_TEXT,
+    PAYLOAD_TITLE,
+    PAYLOAD_TOMBSTONED_AT,
+    PAYLOAD_URI,
+    PAYLOAD_WORKSPACE_ID,
+)
+from omniscience_index.stores.qdrant_filters import (
+    QdrantFilterBuilder,
+    build_tombstone_sweep_filter,
+)
+
+if TYPE_CHECKING:  # Lazy type-only import to avoid a core <-> retrieval cycle.
+    from omniscience_retrieval.models import SearchRequest, SearchResult
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Embedding provider protocol — minimal shape required by the adapter
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Internal result containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _DocumentRecord:
+    """Reconstructed logical-document view of the Qdrant points.
+
+    Qdrant has no "documents" table — a logical document is the set of
+    points that share ``document_id``.  Methods like ``upsert_chunks``
+    that need document-level metadata reconstruct it by querying for
+    one representative point.
+    """
+
+    document_id: uuid.UUID
+    content_hash: str
+    doc_version: int
+    chunk_point_ids: tuple[uuid.UUID, ...]
+    tombstoned: bool
+
+
+# ---------------------------------------------------------------------------
+# Collection name builder (deterministic, idempotent)
+# ---------------------------------------------------------------------------
+
+
+def build_collection_name(*, embedding_model: str, dim: int) -> str:
+    """Build the collection name for a (model, dim) pair.
+
+    ADR-0006 §Schema posture: one collection per embedding model; the
+    collection is uniquely identified by the model id and its
+    dimensionality.  The name is deterministic so startup bootstrap is
+    idempotent.
+    """
+    safe_model = embedding_model.replace("/", "__").replace(":", "__")
+    return f"{COLLECTION_NAME_PREFIX}__{safe_model}__d{dim}"
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class QdrantVectorStore:
+    """Qdrant-backed ``VectorStore`` — the Phase-2 adapter (issue #106).
+
+    Satisfies ``omniscience_core.storage.VectorStore`` with native
+    payload-aware HNSW, mandatory workspace filtering on every read,
+    and idempotent collection bootstrap.
+
+    Concurrency
+    -----------
+    ``AsyncQdrantClient`` is the asyncio entry point.  It holds an
+    internal gRPC channel (or HTTPX client) and is safe to share
+    across tasks.  The adapter keeps a single client instance and
+    its lifecycle is bound to ``connect`` / ``close``.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: QdrantConfig,
+        embedding_provider: EmbeddingProvider,
+        client: AsyncQdrantClient | None = None,
+    ) -> None:
+        self._config = config
+        self._embedding_provider = embedding_provider
+        self._collection_name = build_collection_name(
+            embedding_model=embedding_provider.model_name,
+            dim=embedding_provider.dim,
+        )
+        self._client: AsyncQdrantClient | None = client
+        self._bootstrapped: bool = client is not None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """Open the client connection.  Safe to call multiple times."""
+        if self._client is None:
+            self._client = self._build_client()
+        if not self._bootstrapped:
+            await self._ensure_collection()
+            await self._ensure_payload_indexes()
+            self._bootstrapped = True
+
+    async def close(self) -> None:
+        """Close the underlying client and release transport resources."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+            self._bootstrapped = False
+
+    def _build_client(self) -> AsyncQdrantClient:
+        """Construct the Qdrant client with gRPC-preferred transport.
+
+        ADR-0006 §Transport: gRPC (6334) primary, HTTP (6333) fallback.
+        ``qdrant-client`` picks gRPC when ``prefer_grpc=True`` and both
+        ports are reachable, and will fall back to HTTP on RPC errors.
+        """
+        return AsyncQdrantClient(
+            host=self._config.host,
+            port=self._config.http_port,
+            grpc_port=self._config.grpc_port,
+            api_key=self._config.api_key,
+            https=self._config.https,
+            prefer_grpc=self._config.prefer_grpc,
+            timeout=int(self._config.timeout_seconds),
+        )
+
+    @property
+    def _qc(self) -> AsyncQdrantClient:
+        """Return the connected client or raise if not connected."""
+        if self._client is None:
+            raise RuntimeError("QdrantVectorStore: connect() must be awaited first")
+        return self._client
+
+    @property
+    def collection_name(self) -> str:
+        """Return the collection name used by this adapter instance."""
+        return self._collection_name
+
+    # ------------------------------------------------------------------
+    # Collection bootstrap — idempotent
+    # ------------------------------------------------------------------
+
+    async def _ensure_collection(self) -> None:
+        """Create the collection if missing.  Idempotent."""
+        exists = await self._qc.collection_exists(self._collection_name)
+        if exists:
+            return
+        await self._qc.create_collection(
+            collection_name=self._collection_name,
+            vectors_config={
+                NAMED_VECTOR_DENSE_PRIMARY: qm.VectorParams(
+                    size=self._embedding_provider.dim,
+                    distance=qm.Distance.COSINE,
+                )
+            },
+            hnsw_config=qm.HnswConfigDiff(m=HNSW_M, ef_construct=HNSW_EF_CONSTRUCT),
+        )
+        logger.info(
+            "qdrant_collection_created",
+            extra={
+                "collection": self._collection_name,
+                "dim": self._embedding_provider.dim,
+                "model": self._embedding_provider.model_name,
+            },
+        )
+
+    async def _ensure_payload_indexes(self) -> None:
+        """Create payload indexes listed in ADR-0006.  Idempotent."""
+        for field_name in INDEXED_PAYLOAD_FIELDS:
+            await self._create_payload_index_if_missing(field_name)
+
+    async def _create_payload_index_if_missing(self, field_name: str) -> None:
+        """Best-effort payload-index create; already-exists is tolerated."""
+        schema = self._payload_schema_for(field_name)
+        try:
+            await self._qc.create_payload_index(
+                collection_name=self._collection_name,
+                field_name=field_name,
+                field_schema=schema,
+            )
+        except UnexpectedResponse:
+            # Already exists — Qdrant returns 4xx for duplicate index
+            # creation; adapter treats as idempotent success.
+            logger.debug("payload_index_exists", extra={"field": field_name})
+
+    @staticmethod
+    def _payload_schema_for(field_name: str) -> qm.PayloadSchemaType:
+        """Map payload field name to its Qdrant index schema type."""
+        if field_name in (PAYLOAD_RECORDED_AT, PAYLOAD_TOMBSTONED_AT):
+            return qm.PayloadSchemaType.DATETIME
+        return qm.PayloadSchemaType.KEYWORD
+
+    # ------------------------------------------------------------------
+    # Write API — upsert_chunks
+    # ------------------------------------------------------------------
+
+    async def upsert_chunks(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+        uri: str,
+        title: str | None,
+        content_hash: str,
+        metadata: dict[str, Any],
+        chunks: list[ChunkPayload],
+        ingestion_run_id: uuid.UUID | None = None,
+    ) -> UpsertOutcome:
+        """Atomically upsert a document and its chunks into Qdrant.
+
+        Decision table (mirrors pgvector semantics):
+        - No existing chunks for (source, external_id)  → insert → action="created"
+        - Existing with same content_hash               → no-op   → action="unchanged"
+        - Existing with different hash                  → replace → action="updated"
+
+        ``workspace_id`` must be present in every chunk's metadata
+        (propagated via ``metadata[workspace_id]``); missing or null
+        is rejected at this layer per ADR-0006 §ACL carry-forward.
+        """
+        workspace_id = _extract_workspace_id(metadata)
+        existing = await self._find_document(
+            workspace_id=workspace_id,
+            source_id=source_id,
+            external_id=external_id,
+        )
+        if existing is not None and existing.content_hash == content_hash:
+            return UpsertOutcome(
+                action="unchanged",
+                document_id=existing.document_id,
+                chunks_written=0,
+                doc_version=existing.doc_version,
+            )
+        return await self._write_document(
+            existing=existing,
+            workspace_id=workspace_id,
+            source_id=source_id,
+            external_id=external_id,
+            uri=uri,
+            title=title,
+            content_hash=content_hash,
+            metadata=metadata,
+            chunks=chunks,
+            ingestion_run_id=ingestion_run_id,
+        )
+
+    async def _write_document(
+        self,
+        *,
+        existing: _DocumentRecord | None,
+        workspace_id: uuid.UUID,
+        source_id: uuid.UUID,
+        external_id: str,
+        uri: str,
+        title: str | None,
+        content_hash: str,
+        metadata: dict[str, Any],
+        chunks: list[ChunkPayload],
+        ingestion_run_id: uuid.UUID | None,
+    ) -> UpsertOutcome:
+        """Create or replace the document's chunks as a single logical batch."""
+        document_id = existing.document_id if existing else uuid.uuid4()
+        doc_version = (existing.doc_version + 1) if existing else 1
+        action: Literal["created", "updated"] = "updated" if existing else "created"
+        if existing is not None:
+            await self._delete_points(list(existing.chunk_point_ids))
+        points = [
+            self._chunk_to_point(
+                chunk=chunk,
+                document_id=document_id,
+                workspace_id=workspace_id,
+                source_id=source_id,
+                external_id=external_id,
+                uri=uri,
+                title=title,
+                content_hash=content_hash,
+                doc_version=doc_version,
+                metadata=metadata,
+                ingestion_run_id=ingestion_run_id,
+            )
+            for chunk in chunks
+        ]
+        if points:
+            await self._qc.upsert(collection_name=self._collection_name, points=points, wait=True)
+        return UpsertOutcome(
+            action=action,
+            document_id=document_id,
+            chunks_written=len(chunks),
+            doc_version=doc_version,
+        )
+
+    def _chunk_to_point(
+        self,
+        *,
+        chunk: ChunkPayload,
+        document_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        source_id: uuid.UUID,
+        external_id: str,
+        uri: str,
+        title: str | None,
+        content_hash: str,
+        doc_version: int,
+        metadata: dict[str, Any],
+        ingestion_run_id: uuid.UUID | None,
+    ) -> qm.PointStruct:
+        """Translate a ``ChunkPayload`` + doc context into a Qdrant point."""
+        text, ord_, embedding = _require_chunk_fields(chunk)
+        point_id = str(uuid.uuid4())
+        payload = _build_chunk_payload(
+            text=text,
+            ord_=ord_,
+            chunk=chunk,
+            document_id=document_id,
+            workspace_id=workspace_id,
+            source_id=source_id,
+            external_id=external_id,
+            uri=uri,
+            title=title,
+            content_hash=content_hash,
+            doc_version=doc_version,
+            metadata=metadata,
+            ingestion_run_id=ingestion_run_id,
+        )
+        return qm.PointStruct(
+            id=point_id,
+            vector={NAMED_VECTOR_DENSE_PRIMARY: embedding},
+            payload=payload,
+        )
+
+    # ------------------------------------------------------------------
+    # Document lookup (scroll one point to recover doc-level fields)
+    # ------------------------------------------------------------------
+
+    async def _find_document(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        source_id: uuid.UUID,
+        external_id: str,
+    ) -> _DocumentRecord | None:
+        """Find the logical document identified by (source_id, external_id).
+
+        Reads are scoped to ``workspace_id`` via the filter-builder so
+        cross-workspace aliases never leak across the tenant boundary
+        (ADR-0006 §ACL carry-forward).
+        """
+        flt = (
+            QdrantFilterBuilder(workspace_id=workspace_id)
+            .with_source_ids([source_id])
+            .with_external_id(external_id)
+            .build()
+        )
+        points = await self._scroll_all(flt=flt, with_payload=True)
+        if not points:
+            return None
+        return _record_from_points(points)
+
+    async def _scroll_all(self, *, flt: qm.Filter, with_payload: bool) -> list[qm.Record]:
+        """Scroll the whole result set for a filter, paging internally."""
+        out: list[qm.Record] = []
+        offset: qm.ExtendedPointId | None = None
+        page_size = 256
+        while True:
+            records, next_offset = await self._qc.scroll(
+                collection_name=self._collection_name,
+                scroll_filter=flt,
+                limit=page_size,
+                with_payload=with_payload,
+                with_vectors=False,
+                offset=offset,
+            )
+            out.extend(records)
+            if next_offset is None:
+                break
+            offset = next_offset
+        return out
+
+    async def _delete_points(self, point_ids: list[uuid.UUID]) -> None:
+        """Delete points by id.  No filter — caller must have verified scope."""
+        if not point_ids:
+            return
+        await self._qc.delete(
+            collection_name=self._collection_name,
+            points_selector=qm.PointIdsList(points=[str(p) for p in point_ids]),
+            wait=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Delete API
+    # ------------------------------------------------------------------
+
+    async def delete_by_document(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+        workspace_id: uuid.UUID | None = None,
+    ) -> bool:
+        """Tombstone a document by marking its chunks with ``tombstoned_at``.
+
+        ``workspace_id`` is keyword-only.  It defaults to ``None`` ONLY
+        to remain signature-compatible with the ``VectorStore``
+        protocol (which predates this call gaining the kwarg); when
+        ``None`` this method raises — the caller MUST pass a workspace.
+        """
+        if workspace_id is None:
+            raise ValueError(
+                "QdrantVectorStore.delete_by_document requires workspace_id; "
+                "cross-workspace tombstoning is forbidden (ADR-0006 §ACL)."
+            )
+        existing = await self._find_document(
+            workspace_id=workspace_id,
+            source_id=source_id,
+            external_id=external_id,
+        )
+        if existing is None or existing.tombstoned:
+            return False
+        await self._qc.set_payload(
+            collection_name=self._collection_name,
+            payload={PAYLOAD_TOMBSTONED_AT: datetime.now(UTC).isoformat()},
+            points=[str(p) for p in existing.chunk_point_ids],
+            wait=True,
+        )
+        return True
+
+    async def delete_tombstoned(self, older_than: timedelta) -> int:
+        """Hard-delete tombstoned documents older than ``older_than``.
+
+        Because tombstoning is a per-point flag in Qdrant (no
+        separate documents table), this counts distinct
+        ``document_id`` values among the deleted points.
+        """
+        cutoff = (datetime.now(UTC) - older_than).isoformat()
+        flt = build_tombstone_sweep_filter(cutoff_iso=cutoff)
+        records = await self._scroll_all(flt=flt, with_payload=True)
+        doc_ids = {r.payload.get(PAYLOAD_DOCUMENT_ID) for r in records if r.payload}
+        if records:
+            await self._qc.delete(
+                collection_name=self._collection_name,
+                points_selector=qm.PointIdsList(points=[str(r.id) for r in records]),
+                wait=True,
+            )
+        return len({d for d in doc_ids if d is not None})
+
+    # ------------------------------------------------------------------
+    # Read API — search (workspace_id required)
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+    ) -> SearchResult:
+        """Vector-only search, confined to the caller's workspace.
+
+        ADR-0006 §ACL carry-forward: ``workspace_id`` is the
+        mandatory must-clause filter; no code path in this method
+        can construct a ``Filter`` without it.
+        """
+        start = time.monotonic()
+        query_vector = await self._embed_query(request.query)
+        flt = self._request_to_filter(request=request, workspace_id=workspace_id)
+        hits = await self._qc.query_points(
+            collection_name=self._collection_name,
+            query=query_vector,
+            using=NAMED_VECTOR_DENSE_PRIMARY,
+            query_filter=flt,
+            limit=request.top_k,
+            with_payload=True,
+            with_vectors=False,
+        )
+        duration_ms = (time.monotonic() - start) * 1000.0
+        return _build_search_result(
+            scored=hits.points, top_k=request.top_k, duration_ms=duration_ms
+        )
+
+    def _request_to_filter(self, *, request: SearchRequest, workspace_id: uuid.UUID) -> qm.Filter:
+        """Build the Qdrant filter for a search request.
+
+        ``workspace_id`` is always present.  Optional narrowers
+        (sources, tombstone exclusion) are layered on top.
+        """
+        builder = QdrantFilterBuilder(workspace_id=workspace_id)
+        source_ids = _extract_source_ids(request)
+        if source_ids:
+            builder = builder.with_source_ids(source_ids)
+        if not request.include_tombstoned:
+            builder = builder.exclude_tombstoned()
+        return builder.build()
+
+    async def _embed_query(self, query: str) -> list[float]:
+        vectors = await self._embedding_provider.embed([query])
+        return vectors[0]
+
+    # ------------------------------------------------------------------
+    # Count
+    # ------------------------------------------------------------------
+
+    async def count(self, *, source_id: uuid.UUID, workspace_id: uuid.UUID | None = None) -> int:
+        """Return the number of active (non-tombstoned) documents for a source.
+
+        ``workspace_id`` is keyword-only; see ``delete_by_document`` for
+        the rationale on the ``| None`` default and the fail-closed
+        check.
+        """
+        if workspace_id is None:
+            raise ValueError("QdrantVectorStore.count requires workspace_id (ADR-0006 §ACL).")
+        flt = (
+            QdrantFilterBuilder(workspace_id=workspace_id)
+            .with_source_ids([source_id])
+            .exclude_tombstoned()
+            .build()
+        )
+        records = await self._scroll_all(flt=flt, with_payload=True)
+        document_ids = {r.payload.get(PAYLOAD_DOCUMENT_ID) for r in records if r.payload}
+        return len({d for d in document_ids if d is not None})
+
+
+# ---------------------------------------------------------------------------
+# Free functions (small, pure, easy to unit-test)
+# ---------------------------------------------------------------------------
+
+
+def _extract_workspace_id(metadata: dict[str, Any]) -> uuid.UUID:
+    """Read and validate ``workspace_id`` from document metadata.
+
+    Rejects missing / ``None`` / non-UUID values.  This is the
+    enforcement point for ADR-0006 §ACL "Require ``workspace_id`` as
+    a non-null payload field on every point".
+    """
+    raw = metadata.get("workspace_id")
+    if raw is None:
+        raise ValueError(
+            "QdrantVectorStore upsert rejected: metadata['workspace_id'] "
+            "is required and must be a non-null UUID (ADR-0006 §ACL)."
+        )
+    if isinstance(raw, uuid.UUID):
+        return raw
+    if isinstance(raw, str):
+        return uuid.UUID(raw)
+    raise TypeError(f"workspace_id must be UUID or str, got {type(raw).__name__}")
+
+
+def _extract_source_ids(request: SearchRequest) -> list[uuid.UUID]:
+    """Resolve ``request.sources`` (names) to source-id UUIDs when possible."""
+    sources = request.sources or []
+    out: list[uuid.UUID] = []
+    for s in sources:
+        try:
+            out.append(uuid.UUID(s))
+        except (ValueError, TypeError):
+            # Source names (non-UUID) are not supported at the Qdrant
+            # layer — retrieval orchestration must resolve names to
+            # IDs before calling search.  Silently skipping a bad
+            # token would be an ACL-adjacent smell; raise instead.
+            raise ValueError(
+                "QdrantVectorStore.search: request.sources must contain "
+                "source-id UUIDs; name resolution is a retrieval-layer "
+                "concern."
+            ) from None
+    return out
+
+
+def _require_chunk_fields(chunk: ChunkPayload) -> tuple[str, int, list[float]]:
+    """Enforce the (ord, text, embedding) required keys on a chunk payload."""
+    try:
+        ord_ = chunk["ord"]
+        text = chunk["text"]
+        embedding = chunk["embedding"]
+    except KeyError as exc:
+        raise ValueError(f"chunk payload missing required key: {exc}") from exc
+    return text, ord_, embedding
+
+
+def _build_chunk_payload(
+    *,
+    text: str,
+    ord_: int,
+    chunk: ChunkPayload,
+    document_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+    source_id: uuid.UUID,
+    external_id: str,
+    uri: str,
+    title: str | None,
+    content_hash: str,
+    doc_version: int,
+    metadata: dict[str, Any],
+    ingestion_run_id: uuid.UUID | None,
+) -> dict[str, Any]:
+    """Assemble the Qdrant payload dict for a single chunk point.
+
+    Fields follow ADR-0006 §Schema posture §Required payload fields
+    plus doc-level fields needed for document reconstruction
+    (external_id, uri, title, content_hash, doc_version).
+    """
+    return {
+        PAYLOAD_WORKSPACE_ID: str(workspace_id),
+        PAYLOAD_SOURCE_ID: str(source_id),
+        PAYLOAD_DOCUMENT_ID: str(document_id),
+        PAYLOAD_EXTERNAL_ID: external_id,
+        PAYLOAD_URI: uri,
+        PAYLOAD_TITLE: title,
+        PAYLOAD_CONTENT_HASH: content_hash,
+        PAYLOAD_DOC_VERSION: doc_version,
+        PAYLOAD_ORD: ord_,
+        PAYLOAD_TEXT: text,
+        PAYLOAD_SYMBOL: chunk.get("symbol"),
+        PAYLOAD_METADATA: dict(chunk.get("metadata", {})),
+        PAYLOAD_EMBEDDING_MODEL: chunk.get("embedding_model", ""),
+        PAYLOAD_EMBEDDING_PROVIDER: chunk.get("embedding_provider", ""),
+        PAYLOAD_PARSER_VERSION: chunk.get("parser_version", ""),
+        PAYLOAD_CHUNKER_STRATEGY: chunk.get("chunker_strategy", ""),
+        PAYLOAD_INGESTION_RUN_ID: (
+            str(ingestion_run_id) if ingestion_run_id is not None else None
+        ),
+        PAYLOAD_TOMBSTONED_AT: None,
+        PAYLOAD_RECORDED_AT: datetime.now(UTC).isoformat(),
+        "doc_metadata": dict(metadata),
+    }
+
+
+def _record_from_points(points: list[qm.Record]) -> _DocumentRecord:
+    """Reduce a set of chunk points to a logical ``_DocumentRecord``."""
+    first = points[0]
+    payload = first.payload or {}
+    doc_id_raw = payload.get(PAYLOAD_DOCUMENT_ID)
+    if not isinstance(doc_id_raw, str):
+        raise ValueError("qdrant point missing document_id in payload")
+    return _DocumentRecord(
+        document_id=uuid.UUID(doc_id_raw),
+        content_hash=str(payload.get(PAYLOAD_CONTENT_HASH, "")),
+        doc_version=int(payload.get(PAYLOAD_DOC_VERSION, 0)),
+        chunk_point_ids=tuple(_coerce_point_id(p.id) for p in points),
+        tombstoned=payload.get(PAYLOAD_TOMBSTONED_AT) is not None,
+    )
+
+
+def _coerce_point_id(pid: qm.ExtendedPointId) -> uuid.UUID:
+    """Coerce a Qdrant point id to ``uuid.UUID``; reject non-UUID ids."""
+    if isinstance(pid, uuid.UUID):
+        return pid
+    if isinstance(pid, str):
+        return uuid.UUID(pid)
+    raise TypeError(f"unexpected point id type: {type(pid).__name__}")
+
+
+def _build_search_result(
+    *, scored: list[qm.ScoredPoint], top_k: int, duration_ms: float
+) -> SearchResult:
+    """Convert Qdrant scored points to a ``SearchResult`` pydantic model.
+
+    Imported lazily to avoid the core<-retrieval dependency cycle
+    (``omniscience_index`` must not statically import from
+    ``omniscience_retrieval``).
+    """
+    from omniscience_retrieval.models import (
+        ChunkLineage,
+        Citation,
+        QueryStats,
+        SearchHit,
+        SearchResult,
+        SourceInfo,
+    )
+
+    hits: list[SearchHit] = []
+    for sp in scored[:top_k]:
+        payload = sp.payload or {}
+        hits.append(
+            SearchHit(
+                chunk_id=_coerce_point_id(sp.id),
+                document_id=uuid.UUID(cast("str", payload.get(PAYLOAD_DOCUMENT_ID))),
+                score=float(sp.score),
+                text=str(payload.get(PAYLOAD_TEXT, "")),
+                source=SourceInfo(
+                    id=uuid.UUID(cast("str", payload.get(PAYLOAD_SOURCE_ID))),
+                    name=str(payload.get(PAYLOAD_SOURCE_ID)),
+                    type="qdrant",
+                ),
+                citation=Citation(
+                    uri=str(payload.get(PAYLOAD_URI, "")),
+                    title=payload.get(PAYLOAD_TITLE),
+                    indexed_at=_parse_datetime(payload.get(PAYLOAD_RECORDED_AT)),
+                    doc_version=int(payload.get(PAYLOAD_DOC_VERSION, 0)),
+                ),
+                lineage=ChunkLineage(
+                    ingestion_run_id=_parse_opt_uuid(payload.get(PAYLOAD_INGESTION_RUN_ID)),
+                    embedding_model=str(payload.get(PAYLOAD_EMBEDDING_MODEL, "")),
+                    embedding_provider=str(payload.get(PAYLOAD_EMBEDDING_PROVIDER, "")),
+                    parser_version=str(payload.get(PAYLOAD_PARSER_VERSION, "")),
+                    chunker_strategy=str(payload.get(PAYLOAD_CHUNKER_STRATEGY, "")),
+                ),
+                metadata=_safe_dict(payload.get(PAYLOAD_METADATA)),
+            )
+        )
+    return SearchResult(
+        hits=hits,
+        query_stats=QueryStats(
+            total_matches_before_filters=len(scored),
+            vector_matches=len(scored),
+            text_matches=0,
+            duration_ms=duration_ms,
+        ),
+    )
+
+
+def _parse_datetime(raw: Any) -> datetime:
+    """Parse an ISO-8601 string from payload.  Falls back to ``now`` on None."""
+    if isinstance(raw, str):
+        return datetime.fromisoformat(raw)
+    if isinstance(raw, datetime):
+        return raw
+    return datetime.now(UTC)
+
+
+def _parse_opt_uuid(raw: Any) -> uuid.UUID | None:
+    """Parse an optional UUID field from a payload value."""
+    if raw is None:
+        return None
+    if isinstance(raw, uuid.UUID):
+        return raw
+    if isinstance(raw, str):
+        return uuid.UUID(raw)
+    return None
+
+
+def _safe_dict(raw: Any) -> dict[str, Any]:
+    """Return ``raw`` as a dict or an empty dict when it is not mappable."""
+    if isinstance(raw, dict):
+        return cast("dict[str, Any]", raw)
+    return {}
+
+
+__all__ = [
+    "QdrantConfig",
+    "QdrantVectorStore",
+    "build_collection_name",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     "rich>=13.7.0",
     "moto>=5.1.22",
     "boto3-stubs[s3]>=1.42.91",
-    "testcontainers[neo4j]>=4.7.0",
+    "testcontainers[neo4j,qdrant]>=4.8.0",
 ]
 
 [tool.ruff]

--- a/tests/test_qdrant_contract.py
+++ b/tests/test_qdrant_contract.py
@@ -150,8 +150,28 @@ async def test_collection_bootstrap_is_idempotent(qdrant_store: QdrantVectorStor
 # ---------------------------------------------------------------------------
 
 
+def _stub_vector(text: str, dim: int = 8) -> list[float]:
+    """Same hash-based unit-norm vector that ``_StubEmbedding`` produces.
+
+    Used as the default embedding in ``_chunk`` so upsert-time and
+    query-time embeddings agree on the same text — otherwise every
+    chunk would land with the same constant vector and cosine
+    ordering would be a tie-break among identical points.
+    """
+    import math
+
+    h = hash(text)
+    raw = [((h >> (i * 4)) & 0xF) / 15.0 for i in range(dim)]
+    n = math.sqrt(sum(x * x for x in raw)) or 1.0
+    return [x / n for x in raw]
+
+
 def _chunk(*, text: str, ord_: int = 0, vector: list[float] | None = None) -> ChunkPayload:
-    payload: ChunkPayload = {"ord": ord_, "text": text, "embedding": vector or [0.1] * 8}
+    payload: ChunkPayload = {
+        "ord": ord_,
+        "text": text,
+        "embedding": vector if vector is not None else _stub_vector(text),
+    }
     return payload
 
 

--- a/tests/test_qdrant_contract.py
+++ b/tests/test_qdrant_contract.py
@@ -1,0 +1,388 @@
+"""Contract tests for ``QdrantVectorStore`` against a real Qdrant container.
+
+These tests validate the Qdrant adapter end-to-end:
+
+- Collection bootstrap is idempotent.
+- ``upsert_chunks`` round-trips through Qdrant and is observable.
+- ``search`` returns the stored chunk when the workspace matches.
+- **Cross-workspace isolation**: two workspaces with overlapping
+  entity names; a search authenticated to workspace A returns no
+  point from workspace B under any filter combination.  This is the
+  direct vector-side analogue of the graph-side isolation test in
+  ``tests/test_graph_workspace_isolation.py`` (PR #119).
+- Top-k regression: against a fixed regression set, Qdrant and
+  pgvector return results within a tolerance threshold.
+
+The tests spin up a single Qdrant container per module via a
+session-scoped fixture.  If Docker is not available the whole module
+is skipped.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("testcontainers.qdrant")
+
+from omniscience_core.storage import ChunkPayload
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from qdrant_client import AsyncQdrantClient
+
+
+def _docker_available() -> bool:
+    """Cheap docker reachability probe to skip on CI without Docker."""
+    if os.environ.get("SKIP_TESTCONTAINERS") == "1":
+        return False
+    try:
+        import docker  # type: ignore[import-not-found]
+
+        docker.from_env().ping()  # type: ignore[no-untyped-call]
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker is not reachable; Qdrant contract tests need testcontainers.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def qdrant_container() -> Any:
+    """Start a Qdrant container for the whole test session."""
+    from testcontainers.qdrant import QdrantContainer
+
+    with QdrantContainer(image="qdrant/qdrant:v1.12.4") as c:
+        yield c
+
+
+class _StubEmbedding:
+    """Deterministic embedding provider for contract tests.
+
+    Maps each text to a tiny fixed-dim vector based on the hash of
+    the content so searches are reproducible.  The unit-norm
+    vectors make cosine similarity match what a real provider would
+    produce in shape if not in quality.
+    """
+
+    dim = 8
+    model_name = "stub-embedding"
+    provider_name = "stub"
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        import math
+
+        out: list[list[float]] = []
+        for t in texts:
+            h = hash(t)
+            raw = [((h >> (i * 4)) & 0xF) / 15.0 for i in range(self.dim)]
+            n = math.sqrt(sum(x * x for x in raw)) or 1.0
+            out.append([x / n for x in raw])
+        return out
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest_asyncio.fixture()
+async def qdrant_store(qdrant_container: Any) -> AsyncIterator[QdrantVectorStore]:
+    """Fresh adapter instance bound to the shared container."""
+    # testcontainers-qdrant exposes ports 6333/6334 and the host
+    # resolves via ``get_container_host_ip`` + ``get_exposed_port``.
+    host = qdrant_container.get_container_host_ip()
+    http_port = int(qdrant_container.get_exposed_port(6333))
+    grpc_port = int(qdrant_container.get_exposed_port(6334))
+    # Use HTTP to avoid gRPC port mapping quirks in testcontainers on CI.
+    config = QdrantConfig(
+        host=host,
+        grpc_port=grpc_port,
+        http_port=http_port,
+        api_key=None,
+        prefer_grpc=False,
+    )
+    store = QdrantVectorStore(config=config, embedding_provider=_StubEmbedding())
+    # Use a unique collection per test run to isolate tests.
+    store._collection_name = f"omniscience__stub-embedding__d8__t{uuid.uuid4().hex[:8]}"  # type: ignore[attr-defined]
+    await store.connect()
+    try:
+        yield store
+    finally:
+        # Drop the collection so each test is independent.
+        if store._client is not None:  # type: ignore[attr-defined]
+            client = cast("AsyncQdrantClient", store._client)  # type: ignore[attr-defined]
+            # Teardown is best-effort — a previous test failure can leave
+            # the container in an odd state; swallow cleanup errors.
+            with contextlib.suppress(Exception):
+                await client.delete_collection(store.collection_name)
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Collection bootstrap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collection_bootstrap_is_idempotent(qdrant_store: QdrantVectorStore) -> None:
+    """Calling ``connect`` twice must not raise and must not duplicate state."""
+    await qdrant_store.connect()
+    await qdrant_store.connect()
+    # collection_name is stable.
+    assert qdrant_store.collection_name.startswith("omniscience__stub-embedding__d8")
+
+
+# ---------------------------------------------------------------------------
+# Upsert + search round-trip
+# ---------------------------------------------------------------------------
+
+
+def _chunk(*, text: str, ord_: int = 0, vector: list[float] | None = None) -> ChunkPayload:
+    payload: ChunkPayload = {"ord": ord_, "text": text, "embedding": vector or [0.1] * 8}
+    return payload
+
+
+async def _upsert_simple(
+    store: QdrantVectorStore, *, workspace: uuid.UUID, external_id: str, text: str
+) -> uuid.UUID:
+    outcome = await store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id=external_id,
+        uri=f"mem://{external_id}",
+        title=external_id,
+        content_hash=f"hash-{external_id}",
+        metadata={"workspace_id": str(workspace)},
+        chunks=[_chunk(text=text)],
+    )
+    return outcome.document_id
+
+
+@pytest.mark.asyncio
+async def test_upsert_then_search_roundtrip(qdrant_store: QdrantVectorStore) -> None:
+    """A stored chunk is retrievable by search within the same workspace."""
+    from omniscience_retrieval.models import SearchRequest
+
+    ws = uuid.uuid4()
+    await _upsert_simple(qdrant_store, workspace=ws, external_id="doc1", text="quantum computing")
+    request = SearchRequest(query="quantum computing", top_k=5)
+    result = await qdrant_store.search(request=request, workspace_id=ws)
+    assert len(result.hits) == 1
+    assert result.hits[0].text == "quantum computing"
+
+
+@pytest.mark.asyncio
+async def test_upsert_unchanged_on_same_content_hash(
+    qdrant_store: QdrantVectorStore,
+) -> None:
+    """Re-ingesting with identical hash must be a no-op."""
+    ws = uuid.uuid4()
+    outcome1 = await qdrant_store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="doc1",
+        uri="mem://doc1",
+        title=None,
+        content_hash="fixed-hash",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text="a")],
+    )
+    outcome2 = await qdrant_store.upsert_chunks(
+        source_id=uuid.uuid4(),  # source id changes; (source, external) is key
+        external_id="doc1",
+        uri="mem://doc1",
+        title=None,
+        content_hash="fixed-hash",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text="a")],
+    )
+    # Second call with different source_id is a distinct doc — ensure
+    # the FIRST path (same source+external+hash) is unchanged.
+    same_src_outcome = await qdrant_store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="doc2",
+        uri="mem://doc2",
+        title=None,
+        content_hash="hx",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text="b")],
+    )
+    assert outcome1.action == "created"
+    assert outcome2.action == "created"  # different source_id -> new logical doc
+    assert same_src_outcome.action == "created"
+
+
+# ---------------------------------------------------------------------------
+# Cross-workspace isolation contract test — THE mandatory ACL check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_workspace_isolation_is_absolute(
+    qdrant_store: QdrantVectorStore,
+) -> None:
+    """ADR-0006 §ACL carry-forward: no B points may appear in an A search.
+
+    Setup:
+      - Workspace A contains "database indexing"
+      - Workspace B contains "database indexing"  (SAME text, different tenant)
+
+    A search authenticated to A must return only A's point, regardless
+    of overlapping content.  Running the same query as B returns only
+    B's point.  Under no filter combination can either side see the
+    other.
+    """
+    from omniscience_retrieval.models import SearchRequest
+
+    ws_a = uuid.uuid4()
+    ws_b = uuid.uuid4()
+    doc_a = await _upsert_simple(
+        qdrant_store, workspace=ws_a, external_id="docA", text="database indexing"
+    )
+    doc_b = await _upsert_simple(
+        qdrant_store, workspace=ws_b, external_id="docB", text="database indexing"
+    )
+    assert doc_a != doc_b
+
+    request = SearchRequest(query="database indexing", top_k=50)
+
+    a_result = await qdrant_store.search(request=request, workspace_id=ws_a)
+    a_doc_ids = {h.document_id for h in a_result.hits}
+    assert doc_a in a_doc_ids
+    assert doc_b not in a_doc_ids
+
+    b_result = await qdrant_store.search(request=request, workspace_id=ws_b)
+    b_doc_ids = {h.document_id for h in b_result.hits}
+    assert doc_b in b_doc_ids
+    assert doc_a not in b_doc_ids
+
+    # Third workspace with no data must return nothing — not A's, not B's.
+    ws_c = uuid.uuid4()
+    c_result = await qdrant_store.search(request=request, workspace_id=ws_c)
+    assert c_result.hits == []
+
+
+# ---------------------------------------------------------------------------
+# Delete by document + count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_by_document_tombstones_chunks(
+    qdrant_store: QdrantVectorStore,
+) -> None:
+    """After delete_by_document the document no longer shows in active search."""
+    from omniscience_retrieval.models import SearchRequest
+
+    ws = uuid.uuid4()
+    source_id = uuid.uuid4()
+    await qdrant_store.upsert_chunks(
+        source_id=source_id,
+        external_id="doc1",
+        uri="mem://doc1",
+        title=None,
+        content_hash="h1",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text="alpha")],
+    )
+    ok = await qdrant_store.delete_by_document(
+        source_id=source_id, external_id="doc1", workspace_id=ws
+    )
+    assert ok is True
+
+    # Default search excludes tombstoned chunks (include_tombstoned=False).
+    result = await qdrant_store.search(
+        request=SearchRequest(query="alpha", top_k=10), workspace_id=ws
+    )
+    assert result.hits == []
+
+
+@pytest.mark.asyncio
+async def test_count_returns_active_document_count(
+    qdrant_store: QdrantVectorStore,
+) -> None:
+    ws = uuid.uuid4()
+    source_id = uuid.uuid4()
+    await qdrant_store.upsert_chunks(
+        source_id=source_id,
+        external_id="doc1",
+        uri="mem://doc1",
+        title=None,
+        content_hash="h1",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text="one", ord_=0), _chunk(text="two", ord_=1)],
+    )
+    await qdrant_store.upsert_chunks(
+        source_id=source_id,
+        external_id="doc2",
+        uri="mem://doc2",
+        title=None,
+        content_hash="h2",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text="three")],
+    )
+    # Different source — must not be counted.
+    await qdrant_store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="doc3",
+        uri="mem://doc3",
+        title=None,
+        content_hash="h3",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text="four")],
+    )
+    assert await qdrant_store.count(source_id=source_id, workspace_id=ws) == 2
+
+
+# ---------------------------------------------------------------------------
+# Top-k regression — Qdrant returns sane results on a fixed fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_returns_sensible_top_k(qdrant_store: QdrantVectorStore) -> None:
+    """Regression guard: on a small fixed corpus the top hit is
+    the most-similar text, not a random neighbour.
+
+    This is the adapter-local analogue of the "top-k overlap vs
+    pgvector baseline" shadow-read check that #107 will formalise;
+    here we simply assert that the nearest-neighbour ordering is
+    deterministic and non-degenerate.
+    """
+    from omniscience_retrieval.models import SearchRequest
+
+    ws = uuid.uuid4()
+    source = uuid.uuid4()
+    corpus = [
+        ("doc-1", "vector search with payload filtering"),
+        ("doc-2", "graph traversal and entity linking"),
+        ("doc-3", "tsvector BM25 keyword ranking"),
+    ]
+    for ext_id, text in corpus:
+        await qdrant_store.upsert_chunks(
+            source_id=source,
+            external_id=ext_id,
+            uri=f"mem://{ext_id}",
+            title=ext_id,
+            content_hash=f"h-{ext_id}",
+            metadata={"workspace_id": str(ws)},
+            chunks=[_chunk(text=text)],
+        )
+    # Query very close to the first entry — it should rank first.
+    result = await qdrant_store.search(
+        request=SearchRequest(query="vector search with payload filtering", top_k=3),
+        workspace_id=ws,
+    )
+    assert len(result.hits) == 3
+    assert result.hits[0].text == "vector search with payload filtering"

--- a/tests/test_qdrant_filter_builder.py
+++ b/tests/test_qdrant_filter_builder.py
@@ -1,0 +1,144 @@
+"""Unit tests for the Qdrant filter-builder (issue #106).
+
+These tests encode the ACL invariant from ADR-0006 §ACL carry-forward
+at the source level — they do NOT need a Qdrant cluster to run.
+
+Failure of any of these tests must block merge: the class of bug they
+protect against (workspace bypass) is a direct analogue of the one
+PR #119 fixed on the graph side.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from omniscience_index.stores.qdrant_constants import (
+    PAYLOAD_DOCUMENT_ID,
+    PAYLOAD_EXTERNAL_ID,
+    PAYLOAD_SOURCE_ID,
+    PAYLOAD_TOMBSTONED_AT,
+    PAYLOAD_WORKSPACE_ID,
+)
+from omniscience_index.stores.qdrant_filters import (
+    QdrantFilterBuilder,
+    build_tombstone_sweep_filter,
+)
+from qdrant_client import models as qm
+
+_WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_WS_B = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+
+
+def _field_keys(flt: qm.Filter) -> list[str]:
+    """Extract the ``key`` strings of every FieldCondition in ``must``."""
+    return [c.key for c in (flt.must or []) if isinstance(c, qm.FieldCondition)]
+
+
+def test_builder_requires_workspace_id_at_construction() -> None:
+    """The builder has no default for ``workspace_id`` — can't instantiate without it."""
+    with pytest.raises(TypeError):
+        QdrantFilterBuilder()  # type: ignore[call-arg]
+
+
+def test_build_emits_workspace_id_must_clause() -> None:
+    """ACL invariant: every build() output has workspace_id in ``must``."""
+    flt = QdrantFilterBuilder(workspace_id=_WS_A).build()
+    keys = _field_keys(flt)
+    assert PAYLOAD_WORKSPACE_ID in keys
+    # ``workspace_id`` is first — it is the ACL anchor, not an afterthought.
+    assert keys[0] == PAYLOAD_WORKSPACE_ID
+
+
+def test_build_workspace_value_matches_constructor_input() -> None:
+    flt = QdrantFilterBuilder(workspace_id=_WS_A).build()
+    must = flt.must or []
+    ws_conds = [
+        c for c in must if isinstance(c, qm.FieldCondition) and c.key == PAYLOAD_WORKSPACE_ID
+    ]
+    assert len(ws_conds) == 1
+    match = ws_conds[0].match
+    assert isinstance(match, qm.MatchValue)
+    assert match.value == str(_WS_A)
+
+
+def test_with_source_ids_narrows_filter() -> None:
+    src = uuid.uuid4()
+    flt = QdrantFilterBuilder(workspace_id=_WS_A).with_source_ids([src]).build()
+    assert PAYLOAD_SOURCE_ID in _field_keys(flt)
+    # Workspace still present after narrowing.
+    assert PAYLOAD_WORKSPACE_ID in _field_keys(flt)
+
+
+def test_with_document_ids_narrows_filter() -> None:
+    doc = uuid.uuid4()
+    flt = QdrantFilterBuilder(workspace_id=_WS_A).with_document_ids([doc]).build()
+    assert PAYLOAD_DOCUMENT_ID in _field_keys(flt)
+    assert PAYLOAD_WORKSPACE_ID in _field_keys(flt)
+
+
+def test_with_external_id_narrows_filter() -> None:
+    flt = QdrantFilterBuilder(workspace_id=_WS_A).with_external_id("doc-123").build()
+    assert PAYLOAD_EXTERNAL_ID in _field_keys(flt)
+    # The external_id value is threaded through unchanged.
+    ext = [
+        c
+        for c in (flt.must or [])
+        if isinstance(c, qm.FieldCondition) and c.key == PAYLOAD_EXTERNAL_ID
+    ]
+    assert isinstance(ext[0].match, qm.MatchValue)
+    assert ext[0].match.value == "doc-123"
+
+
+def test_exclude_tombstoned_adds_is_null_clause() -> None:
+    flt = QdrantFilterBuilder(workspace_id=_WS_A).exclude_tombstoned().build()
+    null_conds = [c for c in (flt.must or []) if isinstance(c, qm.IsNullCondition)]
+    assert len(null_conds) == 1
+    assert null_conds[0].is_null.key == PAYLOAD_TOMBSTONED_AT
+
+
+def test_builder_is_immutable_and_returns_new_instances() -> None:
+    """Builders are frozen dataclasses — composition never mutates in-place."""
+    b0 = QdrantFilterBuilder(workspace_id=_WS_A)
+    b1 = b0.with_source_ids([uuid.uuid4()])
+    assert b0 is not b1
+    assert b0.source_ids == ()
+    assert len(b1.source_ids) == 1
+    # workspace_id survives every narrowing step.
+    assert b1.workspace_id == _WS_A
+
+
+def test_workspace_can_never_be_widened_by_composition() -> None:
+    """No public API widens workspace; it is fixed at construction time.
+
+    Regression guard for ADR-0006 §ACL: the builder must not expose a
+    ``with_workspace_id`` or similar mutator.
+    """
+    b = QdrantFilterBuilder(workspace_id=_WS_A)
+    assert not hasattr(b, "with_workspace_id")
+    # dataclasses.replace could widen it programmatically — but callers
+    # have no reason to, and the lint guard below catches raw Filter
+    # construction elsewhere.
+
+
+def test_different_workspaces_produce_different_filters() -> None:
+    a = QdrantFilterBuilder(workspace_id=_WS_A).build()
+    b = QdrantFilterBuilder(workspace_id=_WS_B).build()
+    a_match = a.must[0].match  # type: ignore[union-attr, index]
+    b_match = b.must[0].match  # type: ignore[union-attr, index]
+    assert isinstance(a_match, qm.MatchValue)
+    assert isinstance(b_match, qm.MatchValue)
+    assert a_match.value != b_match.value
+
+
+def test_tombstone_sweep_filter_is_explicitly_global() -> None:
+    """The sweep filter is the single sanctioned cross-workspace filter.
+
+    It is used ONLY by ``delete_tombstoned`` (admin cron).  The builder
+    module is where this exception lives so the lint rule can allow-list
+    a single file.
+    """
+    flt = build_tombstone_sweep_filter(cutoff_iso="2026-01-01T00:00:00+00:00")
+    keys = _field_keys(flt)
+    assert PAYLOAD_TOMBSTONED_AT in keys
+    assert PAYLOAD_WORKSPACE_ID not in keys  # by design — admin-global

--- a/tests/test_qdrant_filter_builder_lint.py
+++ b/tests/test_qdrant_filter_builder_lint.py
@@ -1,0 +1,107 @@
+"""Static lint guard: raw ``qdrant_client.models.Filter`` construction
+outside the filter-builder module is forbidden.
+
+ADR-0006 §ACL carry-forward mandates: "Add a linter or review rule
+that rejects construction of Qdrant ``Filter`` objects that omit
+``workspace_id`` in the ``must`` clause; prefer a thin typed
+filter-builder that takes ``workspace_id`` as a required constructor
+argument."
+
+This test is the mechanised form of that rule.  It walks every
+``.py`` under ``apps/``, ``packages/``, and ``tests/`` and asserts
+that only the allow-listed files construct ``qm.Filter(...)`` /
+``Filter(...)`` directly.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Final
+
+# Files permitted to construct a raw Qdrant Filter.  These are the
+# ONLY exceptions; adding a new path requires a PR that explains why
+# the construction cannot go through ``QdrantFilterBuilder``.
+_ALLOWED_FILES: Final[frozenset[str]] = frozenset(
+    {
+        # The filter-builder itself.
+        "packages/index/src/omniscience_index/stores/qdrant_filters.py",
+        # The lint test itself references Filter in strings / type names.
+        "tests/test_qdrant_filter_builder_lint.py",
+        # Unit tests for the builder that inspect .must / Filter shape.
+        "tests/test_qdrant_filter_builder.py",
+    }
+)
+
+_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
+_SCAN_DIRS: Final[tuple[Path, ...]] = (
+    _ROOT / "apps",
+    _ROOT / "packages",
+    _ROOT / "tests",
+)
+
+
+def _is_filter_construction(node: ast.Call) -> bool:
+    """Return True iff ``node`` is a call to ``Filter(...)`` or ``qm.Filter(...)``.
+
+    This matches both the bare name (``from qdrant_client.models import
+    Filter``) and the qualified attribute (``qm.Filter`` / ``models.Filter``).
+    """
+    func = node.func
+    # Bare name: ``from qdrant_client.models import Filter``.
+    if isinstance(func, ast.Name) and func.id == "Filter":
+        return True
+    # Attribute access: ``qm.Filter`` / ``models.Filter``.  Only flag
+    # attribute access spelt ``.Filter``; other libs could reuse the
+    # name but the ``qdrant_client`` import gate below keeps false
+    # positives out of scope.
+    return bool(isinstance(func, ast.Attribute) and func.attr == "Filter")
+
+
+def _file_imports_qdrant(tree: ast.Module) -> bool:
+    """Cheap check: the file imports from ``qdrant_client`` (or an alias)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("qdrant_client"):
+            return True
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("qdrant_client"):
+                    return True
+    return False
+
+
+def _scan_file(path: Path) -> list[int]:
+    """Return the line numbers of offending ``Filter(...)`` calls in ``path``."""
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:  # pragma: no cover — defensive only
+        return []
+    if not _file_imports_qdrant(tree):
+        return []
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_filter_construction(node):
+            offenders.append(node.lineno)
+    return offenders
+
+
+def test_no_raw_qdrant_filter_construction_outside_builder() -> None:
+    """ADR-0006 §ACL: only ``qdrant_filters.py`` may construct a ``Filter``."""
+    offenders: list[str] = []
+    for scan_dir in _SCAN_DIRS:
+        if not scan_dir.exists():
+            continue
+        for path in scan_dir.rglob("*.py"):
+            rel = path.relative_to(_ROOT).as_posix()
+            if rel in _ALLOWED_FILES:
+                continue
+            for lineno in _scan_file(path):
+                offenders.append(f"{rel}:{lineno}")
+
+    assert not offenders, (
+        "Raw qdrant_client Filter construction detected outside the "
+        "sanctioned filter-builder module.  Route through "
+        "``QdrantFilterBuilder`` or, for admin sweeps, through "
+        "``build_tombstone_sweep_filter``.  Offending sites: " + ", ".join(offenders)
+    )

--- a/tests/test_qdrant_store_unit.py
+++ b/tests/test_qdrant_store_unit.py
@@ -1,0 +1,277 @@
+"""Unit tests for ``QdrantVectorStore`` pure functions and mock-based flows.
+
+These tests do not spin up a Qdrant container; they cover the
+deterministic logic that does not depend on the backing cluster:
+
+- collection-name derivation
+- payload-construction from ``ChunkPayload``
+- workspace extraction + rejection of missing workspace
+- protocol compliance (runtime ``isinstance(store, VectorStore)``)
+- ``delete_by_document`` / ``count`` fail-closed on missing workspace
+
+Container-backed tests live in ``tests/test_qdrant_contract.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_core.storage import ChunkPayload, VectorStore
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_constants import (
+    NAMED_VECTOR_DENSE_PRIMARY,
+    PAYLOAD_DOCUMENT_ID,
+    PAYLOAD_ORD,
+    PAYLOAD_SOURCE_ID,
+    PAYLOAD_TEXT,
+    PAYLOAD_TOMBSTONED_AT,
+    PAYLOAD_WORKSPACE_ID,
+)
+from omniscience_index.stores.qdrant_store import (
+    QdrantVectorStore,
+    build_collection_name,
+)
+from qdrant_client import AsyncQdrantClient
+
+_WS = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Collection naming is deterministic + model/dim-bound
+# ---------------------------------------------------------------------------
+
+
+def test_collection_name_is_deterministic() -> None:
+    name = build_collection_name(embedding_model="nomic-embed-text", dim=768)
+    assert name == build_collection_name(embedding_model="nomic-embed-text", dim=768)
+
+
+def test_collection_name_includes_model_and_dim() -> None:
+    name = build_collection_name(embedding_model="mxbai-embed-large", dim=1024)
+    assert "mxbai-embed-large" in name
+    assert "d1024" in name
+
+
+def test_collection_name_sanitises_separator_chars() -> None:
+    """Model ids with ``/`` or ``:`` map to collection names Qdrant accepts."""
+    a = build_collection_name(embedding_model="voyage-ai/voyage-3", dim=1024)
+    b = build_collection_name(embedding_model="hf:BAAI/bge-m3", dim=1024)
+    assert "/" not in a
+    assert ":" not in b
+
+
+def test_different_models_produce_different_collections() -> None:
+    """One-collection-per-model invariant from ADR-0006 §Schema posture."""
+    a = build_collection_name(embedding_model="ollama-nomic", dim=768)
+    b = build_collection_name(embedding_model="voyage-3", dim=768)
+    assert a != b
+
+
+def test_different_dims_produce_different_collections() -> None:
+    """A dim change is also a collection split — embeddings are non-mixable."""
+    a = build_collection_name(embedding_model="some-model", dim=768)
+    b = build_collection_name(embedding_model="some-model", dim=1024)
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Adapter construction + runtime-protocol compliance
+# ---------------------------------------------------------------------------
+
+
+def _embedding_provider(*, dim: int = 4, model: str = "test-model") -> Any:
+    """Build a Mock that satisfies the EmbeddingProvider protocol."""
+    m = MagicMock()
+    m.dim = dim
+    m.model_name = model
+    m.provider_name = "mock"
+    m.embed = AsyncMock(return_value=[[0.1] * dim])
+    m.close = AsyncMock()
+    return m
+
+
+def _mock_client() -> Any:
+    """Return an ``AsyncQdrantClient``-shaped mock with async methods."""
+    c = MagicMock(spec=AsyncQdrantClient)
+    c.collection_exists = AsyncMock(return_value=True)
+    c.create_collection = AsyncMock()
+    c.create_payload_index = AsyncMock()
+    c.upsert = AsyncMock()
+    c.scroll = AsyncMock(return_value=([], None))
+    c.delete = AsyncMock()
+    c.set_payload = AsyncMock()
+    c.query_points = AsyncMock()
+    c.close = AsyncMock()
+    return c
+
+
+def test_qdrant_store_satisfies_vector_store_protocol() -> None:
+    """Runtime ``isinstance`` — the adapter fulfils the protocol (#103)."""
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=_mock_client(),
+    )
+    assert isinstance(store, VectorStore)
+
+
+def test_qdrant_store_uses_embedding_provider_for_collection_name() -> None:
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(dim=1024, model="m1"),
+        client=_mock_client(),
+    )
+    assert store.collection_name == build_collection_name(embedding_model="m1", dim=1024)
+
+
+# ---------------------------------------------------------------------------
+# ACL: upsert rejects missing workspace, delete/count fail closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_missing_workspace_id() -> None:
+    """ADR-0006 §ACL: non-null workspace_id is mandatory on every point."""
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=_mock_client(),
+    )
+    chunks: list[ChunkPayload] = [{"ord": 0, "text": "t", "embedding": [0.0, 0.0, 0.0, 0.0]}]
+    with pytest.raises(ValueError, match="workspace_id"):
+        await store.upsert_chunks(
+            source_id=uuid.uuid4(),
+            external_id="e1",
+            uri="u",
+            title=None,
+            content_hash="h",
+            metadata={},  # missing workspace_id
+            chunks=chunks,
+        )
+
+
+@pytest.mark.asyncio
+async def test_upsert_rejects_null_workspace_id() -> None:
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=_mock_client(),
+    )
+    chunks: list[ChunkPayload] = [{"ord": 0, "text": "t", "embedding": [0.0, 0.0, 0.0, 0.0]}]
+    with pytest.raises(ValueError, match="workspace_id"):
+        await store.upsert_chunks(
+            source_id=uuid.uuid4(),
+            external_id="e1",
+            uri="u",
+            title=None,
+            content_hash="h",
+            metadata={"workspace_id": None},
+            chunks=chunks,
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_by_document_fails_closed_on_missing_workspace() -> None:
+    """Without a workspace, delete is cross-tenant — fail closed per #117 carry-forward."""
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=_mock_client(),
+    )
+    with pytest.raises(ValueError, match="workspace_id"):
+        await store.delete_by_document(source_id=uuid.uuid4(), external_id="e1")
+
+
+@pytest.mark.asyncio
+async def test_count_fails_closed_on_missing_workspace() -> None:
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=_mock_client(),
+    )
+    with pytest.raises(ValueError, match="workspace_id"):
+        await store.count(source_id=uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Upsert happy-path: points carry required payload fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_points_with_workspace_payload() -> None:
+    client = _mock_client()
+    client.scroll = AsyncMock(return_value=([], None))  # no existing doc
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    source_id = uuid.uuid4()
+    chunks: list[ChunkPayload] = [{"ord": 0, "text": "hello", "embedding": [0.1, 0.2, 0.3, 0.4]}]
+    outcome = await store.upsert_chunks(
+        source_id=source_id,
+        external_id="e1",
+        uri="u",
+        title="t",
+        content_hash="h",
+        metadata={"workspace_id": str(_WS)},
+        chunks=chunks,
+    )
+    assert outcome.action == "created"
+    assert outcome.chunks_written == 1
+    assert outcome.doc_version == 1
+    # Verify the Qdrant upsert was called with a properly-shaped point.
+    call = client.upsert.await_args
+    points = call.kwargs["points"]
+    assert len(points) == 1
+    p = points[0]
+    assert NAMED_VECTOR_DENSE_PRIMARY in p.vector
+    assert p.payload[PAYLOAD_WORKSPACE_ID] == str(_WS)
+    assert p.payload[PAYLOAD_SOURCE_ID] == str(source_id)
+    assert PAYLOAD_DOCUMENT_ID in p.payload
+    assert p.payload[PAYLOAD_TEXT] == "hello"
+    assert p.payload[PAYLOAD_ORD] == 0
+    assert p.payload[PAYLOAD_TOMBSTONED_AT] is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_is_unchanged_when_content_hash_matches() -> None:
+    """Same-hash re-ingest is a no-op (mirrors pgvector writer semantics)."""
+    from qdrant_client.http.models import Record
+
+    existing_doc_id = uuid.uuid4()
+    existing_point = Record(
+        id=str(uuid.uuid4()),
+        payload={
+            PAYLOAD_WORKSPACE_ID: str(_WS),
+            PAYLOAD_DOCUMENT_ID: str(existing_doc_id),
+            "content_hash": "h1",
+            "doc_version": 3,
+        },
+        vector=None,
+    )
+    client = _mock_client()
+    client.scroll = AsyncMock(return_value=([existing_point], None))
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    chunks: list[ChunkPayload] = [{"ord": 0, "text": "t", "embedding": [0.0, 0.0, 0.0, 0.0]}]
+    outcome = await store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="e1",
+        uri="u",
+        title=None,
+        content_hash="h1",  # same as existing
+        metadata={"workspace_id": str(_WS)},
+        chunks=chunks,
+    )
+    assert outcome.action == "unchanged"
+    assert outcome.chunks_written == 0
+    assert outcome.document_id == existing_doc_id
+    client.upsert.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -1149,6 +1149,18 @@ wheels = [
 ]
 
 [[package]]
+name = "neo4j"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/01/d6ce65e4647f6cb2b9cca3b813978f7329b54b4e36660aaec1ddf0ccce7a/neo4j-6.1.0.tar.gz", hash = "sha256:b5dde8c0d8481e7b6ae3733569d990dd3e5befdc5d452f531ad1884ed3500b84", size = 239629, upload-time = "2026-01-12T11:27:34.777Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/5c/ee71e2dd955045425ef44283f40ba1da67673cf06404916ca2950ac0cd39/neo4j-6.1.0-py3-none-any.whl", hash = "sha256:3bd93941f3a3559af197031157220af9fd71f4f93a311db687bd69ffa417b67d", size = 325326, upload-time = "2026-01-12T11:27:33.196Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1250,7 +1262,7 @@ dev = [
     { name = "rich" },
     { name = "ruff" },
     { name = "tenacity" },
-    { name = "testcontainers", extra = ["qdrant"] },
+    { name = "testcontainers", extra = ["neo4j", "qdrant"] },
     { name = "typer" },
 ]
 
@@ -1283,7 +1295,7 @@ dev = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", specifier = ">=0.4.7" },
     { name = "tenacity", specifier = ">=9.1.4" },
-    { name = "testcontainers", extras = ["qdrant"], specifier = ">=4.8.0" },
+    { name = "testcontainers", extras = ["neo4j", "qdrant"], specifier = ">=4.8.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 
@@ -1391,19 +1403,23 @@ version = "0.1.0"
 source = { editable = "packages/index" }
 dependencies = [
     { name = "asyncpg" },
+    { name = "neo4j" },
     { name = "omniscience-core" },
     { name = "omniscience-embeddings" },
     { name = "qdrant-client" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "structlog" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "neo4j", specifier = ">=5.19.0" },
     { name = "omniscience-core", editable = "packages/core" },
     { name = "omniscience-embeddings", editable = "packages/embeddings" },
     { name = "qdrant-client", specifier = ">=1.12.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.30" },
+    { name = "structlog", specifier = ">=24.1.0" },
 ]
 
 [[package]]
@@ -2012,6 +2028,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -2407,6 +2432,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+neo4j = [
+    { name = "neo4j" },
+]
 qdrant = [
     { name = "qdrant-client" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -689,6 +689,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -745,6 +767,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
@@ -752,6 +779,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1113,18 +1149,6 @@ wheels = [
 ]
 
 [[package]]
-name = "neo4j"
-version = "6.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/01/d6ce65e4647f6cb2b9cca3b813978f7329b54b4e36660aaec1ddf0ccce7a/neo4j-6.1.0.tar.gz", hash = "sha256:b5dde8c0d8481e7b6ae3733569d990dd3e5befdc5d452f531ad1884ed3500b84", size = 239629, upload-time = "2026-01-12T11:27:34.777Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/5c/ee71e2dd955045425ef44283f40ba1da67673cf06404916ca2950ac0cd39/neo4j-6.1.0-py3-none-any.whl", hash = "sha256:3bd93941f3a3559af197031157220af9fd71f4f93a311db687bd69ffa417b67d", size = 325326, upload-time = "2026-01-12T11:27:33.196Z" },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1226,7 +1250,7 @@ dev = [
     { name = "rich" },
     { name = "ruff" },
     { name = "tenacity" },
-    { name = "testcontainers", extra = ["neo4j"] },
+    { name = "testcontainers", extra = ["qdrant"] },
     { name = "typer" },
 ]
 
@@ -1259,7 +1283,7 @@ dev = [
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", specifier = ">=0.4.7" },
     { name = "tenacity", specifier = ">=9.1.4" },
-    { name = "testcontainers", extras = ["neo4j"], specifier = ">=4.7.0" },
+    { name = "testcontainers", extras = ["qdrant"], specifier = ">=4.8.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 
@@ -1367,19 +1391,19 @@ version = "0.1.0"
 source = { editable = "packages/index" }
 dependencies = [
     { name = "asyncpg" },
-    { name = "neo4j" },
     { name = "omniscience-core" },
+    { name = "omniscience-embeddings" },
+    { name = "qdrant-client" },
     { name = "sqlalchemy", extra = ["asyncio"] },
-    { name = "structlog" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
-    { name = "neo4j", specifier = ">=5.19.0" },
     { name = "omniscience-core", editable = "packages/core" },
+    { name = "omniscience-embeddings", editable = "packages/embeddings" },
+    { name = "qdrant-client", specifier = ">=1.12.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.30" },
-    { name = "structlog", specifier = ">=24.1.0" },
 ]
 
 [[package]]
@@ -1702,6 +1726,18 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1976,15 +2012,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytz"
-version = "2026.1.post1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
-]
-
-[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -2044,6 +2071,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/dd/f8a8261b83946af3cd65943c93c4f83e044f01184e8525404989d22a81a5/qdrant_client-1.17.1.tar.gz", hash = "sha256:22f990bbd63485ed97ba551a4c498181fcb723f71dcab5d6e4e43fe1050a2bc0", size = 344979, upload-time = "2026-03-13T17:13:44.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/69/77d1a971c4b933e8c79403e99bcbb790463da5e48333cc4fd5d412c63c98/qdrant_client-1.17.1-py3-none-any.whl", hash = "sha256:6cda4064adfeaf211c751f3fbc00edbbdb499850918c7aff4855a9a759d56cbd", size = 389947, upload-time = "2026-03-13T17:13:43.156Z" },
 ]
 
 [[package]]
@@ -2362,8 +2407,8 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-neo4j = [
-    { name = "neo4j" },
+qdrant = [
+    { name = "qdrant-client" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #106. Phase 2b of Epic #96.

## Summary

Implements the Qdrant-backed `VectorStore` adapter per [ADR-0006](../blob/main/docs/decisions/0006-qdrant-as-vector-store.md). The pgvector path is untouched and remains the default; routing flips to Qdrant via `STORAGE_VECTOR_BACKEND=qdrant`.

This is the vector-side twin of #104 (Neo4j adapter). Together they complete Phase 2 of Epic #96. Cutover (#105) is the next gate.

## What's in this PR

### Adapter

- `packages/index/src/omniscience_index/stores/qdrant_store.py` — `QdrantVectorStore` satisfying the `VectorStore` protocol.
  - Collection bootstrap is idempotent: one collection per embedding model (`omniscience__<model>__d<dim>`), HNSW with `m=16`, `ef_construct=128`, cosine distance, named vector `dense_primary`.
  - Upsert decision table mirrors `IndexWriter.upsert_document` (created / updated / unchanged). Point ids are chunk UUIDs.
  - Delete is tombstone-based; `delete_tombstoned` is an admin-global sweep.
  - Search is vector-only (hybrid composition is #107's scope).
- `packages/index/src/omniscience_index/stores/qdrant_filters.py` — `QdrantFilterBuilder` (frozen dataclass, `workspace_id` required at construction; immutable composition). Raw `qm.Filter(...)` outside this module is **forbidden** and enforced by an AST lint test.
- `packages/index/src/omniscience_index/stores/qdrant_constants.py` — every tunable from ADR-0006 as a named `Final` constant with a docstring citing the ADR. No magic numbers.
- `packages/index/src/omniscience_index/stores/qdrant_config.py` — connection + TLS config.

### Wiring

- `apps/server/src/omniscience_server/app.py` — new `STORAGE_VECTOR_BACKEND` env selector. Pgvector remains the default; Qdrant opts in. Qdrant client is closed on lifespan shutdown. Does **not** touch graph-side wiring (that is #104's scope).
- `packages/core/src/omniscience_core/config.py` — `qdrant_*` settings (host, ports, API key, TLS, gRPC preference, timeout). API key read from `QDRANT_API_KEY`; never logged.
- `docker-compose.yml` — `qdrant` service on `profiles: [graph]`, ports 6333/6334, persistent `qdrant_data` volume, health check, API key injected from env. Appended at the end of services in a clearly-delimited block per the parallel-execution protocol with the #104 team.
- `.env.example` — documented the new env vars.

### ACL invariant (mandatory per ADR-0006 §ACL carry-forward)

PR #119 patched the pgvector equivalent on the graph side (#117). This adapter lands the vector-side guarantee natively, from day one:

- **Non-null `workspace_id` required on every point** — rejected at `upsert_chunks` before any point hits Qdrant.
- **Mandatory `must` clause on `workspace_id` for every read** — `search`, `_find_document`, `count`, `delete_by_document` all route through `QdrantFilterBuilder(workspace_id=...)`.
- **Payload-indexed `workspace_id`** — bootstrapped via `_ensure_payload_indexes`.
- **Typed filter-builder; raw `Filter(...)` fails CI lint** — `tests/test_qdrant_filter_builder_lint.py` walks `apps/`, `packages/`, `tests/` and asserts only the builder module references `qm.Filter`.
- **Cross-workspace isolation contract test** — `test_cross_workspace_isolation_is_absolute`: two workspaces with overlapping text plus a third empty workspace; no leakage under any filter combination.
- **Fail-closed on `workspace_id=None`** — `delete_by_document` / `count` raise `ValueError` immediately rather than sweep cross-tenant.

## Verification

- [x] `make test` — **1581 passed, 9 skipped** (9 skips are the Docker-gated contract tests; everything else runs including the AST lint guard and the ACL unit tests)
- [x] `mypy --strict apps/ packages/` — **Success: no issues found in 156 source files**
- [x] `ruff check .` / `ruff format .` — clean
- [x] Pre-commit hooks pass
- [x] Runtime protocol compliance: `isinstance(QdrantVectorStore(...), VectorStore)` is `True`
- [x] `docker-compose.yml` — validated via PyYAML; `qdrant` is on `profiles: [graph]` with the expected ports and volume

## Test plan

- [ ] Boot Qdrant locally via `docker compose --profile graph up`, flip `STORAGE_VECTOR_BACKEND=qdrant`, verify `/health` returns 200 and the Qdrant collection is created on first startup
- [ ] Run the contract test suite against a real Qdrant container (`tests/test_qdrant_contract.py`) — currently auto-skips when Docker is not reachable
- [ ] Security review of `QdrantFilterBuilder` + the AST lint rule
- [ ] Shadow-read (`#107`) parity check once available — top-k overlap vs pgvector baseline on the fixed regression corpus

## Out of scope (explicitly deferred)

- **Scalar int8 quantization** → v0.6 optimization per ADR-0006
- **Retrieval rewrite / GraphRAG composition** → #107
- **Pgvector cutover / column drop** → #105
- **Dual-write migration tooling** → #108
- **Helm sub-chart integration** → bundled with #105

## Known limitations

- `count()` scrolls matching chunks to count distinct documents (O(chunks)); a cheaper facet API is a follow-up.
- `delete_by_document` and `count` take `workspace_id` as a keyword-only kwarg with a `None` sentinel default that raises — the protocol shape pre-#106 does not yet require it on these methods. Documented in the adapter docstring; follow-up to thread `workspace_id` through the protocol itself.
- gRPC↔HTTP fallback is governed by `qdrant-client`'s internal behaviour; `QdrantConfig.prefer_grpc` routes the initial preference.

## Links

- Epic: #96
- ADR: [0006-qdrant-as-vector-store.md](../blob/main/docs/decisions/0006-qdrant-as-vector-store.md)
- Protocol (merged in #120): `packages/core/src/omniscience_core/storage/vector.py`
- Pgvector reference: `packages/retrieval/src/omniscience_retrieval/adapters/pgvector_vector.py`
- Parallel sibling: #104 (Neo4j adapter)
- ACL carry-forward source: #117 / #119