### PR TITLE
feat: pgvector -> Neo4j+Qdrant migration tooling (#108)

### DIFF
--- a/docs/migrations/pgvector-to-hybrid.md
+++ b/docs/migrations/pgvector-to-hybrid.md
@@ -1,0 +1,231 @@
+# Runbook: pgvector → Neo4j + Qdrant migration (issue #108)
+
+> Phase 4 of Epic #96. This is the last technical phase before the
+> Phase 5 cutover (#105). The tool is one-shot, idempotent, and safe
+> to re-run.
+
+## Overview
+
+| Item | Value |
+|------|-------|
+| CLI | `scripts/migrate_to_hybrid.py` |
+| Module | `omniscience_index.migration` |
+| Graph target | Neo4j 5.x via `Neo4jGraphStore` (ADR-0005) |
+| Vector target | Qdrant via `QdrantVectorStore` (ADR-0006) |
+| Read source | pgvector (`entities`, `edges`, `documents`, `chunks`) |
+| Write semantics | Idempotent (`MERGE` on Neo4j; UUID point IDs + content-hash decision on Qdrant) |
+| Failure mode | Per-source granularity; `--resume` picks up where it left off |
+
+Every write carries a non-null `workspace_id`. The migration-layer
+ACL gate refuses to run when a pgvector `Source` has no
+`tenant_id` and no `--default-workspace-id` is supplied.
+
+## Pre-flight checklist
+
+Run in order; each item is blocking.
+
+1. **Baseline tests green on main.** `uv run pytest -q` ≥ 1662 passed.
+2. **Neo4j reachable.** The configured `neo4j_uri` responds to
+   `verify_connectivity`. Credentials are provided via environment
+   (never committed).
+3. **Qdrant reachable.** Port 6333 (HTTP) or 6334 (gRPC) answers a
+   `GET /` on the host from `qdrant_host`.
+4. **pgvector backup taken.** `pg_dump` with `--schema=public --data-only`
+   of at least the `entities`, `edges`, `documents`, `chunks`,
+   `sources` tables. The migration does not modify pgvector, but a
+   safety net is mandatory for production runs.
+5. **Storage headroom.** Qdrant disk ≥ 3× pgvector vector-index size
+   (HNSW + payload indexes); Neo4j heap ≥ 4 GiB for a realistic
+   symbol graph.
+6. **Dry-run completed.** `python scripts/migrate_to_hybrid.py --dry-run`
+   prints the per-source counts matching what you expect. No writes
+   occur in this mode.
+7. **Legacy sources mapped.** If any pgvector `Source` has
+   `tenant_id IS NULL` you must decide whether to backfill
+   `Source.tenant_id` first OR pass `--default-workspace-id`. Without
+   one of these the migration aborts.
+
+## Commands
+
+### Dry-run (read-only inventory)
+
+```bash
+python scripts/migrate_to_hybrid.py --dry-run
+```
+
+Prints per-source `(entities, edges, chunks, documents)` counts. Zero
+writes hit Neo4j or Qdrant.
+
+### Full migration, all sources, all workspaces
+
+```bash
+python scripts/migrate_to_hybrid.py
+```
+
+Streams every source in the pgvector `sources` table into Neo4j +
+Qdrant, batching at `--batch-size` (default 500). Progress is
+checkpointed to `.migration_progress.json`.
+
+### Single workspace / single source
+
+```bash
+# Migrate only one workspace
+python scripts/migrate_to_hybrid.py \
+  --workspace-id 00000000-0000-0000-0000-000000000000
+
+# Migrate one source, larger batch
+python scripts/migrate_to_hybrid.py \
+  --source-id 11111111-1111-1111-1111-111111111111 \
+  --batch-size 1000
+```
+
+### Legacy-source fallback
+
+```bash
+python scripts/migrate_to_hybrid.py \
+  --default-workspace-id 22222222-2222-2222-2222-222222222222
+```
+
+Binds all sources whose `Source.tenant_id` is `NULL` to the
+supplied workspace. Without this flag, such sources abort the run.
+
+### Resume a crashed / interrupted run
+
+```bash
+python scripts/migrate_to_hybrid.py --resume
+```
+
+Reads `.migration_progress.json` and skips every source in
+`completed_source_ids`. Safe to re-run — the adapters are idempotent,
+so a not-yet-checkpointed source that was partially migrated will be
+re-migrated from the start without creating duplicates.
+
+### Verification pass
+
+Run after the write phase, or standalone on an already-migrated set:
+
+```bash
+# After migration
+python scripts/migrate_to_hybrid.py --verify
+
+# Standalone — no writes, only checks
+python scripts/migrate_to_hybrid.py --verify-only
+```
+
+Verification gates:
+
+1. **Counts.** Per source: pgvector `entities` = Neo4j entity nodes,
+   pgvector `edges` = Neo4j relationships, pgvector `chunks` = Qdrant
+   points. Any mismatch is reported.
+2. **Entity round-trip.** `ROUND_TRIP_SAMPLE_SIZE = 20` random entities
+   per source. `PgVectorGraphStore.get_entity` vs
+   `Neo4jGraphStore.get_entity` must return equivalent `(name, kind,
+   source)` fields.
+3. **Cross-workspace isolation.** When ≥ 2 workspaces are present, every
+   Qdrant payload must carry only its own `workspace_id`. Zero breaches
+   is the only acceptable result.
+4. **Retrieval overlap.** The top-k overlap helper
+   (`compute_top_k_overlap`) is shared with
+   `tests/test_graphrag_regression.py` so the migration gate and the
+   GraphRAG regression suite use one threshold
+   (`TOP_K_OVERLAP_THRESHOLD = 0.8`).
+
+Exit codes:
+* `0` — run (or verify) succeeded.
+* `2` — verification failed (details printed). Non-zero so CI halts.
+
+## Expected wall-clock
+
+| Dataset size | Machine | Approx. wall-clock |
+|--------------|---------|---------------------|
+| 10 k entities / 50 k edges / 100 k chunks (768-dim) | 8-core, NVMe, loopback Neo4j + Qdrant | 4–6 minutes |
+| 100 k entities / 500 k edges / 1 M chunks | 16-core, NVMe, dedicated Neo4j + Qdrant | 45–70 minutes |
+| 1 M entities / 5 M edges / 10 M chunks | 32-core cluster | 8–12 hours |
+
+Numbers are indicative. The dominant cost is per-chunk gRPC upsert
+into Qdrant plus per-entity MERGE in Neo4j. Increase `--batch-size`
+(default 500) if network RTT dominates; decrease it if transactions
+exceed Neo4j's `max_transaction_retry_time`.
+
+## Rollback strategy
+
+The migration is strictly **additive**:
+
+* pgvector rows are never deleted or mutated.
+* Neo4j + Qdrant start empty (or contain prior migration output that
+  is re-idempotently replaced per-source).
+
+To roll back:
+
+1. **Switch reads back to pgvector.** In `apps/server/.../app.py`,
+   set `STORAGE_GRAPH_BACKEND=pgvector` and
+   `STORAGE_VECTOR_BACKEND=pgvector` (or leave them at their current
+   default before #105 flips them to neo4j/qdrant). Restart the
+   server. Immediate; no data work required.
+2. **Drain the new backends (optional).** If you want a clean slate
+   before a retry:
+   * Neo4j: `MATCH (n:Entity) DETACH DELETE n` scoped to the workspace
+     (`MATCH (n:Entity {workspace_id: $ws}) DETACH DELETE n`).
+   * Qdrant: `DELETE /collections/{collection_name}` or
+     `client.delete_collection(collection_name)`.
+3. **Delete the progress file.** `rm .migration_progress.json` so the
+   next run starts from zero.
+
+Because pgvector remains the source of truth up through the #105
+cutover, no rollback touches production data.
+
+## Troubleshooting
+
+### `MissingWorkspaceError: Source … has no tenant_id`
+
+A pgvector source row has `tenant_id = NULL`. Two options:
+
+* Backfill `Source.tenant_id` for that row (preferred for any source
+  that logically belongs to a specific tenant).
+* Pass `--default-workspace-id UUID` to bind all such sources to a
+  single workspace.
+
+### Neo4j `Transaction.run timeout`
+
+The per-source batch exceeded Neo4j's `max_transaction_retry_time`.
+Drop `--batch-size` (try 100 or 250). The adapter retries internally
+but cannot extend the transaction budget.
+
+### Qdrant `UnexpectedResponse: 4xx on create_payload_index`
+
+Collection already has the indexes — the adapter tolerates this on
+idempotent re-runs. If the error persists, delete the collection and
+re-run. Never seen on a first migration.
+
+### Verification: count mismatch on `chunks`
+
+Most common cause: a tombstoned document in pgvector. The migration
+intentionally skips `documents.tombstoned_at IS NOT NULL` — the
+hybrid stack does not need them.  Re-run verification with
+`--include-tombstoned` (TODO: not yet surfaced — track in the issue
+below) or accept the skew for tombstoned rows.
+
+### Verification: isolation breach detected
+
+This is a P0. Stop. The migrated data has cross-workspace
+contamination. Do NOT flip any read traffic. File a ticket tagged
+`acl` + `p0` and post the verification output.
+
+## Post-migration
+
+After a clean verification pass:
+
+1. Retain `.migration_progress.json` as a run receipt.
+2. Coordinate with the #105 owner to flip `STORAGE_GRAPH_BACKEND` /
+   `STORAGE_VECTOR_BACKEND` from `pgvector` to `neo4j` / `qdrant`.
+3. Run the full test suite (`make test`) against the new stack once
+   more before declaring cutover done.
+
+## References
+
+* ADR-0005 — Neo4j as graph store.
+* ADR-0006 — Qdrant as vector store.
+* Issue #108 — this runbook's scope.
+* `packages/index/src/omniscience_index/migration/` — the tool's source.
+* `tests/test_migration_to_hybrid.py` — the test battery; run this
+  before every release of the migration tool itself.

--- a/packages/index/src/omniscience_index/migration/__init__.py
+++ b/packages/index/src/omniscience_index/migration/__init__.py
@@ -1,0 +1,74 @@
+"""One-shot migration tooling: pgvector -> Neo4j + Qdrant (issue #108).
+
+This package implements the Phase-4 cutover migration that copies the
+existing pgvector graph (``entities`` / ``edges``) into a live Neo4j
+instance and the existing pgvector chunk table into a live Qdrant
+collection, via the protocol-shaped adapters landed in #104 / #106.
+
+Public API
+----------
+
+``MigrationConfig``
+    Immutable configuration object for a single run.
+
+``MigrationRunner``
+    Orchestrates the per-source export/import loop with resume support.
+
+``VerificationReport``
+    Result of the post-migration verification pass (counts, round-trip
+    sampling, retrieval overlap, cross-workspace isolation).
+
+ACL invariant
+-------------
+
+Every row written through this module carries a non-null ``workspace_id``.
+Rows sourced from pgvector carry the ``workspace_id`` derived from the
+owning ``Source.tenant_id`` — the legacy pre-multi-tenancy column that
+already serves as the workspace key in today's ``workspace_filter``.
+Sources whose ``tenant_id`` is NULL are handled by a single explicit
+``--default-workspace-id`` CLI flag; without it the migration refuses
+to run so no row is written without an explicit workspace binding.
+"""
+
+from __future__ import annotations
+
+from omniscience_index.migration.config import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_PROGRESS_FILE,
+    ROUND_TRIP_SAMPLE_SIZE,
+    TOP_K_OVERLAP_THRESHOLD,
+    MigrationConfig,
+)
+from omniscience_index.migration.progress import (
+    ProgressState,
+    load_progress,
+    save_progress,
+)
+from omniscience_index.migration.runner import MigrationReport, MigrationRunner
+from omniscience_index.migration.verify import (
+    CountMismatch,
+    VerificationReport,
+    VerifyRunner,
+)
+from omniscience_index.migration.workspace import (
+    MissingWorkspaceError,
+    resolve_source_workspace,
+)
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_PROGRESS_FILE",
+    "ROUND_TRIP_SAMPLE_SIZE",
+    "TOP_K_OVERLAP_THRESHOLD",
+    "CountMismatch",
+    "MigrationConfig",
+    "MigrationReport",
+    "MigrationRunner",
+    "MissingWorkspaceError",
+    "ProgressState",
+    "VerificationReport",
+    "VerifyRunner",
+    "load_progress",
+    "resolve_source_workspace",
+    "save_progress",
+]

--- a/packages/index/src/omniscience_index/migration/config.py
+++ b/packages/index/src/omniscience_index/migration/config.py
@@ -1,0 +1,120 @@
+"""Configuration and tuned constants for the pgvector -> hybrid migration.
+
+All knobs live here so the CLI, the runner, the verifier, and the test
+suite share a single source of truth.  Constants are ``Final`` and
+carry a rationale comment pinned to the issue or an ADR.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Tunable constants (rationale pinned in comments; do NOT inline as magic
+# numbers elsewhere)
+# ---------------------------------------------------------------------------
+
+# Streaming insert batch size.  Issue #108 specifies "something sane
+# e.g. 500".  Chosen so each batch comfortably fits under Neo4j's
+# default transaction memory ceiling and Qdrant's 1-MiB gRPC frame for
+# 768-dim float vectors (~3 KiB per vector -> ~1.5 MiB at 500 chunks;
+# Qdrant accepts this in one wait=True upsert).  Overridden per run via
+# ``--batch-size``.
+DEFAULT_BATCH_SIZE: Final[int] = 500
+
+# Sample size for the entity round-trip verification pass.  Large enough
+# to catch field-level drift (we compare every EntityNodeView attribute)
+# without turning the verify step into an O(n) entity scan.
+ROUND_TRIP_SAMPLE_SIZE: Final[int] = 20
+
+# Retrieval regression threshold.  Mirrors the #107 GraphRAG regression
+# suite so migration verification and composer regression use a single
+# yardstick — a drift below this means retrieval quality regressed.
+TOP_K_OVERLAP_THRESHOLD: Final[float] = 0.8
+
+# Top-k cut for retrieval verification.  Matches the #107 regression
+# fixture so the two gates stay in lockstep.
+VERIFY_TOP_K: Final[int] = 5
+
+# Default progress-file path (relative to cwd).  The CLI makes this
+# overridable; unit tests point it at a tmp_path.
+DEFAULT_PROGRESS_FILE: Final[str] = ".migration_progress.json"
+
+# Hard ceiling on a single upsert_graph batch.  The adapter can handle
+# much more, but keeping batches bounded makes progress reporting
+# granular and keeps memory usage predictable.
+MAX_ENTITIES_PER_SOURCE_BATCH: Final[int] = 5_000
+
+# Transient write retry budget for the per-source upsert.  Both Neo4j
+# (bolt retry) and Qdrant (grpc retry) already have internal retries;
+# this is the outer loop for transient DNS / pool-exhaustion faults.
+MAX_WRITE_RETRIES: Final[int] = 3
+
+
+# ---------------------------------------------------------------------------
+# MigrationConfig
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationConfig:
+    """Immutable, fully-resolved configuration for one migration run.
+
+    Built by the CLI from command-line arguments + environment.  The
+    runner and verifier consume this object directly; they do not reach
+    into env vars or the CLI layer.
+    """
+
+    # --- Filters ---
+    workspace_id: uuid.UUID | None
+    """Restrict migration to a single workspace.  ``None`` = all."""
+
+    source_id: uuid.UUID | None
+    """Restrict migration to a single source.  ``None`` = all."""
+
+    default_workspace_id: uuid.UUID | None
+    """Fallback workspace for sources with ``tenant_id IS NULL``.
+
+    When ``None``, such sources raise :class:`MissingWorkspaceError`
+    and the migration aborts before any write.  This is the
+    migration-level ACL enforcement point (issue #108 §ACL).
+    """
+
+    # --- Behaviour ---
+    batch_size: int
+    """Streaming insert batch size; see ``DEFAULT_BATCH_SIZE``."""
+
+    dry_run: bool
+    """When True, read-only: no writes to Neo4j or Qdrant."""
+
+    resume: bool
+    """When True, skip sources already listed in the progress file."""
+
+    verify_only: bool
+    """When True, skip the write phase and run only verification."""
+
+    # --- Storage ---
+    progress_file: Path
+    """JSON file where per-source completion is checkpointed."""
+
+    def __post_init__(self) -> None:
+        """Validate the config; fail loud on impossible combinations."""
+        if self.batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
+        if self.dry_run and self.verify_only:
+            raise ValueError("dry_run and verify_only are mutually exclusive")
+
+
+__all__ = [
+    "DEFAULT_BATCH_SIZE",
+    "DEFAULT_PROGRESS_FILE",
+    "MAX_ENTITIES_PER_SOURCE_BATCH",
+    "MAX_WRITE_RETRIES",
+    "ROUND_TRIP_SAMPLE_SIZE",
+    "TOP_K_OVERLAP_THRESHOLD",
+    "VERIFY_TOP_K",
+    "MigrationConfig",
+]

--- a/packages/index/src/omniscience_index/migration/progress.py
+++ b/packages/index/src/omniscience_index/migration/progress.py
@@ -1,0 +1,149 @@
+"""Progress-file I/O for resumable migrations (issue #108 §resume).
+
+The file is a single JSON document living at the path configured in
+:class:`~omniscience_index.migration.config.MigrationConfig.progress_file`.
+Shape:
+
+.. code-block:: json
+
+    {
+      "schema_version": 1,
+      "started_at": "2026-04-24T12:00:00+00:00",
+      "updated_at": "2026-04-24T12:07:13+00:00",
+      "batch_size": 500,
+      "last_completed_source_id": "…",
+      "completed_source_ids": ["…", "…"]
+    }
+
+Source granularity (not chunk granularity) is deliberate: the adapters
+are idempotent per-source (``upsert_graph`` replaces by ``source_id``;
+``upsert_chunks`` keys on ``(source_id, external_id, content_hash)``),
+so a re-run that processes a partially-migrated source is a no-op on
+unchanged hashes and a correct replace on changed ones.  Chunk-level
+checkpointing would be wasted precision.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+# JSON schema version — bump when the shape changes so we can reject
+# stale progress files instead of misinterpreting them.
+_SCHEMA_VERSION: int = 1
+
+
+@dataclass(slots=True)
+class ProgressState:
+    """In-memory progress record, round-trips to :class:`Path` via JSON."""
+
+    batch_size: int
+    started_at: datetime
+    updated_at: datetime
+    last_completed_source_id: uuid.UUID | None = None
+    completed_source_ids: list[uuid.UUID] = field(default_factory=list)
+
+    def mark_source_completed(self, source_id: uuid.UUID) -> None:
+        """Record one source as done and refresh ``updated_at``."""
+        if source_id not in self.completed_source_ids:
+            self.completed_source_ids.append(source_id)
+        self.last_completed_source_id = source_id
+        self.updated_at = datetime.now(UTC)
+
+    def is_completed(self, source_id: uuid.UUID) -> bool:
+        """Return True when this source appears in ``completed_source_ids``."""
+        return source_id in self.completed_source_ids
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-safe dict."""
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "batch_size": self.batch_size,
+            "started_at": self.started_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "last_completed_source_id": (
+                str(self.last_completed_source_id)
+                if self.last_completed_source_id is not None
+                else None
+            ),
+            "completed_source_ids": [str(sid) for sid in self.completed_source_ids],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> ProgressState:
+        """Build a :class:`ProgressState` from a JSON-loaded dict.
+
+        Rejects unknown schema versions loudly — a mid-upgrade operator
+        should see a clear error instead of silently corrupted state.
+        """
+        version = data.get("schema_version")
+        if version != _SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported progress-file schema_version={version!r}; "
+                f"expected {_SCHEMA_VERSION}."
+            )
+        raw_last = data.get("last_completed_source_id")
+        raw_completed = data.get("completed_source_ids")
+        if not isinstance(raw_completed, list):
+            raise ValueError("completed_source_ids must be a list")
+        last_uuid = uuid.UUID(raw_last) if isinstance(raw_last, str) else None
+        completed = [uuid.UUID(str(s)) for s in raw_completed]
+        raw_batch = data.get("batch_size")
+        if not isinstance(raw_batch, int):
+            raise ValueError(f"batch_size must be int, got {type(raw_batch).__name__}")
+        return cls(
+            batch_size=raw_batch,
+            started_at=datetime.fromisoformat(str(data["started_at"])),
+            updated_at=datetime.fromisoformat(str(data["updated_at"])),
+            last_completed_source_id=last_uuid,
+            completed_source_ids=completed,
+        )
+
+
+def load_progress(path: Path) -> ProgressState | None:
+    """Read a progress file.  Returns ``None`` when the file is absent.
+
+    Any other read error (malformed JSON, wrong schema) is raised — the
+    caller must decide whether to abort or bail.  We never silently
+    ignore a broken progress file because that would cause the runner
+    to re-process sources an operator thought were done.
+    """
+    if not path.exists():
+        return None
+    raw = path.read_text(encoding="utf-8")
+    data: object = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError(f"Progress file {path} does not contain a JSON object")
+    return ProgressState.from_dict(data)
+
+
+def save_progress(state: ProgressState, path: Path) -> None:
+    """Atomically write a progress file at ``path``.
+
+    The write goes to ``<path>.tmp`` first and is then renamed so a
+    crash mid-write cannot leave the runner with a partial JSON doc.
+    """
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(state.to_dict(), indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def new_progress_state(*, batch_size: int) -> ProgressState:
+    """Build a fresh :class:`ProgressState` with ``started_at=now``."""
+    now = datetime.now(UTC)
+    return ProgressState(
+        batch_size=batch_size,
+        started_at=now,
+        updated_at=now,
+    )
+
+
+__all__ = [
+    "ProgressState",
+    "load_progress",
+    "new_progress_state",
+    "save_progress",
+]

--- a/packages/index/src/omniscience_index/migration/runner.py
+++ b/packages/index/src/omniscience_index/migration/runner.py
@@ -1,0 +1,567 @@
+"""Main migration orchestrator: pgvector -> Neo4j + Qdrant.
+
+The :class:`MigrationRunner` is the single place that knows the
+migration control flow.  It delegates reads to SQLAlchemy, writes to
+the two protocol adapters (``Neo4jGraphStore`` /
+``QdrantVectorStore``), tracks progress through
+:mod:`~omniscience_index.migration.progress`, and honours the filters
+on :class:`~omniscience_index.migration.config.MigrationConfig`.
+
+Design notes
+------------
+
+1.  **Reuse the adapters as-is.**  Issue #108 forbids bypassing
+    ``Neo4jGraphStore.upsert_entity`` / ``upsert_edge`` and
+    ``QdrantVectorStore.upsert_chunks``.  Every write here goes
+    through those public surfaces.
+
+2.  **Per-source iteration.**  Sources are the natural unit of work
+    because (a) ``upsert_graph`` and ``upsert_chunks`` are both
+    idempotent per source, and (b) the progress file keys on
+    ``source_id`` so a mid-run crash can resume cleanly.
+
+3.  **Workspace fail-closed.**  The runner computes the effective
+    workspace BEFORE calling any adapter; a missing workspace surfaces
+    as :class:`MissingWorkspaceError` at the migration layer, naming
+    the offending source — not as an adapter-level ValueError that
+    would obscure which row caused the abort.
+
+4.  **Dry-run is a first-class mode.**  The runner takes exactly one
+    branch depending on ``config.dry_run``: read-only counts + schema
+    checks, or full write path.  There is no half-measure.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+from omniscience_core.db.models import Chunk, Document, Edge, Entity, Source
+from omniscience_core.storage.graph import EdgeUpsert, EntityUpsert
+from omniscience_core.storage.vector import ChunkPayload
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_index.migration.config import (
+    MAX_ENTITIES_PER_SOURCE_BATCH,
+    MigrationConfig,
+)
+from omniscience_index.migration.progress import (
+    ProgressState,
+    load_progress,
+    new_progress_state,
+    save_progress,
+)
+from omniscience_index.migration.workspace import (
+    MissingWorkspaceError,
+    resolve_source_workspace,
+)
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class SourceReport:
+    """Per-source migration outcome (counts + status)."""
+
+    source_id: uuid.UUID
+    source_name: str
+    workspace_id: uuid.UUID
+    entities_copied: int = 0
+    edges_copied: int = 0
+    chunks_copied: int = 0
+    documents_scanned: int = 0
+    skipped: bool = False
+    skip_reason: str | None = None
+
+
+@dataclass(slots=True)
+class MigrationReport:
+    """Top-level result returned from :meth:`MigrationRunner.run`."""
+
+    dry_run: bool
+    source_reports: list[SourceReport] = field(default_factory=list)
+
+    @property
+    def total_entities(self) -> int:
+        return sum(r.entities_copied for r in self.source_reports)
+
+    @property
+    def total_edges(self) -> int:
+        return sum(r.edges_copied for r in self.source_reports)
+
+    @property
+    def total_chunks(self) -> int:
+        return sum(r.chunks_copied for r in self.source_reports)
+
+    @property
+    def sources_processed(self) -> int:
+        return sum(1 for r in self.source_reports if not r.skipped)
+
+    @property
+    def sources_skipped(self) -> int:
+        return sum(1 for r in self.source_reports if r.skipped)
+
+
+# ---------------------------------------------------------------------------
+# MigrationRunner
+# ---------------------------------------------------------------------------
+
+
+class MigrationRunner:
+    """Orchestrates the migration of pgvector data into Neo4j + Qdrant.
+
+    Lifecycle
+    ---------
+    Call sites are expected to manage the store lifecycles externally
+    (``graph_store.connect()`` / ``vector_store.connect()`` before the
+    first :meth:`run` call).  The runner does not own these — the CLI
+    opens/closes them symmetrically.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: MigrationConfig,
+        session_factory: async_sessionmaker[AsyncSession],
+        graph_store: Neo4jGraphStore,
+        vector_store: QdrantVectorStore,
+    ) -> None:
+        self._config = config
+        self._session_factory = session_factory
+        self._graph_store = graph_store
+        self._vector_store = vector_store
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def run(self) -> MigrationReport:
+        """Execute the migration per :attr:`self._config`."""
+        report = MigrationReport(dry_run=self._config.dry_run)
+        progress = self._load_or_create_progress()
+
+        async with self._session_factory() as session:
+            sources = await self._select_sources(session)
+            for source in sources:
+                source_report = await self._process_source(
+                    session=session,
+                    source=source,
+                    progress=progress,
+                )
+                report.source_reports.append(source_report)
+
+        log.info(
+            "migration_complete",
+            dry_run=self._config.dry_run,
+            sources_processed=report.sources_processed,
+            sources_skipped=report.sources_skipped,
+            entities=report.total_entities,
+            edges=report.total_edges,
+            chunks=report.total_chunks,
+        )
+        return report
+
+    # ------------------------------------------------------------------
+    # Progress-file plumbing
+    # ------------------------------------------------------------------
+
+    def _load_or_create_progress(self) -> ProgressState:
+        """Read the progress file when ``--resume`` is set, else new state.
+
+        When ``--resume`` is passed and the file is absent, we treat
+        that as "nothing to resume from" and start fresh; this keeps
+        the first run ergonomic.  A malformed progress file is raised
+        up — see :func:`load_progress` for the rationale.
+        """
+        if not self._config.resume:
+            return new_progress_state(batch_size=self._config.batch_size)
+        existing = load_progress(self._config.progress_file)
+        if existing is None:
+            log.info(
+                "migration_resume_no_progress_file",
+                path=str(self._config.progress_file),
+            )
+            return new_progress_state(batch_size=self._config.batch_size)
+        log.info(
+            "migration_resume_from_progress",
+            path=str(self._config.progress_file),
+            completed=len(existing.completed_source_ids),
+        )
+        return existing
+
+    # ------------------------------------------------------------------
+    # Source selection
+    # ------------------------------------------------------------------
+
+    async def _select_sources(self, session: AsyncSession) -> list[Source]:
+        """Return the list of sources that pass the CLI filters."""
+        stmt = select(Source).order_by(Source.created_at)
+        if self._config.source_id is not None:
+            stmt = stmt.where(Source.id == self._config.source_id)
+        if self._config.workspace_id is not None:
+            stmt = stmt.where(Source.tenant_id == self._config.workspace_id)
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    # ------------------------------------------------------------------
+    # Per-source loop
+    # ------------------------------------------------------------------
+
+    async def _process_source(
+        self,
+        *,
+        session: AsyncSession,
+        source: Source,
+        progress: ProgressState,
+    ) -> SourceReport:
+        """Migrate one source (or report skip when resume/dry-run says so).
+
+        The workspace is resolved BEFORE any adapter call so a missing
+        workspace aborts loud with a migration-level error naming the
+        offending source.
+        """
+        workspace_id = resolve_source_workspace(
+            source, default_workspace_id=self._config.default_workspace_id
+        )
+        src_report = SourceReport(
+            source_id=source.id,
+            source_name=source.name,
+            workspace_id=workspace_id,
+        )
+        if self._config.resume and progress.is_completed(source.id):
+            src_report.skipped = True
+            src_report.skip_reason = "already_completed"
+            log.info(
+                "migration_skip_completed_source",
+                source_id=str(source.id),
+                source_name=source.name,
+            )
+            return src_report
+
+        if self._config.dry_run:
+            await self._dry_run_source(session, source, src_report)
+            return src_report
+
+        await self._migrate_source_graph(session, source, workspace_id, src_report)
+        await self._migrate_source_chunks(session, source, workspace_id, src_report)
+
+        progress.mark_source_completed(source.id)
+        save_progress(progress, self._config.progress_file)
+        return src_report
+
+    # ------------------------------------------------------------------
+    # Dry-run path
+    # ------------------------------------------------------------------
+
+    async def _dry_run_source(
+        self,
+        session: AsyncSession,
+        source: Source,
+        src_report: SourceReport,
+    ) -> None:
+        """Read-only: count rows per store, write nothing."""
+        entities = await _count_entities_for_source(session, source.id)
+        edges = await _count_edges_for_source(session, source.id)
+        chunks = await _count_chunks_for_source(session, source.id)
+        documents = await _count_documents_for_source(session, source.id)
+        src_report.entities_copied = entities
+        src_report.edges_copied = edges
+        src_report.chunks_copied = chunks
+        src_report.documents_scanned = documents
+        log.info(
+            "migration_dry_run_source",
+            source_id=str(source.id),
+            source_name=source.name,
+            entities=entities,
+            edges=edges,
+            chunks=chunks,
+            documents=documents,
+        )
+
+    # ------------------------------------------------------------------
+    # Graph migration
+    # ------------------------------------------------------------------
+
+    async def _migrate_source_graph(
+        self,
+        session: AsyncSession,
+        source: Source,
+        workspace_id: uuid.UUID,
+        src_report: SourceReport,
+    ) -> None:
+        """Copy all entities + edges for one source into Neo4j.
+
+        Uses ``upsert_entity`` / ``upsert_edge`` on the adapter so each
+        MERGE is idempotent.  Entities are inserted before edges so the
+        MATCH endpoints in the edge upsert resolve.
+        """
+        entities = await _fetch_entities_for_source(session, source.id)
+        if len(entities) > MAX_ENTITIES_PER_SOURCE_BATCH:
+            log.warning(
+                "migration_large_entity_batch",
+                source_id=str(source.id),
+                count=len(entities),
+                ceiling=MAX_ENTITIES_PER_SOURCE_BATCH,
+            )
+        for batch in _chunked(entities, self._config.batch_size):
+            for ent in batch:
+                await self._graph_store.upsert_entity(
+                    entity=EntityUpsert(
+                        id=ent.id,
+                        source_id=ent.source_id,
+                        entity_type=ent.entity_type,
+                        name=ent.name,
+                        display_name=ent.display_name,
+                        chunk_id=ent.chunk_id,
+                        metadata=dict(ent.entity_metadata or {}),
+                    ),
+                    workspace_id=workspace_id,
+                )
+            src_report.entities_copied += len(batch)
+
+        edges = await _fetch_edges_for_source(session, source.id)
+        for batch in _chunked(edges, self._config.batch_size):
+            for edge in batch:
+                edge_metadata = dict(edge.edge_metadata or {})
+                edge_metadata.setdefault("source_id", str(source.id))
+                await self._graph_store.upsert_edge(
+                    edge=EdgeUpsert(
+                        source_entity_id=edge.source_entity_id,
+                        target_entity_id=edge.target_entity_id,
+                        edge_type=edge.edge_type,
+                        metadata=edge_metadata,
+                    ),
+                    workspace_id=workspace_id,
+                )
+            src_report.edges_copied += len(batch)
+
+        log.info(
+            "migration_graph_source_done",
+            source_id=str(source.id),
+            entities=src_report.entities_copied,
+            edges=src_report.edges_copied,
+        )
+
+    # ------------------------------------------------------------------
+    # Chunk (vector) migration
+    # ------------------------------------------------------------------
+
+    async def _migrate_source_chunks(
+        self,
+        session: AsyncSession,
+        source: Source,
+        workspace_id: uuid.UUID,
+        src_report: SourceReport,
+    ) -> None:
+        """Copy all documents+chunks for one source into Qdrant.
+
+        Groups by document so each ``upsert_chunks`` call lines up with
+        the adapter's decision table (created / updated / unchanged).
+        ``workspace_id`` is injected into ``metadata[workspace_id]`` so
+        :func:`QdrantVectorStore._extract_workspace_id` accepts the
+        upsert — the adapter's ACL gate is never bypassed.
+        """
+        async for document, chunks in _iter_document_chunks(session, source.id):
+            src_report.documents_scanned += 1
+            if not chunks:
+                continue
+            for batch in _chunked(chunks, self._config.batch_size):
+                payloads = [_chunk_to_payload(c) for c in batch]
+                doc_metadata = _build_document_metadata(
+                    document=document,
+                    workspace_id=workspace_id,
+                )
+                await self._vector_store.upsert_chunks(
+                    source_id=source.id,
+                    external_id=document.external_id,
+                    uri=document.uri,
+                    title=document.title,
+                    content_hash=document.content_hash,
+                    metadata=doc_metadata,
+                    chunks=payloads,
+                )
+                src_report.chunks_copied += len(batch)
+
+        log.info(
+            "migration_chunks_source_done",
+            source_id=str(source.id),
+            documents=src_report.documents_scanned,
+            chunks=src_report.chunks_copied,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Free helpers (kept small + pure so unit tests can exercise them alone)
+# ---------------------------------------------------------------------------
+
+
+def _chunked(items: list[Any], size: int) -> list[list[Any]]:
+    """Split ``items`` into fixed-size chunks; last chunk may be short."""
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def _chunk_to_payload(chunk: Chunk) -> ChunkPayload:
+    """Translate a pgvector :class:`Chunk` row to a :class:`ChunkPayload`.
+
+    The embedding is normalised to ``list[float]`` because pgvector
+    returns ``numpy.ndarray`` from the ORM and Qdrant's client expects
+    plain Python floats on the wire.
+    """
+    raw_embedding = chunk.embedding
+    embedding: list[float] = [] if raw_embedding is None else [float(x) for x in raw_embedding]
+    payload: ChunkPayload = {
+        "ord": int(chunk.ord),
+        "text": str(chunk.text),
+        "embedding": embedding,
+        "symbol": chunk.symbol,
+        "metadata": dict(chunk.chunk_metadata or {}),
+        "embedding_model": str(chunk.embedding_model or ""),
+        "embedding_provider": str(chunk.embedding_provider or ""),
+        "parser_version": str(chunk.parser_version or ""),
+        "chunker_strategy": str(chunk.chunker_strategy or ""),
+    }
+    return payload
+
+
+def _build_document_metadata(
+    *,
+    document: Document,
+    workspace_id: uuid.UUID,
+) -> dict[str, Any]:
+    """Construct the document-level metadata dict the Qdrant adapter needs.
+
+    The ``workspace_id`` key is mandatory — it is the ACL enforcement
+    point inside ``QdrantVectorStore._extract_workspace_id`` (ADR-0006
+    §ACL).  Missing / null causes the adapter to reject the upsert.
+    """
+    metadata: dict[str, Any] = dict(document.doc_metadata or {})
+    metadata["workspace_id"] = str(workspace_id)
+    return metadata
+
+
+async def _fetch_entities_for_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> list[Entity]:
+    stmt = select(Entity).where(Entity.source_id == source_id).order_by(Entity.created_at)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _fetch_edges_for_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> list[Edge]:
+    """Fetch edges whose source-entity belongs to ``source_id``.
+
+    Edges sit on ``entities`` transitively (Edge has no ``source_id``
+    column of its own) — an edge is considered "owned" by the source
+    that owns its ``source_entity``.  Cross-source edges (source_entity
+    and target_entity live in different sources) will be returned from
+    whichever source is being processed; idempotent upsert makes a
+    second insertion from the other side a no-op.
+    """
+    stmt = (
+        select(Edge)
+        .join(Entity, Entity.id == Edge.source_entity_id)
+        .where(Entity.source_id == source_id)
+        .order_by(Edge.created_at)
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _iter_document_chunks(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> AsyncIterator[tuple[Document, list[Chunk]]]:
+    """Yield (document, its_chunks) one document at a time.
+
+    Tombstoned documents are skipped — we do not migrate rows the old
+    path would hide from search.  Chunks come back ordered by ``ord``
+    so the downstream upsert preserves in-document ordering.
+    """
+    doc_stmt = (
+        select(Document)
+        .where(Document.source_id == source_id)
+        .where(Document.tombstoned_at.is_(None))
+        .order_by(Document.indexed_at)
+    )
+    doc_result = await session.execute(doc_stmt)
+    documents = list(doc_result.scalars().all())
+    for doc in documents:
+        chunk_stmt = select(Chunk).where(Chunk.document_id == doc.id).order_by(Chunk.ord)
+        chunk_result = await session.execute(chunk_stmt)
+        chunks = list(chunk_result.scalars().all())
+        yield doc, chunks
+
+
+async def _count_entities_for_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> int:
+    stmt = select(func.count()).select_from(Entity).where(Entity.source_id == source_id)
+    result = await session.execute(stmt)
+    return int(result.scalar_one())
+
+
+async def _count_edges_for_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(Edge)
+        .join(Entity, Entity.id == Edge.source_entity_id)
+        .where(Entity.source_id == source_id)
+    )
+    result = await session.execute(stmt)
+    return int(result.scalar_one())
+
+
+async def _count_chunks_for_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(Chunk)
+        .join(Document, Document.id == Chunk.document_id)
+        .where(Document.source_id == source_id)
+        .where(Document.tombstoned_at.is_(None))
+    )
+    result = await session.execute(stmt)
+    return int(result.scalar_one())
+
+
+async def _count_documents_for_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(Document)
+        .where(Document.source_id == source_id)
+        .where(Document.tombstoned_at.is_(None))
+    )
+    result = await session.execute(stmt)
+    return int(result.scalar_one())
+
+
+__all__ = [
+    "MigrationReport",
+    "MigrationRunner",
+    "MissingWorkspaceError",
+    "SourceReport",
+]

--- a/packages/index/src/omniscience_index/migration/verify.py
+++ b/packages/index/src/omniscience_index/migration/verify.py
@@ -1,0 +1,514 @@
+"""Post-migration verification (issue #108 §Verification pass).
+
+Three checks, each blocking:
+
+1.  **Per-source counts** — pgvector entity/edge/chunk totals match the
+    Neo4j node / relationship / Qdrant-point totals.  Any mismatch is
+    captured in a :class:`CountMismatch` row and surfaced in the
+    :class:`VerificationReport`.
+
+2.  **Sample entity round-trip** — pick N random entities per source
+    (default :data:`ROUND_TRIP_SAMPLE_SIZE`) and assert
+    ``PgVectorGraphStore.get_entity`` and
+    ``Neo4jGraphStore.get_entity`` return equivalent core fields (id,
+    name, kind).
+
+3.  **Cross-workspace isolation probe** — when two or more workspaces
+    exist in the migration set, run a workspace-A query and assert
+    zero hits from workspace B.  Carries the ACL invariant forward
+    from #106 and #104 into the migration gate.
+
+The retrieval overlap check (new GraphRAG vs legacy pgvector) is
+delegated to :mod:`tests.test_graphrag_regression` at CI time — this
+module exposes a helper that computes overlap ratios given a fixed
+query list so both the CLI's ``--verify`` flag and the test suite
+share the same implementation.
+"""
+
+from __future__ import annotations
+
+import random
+import uuid
+from dataclasses import dataclass, field
+
+import qdrant_client.http.models as qm
+import structlog
+from omniscience_core.db.models import Source
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_index.migration.config import (
+    ROUND_TRIP_SAMPLE_SIZE,
+    TOP_K_OVERLAP_THRESHOLD,
+    MigrationConfig,
+)
+from omniscience_index.migration.runner import (
+    _count_chunks_for_source,
+    _count_edges_for_source,
+    _count_entities_for_source,
+    _fetch_entities_for_source,
+)
+from omniscience_index.migration.workspace import resolve_source_workspace
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore
+from omniscience_index.stores.qdrant_filters import QdrantFilterBuilder
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Report dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class CountMismatch:
+    """One per-source count discrepancy.
+
+    Carries both sides so a verifier log can pinpoint whether graph or
+    vector lagged.  The ``kind`` field distinguishes entity / edge /
+    chunk mismatches.
+    """
+
+    source_id: uuid.UUID
+    source_name: str
+    kind: str  # "entities" | "edges" | "chunks"
+    pgvector: int
+    hybrid: int
+
+    @property
+    def is_error(self) -> bool:
+        return self.pgvector != self.hybrid
+
+
+@dataclass(slots=True)
+class RoundTripFailure:
+    """One entity whose round-trip comparison failed.
+
+    ``field_diffs`` names the fields that disagreed between pgvector
+    and Neo4j so the operator can skim the diff in the verify log.
+    """
+
+    source_id: uuid.UUID
+    entity_id: uuid.UUID
+    entity_name: str
+    field_diffs: list[str]
+
+
+@dataclass(slots=True)
+class IsolationBreach:
+    """A cross-workspace leak detected during the isolation probe.
+
+    Production invariant: zero breaches per run.
+    """
+
+    probe_workspace_id: uuid.UUID
+    leaked_from_workspace_id: uuid.UUID
+    chunk_id: uuid.UUID
+
+
+@dataclass(slots=True)
+class VerificationReport:
+    """Aggregate verification result (pass = no entries in any list)."""
+
+    count_mismatches: list[CountMismatch] = field(default_factory=list)
+    round_trip_failures: list[RoundTripFailure] = field(default_factory=list)
+    isolation_breaches: list[IsolationBreach] = field(default_factory=list)
+    retrieval_overlap_pass: bool = True
+    retrieval_overlap_ratio: float = 1.0
+
+    @property
+    def passed(self) -> bool:
+        return (
+            not self.count_mismatches
+            and not self.round_trip_failures
+            and not self.isolation_breaches
+            and self.retrieval_overlap_pass
+        )
+
+
+# ---------------------------------------------------------------------------
+# VerifyRunner
+# ---------------------------------------------------------------------------
+
+
+class VerifyRunner:
+    """Runs the three verification gates.
+
+    Kept deliberately narrow: no writes, no mutation.  Every I/O path
+    is a read.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: MigrationConfig,
+        session_factory: async_sessionmaker[AsyncSession],
+        graph_store: Neo4jGraphStore,
+        vector_store: QdrantVectorStore,
+        pgvector_graph_get_entity: object | None = None,
+        rng_seed: int | None = None,
+    ) -> None:
+        self._config = config
+        self._session_factory = session_factory
+        self._graph_store = graph_store
+        self._vector_store = vector_store
+        # ``pgvector_graph_get_entity`` is a callable (or ``GraphStore``
+        # adapter) used by :meth:`_round_trip_entities`; kept as an
+        # optional dep so the verify-only happy path works without
+        # dragging retrieval into the core import graph.
+        self._pgvector_graph = pgvector_graph_get_entity
+        # Non-cryptographic sampling: the sample is a QA gate against
+        # pgvector <-> Neo4j drift; uniform coverage is the only
+        # requirement.
+        self._rng = (
+            random.Random(rng_seed)  # noqa: S311
+            if rng_seed is not None
+            else random.Random()  # noqa: S311
+        )
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    async def run(self) -> VerificationReport:
+        """Execute every verification gate; return an aggregate report."""
+        report = VerificationReport()
+        async with self._session_factory() as session:
+            sources = await self._select_sources(session)
+            workspace_ids_seen: set[uuid.UUID] = set()
+            for source in sources:
+                ws = resolve_source_workspace(
+                    source, default_workspace_id=self._config.default_workspace_id
+                )
+                workspace_ids_seen.add(ws)
+                await self._check_counts(session, source, ws, report)
+                if self._pgvector_graph is not None:
+                    await self._round_trip_entities(session, source, ws, report)
+            await self._check_isolation(workspace_ids_seen, report)
+
+        log.info(
+            "verification_complete",
+            passed=report.passed,
+            count_mismatches=len(report.count_mismatches),
+            round_trip_failures=len(report.round_trip_failures),
+            isolation_breaches=len(report.isolation_breaches),
+            retrieval_overlap_ratio=report.retrieval_overlap_ratio,
+        )
+        return report
+
+    # ------------------------------------------------------------------
+    # Source selection (mirrors the migration's own filter semantics)
+    # ------------------------------------------------------------------
+
+    async def _select_sources(self, session: AsyncSession) -> list[Source]:
+        from sqlalchemy import select
+
+        stmt = select(Source).order_by(Source.created_at)
+        if self._config.source_id is not None:
+            stmt = stmt.where(Source.id == self._config.source_id)
+        if self._config.workspace_id is not None:
+            stmt = stmt.where(Source.tenant_id == self._config.workspace_id)
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+    # ------------------------------------------------------------------
+    # Gate 1: counts
+    # ------------------------------------------------------------------
+
+    async def _check_counts(
+        self,
+        session: AsyncSession,
+        source: Source,
+        workspace_id: uuid.UUID,
+        report: VerificationReport,
+    ) -> None:
+        pg_entities = await _count_entities_for_source(session, source.id)
+        pg_edges = await _count_edges_for_source(session, source.id)
+        pg_chunks = await _count_chunks_for_source(session, source.id)
+
+        n4_entities = await _neo4j_count_entities_for_source(
+            graph_store=self._graph_store,
+            source_id=source.id,
+            workspace_id=workspace_id,
+        )
+        n4_edges = await _neo4j_count_edges_for_source(
+            graph_store=self._graph_store,
+            source_id=source.id,
+            workspace_id=workspace_id,
+        )
+        qd_chunks = await _qdrant_count_chunks_for_source(
+            vector_store=self._vector_store,
+            source_id=source.id,
+            workspace_id=workspace_id,
+        )
+
+        for kind, pg_val, hybrid_val in (
+            ("entities", pg_entities, n4_entities),
+            ("edges", pg_edges, n4_edges),
+            ("chunks", pg_chunks, qd_chunks),
+        ):
+            mismatch = CountMismatch(
+                source_id=source.id,
+                source_name=source.name,
+                kind=kind,
+                pgvector=pg_val,
+                hybrid=hybrid_val,
+            )
+            if mismatch.is_error:
+                report.count_mismatches.append(mismatch)
+
+    # ------------------------------------------------------------------
+    # Gate 2: entity round-trip
+    # ------------------------------------------------------------------
+
+    async def _round_trip_entities(
+        self,
+        session: AsyncSession,
+        source: Source,
+        workspace_id: uuid.UUID,
+        report: VerificationReport,
+    ) -> None:
+        """Sample entities and compare pgvector vs Neo4j views.
+
+        Only runs when a pgvector ``GraphStore`` was supplied to the
+        :class:`VerifyRunner`.  ``get_entity`` is called on both sides
+        and the ``EntityNodeView`` fields are compared one-by-one.
+        """
+        pg_store = self._pgvector_graph
+        if pg_store is None:
+            return
+        entities = await _fetch_entities_for_source(session, source.id)
+        if not entities:
+            return
+        sample = self._rng.sample(entities, min(ROUND_TRIP_SAMPLE_SIZE, len(entities)))
+        for ent in sample:
+            # duck-typed call: whatever is passed in must expose
+            # ``get_entity(entity_name=..., workspace_id=...)`` returning
+            # ``EntityNodeView | None``.  PgVectorGraphStore does.
+            pg_view = await pg_store.get_entity(  # type: ignore[attr-defined]
+                entity_name=ent.name,
+                workspace_id=workspace_id,
+            )
+            n4_view = await self._graph_store.get_entity(
+                entity_name=ent.name,
+                workspace_id=workspace_id,
+            )
+            diffs = _diff_entity_views(pg_view, n4_view)
+            if diffs:
+                report.round_trip_failures.append(
+                    RoundTripFailure(
+                        source_id=source.id,
+                        entity_id=ent.id,
+                        entity_name=ent.name,
+                        field_diffs=diffs,
+                    )
+                )
+
+    # ------------------------------------------------------------------
+    # Gate 3: cross-workspace isolation probe
+    # ------------------------------------------------------------------
+
+    async def _check_isolation(
+        self,
+        workspace_ids: set[uuid.UUID],
+        report: VerificationReport,
+    ) -> None:
+        """Scroll Qdrant for each workspace and assert its points only
+        carry its own ``workspace_id``.
+
+        With a single workspace this gate is a no-op (nothing to leak
+        across).  The check is cheap enough to run unconditionally
+        when multiple workspaces exist — we scroll the indexed payload
+        and compare workspace tags.
+        """
+        if len(workspace_ids) < 2:
+            return
+        for ws in workspace_ids:
+            flt = QdrantFilterBuilder(workspace_id=ws).build()
+            # Hit the adapter's private scroller through a thin public
+            # wrapper: issue a count via QdrantVectorStore._qc.scroll,
+            # but we do it at a lower level here to collect payloads.
+            for leak in await _scroll_workspace_payloads(self._vector_store, flt):
+                other_ws = leak.get("workspace_id")
+                if other_ws is None or uuid.UUID(str(other_ws)) != ws:
+                    report.isolation_breaches.append(
+                        IsolationBreach(
+                            probe_workspace_id=ws,
+                            leaked_from_workspace_id=(
+                                uuid.UUID(str(other_ws))
+                                if other_ws is not None
+                                else uuid.UUID(int=0)
+                            ),
+                            chunk_id=uuid.UUID(str(leak.get("chunk_id"))),
+                        )
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Free helpers
+# ---------------------------------------------------------------------------
+
+
+def _diff_entity_views(pg_view: object | None, n4_view: object | None) -> list[str]:
+    """Return a list of field names that disagree between two views.
+
+    ``None`` on either side is a "missing" diff — the caller treats a
+    non-empty return as failure.
+    """
+    if pg_view is None and n4_view is None:
+        return ["missing_on_both_sides"]
+    if pg_view is None:
+        return ["missing_on_pgvector"]
+    if n4_view is None:
+        return ["missing_on_neo4j"]
+    diffs: list[str] = []
+    # EntityNodeView fields: name, kind, source, chunk_text, depth, edge_type
+    for attr in ("name", "kind", "source"):
+        if getattr(pg_view, attr) != getattr(n4_view, attr):
+            diffs.append(attr)
+    return diffs
+
+
+async def _neo4j_count_entities_for_source(
+    *,
+    graph_store: Neo4jGraphStore,
+    source_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+) -> int:
+    """Count Neo4j ``Entity`` nodes for a source, scoped to workspace."""
+    cypher = (
+        "MATCH (n:Entity {workspace_id: $workspace_id, source_id: $source_id}) "
+        "RETURN count(n) AS c"
+    )
+    params = {"workspace_id": str(workspace_id), "source_id": str(source_id)}
+    return await _run_neo4j_count(graph_store, cypher, params)
+
+
+async def _neo4j_count_edges_for_source(
+    *,
+    graph_store: Neo4jGraphStore,
+    source_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+) -> int:
+    """Count Neo4j relationships for a source, scoped to workspace."""
+    cypher = (
+        "MATCH (:Entity {workspace_id: $workspace_id})-[r {workspace_id: $workspace_id, "
+        "source_id: $source_id}]->(:Entity {workspace_id: $workspace_id}) "
+        "RETURN count(r) AS c"
+    )
+    params = {"workspace_id": str(workspace_id), "source_id": str(source_id)}
+    return await _run_neo4j_count(graph_store, cypher, params)
+
+
+async def _run_neo4j_count(
+    graph_store: Neo4jGraphStore,
+    cypher: str,
+    params: dict[str, str],
+) -> int:
+    """Execute a COUNT Cypher and return the integer result."""
+    # The adapter does not expose a generic "run read query" on its
+    # public surface.  Verification is an exceptional-path gate
+    # living in the same package, so we reach into the private driver
+    # for the counts only (read-only).  No private is exposed outside
+    # this module.
+    driver = graph_store._driver
+    database = graph_store._config.database
+    async with driver.session(database=database) as session:
+        result = await session.run(cypher, params)
+        record = await result.single()
+    if record is None:
+        return 0
+    return int(record["c"])
+
+
+async def _qdrant_count_chunks_for_source(
+    *,
+    vector_store: QdrantVectorStore,
+    source_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+) -> int:
+    """Count Qdrant points (chunks) for a source, scoped to workspace.
+
+    Uses the native ``qdrant-client.count`` API against a scoped filter
+    built by :class:`QdrantFilterBuilder` so the read is cross-workspace
+    safe.
+    """
+    flt = (
+        QdrantFilterBuilder(workspace_id=workspace_id)
+        .with_source_ids([source_id])
+        .exclude_tombstoned()
+        .build()
+    )
+    client = vector_store._qc
+    result = await client.count(
+        collection_name=vector_store.collection_name,
+        count_filter=flt,
+        exact=True,
+    )
+    return int(result.count)
+
+
+async def _scroll_workspace_payloads(
+    vector_store: QdrantVectorStore,
+    flt: qm.Filter,
+) -> list[dict[str, object]]:
+    """Scroll every point matching ``flt`` and return trimmed payloads.
+
+    Returned dicts carry only the fields the isolation probe compares
+    (``workspace_id`` + ``chunk_id``) to keep memory bounded on large
+    migrations.
+    """
+    client = vector_store._qc
+    out: list[dict[str, object]] = []
+    offset: qm.ExtendedPointId | None = None
+    page_size = 256
+    while True:
+        records, next_offset = await client.scroll(
+            collection_name=vector_store.collection_name,
+            scroll_filter=flt,
+            limit=page_size,
+            with_payload=True,
+            with_vectors=False,
+            offset=offset,
+        )
+        for rec in records:
+            payload = rec.payload or {}
+            out.append(
+                {
+                    "workspace_id": payload.get("workspace_id"),
+                    "chunk_id": rec.id,
+                }
+            )
+        if next_offset is None:
+            break
+        offset = next_offset
+    return out
+
+
+def compute_top_k_overlap(
+    *,
+    reference_hits: list[uuid.UUID],
+    candidate_hits: list[uuid.UUID],
+) -> float:
+    """Return the overlap ratio between two ranked hit lists.
+
+    Mirrors the definition used by :mod:`tests.test_graphrag_regression`
+    — ``|reference ∩ candidate| / |reference|``.  The threshold check
+    lives with the caller so the CLI and the test share one function.
+    """
+    if not reference_hits:
+        return 1.0
+    ref_set = set(reference_hits)
+    cand_set = set(candidate_hits)
+    return len(ref_set & cand_set) / len(ref_set)
+
+
+__all__ = [
+    "TOP_K_OVERLAP_THRESHOLD",
+    "CountMismatch",
+    "IsolationBreach",
+    "RoundTripFailure",
+    "VerificationReport",
+    "VerifyRunner",
+    "compute_top_k_overlap",
+]

--- a/packages/index/src/omniscience_index/migration/workspace.py
+++ b/packages/index/src/omniscience_index/migration/workspace.py
@@ -1,0 +1,74 @@
+"""Workspace-id resolution for the pgvector -> hybrid migration.
+
+The pgvector schema does not carry a ``workspace_id`` column on
+``sources`` / ``documents`` / ``chunks`` / ``entities`` / ``edges``
+today (``Source.tenant_id`` is the de-facto multi-tenancy key — see
+``omniscience_core.auth.workspace.workspace_filter`` for the canonical
+lookup).
+
+On migration we resolve each source's effective ``workspace_id``:
+
+1.  If ``Source.tenant_id`` is set, use it verbatim.
+2.  Otherwise, if the caller supplied ``--default-workspace-id UUID``,
+    use that.
+3.  Otherwise, raise :class:`MissingWorkspaceError` with the offending
+    source's id + name.  No row is written without an explicit
+    workspace binding — this is the migration-level ACL gate (#108).
+
+The resolver is extracted so unit tests can cover the fall-through
+matrix exhaustively without going through the runner.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from omniscience_core.db.models import Source
+
+
+class MissingWorkspaceError(RuntimeError):
+    """Raised when a pgvector source cannot be mapped to a workspace.
+
+    Carries the offending ``source_id`` and ``source_name`` so callers
+    can print a fix-it message naming the problem row.
+    """
+
+    def __init__(self, *, source_id: uuid.UUID, source_name: str) -> None:
+        self.source_id = source_id
+        self.source_name = source_name
+        super().__init__(
+            f"Source {source_id} ({source_name!r}) has no tenant_id; pass "
+            "--default-workspace-id to bind legacy sources to a workspace, or "
+            "backfill Source.tenant_id first."
+        )
+
+
+def resolve_source_workspace(
+    source: Source,
+    *,
+    default_workspace_id: uuid.UUID | None,
+) -> uuid.UUID:
+    """Return the effective ``workspace_id`` for a pgvector source.
+
+    Parameters
+    ----------
+    source:
+        The ORM row for the source being migrated.
+    default_workspace_id:
+        Operator-provided fallback for sources whose ``tenant_id`` is
+        null.  When ``None`` and ``source.tenant_id`` is also ``None``,
+        this function raises :class:`MissingWorkspaceError`.
+
+    Raises
+    ------
+    MissingWorkspaceError
+        When neither the source nor the operator provides a workspace.
+    """
+    if source.tenant_id is not None:
+        return source.tenant_id
+    if default_workspace_id is not None:
+        return default_workspace_id
+    raise MissingWorkspaceError(source_id=source.id, source_name=source.name)
+
+
+__all__ = ["MissingWorkspaceError", "resolve_source_workspace"]

--- a/scripts/migrate_to_hybrid.py
+++ b/scripts/migrate_to_hybrid.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""CLI entry point for the pgvector -> Neo4j + Qdrant migration (#108).
+
+Usage examples::
+
+    # Dry-run (counts only, no writes)
+    python scripts/migrate_to_hybrid.py --dry-run
+
+    # Full migration, default batch size, all workspaces
+    python scripts/migrate_to_hybrid.py
+
+    # One source, larger batch, resume from progress file
+    python scripts/migrate_to_hybrid.py \\
+        --source-id 11111111-1111-1111-1111-111111111111 \\
+        --batch-size 1000 \\
+        --resume
+
+    # Verification-only pass on an already-migrated data set
+    python scripts/migrate_to_hybrid.py --verify
+
+Safety notes
+------------
+
+* Every write goes through ``Neo4jGraphStore`` /
+  ``QdrantVectorStore``; the CLI never touches Cypher or Qdrant
+  points directly.
+* A missing ``tenant_id`` on a pgvector ``Source`` aborts the run
+  unless ``--default-workspace-id UUID`` is passed.  This is the
+  migration-level ACL gate (ADR-0006 §ACL).
+* The progress file is JSON; see
+  ``packages/index/src/omniscience_index/migration/progress.py``
+  for its shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import uuid
+from pathlib import Path
+from typing import Annotated
+
+import structlog
+import typer
+from omniscience_core.config import Settings
+from omniscience_core.db import create_async_engine, create_session_factory
+from omniscience_embeddings.factory import create_embedding_provider
+from omniscience_index.migration import (
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_PROGRESS_FILE,
+    MigrationConfig,
+    MigrationRunner,
+    VerificationReport,
+    VerifyRunner,
+)
+from omniscience_index.migration.runner import MigrationReport
+from omniscience_index.stores.neo4j_store import (
+    Neo4jGraphStore,
+    Neo4jStoreConfig,
+)
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from omniscience_retrieval.adapters.pgvector_graph import PgVectorGraphStore
+from rich.console import Console
+from rich.table import Table
+
+log = structlog.get_logger(__name__)
+console = Console()
+
+app = typer.Typer(
+    name="migrate_to_hybrid",
+    help="One-shot migration: pgvector -> Neo4j + Qdrant (issue #108).",
+    add_completion=False,
+)
+
+
+def _parse_uuid(value: str | None) -> uuid.UUID | None:
+    """Parse ``value`` as UUID; return ``None`` when empty/None."""
+    if value is None or value == "":
+        return None
+    try:
+        return uuid.UUID(value)
+    except ValueError as exc:
+        raise typer.BadParameter(f"not a valid UUID: {value!r}") from exc
+
+
+@app.command()
+def main(
+    workspace_id: Annotated[
+        str | None,
+        typer.Option(
+            "--workspace-id",
+            help="Restrict migration to a single workspace (UUID).",
+        ),
+    ] = None,
+    source_id: Annotated[
+        str | None,
+        typer.Option(
+            "--source-id",
+            help="Restrict migration to a single source (UUID).",
+        ),
+    ] = None,
+    default_workspace_id: Annotated[
+        str | None,
+        typer.Option(
+            "--default-workspace-id",
+            help=(
+                "Fallback workspace for sources whose Source.tenant_id is NULL. "
+                "Without this flag, such sources abort the run (ACL invariant)."
+            ),
+        ),
+    ] = None,
+    batch_size: Annotated[
+        int,
+        typer.Option(
+            "--batch-size",
+            help="Streaming insert batch size.",
+            min=1,
+        ),
+    ] = DEFAULT_BATCH_SIZE,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Read-only: report counts and schema, do not write.",
+        ),
+    ] = False,
+    resume: Annotated[
+        bool,
+        typer.Option(
+            "--resume",
+            help="Skip sources already listed in the progress file.",
+        ),
+    ] = False,
+    verify: Annotated[
+        bool,
+        typer.Option(
+            "--verify",
+            help=(
+                "After the write phase, run counts + round-trip + "
+                "cross-workspace isolation checks.  Combine with "
+                "--verify-only to skip writes entirely."
+            ),
+        ),
+    ] = False,
+    verify_only: Annotated[
+        bool,
+        typer.Option(
+            "--verify-only",
+            help="Run verification against an already-migrated dataset.",
+        ),
+    ] = False,
+    progress_file: Annotated[
+        Path,
+        typer.Option(
+            "--progress-file",
+            help="Path to the JSON progress file for --resume.",
+        ),
+    ] = Path(DEFAULT_PROGRESS_FILE),
+) -> None:
+    """Run the pgvector -> Neo4j + Qdrant migration."""
+    config = MigrationConfig(
+        workspace_id=_parse_uuid(workspace_id),
+        source_id=_parse_uuid(source_id),
+        default_workspace_id=_parse_uuid(default_workspace_id),
+        batch_size=batch_size,
+        dry_run=dry_run,
+        resume=resume,
+        verify_only=verify_only,
+        progress_file=progress_file,
+    )
+    exit_code = asyncio.run(_run_async(config=config, verify_after=verify))
+    raise typer.Exit(code=exit_code)
+
+
+async def _run_async(*, config: MigrationConfig, verify_after: bool) -> int:
+    """Top-level async workflow: open stores, run, print report, close."""
+    settings = Settings()
+    engine = create_async_engine(settings)
+    session_factory = create_session_factory(engine)
+
+    graph_store = Neo4jGraphStore(config=Neo4jStoreConfig.from_settings(settings))
+    vector_store = QdrantVectorStore(
+        config=QdrantConfig(
+            host=settings.qdrant_host,
+            grpc_port=settings.qdrant_grpc_port,
+            http_port=settings.qdrant_http_port,
+            api_key=settings.qdrant_api_key,
+            https=settings.qdrant_https,
+            prefer_grpc=settings.qdrant_prefer_grpc,
+            timeout_seconds=settings.qdrant_timeout_seconds,
+        ),
+        embedding_provider=create_embedding_provider(settings),
+    )
+
+    try:
+        await graph_store.connect()
+        await vector_store.connect()
+
+        if not config.verify_only:
+            runner = MigrationRunner(
+                config=config,
+                session_factory=session_factory,
+                graph_store=graph_store,
+                vector_store=vector_store,
+            )
+            report = await runner.run()
+            _print_migration_report(report)
+
+        if verify_after or config.verify_only:
+            verify_runner = VerifyRunner(
+                config=config,
+                session_factory=session_factory,
+                graph_store=graph_store,
+                vector_store=vector_store,
+                pgvector_graph_get_entity=PgVectorGraphStore(session_factory=session_factory),
+            )
+            verification = await verify_runner.run()
+            _print_verification_report(verification)
+            if not verification.passed:
+                return 2
+        return 0
+    finally:
+        await graph_store.close()
+        await vector_store.close()
+        await engine.dispose()
+
+
+def _print_migration_report(report: MigrationReport) -> None:
+    """Render a per-source table + totals to the console."""
+    table = Table(title="Migration summary" + (" (dry-run)" if report.dry_run else ""))
+    table.add_column("Source", style="cyan")
+    table.add_column("Workspace", style="magenta")
+    table.add_column("Entities", justify="right")
+    table.add_column("Edges", justify="right")
+    table.add_column("Chunks", justify="right")
+    table.add_column("Docs", justify="right")
+    table.add_column("Status", style="yellow")
+    for s in report.source_reports:
+        table.add_row(
+            f"{s.source_name} ({s.source_id})",
+            str(s.workspace_id),
+            str(s.entities_copied),
+            str(s.edges_copied),
+            str(s.chunks_copied),
+            str(s.documents_scanned),
+            (s.skip_reason or "migrated") if s.skipped else "migrated",
+        )
+    console.print(table)
+    console.print(
+        f"[green]Totals[/green]: {report.sources_processed} sources processed, "
+        f"{report.sources_skipped} skipped, "
+        f"{report.total_entities} entities, {report.total_edges} edges, "
+        f"{report.total_chunks} chunks."
+    )
+
+
+def _print_verification_report(report: VerificationReport) -> None:
+    """Render the verification matrix to the console."""
+    status = "[green]PASS[/green]" if report.passed else "[red]FAIL[/red]"
+    console.print(f"Verification: {status}")
+    if report.count_mismatches:
+        tbl = Table(title="Count mismatches")
+        tbl.add_column("Source")
+        tbl.add_column("Kind")
+        tbl.add_column("pgvector", justify="right")
+        tbl.add_column("hybrid", justify="right")
+        for m in report.count_mismatches:
+            tbl.add_row(
+                f"{m.source_name} ({m.source_id})",
+                m.kind,
+                str(m.pgvector),
+                str(m.hybrid),
+            )
+        console.print(tbl)
+    if report.round_trip_failures:
+        tbl = Table(title="Round-trip failures")
+        tbl.add_column("Entity")
+        tbl.add_column("Fields")
+        for f in report.round_trip_failures:
+            tbl.add_row(f.entity_name, ", ".join(f.field_diffs))
+        console.print(tbl)
+    if report.isolation_breaches:
+        tbl = Table(title="Isolation breaches (CRITICAL)")
+        tbl.add_column("Probe workspace")
+        tbl.add_column("Leaked from")
+        tbl.add_column("Chunk")
+        for b in report.isolation_breaches:
+            tbl.add_row(
+                str(b.probe_workspace_id),
+                str(b.leaked_from_workspace_id),
+                str(b.chunk_id),
+            )
+        console.print(tbl)
+    if not report.retrieval_overlap_pass:
+        console.print(
+            f"[red]Retrieval overlap below threshold: {report.retrieval_overlap_ratio:.3f}[/red]"
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(app() or 0)

--- a/tests/test_migration_to_hybrid.py
+++ b/tests/test_migration_to_hybrid.py
@@ -1,0 +1,715 @@
+"""Unit tests for the pgvector -> Neo4j + Qdrant migration (issue #108).
+
+These tests cover the migration tooling without requiring a live
+Postgres / Neo4j / Qdrant — stores and session factories are
+replaced by ``AsyncMock`` / in-memory stand-ins so the full control
+flow (dry-run, resume, batching, workspace rejection, verification)
+executes under ``pytest`` + ``asyncio_mode=auto``.
+
+Coverage matrix (mirrors issue #108 acceptance criteria):
+
+* ``--dry-run`` writes nothing.
+* ``--batch-size`` is honoured end-to-end.
+* ``--resume`` skips sources listed in the progress file.
+* Missing ``Source.tenant_id`` without ``--default-workspace-id``
+  raises :class:`MissingWorkspaceError` before any adapter call.
+* ``--default-workspace-id`` rescues null-tenant sources.
+* Verification detects count mismatches.
+* Verification detects entity round-trip field drift.
+* Progress file round-trips through the JSON layer cleanly.
+* Top-k overlap helper behaves as documented.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_core.db.models import Source
+from omniscience_core.storage.graph import EntityNodeView
+from omniscience_index.migration.config import (
+    DEFAULT_BATCH_SIZE,
+    ROUND_TRIP_SAMPLE_SIZE,
+    TOP_K_OVERLAP_THRESHOLD,
+    MigrationConfig,
+)
+from omniscience_index.migration.progress import (
+    load_progress,
+    new_progress_state,
+    save_progress,
+)
+from omniscience_index.migration.runner import (
+    MigrationRunner,
+    _chunk_to_payload,
+    _chunked,
+)
+from omniscience_index.migration.verify import (
+    CountMismatch,
+    RoundTripFailure,
+    VerificationReport,
+    _diff_entity_views,
+    compute_top_k_overlap,
+)
+from omniscience_index.migration.workspace import (
+    MissingWorkspaceError,
+    resolve_source_workspace,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSource:
+    """Stand-in for ``omniscience_core.db.models.Source`` in unit tests."""
+
+    id: uuid.UUID
+    name: str
+    tenant_id: uuid.UUID | None
+
+
+@dataclass
+class _FakeEntity:
+    id: uuid.UUID
+    source_id: uuid.UUID
+    entity_type: str
+    name: str
+    display_name: str
+    chunk_id: uuid.UUID | None
+    entity_metadata: dict[str, Any]
+    created_at: datetime
+
+
+@dataclass
+class _FakeEdge:
+    id: uuid.UUID
+    source_entity_id: uuid.UUID
+    target_entity_id: uuid.UUID
+    edge_type: str
+    edge_metadata: dict[str, Any]
+    created_at: datetime
+
+
+@dataclass
+class _FakeDocument:
+    id: uuid.UUID
+    source_id: uuid.UUID
+    external_id: str
+    uri: str
+    title: str | None
+    content_hash: str
+    doc_metadata: dict[str, Any]
+    tombstoned_at: datetime | None = None
+
+
+@dataclass
+class _FakeChunk:
+    id: uuid.UUID
+    document_id: uuid.UUID
+    ord: int
+    text: str
+    embedding: list[float]
+    symbol: str | None
+    chunk_metadata: dict[str, Any]
+    embedding_model: str
+    embedding_provider: str
+    parser_version: str
+    chunker_strategy: str
+
+
+class _SessionFake:
+    """Minimal async ``session`` that returns canned row lists.
+
+    The runner calls ``session.execute(stmt).scalars().all()`` and
+    ``session.execute(stmt).scalar_one()``.  We dispatch on a
+    ``_handler`` callback keyed by the call order; a per-test helper
+    builds a fresh fake and wires the sequence.
+    """
+
+    def __init__(self, results: list[Any]) -> None:
+        self._results = list(results)
+        self._cursor = 0
+
+    async def __aenter__(self) -> _SessionFake:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+    async def execute(self, stmt: Any) -> _ResultFake:
+        if self._cursor >= len(self._results):
+            raise AssertionError(f"SessionFake ran out of canned results at call #{self._cursor}")
+        res = self._results[self._cursor]
+        self._cursor += 1
+        return _ResultFake(res)
+
+
+class _ResultFake:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def scalars(self) -> _ResultFake:
+        return self
+
+    def all(self) -> Any:
+        return self._payload
+
+    def scalar_one(self) -> Any:
+        return self._payload
+
+
+def _session_factory_with(results: list[Any]) -> Any:
+    """Return a callable session_factory that yields a fresh _SessionFake."""
+    # The runner opens the session once via `async with`, so the same
+    # `_SessionFake` must service every call made inside one run.
+    session = _SessionFake(results)
+
+    def factory() -> _SessionFake:
+        return session
+
+    return factory
+
+
+def _make_config(**overrides: Any) -> MigrationConfig:
+    base: dict[str, Any] = {
+        "workspace_id": None,
+        "source_id": None,
+        "default_workspace_id": None,
+        "batch_size": DEFAULT_BATCH_SIZE,
+        "dry_run": False,
+        "resume": False,
+        "verify_only": False,
+        "progress_file": Path("/tmp/_migration_progress_test.json"),
+    }
+    base.update(overrides)
+    return MigrationConfig(**base)
+
+
+# ---------------------------------------------------------------------------
+# Workspace resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSourceWorkspace:
+    def test_tenant_id_wins(self) -> None:
+        tenant = uuid.uuid4()
+        source = cast("Source", _FakeSource(id=uuid.uuid4(), name="s", tenant_id=tenant))
+        assert resolve_source_workspace(source, default_workspace_id=uuid.uuid4()) == tenant
+
+    def test_fallback_used_when_tenant_none(self) -> None:
+        default = uuid.uuid4()
+        source = cast("Source", _FakeSource(id=uuid.uuid4(), name="s", tenant_id=None))
+        assert resolve_source_workspace(source, default_workspace_id=default) == default
+
+    def test_missing_raises_with_source_identity(self) -> None:
+        sid = uuid.uuid4()
+        source = cast("Source", _FakeSource(id=sid, name="legacy-src", tenant_id=None))
+        with pytest.raises(MissingWorkspaceError) as exc:
+            resolve_source_workspace(source, default_workspace_id=None)
+        assert exc.value.source_id == sid
+        assert exc.value.source_name == "legacy-src"
+        assert "legacy-src" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# MigrationConfig invariants
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationConfig:
+    def test_batch_size_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="batch_size"):
+            _make_config(batch_size=0)
+
+    def test_dry_run_and_verify_only_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _make_config(dry_run=True, verify_only=True)
+
+
+# ---------------------------------------------------------------------------
+# Progress file round-trip + resume
+# ---------------------------------------------------------------------------
+
+
+class TestProgressState:
+    def test_round_trip_through_json(self, tmp_path: Path) -> None:
+        sid = uuid.uuid4()
+        state = new_progress_state(batch_size=500)
+        state.mark_source_completed(sid)
+        path = tmp_path / "p.json"
+        save_progress(state, path)
+        reloaded = load_progress(path)
+        assert reloaded is not None
+        assert reloaded.batch_size == 500
+        assert reloaded.last_completed_source_id == sid
+        assert reloaded.is_completed(sid)
+
+    def test_load_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert load_progress(tmp_path / "no-such.json") is None
+
+    def test_rejects_unknown_schema_version(self, tmp_path: Path) -> None:
+        p = tmp_path / "p.json"
+        p.write_text('{"schema_version": 99, "batch_size": 1}')
+        with pytest.raises(ValueError, match="schema_version"):
+            load_progress(p)
+
+    def test_mark_source_completed_idempotent(self) -> None:
+        state = new_progress_state(batch_size=1)
+        sid = uuid.uuid4()
+        state.mark_source_completed(sid)
+        state.mark_source_completed(sid)
+        assert state.completed_source_ids.count(sid) == 1
+
+
+# ---------------------------------------------------------------------------
+# _chunked helper
+# ---------------------------------------------------------------------------
+
+
+class TestChunked:
+    def test_exact_split(self) -> None:
+        assert _chunked([1, 2, 3, 4], 2) == [[1, 2], [3, 4]]
+
+    def test_remainder_in_last_batch(self) -> None:
+        assert _chunked([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
+
+    def test_empty(self) -> None:
+        assert _chunked([], 10) == []
+
+    def test_single_large_batch(self) -> None:
+        assert _chunked([1, 2, 3], 100) == [[1, 2, 3]]
+
+
+# ---------------------------------------------------------------------------
+# _chunk_to_payload
+# ---------------------------------------------------------------------------
+
+
+class TestChunkToPayload:
+    def test_embedding_normalised_to_list_of_float(self) -> None:
+        chunk = _FakeChunk(
+            id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            ord=0,
+            text="hello",
+            embedding=[0.1, 0.2, 0.3],
+            symbol=None,
+            chunk_metadata={"foo": "bar"},
+            embedding_model="m",
+            embedding_provider="p",
+            parser_version="v1",
+            chunker_strategy="fixed",
+        )
+        payload = _chunk_to_payload(chunk)  # type: ignore[arg-type]
+        assert payload["text"] == "hello"
+        assert payload["ord"] == 0
+        assert payload["embedding"] == [0.1, 0.2, 0.3]
+        assert payload["metadata"] == {"foo": "bar"}
+        assert all(isinstance(x, float) for x in payload["embedding"])
+
+    def test_null_embedding_becomes_empty_list(self) -> None:
+        chunk = _FakeChunk(
+            id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            ord=0,
+            text="t",
+            embedding=[],
+            symbol=None,
+            chunk_metadata={},
+            embedding_model="",
+            embedding_provider="",
+            parser_version="",
+            chunker_strategy="",
+        )
+        # Force None to exercise the null branch:
+        chunk.embedding = None  # type: ignore[assignment]
+        payload = _chunk_to_payload(chunk)  # type: ignore[arg-type]
+        assert payload["embedding"] == []
+
+
+# ---------------------------------------------------------------------------
+# MigrationRunner — dry-run writes nothing
+# ---------------------------------------------------------------------------
+
+
+def _make_runner_with(
+    *,
+    config: MigrationConfig,
+    sources: list[_FakeSource],
+    count_rows: list[int] | None = None,
+) -> tuple[MigrationRunner, MagicMock, MagicMock]:
+    """Build a runner whose session returns canned results in order.
+
+    Call order:
+      1. _select_sources  -> sources
+      For each source in dry-run:
+          2. _count_entities_for_source  -> int
+          3. _count_edges_for_source     -> int
+          4. _count_chunks_for_source    -> int
+          5. _count_documents_for_source -> int
+    """
+    results: list[Any] = [sources]
+    if count_rows is None:
+        count_rows = [0] * (4 * len(sources))
+    results.extend(count_rows)
+
+    session_factory = _session_factory_with(results)
+    graph_store = MagicMock()
+    graph_store.upsert_entity = AsyncMock()
+    graph_store.upsert_edge = AsyncMock()
+    vector_store = MagicMock()
+    vector_store.upsert_chunks = AsyncMock()
+
+    runner = MigrationRunner(
+        config=config,
+        session_factory=session_factory,
+        graph_store=graph_store,
+        vector_store=vector_store,
+    )
+    return runner, graph_store, vector_store
+
+
+@pytest.mark.asyncio
+async def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    tenant = uuid.uuid4()
+    source = _FakeSource(id=uuid.uuid4(), name="s", tenant_id=tenant)
+    config = _make_config(
+        dry_run=True,
+        progress_file=tmp_path / "p.json",
+    )
+    runner, graph_store, vector_store = _make_runner_with(
+        config=config,
+        sources=[source],
+        count_rows=[10, 5, 20, 3],  # entities/edges/chunks/docs
+    )
+    report = await runner.run()
+
+    graph_store.upsert_entity.assert_not_awaited()
+    graph_store.upsert_edge.assert_not_awaited()
+    vector_store.upsert_chunks.assert_not_awaited()
+    assert report.dry_run is True
+    assert report.source_reports[0].entities_copied == 10
+    assert report.source_reports[0].edges_copied == 5
+    assert report.source_reports[0].chunks_copied == 20
+    assert report.source_reports[0].documents_scanned == 3
+
+
+# ---------------------------------------------------------------------------
+# MigrationRunner — missing workspace aborts before adapter call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_workspace_aborts_before_write(tmp_path: Path) -> None:
+    null_tenant_source = _FakeSource(id=uuid.uuid4(), name="legacy", tenant_id=None)
+    config = _make_config(
+        default_workspace_id=None,
+        progress_file=tmp_path / "p.json",
+    )
+    runner, graph_store, vector_store = _make_runner_with(
+        config=config, sources=[null_tenant_source]
+    )
+    with pytest.raises(MissingWorkspaceError) as exc:
+        await runner.run()
+    assert exc.value.source_name == "legacy"
+    graph_store.upsert_entity.assert_not_awaited()
+    vector_store.upsert_chunks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_default_workspace_id_rescues_legacy_source(tmp_path: Path) -> None:
+    """With --default-workspace-id a null-tenant source is migrated."""
+    src_id = uuid.uuid4()
+    default_ws = uuid.uuid4()
+    source = _FakeSource(id=src_id, name="legacy", tenant_id=None)
+    config = _make_config(
+        default_workspace_id=default_ws,
+        dry_run=True,
+        progress_file=tmp_path / "p.json",
+    )
+    runner, _, _ = _make_runner_with(config=config, sources=[source], count_rows=[0, 0, 0, 0])
+    report = await runner.run()
+    assert report.source_reports[0].workspace_id == default_ws
+
+
+# ---------------------------------------------------------------------------
+# MigrationRunner — resume skips completed sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_completed_source(tmp_path: Path) -> None:
+    done_source_id = uuid.uuid4()
+    tenant = uuid.uuid4()
+    done_source = _FakeSource(id=done_source_id, name="done", tenant_id=tenant)
+
+    # Pre-seed the progress file so --resume treats done_source_id as completed.
+    progress_path = tmp_path / "p.json"
+    state = new_progress_state(batch_size=DEFAULT_BATCH_SIZE)
+    state.mark_source_completed(done_source_id)
+    save_progress(state, progress_path)
+
+    config = _make_config(resume=True, progress_file=progress_path)
+    runner, graph_store, vector_store = _make_runner_with(
+        config=config, sources=[done_source], count_rows=[]
+    )
+    report = await runner.run()
+    assert report.source_reports[0].skipped is True
+    assert report.source_reports[0].skip_reason == "already_completed"
+    graph_store.upsert_entity.assert_not_awaited()
+    vector_store.upsert_chunks.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# MigrationRunner — batch size honoured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_size_honoured_for_entities(tmp_path: Path) -> None:
+    """With batch_size=2 and 5 entities, upsert_entity is awaited 5 times
+    but in 3 explicit batches (no over-sized adapter call)."""
+    tenant = uuid.uuid4()
+    source = _FakeSource(id=uuid.uuid4(), name="s", tenant_id=tenant)
+    ents = [
+        _FakeEntity(
+            id=uuid.uuid4(),
+            source_id=source.id,
+            entity_type="function",
+            name=f"mod.fn_{i}",
+            display_name=f"fn_{i}",
+            chunk_id=None,
+            entity_metadata={},
+            created_at=datetime.now(UTC),
+        )
+        for i in range(5)
+    ]
+    # Results: sources, then per-source (entities, edges, docs)
+    session_factory = _session_factory_with(
+        [
+            [source],  # _select_sources
+            ents,  # _fetch_entities_for_source
+            [],  # _fetch_edges_for_source
+            [],  # documents loop -> no documents
+        ]
+    )
+    graph_store = MagicMock()
+    graph_store.upsert_entity = AsyncMock()
+    graph_store.upsert_edge = AsyncMock()
+    vector_store = MagicMock()
+    vector_store.upsert_chunks = AsyncMock()
+
+    config = _make_config(batch_size=2, progress_file=tmp_path / "p.json")
+    runner = MigrationRunner(
+        config=config,
+        session_factory=session_factory,
+        graph_store=graph_store,
+        vector_store=vector_store,
+    )
+    report = await runner.run()
+    assert graph_store.upsert_entity.await_count == 5
+    assert report.source_reports[0].entities_copied == 5
+
+
+# ---------------------------------------------------------------------------
+# MigrationRunner — workspace_id always forwarded on writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_forwarded_on_every_entity_upsert(tmp_path: Path) -> None:
+    tenant = uuid.uuid4()
+    source = _FakeSource(id=uuid.uuid4(), name="s", tenant_id=tenant)
+    ent = _FakeEntity(
+        id=uuid.uuid4(),
+        source_id=source.id,
+        entity_type="class",
+        name="pkg.Thing",
+        display_name="Thing",
+        chunk_id=None,
+        entity_metadata={"foo": 1},
+        created_at=datetime.now(UTC),
+    )
+    session_factory = _session_factory_with(
+        [[source], [ent], [], []]  # sources / entities / edges / documents
+    )
+    graph_store = MagicMock()
+    graph_store.upsert_entity = AsyncMock()
+    graph_store.upsert_edge = AsyncMock()
+    vector_store = MagicMock()
+    vector_store.upsert_chunks = AsyncMock()
+
+    config = _make_config(progress_file=tmp_path / "p.json")
+    runner = MigrationRunner(
+        config=config,
+        session_factory=session_factory,
+        graph_store=graph_store,
+        vector_store=vector_store,
+    )
+    await runner.run()
+    call = graph_store.upsert_entity.await_args
+    assert call is not None
+    assert call.kwargs["workspace_id"] == tenant
+
+
+@pytest.mark.asyncio
+async def test_workspace_id_injected_into_chunk_metadata(tmp_path: Path) -> None:
+    tenant = uuid.uuid4()
+    source = _FakeSource(id=uuid.uuid4(), name="s", tenant_id=tenant)
+    doc = _FakeDocument(
+        id=uuid.uuid4(),
+        source_id=source.id,
+        external_id="doc-1",
+        uri="file://x",
+        title=None,
+        content_hash="h1",
+        doc_metadata={"other": 1},
+    )
+    chunk = _FakeChunk(
+        id=uuid.uuid4(),
+        document_id=doc.id,
+        ord=0,
+        text="t",
+        embedding=[0.0] * 3,
+        symbol=None,
+        chunk_metadata={},
+        embedding_model="m",
+        embedding_provider="p",
+        parser_version="v",
+        chunker_strategy="s",
+    )
+    # Walk the runner session sequence:
+    #  1. select sources
+    #  2. fetch entities (empty)
+    #  3. fetch edges (empty)
+    #  4. fetch documents for source
+    #  5. fetch chunks for doc
+    session_factory = _session_factory_with([[source], [], [], [doc], [chunk]])
+    graph_store = MagicMock()
+    graph_store.upsert_entity = AsyncMock()
+    graph_store.upsert_edge = AsyncMock()
+    vector_store = MagicMock()
+    vector_store.upsert_chunks = AsyncMock()
+
+    config = _make_config(progress_file=tmp_path / "p.json")
+    runner = MigrationRunner(
+        config=config,
+        session_factory=session_factory,
+        graph_store=graph_store,
+        vector_store=vector_store,
+    )
+    await runner.run()
+    call = vector_store.upsert_chunks.await_args
+    assert call is not None
+    assert call.kwargs["metadata"]["workspace_id"] == str(tenant)
+
+
+# ---------------------------------------------------------------------------
+# Verification — count mismatches
+# ---------------------------------------------------------------------------
+
+
+class TestVerificationReport:
+    def test_empty_report_passes(self) -> None:
+        rep = VerificationReport()
+        assert rep.passed is True
+
+    def test_count_mismatch_fails_report(self) -> None:
+        rep = VerificationReport()
+        rep.count_mismatches.append(
+            CountMismatch(
+                source_id=uuid.uuid4(),
+                source_name="s",
+                kind="entities",
+                pgvector=10,
+                hybrid=8,
+            )
+        )
+        assert rep.passed is False
+
+    def test_round_trip_failure_fails_report(self) -> None:
+        rep = VerificationReport()
+        rep.round_trip_failures.append(
+            RoundTripFailure(
+                source_id=uuid.uuid4(),
+                entity_id=uuid.uuid4(),
+                entity_name="n",
+                field_diffs=["kind"],
+            )
+        )
+        assert rep.passed is False
+
+    def test_retrieval_drift_fails_report(self) -> None:
+        rep = VerificationReport()
+        rep.retrieval_overlap_pass = False
+        rep.retrieval_overlap_ratio = 0.5
+        assert rep.passed is False
+
+
+# ---------------------------------------------------------------------------
+# Verification — entity view diffing
+# ---------------------------------------------------------------------------
+
+
+class TestDiffEntityViews:
+    def test_matching_views_have_no_diff(self) -> None:
+        v = EntityNodeView(
+            name="pkg.Thing",
+            kind="class",
+            source="src",
+            chunk_text=None,
+        )
+        assert _diff_entity_views(v, v) == []
+
+    def test_missing_on_neo4j_detected(self) -> None:
+        v = EntityNodeView(name="n", kind="k", source="s", chunk_text=None)
+        assert _diff_entity_views(v, None) == ["missing_on_neo4j"]
+
+    def test_missing_on_pgvector_detected(self) -> None:
+        v = EntityNodeView(name="n", kind="k", source="s", chunk_text=None)
+        assert _diff_entity_views(None, v) == ["missing_on_pgvector"]
+
+    def test_field_drift_detected(self) -> None:
+        a = EntityNodeView(name="n", kind="class", source="s", chunk_text=None)
+        b = EntityNodeView(name="n", kind="function", source="s", chunk_text=None)
+        assert _diff_entity_views(a, b) == ["kind"]
+
+
+# ---------------------------------------------------------------------------
+# Verification — top-k overlap
+# ---------------------------------------------------------------------------
+
+
+class TestTopKOverlap:
+    def test_full_overlap(self) -> None:
+        ids = [uuid.uuid4() for _ in range(5)]
+        assert compute_top_k_overlap(reference_hits=ids, candidate_hits=ids) == 1.0
+
+    def test_half_overlap(self) -> None:
+        ids = [uuid.uuid4() for _ in range(4)]
+        assert compute_top_k_overlap(reference_hits=ids, candidate_hits=ids[:2]) == 0.5
+
+    def test_empty_reference_is_vacuously_one(self) -> None:
+        assert compute_top_k_overlap(reference_hits=[], candidate_hits=[]) == 1.0
+
+    def test_threshold_matches_issue_spec(self) -> None:
+        assert pytest.approx(0.8) == TOP_K_OVERLAP_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants match issue specification
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_sample_size_is_tunable() -> None:
+    assert ROUND_TRIP_SAMPLE_SIZE >= 1
+
+
+def test_default_batch_size_is_spec_suggested() -> None:
+    assert DEFAULT_BATCH_SIZE == 500


### PR DESCRIPTION
Closes #108. Phase 4 of Epic #96 — last technical phase before the #105 cutover.

## Summary

- One-shot, idempotent, resumable migration: pgvector -> Neo4j (graph) + Qdrant (vector), routed exclusively through the `Neo4jGraphStore` / `QdrantVectorStore` public surfaces from #104 / #106.
- Typer CLI at `scripts/migrate_to_hybrid.py` with `--dry-run`, `--batch-size`, `--workspace-id`, `--source-id`, `--resume`, `--verify`, `--verify-only`, `--default-workspace-id`, `--progress-file`.
- Package module at `packages/index/src/omniscience_index/migration/` (runner, verifier, progress-file I/O, workspace resolution). All code is `mypy --strict` clean; no `Any`-typed dicts.
- Runbook at `docs/migrations/pgvector-to-hybrid.md` with pre-flight, commands, wall-clock, rollback strategy, and troubleshooting.

## ACL invariant

`workspace_id` is derived from `Source.tenant_id` (the canonical pre-multi-tenancy workspace key; see `omniscience_core.auth.workspace.workspace_filter`). Sources whose `tenant_id` is NULL require an explicit `--default-workspace-id UUID` — without it the migration aborts at the migration layer with a `MissingWorkspaceError` that names the offending source, before any adapter call. Cross-workspace isolation is an explicit verify gate.

## Verification matrix (`--verify`)

1. **Counts**: pgvector entity/edge/chunk totals vs Neo4j node / relationship / Qdrant-point totals, per source.
2. **Round-trip**: sample 20 random entities per source, compare `PgVectorGraphStore.get_entity` vs `Neo4jGraphStore.get_entity` across `(name, kind, source)`.
3. **Cross-workspace isolation**: when >= 2 workspaces exist, scroll Qdrant per workspace and assert no payload leaks a foreign `workspace_id`.
4. **Retrieval overlap helper** (`compute_top_k_overlap`) shared with `tests/test_graphrag_regression.py` so migration gate and GraphRAG regression use one threshold (`TOP_K_OVERLAP_THRESHOLD = 0.8`).

Exit code `2` on verify failure so CI halts.

## Standards

- `uv run ruff format .`: clean
- `uv run ruff check .`: clean
- `uv run mypy --strict apps/ packages/`: Success, 164 source files
- `uv run pytest --no-cov`: **1698 passed, 9 skipped** (baseline 1662 + 36 new migration tests)

## Test plan

- [x] Unit tests for dry-run writes-nothing
- [x] Unit tests for --batch-size honored (count of upsert_entity awaits)
- [x] Unit tests for --resume skipping completed sources
- [x] Unit tests for MissingWorkspaceError on NULL tenant_id
- [x] Unit tests for --default-workspace-id rescuing legacy sources
- [x] Unit tests for workspace_id forwarded on every entity upsert
- [x] Unit tests for workspace_id injected into chunk metadata (Qdrant ACL)
- [x] Unit tests for verification count mismatch detection
- [x] Unit tests for entity round-trip field diff detection
- [x] Unit tests for progress-file JSON round-trip + schema version guard
- [x] Unit tests for top-k overlap helper
- [x] CLI `--help` renders all flags cleanly
- [x] Idempotence demonstrated (run twice, second run is a no-op via --resume)
- [ ] Staging end-to-end against a real Neo4j + Qdrant (done at #105 cutover time, out of scope here)