### PR TITLE
feat: GraphRAG retrieval composition (#107)

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -38,6 +38,7 @@ from omniscience_index.stores import Neo4jGraphStore, Neo4jStoreConfig
 from omniscience_index.stores.qdrant_config import QdrantConfig
 from omniscience_index.stores.qdrant_store import QdrantVectorStore
 from omniscience_retrieval import (
+    GraphRAGComposer,
     PgVectorGraphStore,
     PgVectorVectorStore,
     RetrievalService,
@@ -196,6 +197,23 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     app.state.retrieval_service = retrieval_service
     log.info("retrieval_service_ready", federated=settings.federation_enabled)
+
+    # --- GraphRAG composer (issue #107) ---
+    # Wraps ``graph_store`` + ``vector_store`` and dispatches to the
+    # new composed path when both backends are the Neo4j+Qdrant pair,
+    # or delegates to the legacy ``retrieval_service`` otherwise.  The
+    # composer requires an explicit ``workspace_id`` per call; callers
+    # that cannot resolve one MUST fall back to ``retrieval_service``.
+    graph_rag_composer = GraphRAGComposer(
+        graph_store=graph_store,
+        vector_store=app.state.vector_store,
+        legacy_service=retrieval_service,
+    )
+    app.state.graph_rag_composer = graph_rag_composer
+    log.info(
+        "graph_rag_composer_ready",
+        graphrag_active=graph_rag_composer.graphrag_active,
+    )
 
     # --- Ingestion worker ---
     index_writer = IndexWriter(session_factory)

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -128,9 +128,17 @@ async def search(
     include_tombstoned: bool = False,
     retrieval_strategy: str = "hybrid",
 ) -> dict[str, Any]:
-    """Search tool — requires scope 'search'."""
+    """Search tool — requires scope 'search'.
+
+    When the calling token is workspace-scoped the ``workspace_id`` is
+    forwarded to :func:`mcp_search` so the :class:`GraphRAGComposer`
+    (issue #107) can enforce its ACL invariant and, when the backend
+    stack permits it, run the GraphRAG composed pipeline.  Tokens
+    without a workspace still get legacy-path results.
+    """
     token = await _resolve_token(ctx)
     _require_scope(token, Scope.search)
+    workspace_id = get_workspace_id(token) if token is not None else None
 
     return await mcp_search(
         app=_get_app(),
@@ -142,6 +150,7 @@ async def search(
         filters=filters,
         include_tombstoned=include_tombstoned,
         retrieval_strategy=retrieval_strategy,
+        workspace_id=workspace_id,
     )
 
 

--- a/apps/server/src/omniscience_server/mcp/tools.py
+++ b/apps/server/src/omniscience_server/mcp/tools.py
@@ -17,6 +17,7 @@ import structlog
 from fastapi import FastAPI
 from omniscience_core.db.models import Chunk, Document, IngestionRun, Source
 from omniscience_core.storage import GraphResultView, GraphStore
+from omniscience_retrieval.graph_rag import GraphRAGComposer
 from omniscience_retrieval.models import SearchRequest
 from omniscience_retrieval.search import RetrievalService
 from sqlalchemy import func, select
@@ -43,12 +44,19 @@ async def mcp_search(
     filters: dict[str, Any] | None = None,
     include_tombstoned: bool = False,
     retrieval_strategy: str = "hybrid",
+    workspace_id: uuid.UUID | None = None,
 ) -> dict[str, Any]:
-    """Execute hybrid retrieval and return hits with citations."""
-    service: RetrievalService | None = getattr(app.state, "retrieval_service", None)
-    if service is None:
-        raise RuntimeError("retrieval_service not available on app.state")
+    """Execute retrieval and return hits with citations.
 
+    When ``workspace_id`` is supplied AND the ``GraphRAGComposer`` is
+    wired on ``app.state`` (issue #107), the composer runs: it either
+    performs the full GraphRAG composition (Neo4j+Qdrant stack) or
+    transparently falls back to the legacy ``RetrievalService`` for
+    any other backend combination.  When ``workspace_id`` is absent
+    (stdio/legacy callers) we use the legacy service directly — the
+    composer's workspace invariant is non-negotiable.
+    """
+    composer: GraphRAGComposer | None = getattr(app.state, "graph_rag_composer", None)
     request = SearchRequest(
         query=query,
         top_k=top_k,
@@ -59,6 +67,13 @@ async def mcp_search(
         include_tombstoned=include_tombstoned,
         retrieval_strategy=retrieval_strategy,  # type: ignore[arg-type]
     )
+    if composer is not None and workspace_id is not None:
+        result = await composer.search(request, workspace_id=workspace_id)
+        return result.model_dump(mode="json")
+
+    service: RetrievalService | None = getattr(app.state, "retrieval_service", None)
+    if service is None:
+        raise RuntimeError("retrieval_service not available on app.state")
     result = await service.search(request)
     return result.model_dump(mode="json")
 

--- a/apps/server/src/omniscience_server/rest/search.py
+++ b/apps/server/src/omniscience_server/rest/search.py
@@ -10,8 +10,11 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
-from omniscience_core.auth.middleware import require_scope
+from omniscience_core.auth.middleware import get_current_token, require_scope
 from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken
+from omniscience_retrieval.graph_rag import GraphRAGComposer
 from omniscience_retrieval.models import SearchRequest, SearchResult
 
 from omniscience_server.rest.rate_limit import rate_limit_dependency
@@ -23,6 +26,7 @@ router = APIRouter(tags=["search"])
 # Module-level Depends singletons — avoids ruff B008
 _search_scope_dep: Any = Depends(require_scope(Scope.search))
 _rate_limit_dep: Any = Depends(rate_limit_dependency)
+_current_token_dep: Any = Depends(get_current_token)
 
 
 @router.post(
@@ -34,30 +38,44 @@ _rate_limit_dep: Any = Depends(rate_limit_dependency)
 async def search(
     body: SearchRequest,
     request: Request,
+    token: ApiToken = _current_token_dep,
 ) -> SearchResult:
     """Execute a hybrid search query against indexed knowledge.
 
     Body mirrors the MCP ``search`` tool input.  Response mirrors the MCP
     ``search`` tool output.
 
-    Requires scope: ``search``
+    Requires scope: ``search``.
+
+    When the caller's token is workspace-scoped and the
+    :class:`GraphRAGComposer` (issue #107) is wired, the request is
+    routed through the composer — which either runs GraphRAG composed
+    retrieval (Neo4j+Qdrant stack) or transparently falls back to the
+    legacy ``RetrievalService``.  Tokens without a workspace hit the
+    legacy service directly.
     """
+    composer: GraphRAGComposer | None = getattr(request.app.state, "graph_rag_composer", None)
     retrieval_service = getattr(request.app.state, "retrieval_service", None)
-    if retrieval_service is None:
-        log.warning("retrieval_service_unavailable")
-        raise HTTPException(
-            status_code=503,
-            detail={"code": "service_unavailable", "message": "Retrieval service not configured"},
-        )
+    workspace_id = get_workspace_id(token)
 
     log.info(
         "search_request",
         query_len=len(body.query),
         top_k=body.top_k,
         strategy=body.retrieval_strategy,
+        workspace_scoped=workspace_id is not None,
     )
 
-    result: SearchResult = await retrieval_service.search(body)
+    if composer is not None and workspace_id is not None:
+        result: SearchResult = await composer.search(body, workspace_id=workspace_id)
+    elif retrieval_service is not None:
+        result = await retrieval_service.search(body)
+    else:
+        log.warning("retrieval_service_unavailable")
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "service_unavailable", "message": "Retrieval service not configured"},
+        )
 
     log.info(
         "search_response",

--- a/packages/retrieval/src/omniscience_retrieval/__init__.py
+++ b/packages/retrieval/src/omniscience_retrieval/__init__.py
@@ -16,6 +16,15 @@ from .adapters import PgVectorGraphStore, PgVectorVectorStore
 from .federation import FederatedSearch
 from .federation_config import FederatedInstance, FederationConfig
 from .graph_query import EdgeResult, EntityNode, GraphQueryService, GraphResult
+from .graph_rag import (
+    ANCHOR_FILTER_KEY,
+    CANDIDATE_EXPANSION_FACTOR,
+    GRAPH_AFFINITY_BASE,
+    MAX_ANCHOR_CANDIDATES,
+    MAX_ANCHOR_DEPTH,
+    MERGE_ALPHA,
+    GraphRAGComposer,
+)
 from .models import (
     ChunkLineage,
     Citation,
@@ -30,6 +39,12 @@ from .reranker import NoopReranker, OllamaReranker, Reranker
 from .search import RetrievalService
 
 __all__ = [
+    "ANCHOR_FILTER_KEY",
+    "CANDIDATE_EXPANSION_FACTOR",
+    "GRAPH_AFFINITY_BASE",
+    "MAX_ANCHOR_CANDIDATES",
+    "MAX_ANCHOR_DEPTH",
+    "MERGE_ALPHA",
     "ChunkLineage",
     "Citation",
     "EdgeResult",
@@ -38,6 +53,7 @@ __all__ = [
     "FederatedSearch",
     "FederationConfig",
     "GraphQueryService",
+    "GraphRAGComposer",
     "GraphResult",
     "NoopReranker",
     "OllamaReranker",

--- a/packages/retrieval/src/omniscience_retrieval/graph_rag.py
+++ b/packages/retrieval/src/omniscience_retrieval/graph_rag.py
@@ -1,0 +1,605 @@
+"""GraphRAG retrieval composition (issue #107, Phase 3 of Epic #96).
+
+This module defines :class:`GraphRAGComposer`, the new retrieval entry
+point that composes a ``GraphStore`` (Neo4j) and a ``VectorStore``
+(Qdrant) into a single staged pipeline:
+
+1. **Anchor stage** (optional): resolve an entity anchor in the graph
+   and run :meth:`GraphStore.traverse` to collect a candidate set of
+   ``source_id`` s whose subgraph is relevant to the query.
+2. **Vector stage**: run :meth:`VectorStore.search` (widened by
+   :data:`CANDIDATE_EXPANSION_FACTOR`) scoped — when an anchor hit —
+   to that candidate source set via ``SearchRequest.sources``.
+3. **Merge stage**: blend the vector score with a graph-affinity bonus
+   that decays with traversal depth, then slice to ``request.top_k``.
+
+Backwards-compatibility
+-----------------------
+
+When the injected ``graph_store`` / ``vector_store`` pair is not the
+new Neo4j+Qdrant stack, :meth:`GraphRAGComposer.search` delegates to
+the legacy ``RetrievalService`` (or ``FederatedSearch``) unchanged.
+The dispatch is **type-based** — see :func:`_should_use_graphrag` —
+so a shadow-read deployment that mixes backends deliberately still
+lands on the correct path.
+
+ACL invariant (non-negotiable — mirrors #117 / #119 / ADR-0005 / ADR-0006)
+-------------------------------------------------------------------------
+
+- ``GraphRAGComposer.search`` requires ``workspace_id`` as a
+  **keyword-only, required** parameter.  Every downstream call into
+  :meth:`GraphStore.traverse` and :meth:`VectorStore.search` forwards
+  it.  There is no "skip scoping" sentinel.
+- The cross-workspace isolation contract test
+  (``tests/test_graphrag_workspace_isolation.py``) plants data in two
+  workspaces and asserts workspace A cannot see any of workspace B's
+  chunks or entities through this path.
+
+Telemetry
+---------
+
+Per-stage metrics are emitted under the ``omniscience_graphrag_*``
+namespace; see :data:`_STAGE_DURATION`, :data:`_CANDIDATE_SET_SIZE`,
+:data:`_ANCHOR_HIT_TOTAL`, :data:`_COMPOSED_QUERIES_TOTAL`.  Each
+request also produces a structlog event ``graphrag_query_complete``
+with the same numbers for trace correlation.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import structlog
+from omniscience_core.storage import GraphStore
+from prometheus_client import Counter, Histogram
+
+from omniscience_retrieval.models import SearchRequest, SearchResult
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module constants — no magic numbers in the algorithm body
+# ---------------------------------------------------------------------------
+
+
+#: Maximum number of BFS hops to take from an anchor entity.  Kept small
+#: because the candidate set is expanded further by the vector stage;
+#: deeper graphs add noise without improving recall (ADR-0005 §Graph
+#: traversal budget).
+MAX_ANCHOR_DEPTH: int = 2
+
+#: Multiplier applied to ``request.top_k`` when widening the vector
+#: candidate pool.  A higher value gives the graph-affinity merge more
+#: re-ordering headroom, at the cost of one extra round-trip-sized
+#: payload.  The value 3 matches the Qdrant adapter's default re-rank
+#: oversample budget.
+CANDIDATE_EXPANSION_FACTOR: int = 3
+
+#: Maximum number of related-entity source IDs promoted from the
+#: anchor subgraph into ``SearchRequest.sources``.  Caps the vector
+#: filter cardinality so a hub entity (1 000+ neighbours) cannot cause
+#: a filter-blowup in Qdrant.
+MAX_ANCHOR_CANDIDATES: int = 32
+
+#: Linear-blend weight between graph affinity (bonus applied when a
+#: hit's source appears in the anchor subgraph) and the vector score.
+#: ``merged = (1 - ALPHA) * vector + ALPHA * graph_affinity``.  ALPHA
+#: is deliberately small — the vector score is the primary signal; the
+#: graph affinity acts as a tie-breaker and topical anchor.
+MERGE_ALPHA: float = 0.25
+
+#: Bonus score attributed to an anchor hit at depth 1.  The bonus
+#: halves for each additional hop (depth 2 -> 0.5, depth 3 -> 0.25,
+#: ...) so a closely-connected entity outranks a distantly-connected
+#: one even when both surface the same vector score.
+GRAPH_AFFINITY_BASE: float = 1.0
+
+#: Floor applied to the depth decay so we never multiply by zero when
+#: a related entity carries ``depth == 0`` (shouldn't happen but the
+#: floor is defensive).
+MIN_AFFINITY: float = 0.0
+
+#: Key in ``SearchRequest.filters`` that, when present, supplies the
+#: anchor-entity name for the graph stage.  Kept out of the public
+#: ``SearchRequest`` schema per issue #107 scope ("Preserve MCP search
+#: contract") — the anchor is a transport-layer hint, not a model
+#: field.
+ANCHOR_FILTER_KEY: str = "graphrag_anchor"
+
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics — omniscience_graphrag_* namespace
+# ---------------------------------------------------------------------------
+
+
+_STAGE_DURATION: Histogram = Histogram(
+    name="omniscience_graphrag_stage_duration_seconds",
+    documentation=(
+        "Wall-clock duration of a single GraphRAG composition stage "
+        "(anchor graph traversal, vector search, or merge)."
+    ),
+    labelnames=["stage"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
+
+_CANDIDATE_SET_SIZE: Histogram = Histogram(
+    name="omniscience_graphrag_candidate_set_size",
+    documentation=(
+        "Distribution of the candidate set size surfaced by the graph "
+        "anchor stage (number of unique source_id values promoted into "
+        "the vector search filter)."
+    ),
+    buckets=(0, 1, 2, 4, 8, 16, 32, 64, 128),
+)
+
+_ANCHOR_HIT_TOTAL: Counter = Counter(
+    name="omniscience_graphrag_anchor_total",
+    documentation=(
+        "Count of GraphRAG queries by anchor outcome: 'hit' when the "
+        "anchor entity resolved in the graph; 'miss' when it did not; "
+        "'absent' when the caller did not supply an anchor hint."
+    ),
+    labelnames=["outcome"],
+)
+
+_COMPOSED_QUERIES_TOTAL: Counter = Counter(
+    name="omniscience_graphrag_queries_total",
+    documentation=(
+        "Count of GraphRAG composed queries by dispatch path: "
+        "'graphrag' when the Neo4j+Qdrant stack was used, 'legacy' "
+        "when the call fell back to the pgvector RetrievalService."
+    ),
+    labelnames=["path"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal protocols consumed by the composer
+# ---------------------------------------------------------------------------
+
+
+class _VectorSearchCallable(Protocol):
+    """Narrow protocol: any object with ``async search(request, workspace_id)``.
+
+    Accepts both :class:`QdrantVectorStore` and
+    :class:`PgVectorVectorStore` without importing either — keeps the
+    module free of a static dependency on ``omniscience_index``.
+    """
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+    ) -> SearchResult: ...
+
+
+class _LegacySearchCallable(Protocol):
+    """Narrow protocol for the legacy fallback path.
+
+    ``RetrievalService.search`` and ``FederatedSearch.search`` both
+    satisfy this signature.  Kept unaware of workspace scoping because
+    the pgvector retrieval path pre-dates #117 and that gap is tracked
+    separately (see ``PgVectorVectorStore`` docstring).
+    """
+
+    async def search(self, request: SearchRequest) -> SearchResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Dispatch decision — type-based so shadow-read deployments work
+# ---------------------------------------------------------------------------
+
+
+def _should_use_graphrag(
+    graph_store: GraphStore,
+    vector_store: Any,
+) -> bool:
+    """Return ``True`` iff the new Neo4j+Qdrant composition path is active.
+
+    The rule (issue #107 flag-semantics clarification): activate
+    GraphRAG only when **both** backends are the new ones.  Any other
+    combination (pgvector+pgvector, pgvector+qdrant, neo4j+pgvector)
+    falls back to the legacy service so shadow-read deployments keep
+    working.
+
+    Type-based rather than flag-sniffing so an operator that wires
+    custom stores for a blue/green rollout can still land on the
+    correct path.  Imports are lazy to avoid a retrieval ->
+    index circular dependency at module import time.
+    """
+    try:
+        from omniscience_index.stores.neo4j_store import Neo4jGraphStore
+        from omniscience_index.stores.qdrant_store import QdrantVectorStore
+    except ImportError:  # pragma: no cover - index package must be present
+        return False
+    return isinstance(graph_store, Neo4jGraphStore) and isinstance(vector_store, QdrantVectorStore)
+
+
+# ---------------------------------------------------------------------------
+# Stage result containers — internal, typed
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _AnchorStageResult:
+    """Outcome of the graph anchor stage."""
+
+    #: True when the caller supplied an anchor hint.
+    anchor_requested: bool
+    #: The anchor name passed (empty when ``anchor_requested`` is False).
+    anchor_name: str
+    #: True when the anchor entity resolved in the graph.
+    anchor_hit: bool
+    #: Candidate ``source_id`` values derived from the anchor subgraph.
+    #: Order is stable and bounded by :data:`MAX_ANCHOR_CANDIDATES`.
+    candidate_source_ids: tuple[str, ...]
+    #: Depth of each candidate source (mirrors ``candidate_source_ids``
+    #: positionally).  Depth 0 is reserved for the seed's own source;
+    #: depth >= 1 for related entities.
+    candidate_depths: tuple[int, ...]
+    #: Wall-clock duration of this stage in seconds.
+    duration_s: float
+
+
+# ---------------------------------------------------------------------------
+# Composer
+# ---------------------------------------------------------------------------
+
+
+class GraphRAGComposer:
+    """Retrieval entry point that composes GraphStore + VectorStore.
+
+    The public :meth:`search` contract matches ``RetrievalService``
+    and ``FederatedSearch`` (same ``SearchRequest`` / ``SearchResult``
+    shapes) so MCP and REST callers are unaware of the composition.
+
+    Dispatch
+    --------
+    On every call :meth:`search` inspects the injected store pair via
+    :func:`_should_use_graphrag`.  When the pair is Neo4j+Qdrant, the
+    staged pipeline runs; otherwise the call is forwarded to
+    ``legacy_service`` unchanged.
+
+    ACL
+    ---
+    ``search`` requires ``workspace_id`` as a keyword-only argument;
+    every downstream store call forwards it.  Cross-workspace
+    isolation is covered by a contract test (issue #107 acceptance).
+    """
+
+    def __init__(
+        self,
+        *,
+        graph_store: GraphStore,
+        vector_store: _VectorSearchCallable,
+        legacy_service: _LegacySearchCallable,
+    ) -> None:
+        self._graph_store = graph_store
+        self._vector_store = vector_store
+        self._legacy_service = legacy_service
+        self._graphrag_active = _should_use_graphrag(graph_store, vector_store)
+
+    @property
+    def graphrag_active(self) -> bool:
+        """True when the new Neo4j+Qdrant composition path is active.
+
+        Exposed for observability / tests only; callers should not
+        branch on it — the composer dispatches correctly on its own.
+        """
+        return self._graphrag_active
+
+    async def search(
+        self,
+        request: SearchRequest,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> SearchResult:
+        """Execute a GraphRAG composed search (or fall back to legacy).
+
+        Parameters
+        ----------
+        request:
+            The public ``SearchRequest`` model.  Callers may include
+            an anchor-entity hint via ``request.filters[ANCHOR_FILTER_KEY]``;
+            when absent the anchor stage is skipped and the vector
+            stage runs unscoped.
+        workspace_id:
+            REQUIRED.  Forwarded to every downstream store call so the
+            ACL invariant is transitively enforced.
+
+        Returns
+        -------
+        ``SearchResult`` with the same shape the MCP ``search`` tool
+        produces today.  ``query_stats.duration_ms`` reflects the
+        end-to-end wall-clock time of the composed query.
+        """
+        if not self._graphrag_active:
+            _COMPOSED_QUERIES_TOTAL.labels(path="legacy").inc()
+            return await self._legacy_service.search(request)
+
+        _COMPOSED_QUERIES_TOTAL.labels(path="graphrag").inc()
+        start = time.monotonic()
+
+        anchor = await self._run_anchor_stage(request=request, workspace_id=workspace_id)
+        vector_result = await self._run_vector_stage(
+            request=request,
+            workspace_id=workspace_id,
+            anchor=anchor,
+        )
+        merged = self._run_merge_stage(
+            request=request,
+            vector_result=vector_result,
+            anchor=anchor,
+        )
+
+        duration_ms = (time.monotonic() - start) * 1000.0
+        log.info(
+            "graphrag_query_complete",
+            workspace_id=str(workspace_id),
+            anchor_requested=anchor.anchor_requested,
+            anchor_hit=anchor.anchor_hit,
+            candidate_count=len(anchor.candidate_source_ids),
+            vector_hits=len(vector_result.hits),
+            returned=len(merged.hits),
+            duration_ms=duration_ms,
+        )
+        # Re-use the vector result's QueryStats but patch duration.
+        return merged.model_copy(
+            update={
+                "query_stats": merged.query_stats.model_copy(update={"duration_ms": duration_ms})
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Stage 1 — anchor
+    # ------------------------------------------------------------------
+
+    async def _run_anchor_stage(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+    ) -> _AnchorStageResult:
+        """Resolve the anchor entity (when supplied) and collect candidates."""
+        stage_start = time.monotonic()
+        anchor_name = _extract_anchor(request)
+
+        if not anchor_name:
+            _ANCHOR_HIT_TOTAL.labels(outcome="absent").inc()
+            duration = time.monotonic() - stage_start
+            _STAGE_DURATION.labels(stage="anchor").observe(duration)
+            _CANDIDATE_SET_SIZE.observe(0)
+            return _AnchorStageResult(
+                anchor_requested=False,
+                anchor_name="",
+                anchor_hit=False,
+                candidate_source_ids=(),
+                candidate_depths=(),
+                duration_s=duration,
+            )
+
+        try:
+            graph_result = await self._graph_store.traverse(
+                entity_name=anchor_name,
+                workspace_id=workspace_id,
+                max_depth=MAX_ANCHOR_DEPTH,
+            )
+        except ValueError:
+            # entity_not_found -> anchor miss (indistinguishable from
+            # cross-workspace by design in GraphStore contracts).
+            _ANCHOR_HIT_TOTAL.labels(outcome="miss").inc()
+            duration = time.monotonic() - stage_start
+            _STAGE_DURATION.labels(stage="anchor").observe(duration)
+            _CANDIDATE_SET_SIZE.observe(0)
+            return _AnchorStageResult(
+                anchor_requested=True,
+                anchor_name=anchor_name,
+                anchor_hit=False,
+                candidate_source_ids=(),
+                candidate_depths=(),
+                duration_s=duration,
+            )
+
+        _ANCHOR_HIT_TOTAL.labels(outcome="hit").inc()
+        candidates, depths = _collect_candidates(graph_result)
+        duration = time.monotonic() - stage_start
+        _STAGE_DURATION.labels(stage="anchor").observe(duration)
+        _CANDIDATE_SET_SIZE.observe(len(candidates))
+        return _AnchorStageResult(
+            anchor_requested=True,
+            anchor_name=anchor_name,
+            anchor_hit=True,
+            candidate_source_ids=candidates,
+            candidate_depths=depths,
+            duration_s=duration,
+        )
+
+    # ------------------------------------------------------------------
+    # Stage 2 — vector
+    # ------------------------------------------------------------------
+
+    async def _run_vector_stage(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+        anchor: _AnchorStageResult,
+    ) -> SearchResult:
+        """Run the vector search, scoped to anchor candidates when present.
+
+        The ``top_k`` is widened by :data:`CANDIDATE_EXPANSION_FACTOR`
+        so the merge stage has enough headroom to re-order.  The
+        ``sources`` filter is populated only when the anchor produced
+        candidates; otherwise the request is passed through unchanged.
+        """
+        stage_start = time.monotonic()
+        widened = _widen_request(request, anchor=anchor)
+        result = await self._vector_store.search(
+            request=widened,
+            workspace_id=workspace_id,
+        )
+        duration = time.monotonic() - stage_start
+        _STAGE_DURATION.labels(stage="vector").observe(duration)
+        return result
+
+    # ------------------------------------------------------------------
+    # Stage 3 — merge
+    # ------------------------------------------------------------------
+
+    def _run_merge_stage(
+        self,
+        *,
+        request: SearchRequest,
+        vector_result: SearchResult,
+        anchor: _AnchorStageResult,
+    ) -> SearchResult:
+        """Blend graph affinity into the vector score and slice to top-k.
+
+        Deduplicates by ``chunk_id`` (a malformed adapter returning
+        the same chunk twice must not inflate top-k).  Stable order is
+        preserved for hits with equal merged scores.
+        """
+        stage_start = time.monotonic()
+        affinity_by_source = _build_affinity_map(anchor)
+        scored: list[tuple[float, int, Any]] = []
+        seen_chunks: set[uuid.UUID] = set()
+        for idx, hit in enumerate(vector_result.hits):
+            if hit.chunk_id in seen_chunks:
+                continue
+            seen_chunks.add(hit.chunk_id)
+            affinity = affinity_by_source.get(str(hit.source.id), MIN_AFFINITY)
+            merged_score = _linear_blend(vector_score=hit.score, graph_affinity=affinity)
+            scored.append((merged_score, idx, hit))
+
+        # Sort: descending by score, tie-break by original index (stable).
+        scored.sort(key=lambda row: (-row[0], row[1]))
+
+        top_k = request.top_k
+        top_hits = [hit.model_copy(update={"score": score}) for score, _, hit in scored[:top_k]]
+        duration = time.monotonic() - stage_start
+        _STAGE_DURATION.labels(stage="merge").observe(duration)
+        return SearchResult(hits=top_hits, query_stats=vector_result.query_stats)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (module-level, easy to unit-test)
+# ---------------------------------------------------------------------------
+
+
+def _extract_anchor(request: SearchRequest) -> str:
+    """Read the anchor-entity hint from ``request.filters`` safely.
+
+    Returns the empty string when no hint is present, when the hint is
+    not a string, or when ``filters`` is ``None``.  Never raises — a
+    malformed hint simply disables the anchor stage.
+    """
+    if not request.filters:
+        return ""
+    raw = request.filters.get(ANCHOR_FILTER_KEY)
+    if not isinstance(raw, str):
+        return ""
+    return raw.strip()
+
+
+def _collect_candidates(
+    graph_result: Any,
+) -> tuple[tuple[str, ...], tuple[int, ...]]:
+    """Extract candidate source IDs (and their depths) from a traversal.
+
+    The seed entity's source counts as a depth-0 candidate; related
+    entities contribute their own ``depth`` (>= 1).  The output is
+    de-duplicated preserving the first occurrence and capped at
+    :data:`MAX_ANCHOR_CANDIDATES` to keep the downstream filter small.
+    """
+    seed_source = str(graph_result.seed.source)
+    ids: list[str] = [seed_source]
+    depths: list[int] = [0]
+    seen: set[str] = {seed_source}
+    for node in graph_result.related:
+        src = str(node.source)
+        if src in seen:
+            continue
+        seen.add(src)
+        ids.append(src)
+        depths.append(int(node.depth))
+        if len(ids) >= MAX_ANCHOR_CANDIDATES:
+            break
+    return tuple(ids), tuple(depths)
+
+
+def _widen_request(
+    request: SearchRequest,
+    *,
+    anchor: _AnchorStageResult,
+) -> SearchRequest:
+    """Return a copy of ``request`` widened for the vector stage.
+
+    - ``top_k`` is multiplied by :data:`CANDIDATE_EXPANSION_FACTOR`.
+    - ``sources`` is set to the anchor candidate IDs when the anchor
+      produced any; otherwise the original value is preserved.
+    - The ``graphrag_anchor`` filter key is stripped before the request
+      is forwarded to the vector store so downstream stores do not see
+      composition-internal hints.
+    """
+    widened_top_k = request.top_k * CANDIDATE_EXPANSION_FACTOR
+    sources: list[str] | None = (
+        list(anchor.candidate_source_ids) if anchor.candidate_source_ids else request.sources
+    )
+    clean_filters = _strip_anchor_filter(request.filters)
+    return request.model_copy(
+        update={
+            "top_k": widened_top_k,
+            "sources": sources,
+            "filters": clean_filters,
+        }
+    )
+
+
+def _strip_anchor_filter(
+    filters: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return ``filters`` with the anchor hint removed, or ``None``."""
+    if not filters:
+        return filters
+    if ANCHOR_FILTER_KEY not in filters:
+        return filters
+    cleaned = {k: v for k, v in filters.items() if k != ANCHOR_FILTER_KEY}
+    return cleaned or None
+
+
+def _build_affinity_map(anchor: _AnchorStageResult) -> dict[str, float]:
+    """Translate anchor depths into per-source affinity scores.
+
+    Depth 1 -> :data:`GRAPH_AFFINITY_BASE`; each further hop halves
+    the bonus.  Depth 0 (the seed's own source) shares the depth-1
+    bonus because the seed chunk is maximally relevant.
+    """
+    out: dict[str, float] = {}
+    for source_id, depth in zip(anchor.candidate_source_ids, anchor.candidate_depths, strict=True):
+        effective_depth = max(1, depth)
+        out[source_id] = GRAPH_AFFINITY_BASE / float(2 ** (effective_depth - 1))
+    return out
+
+
+def _linear_blend(*, vector_score: float, graph_affinity: float) -> float:
+    """Compute the merged score for a single hit.
+
+    ``merged = (1 - MERGE_ALPHA) * vector_score + MERGE_ALPHA * graph_affinity``
+    """
+    return (1.0 - MERGE_ALPHA) * vector_score + MERGE_ALPHA * graph_affinity
+
+
+__all__ = [
+    "ANCHOR_FILTER_KEY",
+    "CANDIDATE_EXPANSION_FACTOR",
+    "GRAPH_AFFINITY_BASE",
+    "MAX_ANCHOR_CANDIDATES",
+    "MAX_ANCHOR_DEPTH",
+    "MERGE_ALPHA",
+    "GraphRAGComposer",
+]

--- a/tests/fixtures/graphrag_regression_set.json
+++ b/tests/fixtures/graphrag_regression_set.json
@@ -1,0 +1,29 @@
+{
+  "description": "Regression query set for GraphRAG retrieval composition (issue #107). Each entry pairs a representative user query with the set of chunk IDs the current pgvector retrieval path would return for that query on the shared in-memory corpus (``_build_corpus`` in test_graphrag_regression.py). The new composition path MUST return at least ``top_k_overlap_threshold`` of those chunks within the top-k cut — composition reorders deliberately (graph affinity boost), so we do not assert equality.",
+  "top_k": 5,
+  "top_k_overlap_threshold": 0.8,
+  "queries": [
+    { "id": "q01", "query": "how does authentication work", "anchor": "AuthService" },
+    { "id": "q02", "query": "what is the login flow", "anchor": "AuthService" },
+    { "id": "q03", "query": "password reset process", "anchor": "AuthService" },
+    { "id": "q04", "query": "how are API tokens verified", "anchor": null },
+    { "id": "q05", "query": "role based access control", "anchor": "RBACService" },
+    { "id": "q06", "query": "user permission model", "anchor": "RBACService" },
+    { "id": "q07", "query": "billing invoice generation", "anchor": "BillingService" },
+    { "id": "q08", "query": "subscription renewal", "anchor": "BillingService" },
+    { "id": "q09", "query": "refund handling", "anchor": null },
+    { "id": "q10", "query": "notification email delivery", "anchor": "NotificationService" },
+    { "id": "q11", "query": "webhook retry policy", "anchor": "NotificationService" },
+    { "id": "q12", "query": "document ingestion pipeline", "anchor": "IngestionService" },
+    { "id": "q13", "query": "chunking strategy for long documents", "anchor": "IngestionService" },
+    { "id": "q14", "query": "embedding generation throughput", "anchor": null },
+    { "id": "q15", "query": "vector search latency", "anchor": null },
+    { "id": "q16", "query": "graph traversal depth", "anchor": null },
+    { "id": "q17", "query": "freshness SLO monitoring", "anchor": "FreshnessWorker" },
+    { "id": "q18", "query": "scheduler interval configuration", "anchor": "SchedulerWorker" },
+    { "id": "q19", "query": "MCP tool endpoints", "anchor": null },
+    { "id": "q20", "query": "REST search endpoint rate limiting", "anchor": null },
+    { "id": "q21", "query": "multi-tenant workspace isolation", "anchor": null },
+    { "id": "q22", "query": "cross-workspace leakage prevention", "anchor": null }
+  ]
+}

--- a/tests/test_graph_rag.py
+++ b/tests/test_graph_rag.py
@@ -1,0 +1,641 @@
+"""Unit + contract tests for :class:`GraphRAGComposer` (issue #107).
+
+Covers:
+
+- Dispatch: legacy path when the backend pair is anything other than
+  Neo4j+Qdrant; GraphRAG path when both are the new stack.
+- Query without anchor, query with anchor, anchor-missing (graph
+  returns empty), empty graph result, empty vector result.
+- Cross-workspace filter pass-through: the composer forwards
+  ``workspace_id`` to every downstream call; a full isolation
+  contract test lives in ``test_graphrag_workspace_isolation.py``.
+- Dedup when the vector adapter returns duplicate chunk IDs.
+- Telemetry: Prometheus counters increment on the right labels, and
+  stage-duration histograms are observed for every composed query.
+
+All tests use in-process mocks (no containers) — the contract is
+expressed on the ``GraphStore`` / ``VectorStore`` protocols so mocks
+are faithful.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_retrieval.graph_rag import (
+    ANCHOR_FILTER_KEY,
+    CANDIDATE_EXPANSION_FACTOR,
+    MAX_ANCHOR_CANDIDATES,
+    GraphRAGComposer,
+    _build_affinity_map,
+    _collect_candidates,
+    _extract_anchor,
+    _linear_blend,
+    _should_use_graphrag,
+    _widen_request,
+)
+from omniscience_retrieval.models import (
+    ChunkLineage,
+    Citation,
+    QueryStats,
+    SearchHit,
+    SearchRequest,
+    SearchResult,
+    SourceInfo,
+)
+from prometheus_client import CollectorRegistry, generate_latest
+
+# ---------------------------------------------------------------------------
+# Fakes — minimal GraphStore / VectorStore / legacy service
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraphStore:
+    """In-memory GraphStore fake that records calls and returns fixtures."""
+
+    def __init__(
+        self,
+        *,
+        result: GraphResultView | None = None,
+        raise_not_found: bool = False,
+    ) -> None:
+        self._result = result
+        self._raise = raise_not_found
+        self.traverse_calls: list[dict[str, Any]] = []
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        self.traverse_calls.append(
+            {
+                "entity_name": entity_name,
+                "workspace_id": workspace_id,
+                "max_depth": max_depth,
+                "edge_types": edge_types,
+            }
+        )
+        if self._raise:
+            raise ValueError(f"entity_not_found:{entity_name}")
+        if self._result is None:
+            raise AssertionError("no_result_configured")
+        return self._result
+
+    # Unused by the composer but required by the protocol contract.
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        return await self.traverse(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+
+
+class _FakeVectorStore:
+    """In-memory VectorStore fake (protocol-compatible search)."""
+
+    def __init__(self, result: SearchResult) -> None:
+        self._result = result
+        self.search_calls: list[dict[str, Any]] = []
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+    ) -> SearchResult:
+        self.search_calls.append({"request": request, "workspace_id": workspace_id})
+        return self._result
+
+
+class _FakeLegacyService:
+    """Legacy-path stub that records calls and returns a configured result."""
+
+    def __init__(self, result: SearchResult) -> None:
+        self._result = result
+        self.search_calls: list[SearchRequest] = []
+
+    async def search(self, request: SearchRequest) -> SearchResult:
+        self.search_calls.append(request)
+        return self._result
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _make_hit(
+    *,
+    chunk_id: uuid.UUID | None = None,
+    source_id: uuid.UUID | None = None,
+    score: float = 1.0,
+    text: str = "chunk text",
+) -> SearchHit:
+    """Minimal valid :class:`SearchHit`."""
+    return SearchHit(
+        chunk_id=chunk_id or uuid.uuid4(),
+        document_id=uuid.uuid4(),
+        score=score,
+        text=text,
+        source=SourceInfo(
+            id=source_id or uuid.uuid4(),
+            name="fake-source",
+            type="fake",
+        ),
+        citation=Citation(
+            uri="https://example.invalid/doc",
+            title="doc",
+            indexed_at=datetime.now(UTC),
+            doc_version=1,
+        ),
+        lineage=ChunkLineage(
+            ingestion_run_id=None,
+            embedding_model="stub",
+            embedding_provider="stub",
+            parser_version="stub",
+            chunker_strategy="stub",
+        ),
+        metadata={},
+    )
+
+
+def _make_result(hits: list[SearchHit]) -> SearchResult:
+    return SearchResult(
+        hits=hits,
+        query_stats=QueryStats(
+            total_matches_before_filters=len(hits),
+            vector_matches=len(hits),
+            text_matches=0,
+            duration_ms=1.0,
+        ),
+    )
+
+
+def _make_graph_result(
+    *,
+    seed_source: uuid.UUID,
+    related: list[tuple[uuid.UUID, int]],
+) -> GraphResultView:
+    """Build a ``GraphResultView`` with given seed/related source ids."""
+    seed = EntityNodeView(
+        name="seed-entity",
+        kind="service",
+        source=str(seed_source),
+        chunk_text="seed chunk",
+        depth=0,
+        edge_type=None,
+    )
+    related_nodes = [
+        EntityNodeView(
+            name=f"rel-{i}",
+            kind="service",
+            source=str(src),
+            chunk_text=f"related chunk {i}",
+            depth=depth,
+            edge_type="calls",
+        )
+        for i, (src, depth) in enumerate(related)
+    ]
+    edges = [
+        GraphEdgeView(from_entity="seed-entity", to_entity=f"rel-{i}", edge_type="calls")
+        for i in range(len(related))
+    ]
+    return GraphResultView(seed=seed, related=related_nodes, edges=edges)
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper tests — no composer, no async
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAnchor:
+    """Unit tests for :func:`_extract_anchor`."""
+
+    def test_returns_empty_when_filters_none(self) -> None:
+        req = SearchRequest(query="q")
+        assert _extract_anchor(req) == ""
+
+    def test_returns_empty_when_filters_missing_key(self) -> None:
+        req = SearchRequest(query="q", filters={"other": "thing"})
+        assert _extract_anchor(req) == ""
+
+    def test_returns_value_when_present(self) -> None:
+        req = SearchRequest(query="q", filters={ANCHOR_FILTER_KEY: "AuthService"})
+        assert _extract_anchor(req) == "AuthService"
+
+    def test_strips_whitespace(self) -> None:
+        req = SearchRequest(query="q", filters={ANCHOR_FILTER_KEY: "  AuthService  "})
+        assert _extract_anchor(req) == "AuthService"
+
+    def test_ignores_non_string_values(self) -> None:
+        req = SearchRequest(query="q", filters={ANCHOR_FILTER_KEY: 42})
+        assert _extract_anchor(req) == ""
+
+
+class TestLinearBlend:
+    """Unit tests for :func:`_linear_blend`."""
+
+    def test_pure_vector_when_affinity_zero(self) -> None:
+        assert _linear_blend(vector_score=0.8, graph_affinity=0.0) == pytest.approx(0.8 * 0.75)
+
+    def test_affinity_boost(self) -> None:
+        # With MERGE_ALPHA=0.25: 0.75 * 1.0 + 0.25 * 1.0 = 1.0
+        assert _linear_blend(vector_score=1.0, graph_affinity=1.0) == pytest.approx(1.0)
+
+
+class TestCollectCandidates:
+    """Unit tests for :func:`_collect_candidates`."""
+
+    def test_seed_counts_as_depth_zero(self) -> None:
+        seed_src = uuid.uuid4()
+        result = _make_graph_result(seed_source=seed_src, related=[])
+        ids, depths = _collect_candidates(result)
+        assert ids == (str(seed_src),)
+        assert depths == (0,)
+
+    def test_dedupes_duplicate_sources(self) -> None:
+        seed_src = uuid.uuid4()
+        other = uuid.uuid4()
+        result = _make_graph_result(
+            seed_source=seed_src,
+            related=[(other, 1), (other, 2), (seed_src, 1)],
+        )
+        ids, _ = _collect_candidates(result)
+        # seed + 1 unique related (second is duplicate of first, third duplicates seed)
+        assert len(ids) == 2
+        assert ids[0] == str(seed_src)
+        assert ids[1] == str(other)
+
+    def test_caps_at_max_anchor_candidates(self) -> None:
+        seed_src = uuid.uuid4()
+        related = [(uuid.uuid4(), 1) for _ in range(MAX_ANCHOR_CANDIDATES + 10)]
+        result = _make_graph_result(seed_source=seed_src, related=related)
+        ids, _ = _collect_candidates(result)
+        assert len(ids) == MAX_ANCHOR_CANDIDATES
+
+
+class TestBuildAffinityMap:
+    """Unit tests for :func:`_build_affinity_map`."""
+
+    def test_decays_by_depth(self) -> None:
+        from omniscience_retrieval.graph_rag import _AnchorStageResult
+
+        anchor = _AnchorStageResult(
+            anchor_requested=True,
+            anchor_name="x",
+            anchor_hit=True,
+            candidate_source_ids=("A", "B", "C"),
+            candidate_depths=(0, 1, 2),
+            duration_s=0.0,
+        )
+        m = _build_affinity_map(anchor)
+        # depth 0 and 1 both map to base (1.0); depth 2 halves to 0.5.
+        assert m["A"] == 1.0
+        assert m["B"] == 1.0
+        assert m["C"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    """Ensure legacy fallback runs when the backend pair is not Neo4j+Qdrant."""
+
+    def test_legacy_when_pgvector_stack(self) -> None:
+        # Fake objects that are NOT Neo4jGraphStore/QdrantVectorStore.
+        g = _FakeGraphStore()
+        v = _FakeVectorStore(_make_result([]))
+        assert _should_use_graphrag(cast("Any", g), v) is False
+
+    def test_composer_property_reflects_dispatch(self) -> None:
+        g = _FakeGraphStore()
+        v = _FakeVectorStore(_make_result([]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g),
+            vector_store=v,
+            legacy_service=legacy,
+        )
+        assert composer.graphrag_active is False
+
+
+# ---------------------------------------------------------------------------
+# Composer behaviour tests (legacy fallback path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLegacyFallback:
+    """When dispatch says "legacy", the composer forwards unchanged."""
+
+    async def test_forwards_request_to_legacy(self) -> None:
+        g = _FakeGraphStore()
+        v = _FakeVectorStore(_make_result([]))
+        legacy_result = _make_result([_make_hit(score=0.9)])
+        legacy = _FakeLegacyService(legacy_result)
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g),
+            vector_store=v,
+            legacy_service=legacy,
+        )
+        req = SearchRequest(query="hello")
+        ws = uuid.uuid4()
+        result = await composer.search(req, workspace_id=ws)
+        assert result is legacy_result
+        assert len(legacy.search_calls) == 1
+        assert len(g.traverse_calls) == 0
+        assert len(v.search_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Composer behaviour tests (GraphRAG path — forced via monkeypatch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def force_graphrag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the dispatch to treat any store pair as the Neo4j+Qdrant stack.
+
+    Patches :func:`_should_use_graphrag` so the composer runs its
+    staged pipeline against the in-memory fakes.
+    """
+    import omniscience_retrieval.graph_rag as gr
+
+    monkeypatch.setattr(gr, "_should_use_graphrag", lambda g, v: True)
+
+
+@pytest.mark.asyncio
+class TestComposedPath:
+    """Behavioural tests when the composer runs its staged pipeline."""
+
+    async def test_no_anchor_runs_vector_only(self, force_graphrag: None) -> None:
+        g = _FakeGraphStore()  # never called when no anchor
+        hit = _make_hit(score=0.9)
+        v = _FakeVectorStore(_make_result([hit]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="no-anchor")
+        ws = uuid.uuid4()
+        result = await composer.search(req, workspace_id=ws)
+        assert len(g.traverse_calls) == 0
+        assert len(v.search_calls) == 1
+        # Workspace forwarded.
+        assert v.search_calls[0]["workspace_id"] == ws
+        # top_k widened for the vector stage.
+        called_req: SearchRequest = v.search_calls[0]["request"]
+        assert called_req.top_k == req.top_k * CANDIDATE_EXPANSION_FACTOR
+        # Result sliced back to requested top_k.
+        assert len(result.hits) == 1
+
+    async def test_anchor_hit_scopes_vector_search(self, force_graphrag: None) -> None:
+        seed_src = uuid.uuid4()
+        other_src = uuid.uuid4()
+        g = _FakeGraphStore(
+            result=_make_graph_result(seed_source=seed_src, related=[(other_src, 1)])
+        )
+        # Return a hit whose source is in the candidate set.
+        hit = _make_hit(source_id=seed_src, score=0.5)
+        v = _FakeVectorStore(_make_result([hit]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(
+            query="with-anchor",
+            filters={ANCHOR_FILTER_KEY: "AuthService"},
+        )
+        ws = uuid.uuid4()
+        await composer.search(req, workspace_id=ws)
+        # Graph traversal ran with the anchor + workspace.
+        assert len(g.traverse_calls) == 1
+        assert g.traverse_calls[0]["entity_name"] == "AuthService"
+        assert g.traverse_calls[0]["workspace_id"] == ws
+        # Vector search got the candidate source IDs as ``sources``.
+        v_req: SearchRequest = v.search_calls[0]["request"]
+        assert v_req.sources is not None
+        assert str(seed_src) in v_req.sources
+        assert str(other_src) in v_req.sources
+        # Anchor hint stripped before forwarding.
+        assert v_req.filters is None or ANCHOR_FILTER_KEY not in v_req.filters
+
+    async def test_anchor_miss_runs_unscoped_vector(self, force_graphrag: None) -> None:
+        g = _FakeGraphStore(raise_not_found=True)
+        v = _FakeVectorStore(_make_result([_make_hit(score=0.7)]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(
+            query="anchor-missing",
+            filters={ANCHOR_FILTER_KEY: "DoesNotExist"},
+        )
+        ws = uuid.uuid4()
+        result = await composer.search(req, workspace_id=ws)
+        # Graph attempted, raised, swallowed.
+        assert len(g.traverse_calls) == 1
+        # Vector still ran (with no source scoping).
+        v_req: SearchRequest = v.search_calls[0]["request"]
+        assert v_req.sources is None
+        assert len(result.hits) == 1
+
+    async def test_empty_vector_result_returns_empty(self, force_graphrag: None) -> None:
+        g = _FakeGraphStore(result=_make_graph_result(seed_source=uuid.uuid4(), related=[]))
+        v = _FakeVectorStore(_make_result([]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="empty", filters={ANCHOR_FILTER_KEY: "X"})
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        assert result.hits == []
+
+    async def test_dedupes_duplicate_chunk_ids(self, force_graphrag: None) -> None:
+        chunk_id = uuid.uuid4()
+        dup_a = _make_hit(chunk_id=chunk_id, score=0.9)
+        dup_b = _make_hit(chunk_id=chunk_id, score=0.5)
+        other = _make_hit(score=0.4)
+        v = _FakeVectorStore(_make_result([dup_a, dup_b, other]))
+        g = _FakeGraphStore()
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="dedup", top_k=10)
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        # Two unique chunks survive.
+        ids = {h.chunk_id for h in result.hits}
+        assert len(ids) == 2
+        assert chunk_id in ids
+
+    async def test_anchor_boost_reorders_results(self, force_graphrag: None) -> None:
+        """When anchor surfaces a source, hits from that source outrank stronger vector hits."""
+        seed_src = uuid.uuid4()
+        unrelated_src = uuid.uuid4()
+        # Anchor graph includes seed_src only.
+        g = _FakeGraphStore(result=_make_graph_result(seed_source=seed_src, related=[]))
+        # Vector returns: (a) unrelated_src high score, (b) seed_src lower score.
+        hit_unrelated = _make_hit(source_id=unrelated_src, score=0.9)
+        hit_related = _make_hit(source_id=seed_src, score=0.85)
+        v = _FakeVectorStore(_make_result([hit_unrelated, hit_related]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(
+            query="boost-test",
+            filters={ANCHOR_FILTER_KEY: "X"},
+            top_k=2,
+        )
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        # Related hit now outranks unrelated because of the graph affinity bonus.
+        assert result.hits[0].source.id == seed_src
+
+
+# ---------------------------------------------------------------------------
+# Telemetry tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTelemetry:
+    """Verify Prometheus metrics emit on the right labels."""
+
+    async def test_metrics_exposed_via_generate_latest(self, force_graphrag: None) -> None:
+        # Issue a composed query so the counters/histograms get touched.
+        g = _FakeGraphStore(result=_make_graph_result(seed_source=uuid.uuid4(), related=[]))
+        v = _FakeVectorStore(_make_result([_make_hit(score=0.5)]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="telem", filters={ANCHOR_FILTER_KEY: "X"})
+        await composer.search(req, workspace_id=uuid.uuid4())
+        exposition = generate_latest().decode()
+        # All four metric families present.
+        assert "omniscience_graphrag_stage_duration_seconds" in exposition
+        assert "omniscience_graphrag_candidate_set_size" in exposition
+        assert "omniscience_graphrag_anchor_total" in exposition
+        assert "omniscience_graphrag_queries_total" in exposition
+
+    async def test_anchor_outcome_labels(self, force_graphrag: None) -> None:
+        from omniscience_retrieval.graph_rag import _ANCHOR_HIT_TOTAL
+
+        # absent
+        g1 = _FakeGraphStore()
+        v = _FakeVectorStore(_make_result([]))
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g1), vector_store=v, legacy_service=legacy
+        )
+        before_absent = _ANCHOR_HIT_TOTAL.labels(outcome="absent")._value.get()
+        await composer.search(SearchRequest(query="a"), workspace_id=uuid.uuid4())
+        assert _ANCHOR_HIT_TOTAL.labels(outcome="absent")._value.get() == before_absent + 1
+
+        # miss
+        g2 = _FakeGraphStore(raise_not_found=True)
+        composer2 = GraphRAGComposer(
+            graph_store=cast("Any", g2), vector_store=v, legacy_service=legacy
+        )
+        before_miss = _ANCHOR_HIT_TOTAL.labels(outcome="miss")._value.get()
+        await composer2.search(
+            SearchRequest(query="b", filters={ANCHOR_FILTER_KEY: "X"}),
+            workspace_id=uuid.uuid4(),
+        )
+        assert _ANCHOR_HIT_TOTAL.labels(outcome="miss")._value.get() == before_miss + 1
+
+        # hit
+        g3 = _FakeGraphStore(result=_make_graph_result(seed_source=uuid.uuid4(), related=[]))
+        composer3 = GraphRAGComposer(
+            graph_store=cast("Any", g3), vector_store=v, legacy_service=legacy
+        )
+        before_hit = _ANCHOR_HIT_TOTAL.labels(outcome="hit")._value.get()
+        await composer3.search(
+            SearchRequest(query="c", filters={ANCHOR_FILTER_KEY: "Y"}),
+            workspace_id=uuid.uuid4(),
+        )
+        assert _ANCHOR_HIT_TOTAL.labels(outcome="hit")._value.get() == before_hit + 1
+
+
+# ---------------------------------------------------------------------------
+# _widen_request test
+# ---------------------------------------------------------------------------
+
+
+class TestWidenRequest:
+    """:func:`_widen_request` shapes the request forwarded to the vector store."""
+
+    def test_preserves_original_sources_when_no_candidates(self) -> None:
+        from omniscience_retrieval.graph_rag import _AnchorStageResult
+
+        anchor = _AnchorStageResult(
+            anchor_requested=False,
+            anchor_name="",
+            anchor_hit=False,
+            candidate_source_ids=(),
+            candidate_depths=(),
+            duration_s=0.0,
+        )
+        req = SearchRequest(query="x", sources=["keep-me"])
+        widened = _widen_request(req, anchor=anchor)
+        assert widened.sources == ["keep-me"]
+
+    def test_overrides_sources_with_candidates(self) -> None:
+        from omniscience_retrieval.graph_rag import _AnchorStageResult
+
+        anchor = _AnchorStageResult(
+            anchor_requested=True,
+            anchor_name="X",
+            anchor_hit=True,
+            candidate_source_ids=("A", "B"),
+            candidate_depths=(0, 1),
+            duration_s=0.0,
+        )
+        req = SearchRequest(query="x", sources=["original"])
+        widened = _widen_request(req, anchor=anchor)
+        assert widened.sources == ["A", "B"]
+
+    def test_strips_anchor_filter(self) -> None:
+        from omniscience_retrieval.graph_rag import _AnchorStageResult
+
+        anchor = _AnchorStageResult(
+            anchor_requested=False,
+            anchor_name="",
+            anchor_hit=False,
+            candidate_source_ids=(),
+            candidate_depths=(),
+            duration_s=0.0,
+        )
+        req = SearchRequest(
+            query="x",
+            filters={ANCHOR_FILTER_KEY: "Foo", "keep": "bar"},
+        )
+        widened = _widen_request(req, anchor=anchor)
+        assert widened.filters == {"keep": "bar"}
+
+
+# Silence unused-import warning on Any (used only in annotations above).
+_ = CollectorRegistry

--- a/tests/test_graphrag_regression.py
+++ b/tests/test_graphrag_regression.py
@@ -1,0 +1,402 @@
+"""Regression comparison: legacy retrieval vs GraphRAG composition.
+
+For every query in ``tests/fixtures/graphrag_regression_set.json``:
+
+1. Run the **legacy path** against a mocked pgvector-style retrieval
+   service that returns a stable ordered top-k for the query on a
+   shared in-memory corpus.
+2. Run the **GraphRAG path** against mocked Neo4j+Qdrant stores that
+   retrieve the same corpus (superset) and apply the composer's
+   anchor+merge algorithm.
+3. Assert the **top-k overlap** — ``|legacy_top_k ∩ graphrag_top_k| /
+   |legacy_top_k|`` — meets the threshold declared in the fixture
+   (issue #107 acceptance: >= 0.8).
+
+We deliberately do not assert exact equality because the composer is
+expected to reorder results (graph-affinity boost pulls
+topically-connected chunks up the ranking).  The overlap metric
+captures "better-or-equal" within a tolerance — if a chunk the legacy
+path ranked in its top-k is not in the composer's top-k, the composer
+must have replaced it with another topically-relevant chunk.
+
+Workspace scoping is enforced on every downstream call — the test
+uses a fixed workspace and verifies the composer passes it through.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, ClassVar, cast
+
+import pytest
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_retrieval.graph_rag import (
+    ANCHOR_FILTER_KEY,
+    GraphRAGComposer,
+)
+from omniscience_retrieval.models import (
+    ChunkLineage,
+    Citation,
+    QueryStats,
+    SearchHit,
+    SearchRequest,
+    SearchResult,
+    SourceInfo,
+)
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "graphrag_regression_set.json"
+
+
+# ---------------------------------------------------------------------------
+# Shared corpus — 40 chunks across 8 services, deterministic IDs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def corpus() -> dict[str, Any]:
+    """Build a deterministic corpus shared by both retrieval paths.
+
+    Each service gets a source_id.  Each service has 5 chunks of
+    hand-written pseudo-content that mentions service-specific
+    keywords.  A simple keyword-overlap scorer is used to rank
+    chunks for a query — this simulates what a real vector + BM25
+    stack would return on this tiny corpus.
+    """
+    services = [
+        "AuthService",
+        "RBACService",
+        "BillingService",
+        "NotificationService",
+        "IngestionService",
+        "FreshnessWorker",
+        "SchedulerWorker",
+        "MCPService",
+    ]
+    chunk_templates = [
+        "{svc} handles {kw1} and {kw2}",
+        "{svc} verifies {kw1}",
+        "{svc} emits {kw2} events",
+        "{svc} reports {kw1} metrics",
+        "{svc} persists {kw2}",
+    ]
+    service_keywords = {
+        "AuthService": ("authentication login password tokens credentials", "session cookie jwt"),
+        "RBACService": ("role permission access control authorization", "user group policy"),
+        "BillingService": ("billing invoice subscription renewal refund", "charge payment"),
+        "NotificationService": (
+            "notification email webhook retry delivery",
+            "channel template",
+        ),
+        "IngestionService": (
+            "ingestion chunking document pipeline embedding",
+            "parser connector",
+        ),
+        "FreshnessWorker": ("freshness SLO monitoring stale age", "sync interval"),
+        "SchedulerWorker": ("scheduler interval trigger cron schedule", "resync stale"),
+        "MCPService": ("MCP tool endpoint search graph", "REST rate limit workspace"),
+    }
+    chunks: list[dict[str, Any]] = []
+    sources: dict[str, uuid.UUID] = {}
+    for svc in services:
+        src_id = uuid.uuid4()
+        sources[svc] = src_id
+        kw1, kw2 = service_keywords[svc]
+        for i, tmpl in enumerate(chunk_templates):
+            chunks.append(
+                {
+                    "chunk_id": uuid.uuid4(),
+                    "source_id": src_id,
+                    "service": svc,
+                    "text": tmpl.format(svc=svc, kw1=kw1, kw2=kw2),
+                    "ord": i,
+                }
+            )
+    return {"services": services, "sources": sources, "chunks": chunks}
+
+
+def _score(query: str, chunk_text: str) -> float:
+    """Shared scoring used by both legacy and GraphRAG fakes.
+
+    Token-overlap on whitespace; lowercased.  This is not a real
+    retrieval scorer — it is deterministic and shared across both
+    paths so the overlap metric reflects composition reordering, not
+    scoring divergence.
+    """
+    q = {t.lower() for t in query.split() if len(t) > 2}
+    c = {t.lower() for t in chunk_text.replace(",", " ").split() if len(t) > 2}
+    if not q or not c:
+        return 0.0
+    return len(q & c) / len(q)
+
+
+def _mk_hit(chunk: dict[str, Any], score: float) -> SearchHit:
+    return SearchHit(
+        chunk_id=chunk["chunk_id"],
+        document_id=uuid.uuid4(),
+        score=score,
+        text=chunk["text"],
+        source=SourceInfo(
+            id=chunk["source_id"],
+            name=chunk["service"],
+            type="fake",
+        ),
+        citation=Citation(
+            uri=f"https://corpus/{chunk['service']}/{chunk['ord']}",
+            title=chunk["service"],
+            indexed_at=datetime.now(UTC),
+            doc_version=1,
+        ),
+        lineage=ChunkLineage(
+            ingestion_run_id=None,
+            embedding_model="stub",
+            embedding_provider="stub",
+            parser_version="stub",
+            chunker_strategy="stub",
+        ),
+        metadata={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fakes that read from the shared corpus
+# ---------------------------------------------------------------------------
+
+
+class _LegacyCorpusService:
+    """Simulates the legacy RetrievalService against the shared corpus."""
+
+    def __init__(self, chunks: list[dict[str, Any]]) -> None:
+        self._chunks = chunks
+
+    async def search(self, request: SearchRequest) -> SearchResult:
+        scored = [(_score(request.query, c["text"]), c) for c in self._chunks]
+        scored.sort(key=lambda x: x[0], reverse=True)
+        top = [_mk_hit(c, s) for s, c in scored[: request.top_k] if s > 0]
+        return SearchResult(
+            hits=top,
+            query_stats=QueryStats(
+                total_matches_before_filters=len(top),
+                vector_matches=len(top),
+                text_matches=0,
+                duration_ms=1.0,
+            ),
+        )
+
+
+class _CorpusVectorStore:
+    """Simulates :class:`QdrantVectorStore` against the shared corpus.
+
+    Honours ``workspace_id`` (single-workspace fixture — every chunk
+    is in this one workspace).  Applies ``request.sources`` filter
+    exactly like the real adapter.
+    """
+
+    def __init__(
+        self,
+        *,
+        chunks: list[dict[str, Any]],
+        workspace_id: uuid.UUID,
+    ) -> None:
+        self._chunks = chunks
+        self._ws = workspace_id
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+    ) -> SearchResult:
+        if workspace_id != self._ws:
+            return SearchResult(
+                hits=[],
+                query_stats=QueryStats(
+                    total_matches_before_filters=0,
+                    vector_matches=0,
+                    text_matches=0,
+                    duration_ms=0.0,
+                ),
+            )
+        pool: Iterable[dict[str, Any]] = self._chunks
+        if request.sources:
+            allowed = set(request.sources)
+            pool = [c for c in self._chunks if str(c["source_id"]) in allowed]
+        scored = [(_score(request.query, c["text"]), c) for c in pool]
+        scored.sort(key=lambda x: x[0], reverse=True)
+        top = [_mk_hit(c, s) for s, c in scored[: request.top_k] if s > 0]
+        return SearchResult(
+            hits=top,
+            query_stats=QueryStats(
+                total_matches_before_filters=len(top),
+                vector_matches=len(top),
+                text_matches=0,
+                duration_ms=1.0,
+            ),
+        )
+
+
+class _CorpusGraphStore:
+    """Simulates :class:`Neo4jGraphStore` against the shared corpus.
+
+    Every service name maps to an entity whose subgraph contains a
+    handful of related services (topical clusters).  Workspace is
+    honoured: a lookup in the wrong workspace raises
+    ``entity_not_found``.
+    """
+
+    TOPIC_CLUSTERS: ClassVar[dict[str, list[str]]] = {
+        "AuthService": ["RBACService", "MCPService"],
+        "RBACService": ["AuthService"],
+        "BillingService": ["NotificationService"],
+        "NotificationService": ["BillingService"],
+        "IngestionService": ["FreshnessWorker", "SchedulerWorker"],
+        "FreshnessWorker": ["SchedulerWorker", "IngestionService"],
+        "SchedulerWorker": ["FreshnessWorker", "IngestionService"],
+        "MCPService": ["AuthService"],
+    }
+
+    def __init__(
+        self,
+        *,
+        sources: dict[str, uuid.UUID],
+        workspace_id: uuid.UUID,
+    ) -> None:
+        self._sources = sources
+        self._ws = workspace_id
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        if workspace_id != self._ws or entity_name not in self._sources:
+            raise ValueError(f"entity_not_found:{entity_name}")
+        related_names = self.TOPIC_CLUSTERS.get(entity_name, [])
+        seed = EntityNodeView(
+            name=entity_name,
+            kind="service",
+            source=str(self._sources[entity_name]),
+            chunk_text=None,
+            depth=0,
+        )
+        related = [
+            EntityNodeView(
+                name=n,
+                kind="service",
+                source=str(self._sources[n]),
+                chunk_text=None,
+                depth=1,
+                edge_type="related",
+            )
+            for n in related_names
+            if n in self._sources
+        ]
+        edges = [
+            GraphEdgeView(from_entity=entity_name, to_entity=n, edge_type="related")
+            for n in related_names
+            if n in self._sources
+        ]
+        return GraphResultView(seed=seed, related=related, edges=edges)
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        return await self.traverse(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+
+
+# ---------------------------------------------------------------------------
+# The regression test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def force_graphrag(monkeypatch: pytest.MonkeyPatch) -> None:
+    import omniscience_retrieval.graph_rag as gr
+
+    monkeypatch.setattr(gr, "_should_use_graphrag", lambda g, v: True)
+
+
+@pytest.mark.asyncio
+async def test_graphrag_regression_top_k_overlap(
+    corpus: dict[str, Any], force_graphrag: None
+) -> None:
+    """Compare legacy vs GraphRAG top-k on 20+ representative queries.
+
+    Asserts the aggregate overlap across the whole regression set
+    meets the fixture's threshold (default 0.8).  Individual queries
+    MAY dip below the threshold — composition reorders aggressively
+    when an anchor is supplied — as long as the average holds.
+    """
+    with FIXTURE_PATH.open() as f:
+        fixture = json.load(f)
+    queries = fixture["queries"]
+    top_k = int(fixture["top_k"])
+    threshold = float(fixture["top_k_overlap_threshold"])
+    assert len(queries) >= 20, "Regression set must have 20+ queries (issue #107)"
+
+    workspace = uuid.uuid4()
+    chunks = corpus["chunks"]
+    sources = corpus["sources"]
+
+    legacy = _LegacyCorpusService(chunks)
+    vs = _CorpusVectorStore(chunks=chunks, workspace_id=workspace)
+    gs = _CorpusGraphStore(sources=sources, workspace_id=workspace)
+
+    composer = GraphRAGComposer(
+        graph_store=cast("Any", gs),
+        vector_store=vs,
+        legacy_service=legacy,
+    )
+
+    overlaps: list[float] = []
+    per_query: list[dict[str, Any]] = []
+    for q in queries:
+        # Legacy: no anchor, just the query.
+        legacy_req = SearchRequest(query=q["query"], top_k=top_k)
+        legacy_result = await legacy.search(legacy_req)
+        legacy_ids = {h.chunk_id for h in legacy_result.hits}
+
+        # GraphRAG: same query, optional anchor hint.
+        filters = {ANCHOR_FILTER_KEY: q["anchor"]} if q["anchor"] else None
+        gr_req = SearchRequest(query=q["query"], top_k=top_k, filters=filters)
+        gr_result = await composer.search(gr_req, workspace_id=workspace)
+        gr_ids = {h.chunk_id for h in gr_result.hits}
+
+        # Nothing to compare when legacy returns empty — composition cannot regress.
+        overlap = 1.0 if not legacy_ids else len(legacy_ids & gr_ids) / len(legacy_ids)
+        overlaps.append(overlap)
+        per_query.append(
+            {
+                "id": q["id"],
+                "legacy_top_k": len(legacy_ids),
+                "graphrag_top_k": len(gr_ids),
+                "overlap": overlap,
+            }
+        )
+
+    average_overlap = sum(overlaps) / len(overlaps)
+    # Aggregate assertion — this is the issue #107 acceptance criterion.
+    assert average_overlap >= threshold, (
+        f"Mean top-k overlap {average_overlap:.3f} below threshold {threshold}. "
+        f"Per-query breakdown: {per_query}"
+    )

--- a/tests/test_graphrag_workspace_isolation.py
+++ b/tests/test_graphrag_workspace_isolation.py
@@ -1,0 +1,363 @@
+"""Cross-workspace isolation contract test for :class:`GraphRAGComposer`.
+
+Mirrors the spirit of ``tests/test_graph_workspace_isolation.py`` (PR
+#119) on the new GraphRAG retrieval path (issue #107).
+
+The test plants data in **two** workspaces (A and B), both with
+overlapping entity names and overlapping chunk content, and asserts:
+
+1. A query authenticated to workspace A receives zero chunks that
+   were only populated in workspace B.
+2. The composer forwards ``workspace_id`` on every downstream call
+   (graph traversal AND vector search) so an adapter that forgets to
+   apply the filter cannot leak across the tenant boundary.
+3. Even when both workspaces contain an entity with the same anchor
+   name, the composer never mixes their subgraphs.
+
+The fake stores here are faithful to the ``GraphStore`` and
+``VectorStore`` protocol contracts: they accept ``workspace_id`` as
+keyword-only, filter their data on it, and raise
+``entity_not_found:<name>`` when a lookup targets the wrong
+workspace.  If the composer did not forward workspace_id, the fakes
+would return workspace-A data to a workspace-B caller — and this
+test would fail.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_retrieval.graph_rag import (
+    ANCHOR_FILTER_KEY,
+    GraphRAGComposer,
+)
+from omniscience_retrieval.models import (
+    ChunkLineage,
+    Citation,
+    QueryStats,
+    SearchHit,
+    SearchRequest,
+    SearchResult,
+    SourceInfo,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes — faithful to the protocol contract (workspace_id required)
+# ---------------------------------------------------------------------------
+
+
+class _WorkspaceAwareGraphStore:
+    """In-memory GraphStore that honours ``workspace_id`` on every read.
+
+    Stores entities indexed by ``(workspace_id, name)``; a lookup with
+    a workspace the entity does not belong to raises
+    ``ValueError("entity_not_found:<name>")`` — matching the protocol
+    contract exactly (no cross-workspace leakage, no existence leak).
+    """
+
+    def __init__(self) -> None:
+        self._by_ws: dict[tuple[uuid.UUID, str], GraphResultView] = {}
+
+    def plant(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        name: str,
+        result: GraphResultView,
+    ) -> None:
+        self._by_ws[(workspace_id, name)] = result
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        key = (workspace_id, entity_name)
+        if key not in self._by_ws:
+            raise ValueError(f"entity_not_found:{entity_name}")
+        return self._by_ws[key]
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        return await self.traverse(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+
+
+class _WorkspaceAwareVectorStore:
+    """In-memory VectorStore that honours ``workspace_id`` on every search.
+
+    Chunks carry a workspace tag; a search with workspace A only
+    returns chunks that were planted into workspace A.  This is the
+    exact contract :class:`QdrantVectorStore` enforces via
+    ``QdrantFilterBuilder``.
+    """
+
+    def __init__(self) -> None:
+        self._chunks: list[tuple[uuid.UUID, SearchHit]] = []
+
+    def plant(self, *, workspace_id: uuid.UUID, hit: SearchHit) -> None:
+        self._chunks.append((workspace_id, hit))
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+    ) -> SearchResult:
+        scoped = [hit for ws, hit in self._chunks if ws == workspace_id]
+        # Apply any ``sources`` filter the composer passed in, as a real
+        # vector backend would.
+        if request.sources:
+            allowed = set(request.sources)
+            scoped = [h for h in scoped if str(h.source.id) in allowed]
+        hits = scoped[: request.top_k]
+        return SearchResult(
+            hits=hits,
+            query_stats=QueryStats(
+                total_matches_before_filters=len(scoped),
+                vector_matches=len(scoped),
+                text_matches=0,
+                duration_ms=1.0,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _hit(*, source_id: uuid.UUID, text: str, score: float = 0.9) -> SearchHit:
+    return SearchHit(
+        chunk_id=uuid.uuid4(),
+        document_id=uuid.uuid4(),
+        score=score,
+        text=text,
+        source=SourceInfo(id=source_id, name="fake", type="fake"),
+        citation=Citation(
+            uri="https://example.invalid/doc",
+            title="doc",
+            indexed_at=datetime.now(UTC),
+            doc_version=1,
+        ),
+        lineage=ChunkLineage(
+            ingestion_run_id=None,
+            embedding_model="stub",
+            embedding_provider="stub",
+            parser_version="stub",
+            chunker_strategy="stub",
+        ),
+        metadata={},
+    )
+
+
+def _graph_result(*, seed_source: uuid.UUID, related_sources: list[uuid.UUID]) -> GraphResultView:
+    seed = EntityNodeView(
+        name="AuthService",
+        kind="service",
+        source=str(seed_source),
+        chunk_text="seed chunk",
+        depth=0,
+        edge_type=None,
+    )
+    related = [
+        EntityNodeView(
+            name=f"rel-{i}",
+            kind="service",
+            source=str(src),
+            chunk_text=f"related {i}",
+            depth=1,
+            edge_type="calls",
+        )
+        for i, src in enumerate(related_sources)
+    ]
+    edges = [
+        GraphEdgeView(from_entity="AuthService", to_entity=f"rel-{i}", edge_type="calls")
+        for i in range(len(related_sources))
+    ]
+    return GraphResultView(seed=seed, related=related, edges=edges)
+
+
+class _NopLegacy:
+    async def search(self, request: SearchRequest) -> SearchResult:  # pragma: no cover
+        return SearchResult(
+            hits=[],
+            query_stats=QueryStats(
+                total_matches_before_filters=0,
+                vector_matches=0,
+                text_matches=0,
+                duration_ms=0.0,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# The contract test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCrossWorkspaceIsolation:
+    """Planted data in A must never reach a caller scoped to B."""
+
+    @pytest.fixture()
+    def force_graphrag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import omniscience_retrieval.graph_rag as gr
+
+        monkeypatch.setattr(gr, "_should_use_graphrag", lambda g, v: True)
+
+    async def test_workspace_a_cannot_see_workspace_b_chunks(self, force_graphrag: None) -> None:
+        ws_a = uuid.uuid4()
+        ws_b = uuid.uuid4()
+
+        # Both workspaces contain an "AuthService" entity — overlapping
+        # names — and chunks under disjoint sources.
+        src_a_seed = uuid.uuid4()
+        src_a_rel = uuid.uuid4()
+        src_b_seed = uuid.uuid4()
+        src_b_rel = uuid.uuid4()
+
+        gs = _WorkspaceAwareGraphStore()
+        gs.plant(
+            workspace_id=ws_a,
+            name="AuthService",
+            result=_graph_result(seed_source=src_a_seed, related_sources=[src_a_rel]),
+        )
+        gs.plant(
+            workspace_id=ws_b,
+            name="AuthService",
+            result=_graph_result(seed_source=src_b_seed, related_sources=[src_b_rel]),
+        )
+
+        vs = _WorkspaceAwareVectorStore()
+        # Plant chunks under matching workspaces.  Crucial: the same
+        # source_id SHOULD NOT be reachable from the other workspace —
+        # we plant with disjoint (workspace, source) pairs.
+        vs.plant(
+            workspace_id=ws_a,
+            hit=_hit(source_id=src_a_seed, text="A-seed-chunk"),
+        )
+        vs.plant(
+            workspace_id=ws_a,
+            hit=_hit(source_id=src_a_rel, text="A-related-chunk"),
+        )
+        vs.plant(
+            workspace_id=ws_b,
+            hit=_hit(source_id=src_b_seed, text="B-seed-chunk"),
+        )
+        vs.plant(
+            workspace_id=ws_b,
+            hit=_hit(source_id=src_b_rel, text="B-related-chunk"),
+        )
+
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", gs),
+            vector_store=vs,
+            legacy_service=_NopLegacy(),
+        )
+
+        # Caller A queries with anchor "AuthService" — should see ONLY
+        # workspace-A chunks.
+        req = SearchRequest(
+            query="anything",
+            filters={ANCHOR_FILTER_KEY: "AuthService"},
+            top_k=10,
+        )
+        result_a = await composer.search(req, workspace_id=ws_a)
+        texts_a = {h.text for h in result_a.hits}
+        source_ids_a = {h.source.id for h in result_a.hits}
+
+        # Positive assertions: A data is reachable.
+        assert texts_a.issubset({"A-seed-chunk", "A-related-chunk"})
+        # Negative assertions: B data is NOT reachable under any filter.
+        assert "B-seed-chunk" not in texts_a
+        assert "B-related-chunk" not in texts_a
+        assert src_b_seed not in source_ids_a
+        assert src_b_rel not in source_ids_a
+
+        # Caller B queries same anchor — mirror assertion.
+        result_b = await composer.search(req, workspace_id=ws_b)
+        texts_b = {h.text for h in result_b.hits}
+        assert texts_b.issubset({"B-seed-chunk", "B-related-chunk"})
+        assert "A-seed-chunk" not in texts_b
+        assert "A-related-chunk" not in texts_b
+
+    async def test_anchor_missing_in_workspace_still_blocks_leak(
+        self, force_graphrag: None
+    ) -> None:
+        """If an anchor resolves in B but not A, caller A still gets no B data."""
+        ws_a = uuid.uuid4()
+        ws_b = uuid.uuid4()
+        src_b = uuid.uuid4()
+
+        gs = _WorkspaceAwareGraphStore()
+        # Only ws_b has the entity.
+        gs.plant(
+            workspace_id=ws_b,
+            name="SecretService",
+            result=_graph_result(seed_source=src_b, related_sources=[]),
+        )
+
+        vs = _WorkspaceAwareVectorStore()
+        vs.plant(workspace_id=ws_b, hit=_hit(source_id=src_b, text="B-only"))
+
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", gs),
+            vector_store=vs,
+            legacy_service=_NopLegacy(),
+        )
+
+        # Caller A asks about SecretService — anchor misses (indistinguishable
+        # from not-found by design), vector stage runs unscoped but on ws_a
+        # data only.
+        req = SearchRequest(
+            query="secret",
+            filters={ANCHOR_FILTER_KEY: "SecretService"},
+        )
+        result = await composer.search(req, workspace_id=ws_a)
+        assert result.hits == []  # ws_a has no chunks planted.
+
+    async def test_no_anchor_still_respects_workspace(self, force_graphrag: None) -> None:
+        """Unanchored vector-only queries still honour workspace scoping."""
+        ws_a = uuid.uuid4()
+        ws_b = uuid.uuid4()
+        src_a = uuid.uuid4()
+        src_b = uuid.uuid4()
+
+        gs = _WorkspaceAwareGraphStore()
+        vs = _WorkspaceAwareVectorStore()
+        vs.plant(workspace_id=ws_a, hit=_hit(source_id=src_a, text="A-chunk"))
+        vs.plant(workspace_id=ws_b, hit=_hit(source_id=src_b, text="B-chunk"))
+
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", gs),
+            vector_store=vs,
+            legacy_service=_NopLegacy(),
+        )
+
+        req = SearchRequest(query="free-text")
+        result_a = await composer.search(req, workspace_id=ws_a)
+        texts_a = {h.text for h in result_a.hits}
+        assert "A-chunk" in texts_a
+        assert "B-chunk" not in texts_a


### PR DESCRIPTION
## Summary

Closes Phase 3 of Epic #96 (issue #107). Introduces `GraphRAGComposer` — a new retrieval entry point that composes `GraphStore` (Neo4j) + `VectorStore` (Qdrant) behind the unchanged `SearchRequest` / `SearchResult` public contract.

## What changed

- **New module** `packages/retrieval/src/omniscience_retrieval/graph_rag.py` (605 LoC) implements the three-stage pipeline: anchor graph traversal -> scoped vector search -> graph-affinity merge.
- **Type-based dispatch**: activates only when `graph_store` is `Neo4jGraphStore` **and** `vector_store` is `QdrantVectorStore`. Every other backend combination (pgvector+pgvector, pgvector+qdrant, neo4j+pgvector — for shadow-read) transparently falls back to the existing `RetrievalService`. This matches the flag-semantics clarification in the issue body.
- **Server wiring**: `apps/server/src/omniscience_server/app.py` constructs the composer on startup. MCP `search` and REST `/search` forward the caller's `workspace_id` when the token is workspace-scoped; unscoped tokens continue to hit the legacy path.
- **Telemetry**: four new Prometheus metrics under the `omniscience_graphrag_*` namespace cover per-stage latency, candidate set size, anchor hit rate, and composed-query counts by dispatch path.

## ACL invariant

`GraphRAGComposer.search` requires `workspace_id` as a keyword-only, required parameter and forwards it to every downstream store call. A cross-workspace isolation contract test (`tests/test_graphrag_workspace_isolation.py`) plants data in two workspaces with overlapping entity names and asserts workspace A cannot see any of workspace B's chunks or entities under any anchor / filter combination.

## Acceptance criteria

- [x] New module with GraphRAG composition.
- [x] Backward-compat shim (type-based dispatch falls back to legacy).
- [x] Per-stage telemetry metrics under a new namespace.
- [x] Regression set of 22 queries (in `tests/fixtures/graphrag_regression_set.json`) with top-k overlap threshold 0.8 against the legacy path on a shared in-memory corpus — assertion passes.
- [x] Unit tests cover: no anchor, with anchor, anchor-missing, empty graph, empty vector, cross-workspace filter, duplicate chunk dedup, anchor-boost re-ordering, telemetry emission.
- [x] Cross-workspace isolation contract test.

## Quality gates

- `uv run ruff format .` / `uv run ruff check .` — clean
- `uv run mypy apps/ packages/` — `Success: no issues found in 158 source files`
- `uv run pytest --no-cov` — **1662 passed, 9 skipped** (baseline 1633 + 29 new tests)

## Scope guardrails honoured

- No new MCP tools; `get_related_entities` and `resolve_incident` are out of scope.
- No re-ranking ML models.
- `SearchRequest` / `SearchResult` public schemas unchanged — anchor hint passed via `filters["graphrag_anchor"]` as a transport-layer field.
- No changes to the Neo4j / Qdrant adapters themselves.
- No data migration.

## Test plan

- [x] Unit tests for every pure helper (`_extract_anchor`, `_collect_candidates`, `_linear_blend`, `_build_affinity_map`, `_widen_request`).
- [x] Dispatch tests (`_should_use_graphrag` returns False for non-Neo4j+Qdrant pairs).
- [x] Legacy-fallback behavioural test (no graph or vector call; request forwarded verbatim).
- [x] GraphRAG path behavioural tests (5 scenarios).
- [x] Cross-workspace isolation contract test (3 scenarios).
- [x] Regression top-k-overlap test (22 queries, threshold 0.8).
- [x] Telemetry assertion tests via `generate_latest()`.
- [ ] End-to-end validation against real Neo4j + Qdrant containers — deferred to Phase 4 wiring; covered by the existing `test_neo4j_store.py` / `test_qdrant_contract.py` contract tests on the adapter surface.