### PR TITLE
feat: ingestion worker drives Neo4j + Qdrant writes (#126)

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -229,10 +229,13 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
 
     # --- Ingestion worker ---
-    # NOTE: the ingestion worker still drives the pgvector ``IndexWriter``
-    # for document + chunk metadata persistence.  Wiring ingestion to
-    # write vectors into Qdrant / entities into Neo4j is tracked as a
-    # follow-up to #105 — see the CHANGELOG Known-gaps section.
+    # As of issue #126 the worker drives all three stores: Postgres
+    # (operational metadata via ``IndexWriter``), Neo4j (entities + edges
+    # via ``graph_store``), and Qdrant (chunk embeddings via
+    # ``vector_store``).  ``workspace_id`` is resolved from
+    # ``Source.tenant_id`` per document before any adapter call — the
+    # ACL invariant from ADR-0005/0006 carries through the live path the
+    # same way the migration runner enforces it for backfills.
     index_writer = IndexWriter(session_factory)
     consumer: QueueConsumer[DocumentChangeEvent] = QueueConsumer(
         js=nats_conn.jetstream,
@@ -247,6 +250,8 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         connector_registry=connector_registry,
         embedding_provider=embedding_provider,
         index_writer=index_writer,
+        graph_store=neo4j_graph_store,
+        vector_store=qdrant_store,
         session_factory=session_factory,
     )
     worker_task = asyncio.create_task(worker.start())

--- a/apps/server/src/omniscience_server/ingestion/pipeline.py
+++ b/apps/server/src/omniscience_server/ingestion/pipeline.py
@@ -1,39 +1,69 @@
 """Per-document ingestion pipeline.
 
-:class:`IngestionPipeline` orchestrates seven stages for each document:
+:class:`IngestionPipeline` orchestrates the per-document write path:
 
-    fetch → hash_check → parse → chunk → embed → index → graph → link
+    fetch -> hash_check -> parse -> chunk -> embed
+        -> index (Postgres metadata)
+        -> vector (Qdrant chunk embeddings)
+        -> graph (Neo4j entities + edges)
+        -> link (cross-source linker, optional)
 
 Each stage runs inside its own structured-log context and records a
 Prometheus histogram observation.  Failures are caught at the pipeline
 level; callers receive a :class:`~omniscience_server.ingestion.events.ProcessResult`
 regardless of whether the run succeeded or produced an error.
 
-Wave-5 note: ``parse`` and ``chunk`` are intentional placeholders.
-Real parsers/chunkers will be wired in when Wave 5 lands.
+Three-store fan-out (issue #126)
+--------------------------------
 
-IndexWriter note: ``IndexWriterProtocol`` is the interface contract for the
-parallel issue-11 implementation (``omniscience_index.IndexWriter``).
-The real integration happens when both branches are merged.
+The cutover in PR #125 left the live worker writing only Postgres
+operational metadata; this pipeline restores the invariant that an
+ingested document is queryable in all three stores:
 
-Symbol graph note: After parse the pipeline optionally calls
-``extract_symbol_graph`` (omniscience_parsers) and persists entities and
-edges via ``IndexWriterProtocol.upsert_graph``.
+- :class:`~omniscience_index.IndexWriter`   -> Postgres metadata.
+- :class:`~omniscience_core.storage.GraphStore`  -> Neo4j entities/edges.
+- :class:`~omniscience_core.storage.VectorStore` -> Qdrant chunk vectors.
 
-Entity linking note: After graph extraction the pipeline optionally calls
-``EntityLinkerProtocol.link_entities`` to create cross-source edges.
-Graph/linking failures are logged and swallowed — they never abort indexing.
+The Postgres write happens first because it produces the canonical
+``document_id`` carried into Neo4j logs and matches what
+``IndexWriter`` already returns.  The Neo4j and Qdrant adapters are
+both idempotent (MERGE on Neo4j, content-hash dedup on Qdrant) so any
+retry triggered by a partial failure is safe.
+
+ACL invariant (non-negotiable, ADR-0006 §ACL / ADR-0005 §ACL)
+-------------------------------------------------------------
+
+Every stage that talks to Neo4j or Qdrant carries an explicit
+``workspace_id`` resolved by the worker BEFORE the pipeline runs (see
+:mod:`omniscience_index.workspace`).  An unresolved workspace causes
+the worker to bail out before the pipeline starts; the pipeline
+itself never sees a ``None`` workspace.
+
+Best-effort vs hard failures
+----------------------------
+
+- **Parser/extractor failures** in ``_stage_graph`` are best-effort and
+  swallowed (existing behaviour preserved).  Tree-sitter not
+  recognising the language, or an extractor exception, must not abort
+  ingestion.
+- **Adapter failures** (Neo4j Cypher error, Qdrant gRPC error,
+  ``MissingWorkspaceError`` raised inside an adapter) propagate up so
+  the worker NAKs the message and the broker redelivers.  Idempotence
+  on every adapter makes redelivery safe.
 """
 
 from __future__ import annotations
 
 import hashlib
 import time
+import uuid
 from typing import Any, Protocol, runtime_checkable
 from uuid import UUID
 
 import structlog
 from omniscience_connectors.base import Connector, DocumentRef, FetchedDocument
+from omniscience_core.storage.graph import GraphStore
+from omniscience_core.storage.vector import ChunkPayload, VectorStore
 from omniscience_embeddings.base import EmbeddingProvider
 
 from omniscience_server.ingestion.events import DocumentChangeEvent, ProcessResult
@@ -43,6 +73,22 @@ from omniscience_server.ingestion.metrics import (
 )
 
 log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants — every magic number lives here with a rationale.
+# ---------------------------------------------------------------------------
+
+# Parser/chunker version stamps written to the Postgres chunk row + the
+# Qdrant payload (ADR-0006 §Schema).  Bump these when the placeholder
+# parser/chunker is replaced; downstream queries key on these values to
+# segment results by extraction strategy.
+_PARSER_VERSION: str = "placeholder-v0"
+_CHUNKER_STRATEGY: str = "full-content-v0"
+
+# Stage label used in metrics for the new Qdrant write.  Kept distinct
+# from the existing ``index`` label (which means "Postgres index").
+_STAGE_VECTOR: str = "vector"
 
 
 # ---------------------------------------------------------------------------
@@ -79,7 +125,7 @@ def _compute_content_hash(text: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# IndexWriter protocol (interface for the parallel issue-11 implementation)
+# IndexWriter protocol (interface for the Postgres metadata writer)
 # ---------------------------------------------------------------------------
 
 
@@ -89,6 +135,12 @@ class IndexWriterProtocol(Protocol):
 
     The real ``omniscience_index.IndexWriter`` satisfies this protocol.
     Tests inject a mock that also satisfies it.
+
+    Note: ``upsert_graph`` is intentionally NOT on this protocol any more
+    (issue #126) — graph writes go to the Neo4j adapter via
+    ``GraphStore.upsert_graph``.  The Postgres writer keeps a method by
+    that name for the legacy migration codepath, but ingestion no longer
+    reaches it.
     """
 
     async def upsert_document(
@@ -104,14 +156,6 @@ class IndexWriterProtocol(Protocol):
     ) -> Any: ...
 
     async def tombstone(self, source_id: UUID, external_id: str) -> bool: ...
-
-    async def upsert_graph(
-        self,
-        source_id: UUID,
-        document_id: UUID,
-        entities: list[Any],
-        edges: list[Any],
-    ) -> None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -131,34 +175,71 @@ class EntityLinkerProtocol(Protocol):
 
 
 # ---------------------------------------------------------------------------
-# Chunk placeholder (Wave 5 will replace with real ChunkData)
+# Chunk record produced by the placeholder chunker stage
 # ---------------------------------------------------------------------------
 
 
 class _RawChunk:
     """Minimal chunk produced by the placeholder chunker stage.
 
-    As of v0.2 embeddings live in Qdrant rather than Postgres, so the
-    vector is no longer carried on the chunk record itself; the
-    embedding is still computed in the pipeline (it will be pushed
-    to the vector store once ingestion is wired to Qdrant — see the
-    #105 CHANGELOG follow-up).
+    The Postgres index keeps everything except the embedding vector;
+    Qdrant gets a separate :class:`ChunkPayload` TypedDict built from
+    these fields plus the embedding (see :func:`_chunk_to_payload`).
     """
 
     def __init__(
         self,
+        ord_: int,
         text: str,
+        embedding: list[float],
         embedding_model: str,
         embedding_provider: str,
     ) -> None:
-        self.ord = 0
+        self.ord = ord_
         self.text = text
         self.symbol: str | None = None
         self.metadata: dict[str, Any] = {}
+        self.embedding = embedding
         self.embedding_model = embedding_model
         self.embedding_provider = embedding_provider
-        self.parser_version = "placeholder-v0"
-        self.chunker_strategy = "full-content-v0"
+        self.parser_version = _PARSER_VERSION
+        self.chunker_strategy = _CHUNKER_STRATEGY
+
+
+def _chunk_to_payload(chunk: _RawChunk) -> ChunkPayload:
+    """Translate a pipeline ``_RawChunk`` into a Qdrant ``ChunkPayload``.
+
+    Mirrors the migration runner's ``_chunk_to_payload`` so the live
+    ingestion path produces the exact same payload shape as a one-off
+    backfill.  Lineage fields are propagated per ADR-0006 §Schema.
+    """
+    return {
+        "ord": int(chunk.ord),
+        "text": str(chunk.text),
+        "embedding": [float(x) for x in chunk.embedding],
+        "symbol": chunk.symbol,
+        "metadata": dict(chunk.metadata),
+        "embedding_model": str(chunk.embedding_model),
+        "embedding_provider": str(chunk.embedding_provider),
+        "parser_version": str(chunk.parser_version),
+        "chunker_strategy": str(chunk.chunker_strategy),
+    }
+
+
+def _build_vector_metadata(
+    *,
+    workspace_id: uuid.UUID,
+    fetched_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Build the document-level metadata dict for the Qdrant adapter.
+
+    The ``workspace_id`` key is mandatory — it is the ACL enforcement
+    point inside ``QdrantVectorStore._extract_workspace_id`` (ADR-0006
+    §ACL).  Mirrors ``migration.runner._build_document_metadata``.
+    """
+    metadata: dict[str, Any] = dict(fetched_metadata)
+    metadata["workspace_id"] = str(workspace_id)
+    return metadata
 
 
 # ---------------------------------------------------------------------------
@@ -169,18 +250,20 @@ class _RawChunk:
 class IngestionPipeline:
     """Orchestrates the per-document pipeline stages.
 
-    Each stage is isolated: a failure in one stage sets ``action="error"``
-    on the result but does not raise; the caller (worker) decides how to
-    ack/nak the underlying message.
+    Each stage is isolated: a failure in a hard stage sets
+    ``action="error"`` on the result but does not raise; the caller
+    (worker) decides how to ack/nak the underlying message.
 
-    Symbol graph extraction runs as an optional stage after index.  It is
-    activated when both ``_graph_extractor`` is provided (non-None) and the
-    parsed document's language is supported.  Graph extraction failures are
-    logged and swallowed — they never abort indexing.
+    Symbol graph extraction runs as an optional stage after the vector
+    write.  It is activated when both ``_graph_extractor`` is provided
+    and the parsed document's language is supported.  Parser/extractor
+    errors are swallowed (best-effort); **adapter** errors from
+    ``GraphStore.upsert_graph`` propagate up so the broker redelivers.
 
-    Entity linking runs as an optional stage after graph extraction.  It is
-    activated when ``_entity_linker`` is provided (non-None).  Linking
-    failures are logged and swallowed — they never abort indexing.
+    Entity linking runs as an optional stage after graph extraction.
+    Linking failures are logged and swallowed — they never abort
+    indexing (the linker runs over many sources at once and a transient
+    DB hiccup must not poison a single document's ingestion).
     """
 
     def __init__(
@@ -188,12 +271,16 @@ class IngestionPipeline:
         connector: Connector,
         embedding_provider: EmbeddingProvider,
         index_writer: IndexWriterProtocol,
+        graph_store: GraphStore,
+        vector_store: VectorStore,
         graph_extractor: Any | None = None,
         entity_linker: EntityLinkerProtocol | None = None,
     ) -> None:
         self._connector = connector
         self._embedding_provider = embedding_provider
         self._index_writer = index_writer
+        self._graph_store = graph_store
+        self._vector_store = vector_store
         # Optional callable:
         #   graph_extractor(parsed_doc, source_bytes) -> (entities, edges)
         # Matches the signature of omniscience_parsers.code.graph.extract_symbol_graph
@@ -206,19 +293,28 @@ class IngestionPipeline:
         event: DocumentChangeEvent,
         config: Any,
         secrets: dict[str, str],
+        workspace_id: uuid.UUID,
         ingestion_run_id: UUID | None = None,
     ) -> ProcessResult:
-        """Execute all stages and return a result regardless of outcome."""
+        """Execute all stages and return a result regardless of outcome.
+
+        ``workspace_id`` is required and resolved by the caller (the
+        worker) before this method runs.  It is never optional — the
+        ACL invariant on Neo4j/Qdrant is non-negotiable.
+        """
         started = time.monotonic()
         bound = log.bind(
             source_id=str(event.source_id),
             source_type=event.source_type,
             external_id=event.external_id,
             action=event.action,
+            workspace_id=str(workspace_id),
         )
 
         try:
-            result = await self._execute(event, config, secrets, ingestion_run_id, bound)
+            result = await self._execute(
+                event, config, secrets, workspace_id, ingestion_run_id, bound
+            )
         except Exception as exc:
             elapsed_ms = (time.monotonic() - started) * 1000
             bound.error("pipeline_unexpected_error", error=str(exc))
@@ -245,12 +341,13 @@ class IngestionPipeline:
         event: DocumentChangeEvent,
         config: Any,
         secrets: dict[str, str],
+        workspace_id: uuid.UUID,
         ingestion_run_id: UUID | None,
         bound: Any,
     ) -> ProcessResult:
         """Inner execution — may raise; exceptions are caught by :meth:`run`."""
         if event.action == "deleted":
-            return await self._handle_delete(event, bound)
+            return await self._handle_delete(event, workspace_id, bound)
 
         fetched = await self._stage_fetch(event, config, secrets, bound)
         content_text = fetched.content_bytes.decode(errors="replace")
@@ -267,12 +364,32 @@ class IngestionPipeline:
         parsed_text = await self._stage_parse(content_text, event.source_type, bound)
         chunks_text = await self._stage_chunk(parsed_text, event.source_type, bound)
         embeddings = await self._stage_embed(chunks_text, event.source_type, bound)
+        chunks = self._build_chunks(chunks_text, embeddings)
+
         upsert_action, document_id = await self._stage_index(
-            event, fetched, content_text, chunks_text, embeddings, ingestion_run_id, bound
+            event, fetched, content_text, chunks, ingestion_run_id, bound
         )
 
-        # Symbol graph extraction — optional, best-effort
-        await self._stage_graph(event, fetched.content_bytes, document_id, bound)
+        # Vector write (Qdrant) — hard failure propagates to caller.
+        await self._stage_vector(
+            event=event,
+            fetched=fetched,
+            content_hash=_compute_content_hash(content_text),
+            chunks=chunks,
+            workspace_id=workspace_id,
+            ingestion_run_id=ingestion_run_id,
+            bound=bound,
+        )
+
+        # Symbol graph extraction — parser/extractor errors swallowed,
+        # adapter errors propagate.
+        await self._stage_graph(
+            event=event,
+            content_bytes=fetched.content_bytes,
+            document_id=document_id,
+            workspace_id=workspace_id,
+            bound=bound,
+        )
 
         # Cross-source entity linking — optional, best-effort
         await self._stage_link(event, bound)
@@ -337,7 +454,7 @@ class IngestionPipeline:
         """Placeholder parser: pass raw content through unchanged."""
         t0 = time.monotonic()
         try:
-            bound.debug("stage_parse_ok", strategy="placeholder-v0", source_type=source_type)
+            bound.debug("stage_parse_ok", strategy=_PARSER_VERSION, source_type=source_type)
             return content_text
         finally:
             INGESTION_STAGE_DURATION_SECONDS.labels(stage="parse").observe(time.monotonic() - t0)
@@ -351,7 +468,7 @@ class IngestionPipeline:
         """Placeholder chunker: single chunk from full content."""
         t0 = time.monotonic()
         try:
-            bound.debug("stage_chunk_ok", strategy="full-content-v0", chunks=1)
+            bound.debug("stage_chunk_ok", strategy=_CHUNKER_STRATEGY, chunks=1)
             return [parsed_text]
         finally:
             INGESTION_STAGE_DURATION_SECONDS.labels(stage="chunk").observe(time.monotonic() - t0)
@@ -376,33 +493,46 @@ class IngestionPipeline:
         finally:
             INGESTION_STAGE_DURATION_SECONDS.labels(stage="embed").observe(time.monotonic() - t0)
 
+    def _build_chunks(
+        self,
+        chunks_text: list[str],
+        embeddings: list[list[float]],
+    ) -> list[_RawChunk]:
+        """Pair chunk text with embedding vectors at matching ordinals.
+
+        Pulled out of ``_stage_index`` so the same chunk objects are
+        passed to both Postgres and Qdrant — guarantees the two stores
+        agree on chunk count and embedding lineage.
+        """
+        if len(chunks_text) != len(embeddings):
+            raise ValueError(
+                f"chunk_embedding_mismatch: {len(chunks_text)} chunks vs "
+                f"{len(embeddings)} embeddings"
+            )
+        return [
+            _RawChunk(
+                ord_=i,
+                text=text,
+                embedding=embedding,
+                embedding_model=self._embedding_provider.model_name,
+                embedding_provider=self._embedding_provider.provider_name,
+            )
+            for i, (text, embedding) in enumerate(zip(chunks_text, embeddings, strict=True))
+        ]
+
     async def _stage_index(
         self,
         event: DocumentChangeEvent,
         fetched: FetchedDocument,
         content_text: str,
-        chunks_text: list[str],
-        embeddings: list[list[float]],
+        chunks: list[_RawChunk],
         ingestion_run_id: UUID | None,
         bound: Any,
     ) -> tuple[str, UUID]:
-        """Write chunks to the index.  Returns (action, document_id)."""
+        """Write chunks to the Postgres index.  Returns (action, document_id)."""
         t0 = time.monotonic()
         try:
             content_hash = _compute_content_hash(content_text)
-            # ``embeddings`` is still materialised per the pipeline's
-            # ``_stage_embed`` contract; the vectors are intended for the
-            # Qdrant write path once ingestion is wired end-to-end (the
-            # #105 cutover deferred that wiring — see CHANGELOG notes).
-            _ = embeddings
-            chunks = [
-                _RawChunk(
-                    text=text,
-                    embedding_model=self._embedding_provider.model_name,
-                    embedding_provider=self._embedding_provider.provider_name,
-                )
-                for text in chunks_text
-            ]
             result = await self._index_writer.upsert_document(
                 source_id=event.source_id,
                 external_id=event.external_id,
@@ -427,49 +557,152 @@ class IngestionPipeline:
         finally:
             INGESTION_STAGE_DURATION_SECONDS.labels(stage="index").observe(time.monotonic() - t0)
 
+    async def _stage_vector(
+        self,
+        *,
+        event: DocumentChangeEvent,
+        fetched: FetchedDocument,
+        content_hash: str,
+        chunks: list[_RawChunk],
+        workspace_id: uuid.UUID,
+        ingestion_run_id: UUID | None,
+        bound: Any,
+    ) -> None:
+        """Push chunk embeddings to Qdrant.  Hard failure propagates."""
+        t0 = time.monotonic()
+        try:
+            payloads = [_chunk_to_payload(c) for c in chunks]
+            metadata = _build_vector_metadata(
+                workspace_id=workspace_id,
+                fetched_metadata=dict(fetched.ref.metadata),
+            )
+            outcome = await self._vector_store.upsert_chunks(
+                source_id=event.source_id,
+                external_id=event.external_id,
+                uri=event.uri,
+                title=None,
+                content_hash=content_hash,
+                metadata=metadata,
+                chunks=payloads,
+                ingestion_run_id=ingestion_run_id,
+            )
+            bound.debug(
+                "stage_vector_ok",
+                action=outcome.action,
+                chunks_written=outcome.chunks_written,
+                document_id=str(outcome.document_id),
+            )
+        except Exception as exc:
+            INGESTION_ERRORS_TOTAL.labels(source_type=event.source_type, stage=_STAGE_VECTOR).inc()
+            bound.error("stage_vector_error", error=str(exc))
+            raise
+        finally:
+            INGESTION_STAGE_DURATION_SECONDS.labels(stage=_STAGE_VECTOR).observe(
+                time.monotonic() - t0
+            )
+
     async def _stage_graph(
         self,
+        *,
         event: DocumentChangeEvent,
         content_bytes: bytes,
         document_id: UUID,
+        workspace_id: uuid.UUID,
         bound: Any,
     ) -> None:
-        """Extract symbol graph and persist entities/edges.  Best-effort: never raises."""
+        """Extract and persist the symbol graph.
+
+        Two-tier failure handling:
+        - Parser / extractor problems are best-effort (logged + swallowed).
+        - Adapter problems on ``GraphStore.upsert_graph`` propagate up so
+          the broker NAKs the message.  Idempotent MERGE on the Neo4j
+          side makes redelivery safe.
+        """
         if self._graph_extractor is None:
             return
 
         t0 = time.monotonic()
+        try:
+            extracted = self._extract_graph(event, content_bytes, bound)
+            if extracted is None:
+                return
+            entities, edges = extracted
+            await self._upsert_graph_with_acl(
+                event=event,
+                document_id=document_id,
+                workspace_id=workspace_id,
+                entities=entities,
+                edges=edges,
+                bound=bound,
+            )
+        finally:
+            INGESTION_STAGE_DURATION_SECONDS.labels(stage="graph").observe(time.monotonic() - t0)
+
+    def _extract_graph(
+        self,
+        event: DocumentChangeEvent,
+        content_bytes: bytes,
+        bound: Any,
+    ) -> tuple[list[Any], list[Any]] | None:
+        """Run the parser + extractor.  Best-effort: returns ``None`` on miss.
+
+        Failures here are NOT propagated — extraction is non-critical
+        (the document is still queryable via Postgres + Qdrant even
+        without a symbol graph).  Returning ``None`` tells the caller
+        to skip the adapter call.
+        """
         try:
             from omniscience_parsers import TreeSitterParser
 
             parser = TreeSitterParser()
             ext = "." + event.external_id.rsplit(".", 1)[-1] if "." in event.external_id else ""
             if not parser.can_handle("", ext):
-                return
+                return None
 
             parsed = parser.parse(content_bytes, file_path=event.external_id)
-            entities, edges = self._graph_extractor(parsed, content_bytes)
-
+            entities, edges = self._graph_extractor(parsed, content_bytes)  # type: ignore[misc]
             if not entities and not edges:
-                return
+                return None
+        except Exception as exc:
+            INGESTION_ERRORS_TOTAL.labels(
+                source_type=event.source_type, stage="graph_extract"
+            ).inc()
+            bound.warning("stage_graph_extract_error", error=str(exc))
+            return None
+        return list(entities), list(edges)
 
-            await self._index_writer.upsert_graph(
+    async def _upsert_graph_with_acl(
+        self,
+        *,
+        event: DocumentChangeEvent,
+        document_id: UUID,
+        workspace_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+        bound: Any,
+    ) -> None:
+        """Tag entities with ``workspace_id`` and call the Neo4j adapter.
+
+        The adapter's :meth:`Neo4jGraphStore.upsert_graph` reads the
+        workspace from the first entity (or its metadata) — see
+        ``_workspace_from_entities`` in the adapter.  We tag every
+        entity defensively so the adapter's lookup is unambiguous.
+
+        Adapter errors propagate so the worker NAKs the message.
+        """
+        try:
+            tagged = [_tag_entity_workspace(ent, workspace_id) for ent in entities]
+            await self._graph_store.upsert_graph(
                 source_id=event.source_id,
                 document_id=document_id,
-                entities=entities,
+                entities=tagged,
                 edges=edges,
             )
-            bound.debug(
-                "stage_graph_ok",
-                entities=len(entities),
-                edges=len(edges),
-            )
+            bound.debug("stage_graph_ok", entities=len(entities), edges=len(edges))
         except Exception as exc:
             INGESTION_ERRORS_TOTAL.labels(source_type=event.source_type, stage="graph").inc()
-            bound.warning("stage_graph_error", error=str(exc))
-            # Swallow: graph extraction is non-critical
-        finally:
-            INGESTION_STAGE_DURATION_SECONDS.labels(stage="graph").observe(time.monotonic() - t0)
+            bound.error("stage_graph_adapter_error", error=str(exc))
+            raise
 
     async def _stage_link(
         self,
@@ -491,10 +724,35 @@ class IngestionPipeline:
         finally:
             INGESTION_STAGE_DURATION_SECONDS.labels(stage="link").observe(time.monotonic() - t0)
 
-    async def _handle_delete(self, event: DocumentChangeEvent, bound: Any) -> ProcessResult:
+    async def _handle_delete(
+        self,
+        event: DocumentChangeEvent,
+        workspace_id: uuid.UUID,
+        bound: Any,
+    ) -> ProcessResult:
+        """Tombstone the document in Postgres and Qdrant.
+
+        Neo4j entities are not actively tombstoned per-document — the
+        next re-ingestion of any document for the same source replaces
+        the source's graph slice via :meth:`Neo4jGraphStore.upsert_graph`
+        (DETACH DELETE by source_id).  This matches the migration
+        runner's semantics.
+        """
         t0 = time.monotonic()
         try:
             found = await self._index_writer.tombstone(event.source_id, event.external_id)
+            try:
+                await self._vector_store.delete_by_document(  # type: ignore[call-arg]
+                    source_id=event.source_id,
+                    external_id=event.external_id,
+                    workspace_id=workspace_id,
+                )
+            except Exception as exc:
+                INGESTION_ERRORS_TOTAL.labels(
+                    source_type=event.source_type, stage=_STAGE_VECTOR
+                ).inc()
+                bound.error("stage_delete_vector_error", error=str(exc))
+                raise
             action = "deleted" if found else "unchanged"
             bound.info("stage_delete_ok", found=found)
             return ProcessResult(
@@ -509,6 +767,32 @@ class IngestionPipeline:
             raise
         finally:
             INGESTION_STAGE_DURATION_SECONDS.labels(stage="index").observe(time.monotonic() - t0)
+
+
+# ---------------------------------------------------------------------------
+# Free helpers (small + pure)
+# ---------------------------------------------------------------------------
+
+
+def _tag_entity_workspace(entity: Any, workspace_id: uuid.UUID) -> Any:
+    """Stamp ``workspace_id`` onto an extracted entity's ``metadata``.
+
+    The Neo4j adapter resolves the workspace via the first entity's
+    ``metadata['workspace_id']`` (see
+    ``Neo4jGraphStore._workspace_from_entities``).  The parser's
+    ``ExtractedEntity`` does not carry a ``workspace_id`` natively, so
+    we set it on every entity defensively.  Mutating the existing
+    ``metadata`` dict is safe — extraction is per-document and the
+    caller does not retain a reference to the originals after this
+    point.
+    """
+    metadata: dict[str, Any] | None = getattr(entity, "metadata", None)
+    if metadata is None:
+        # Some duck-typed shapes may not own a metadata attribute; raise
+        # so the bug is visible rather than silently dropping ACL.
+        raise ValueError("entity_missing_metadata_attribute")
+    metadata["workspace_id"] = str(workspace_id)
+    return entity
 
 
 __all__ = ["EntityLinkerProtocol", "IndexWriterProtocol", "IngestionPipeline"]

--- a/apps/server/src/omniscience_server/ingestion/worker.py
+++ b/apps/server/src/omniscience_server/ingestion/worker.py
@@ -4,18 +4,34 @@
 ``INGEST_CHANGES`` stream, passes each through :class:`IngestionPipeline`,
 updates :class:`RunTracker` counters, and acks/naks the broker accordingly.
 
+Responsibilities (issue #126)
+-----------------------------
+
+The worker is the single place where ``Source.tenant_id`` is converted
+into the ``workspace_id`` that every Neo4j / Qdrant adapter call must
+carry.  Doing this BEFORE the pipeline runs means:
+
+1. The pipeline never has to handle a ``None`` workspace.
+2. A tenant-less source is rejected with a clear, structured-log error
+   (``workspace_resolution_failed``) and surfaced as a hard failure so
+   the broker NAKs the message and (after ``max_deliver``) routes it
+   to the DLQ via the existing failure path.
+3. Adapter-side ``MissingWorkspaceError``-equivalents bubble up as
+   pipeline errors and are treated identically to other adapter
+   failures — never swallowed.
+
 Design decisions:
-- A ``nak()`` is issued on pipeline errors so the broker can redeliver up to
-  ``max_deliver`` times.  After ``max_deliver`` the queue framework routes the
-  message to the DLQ transparently.
-- ``stop()`` signals the consumer iterator to drain the current batch and exit;
-  the worker coroutine completes cleanly.
-- One ``IngestionRun`` row covers the entire worker lifetime so counters
-  aggregate across all processed documents.
+- A ``nak()`` is issued on pipeline errors so the broker can redeliver
+  up to ``max_deliver`` times.  After ``max_deliver`` the queue
+  framework routes the message to the DLQ transparently.
+- ``stop()`` signals the consumer iterator to drain the current batch
+  and exit; the worker coroutine completes cleanly.
+- One ``IngestionRun`` row covers the entire worker lifetime so
+  counters aggregate across all processed documents.
 - Secrets are resolved at message-processing time via
-  :class:`~omniscience_core.secrets.SecretsResolver`.  Resolution failures
-  (missing env vars, unreadable files) produce an error result so the broker
-  can redeliver or route to the DLQ.
+  :class:`~omniscience_core.secrets.SecretsResolver`.  Resolution
+  failures (missing env vars, unreadable files) produce an error
+  result so the broker can redeliver or route to the DLQ.
 """
 
 from __future__ import annotations
@@ -24,9 +40,14 @@ import uuid
 
 import structlog
 from omniscience_connectors.registry import ConnectorRegistry
+from omniscience_core.db.models import Source
 from omniscience_core.queue.consumer import QueueConsumer
 from omniscience_core.secrets import SecretsResolver
+from omniscience_core.storage.graph import GraphStore
+from omniscience_core.storage.vector import VectorStore
 from omniscience_embeddings.base import EmbeddingProvider
+from omniscience_index.workspace import MissingWorkspaceError, resolve_source_workspace
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from omniscience_server.ingestion.events import DocumentChangeEvent, ProcessResult
@@ -44,8 +65,11 @@ class IngestionWorker:
         queue_consumer: Typed consumer for ``DocumentChangeEvent`` messages.
         connector_registry: Registry used to look up connectors by source type.
         embedding_provider: Backend used to generate embedding vectors.
-        index_writer: Writer for the document/chunk index.
-        session_factory: SQLAlchemy async session factory for run tracking.
+        index_writer: Writer for the Postgres operational metadata.
+        graph_store: Neo4j adapter used by the pipeline's graph stage.
+        vector_store: Qdrant adapter used by the pipeline's vector stage.
+        session_factory: SQLAlchemy async session factory for run tracking
+            and workspace resolution.
         secrets_resolver: Resolver for ``secrets_ref`` strings.  When ``None``
             a default :class:`~omniscience_core.secrets.SecretsResolver` is
             created automatically.
@@ -57,6 +81,8 @@ class IngestionWorker:
         connector_registry: ConnectorRegistry,
         embedding_provider: EmbeddingProvider,
         index_writer: IndexWriterProtocol,
+        graph_store: GraphStore,
+        vector_store: VectorStore,
         session_factory: async_sessionmaker[AsyncSession],
         secrets_resolver: SecretsResolver | None = None,
     ) -> None:
@@ -64,6 +90,9 @@ class IngestionWorker:
         self._connector_registry = connector_registry
         self._embedding_provider = embedding_provider
         self._index_writer = index_writer
+        self._graph_store = graph_store
+        self._vector_store = vector_store
+        self._session_factory = session_factory
         self._run_tracker = RunTracker(session_factory)
         self._secrets_resolver = secrets_resolver or SecretsResolver()
         self._run_id: uuid.UUID | None = None
@@ -112,13 +141,36 @@ class IngestionWorker:
     async def process_document(self, event: DocumentChangeEvent) -> ProcessResult:
         """Fetch, parse, embed, and index a single document change event.
 
-        Secrets are resolved from the ``secrets_ref`` attribute on the event
-        (when present) via :class:`~omniscience_core.secrets.SecretsResolver`.
-        When the event carries no ``secrets_ref`` an empty dict is used.
+        Workflow per document:
 
-        Resolution failures surface as error results so the broker can
-        redeliver the message or route it to the DLQ after ``max_deliver``.
+        1. Resolve ``workspace_id`` from the source row's ``tenant_id``.
+           A null tenant produces an error result (structured log
+           ``workspace_resolution_failed``) and the broker NAKs.
+        2. Resolve secrets from the event's ``secrets_ref`` (when set).
+        3. Run the per-document :class:`IngestionPipeline` with the
+           resolved workspace.
+
+        Resolution failures and adapter ``MissingWorkspaceError`` raises
+        surface as ``action="error"`` so the broker redelivers /
+        routes to the DLQ.
         """
+        try:
+            workspace_id = await self._resolve_workspace(event.source_id)
+        except MissingWorkspaceError as exc:
+            log.error(
+                "workspace_resolution_failed",
+                source_id=str(event.source_id),
+                source_name=exc.source_name,
+                external_id=event.external_id,
+            )
+            return ProcessResult(
+                source_id=event.source_id,
+                external_id=event.external_id,
+                action="error",
+                duration_ms=0.0,
+                error=str(exc),
+            )
+
         connector = self._connector_registry.get(event.source_type)
 
         # Resolve secrets for this source. The secrets_ref attribute may be
@@ -131,11 +183,14 @@ class IngestionWorker:
             connector=connector,
             embedding_provider=self._embedding_provider,
             index_writer=self._index_writer,
+            graph_store=self._graph_store,
+            vector_store=self._vector_store,
         )
         result = await pipeline.run(
             event=event,
             config=None,
             secrets=secrets,
+            workspace_id=workspace_id,
             ingestion_run_id=self._run_id,
         )
         INGESTION_DOCUMENTS_PROCESSED_TOTAL.labels(
@@ -143,6 +198,45 @@ class IngestionWorker:
             action=result.action,
         ).inc()
         return result
+
+    # ------------------------------------------------------------------
+    # Workspace resolution
+    # ------------------------------------------------------------------
+
+    async def _resolve_workspace(self, source_id: uuid.UUID) -> uuid.UUID:
+        """Look up the ``Source`` and resolve its ``workspace_id``.
+
+        Reuses :func:`omniscience_index.workspace.resolve_source_workspace`
+        — the same helper the migration runner uses — so live ingestion
+        and the legacy backfill follow identical ACL rules.
+
+        Raises
+        ------
+        MissingWorkspaceError
+            When the source row is missing OR its ``tenant_id`` is null.
+            The worker treats both as the same hard failure: a document
+            has no business being indexed without a workspace anchor.
+        """
+        async with self._session_factory() as session:
+            source = await self._fetch_source(session, source_id)
+        if source is None:
+            # Treat a missing source row as the same fail-closed outcome
+            # as a tenant-less source — the worker has no workspace to
+            # write under either way.  We construct an explicit
+            # MissingWorkspaceError so the caller's error handling path
+            # is identical to the canonical case.
+            raise MissingWorkspaceError(
+                source_id=source_id,
+                source_name="<source-not-found>",
+            )
+        return resolve_source_workspace(source)
+
+    @staticmethod
+    async def _fetch_source(session: AsyncSession, source_id: uuid.UUID) -> Source | None:
+        """Fetch a single ``Source`` row by id.  Read-only query."""
+        stmt = select(Source).where(Source.id == source_id)
+        result = await session.execute(stmt)
+        return result.scalar_one_or_none()
 
     # ------------------------------------------------------------------
     # Run tracking helpers

--- a/packages/index/src/omniscience_index/migration/workspace.py
+++ b/packages/index/src/omniscience_index/migration/workspace.py
@@ -1,74 +1,17 @@
-"""Workspace-id resolution for the pgvector -> hybrid migration.
+"""Workspace-id resolution for the legacy pgvector -> hybrid migration.
 
-The pgvector schema does not carry a ``workspace_id`` column on
-``sources`` / ``documents`` / ``chunks`` / ``entities`` / ``edges``
-today (``Source.tenant_id`` is the de-facto multi-tenancy key — see
-``omniscience_core.auth.workspace.workspace_filter`` for the canonical
-lookup).
-
-On migration we resolve each source's effective ``workspace_id``:
-
-1.  If ``Source.tenant_id`` is set, use it verbatim.
-2.  Otherwise, if the caller supplied ``--default-workspace-id UUID``,
-    use that.
-3.  Otherwise, raise :class:`MissingWorkspaceError` with the offending
-    source's id + name.  No row is written without an explicit
-    workspace binding — this is the migration-level ACL gate (#108).
-
-The resolver is extracted so unit tests can cover the fall-through
-matrix exhaustively without going through the runner.
+This module is the legacy import target for the migration runner and
+its tests.  As of issue #126 the canonical implementation lives in
+:mod:`omniscience_index.workspace` so the live ingestion worker can
+import it without reaching into the migration package.  The names
+exported from here are pure re-exports of the canonical module.
 """
 
 from __future__ import annotations
 
-import uuid
-
-from omniscience_core.db.models import Source
-
-
-class MissingWorkspaceError(RuntimeError):
-    """Raised when a pgvector source cannot be mapped to a workspace.
-
-    Carries the offending ``source_id`` and ``source_name`` so callers
-    can print a fix-it message naming the problem row.
-    """
-
-    def __init__(self, *, source_id: uuid.UUID, source_name: str) -> None:
-        self.source_id = source_id
-        self.source_name = source_name
-        super().__init__(
-            f"Source {source_id} ({source_name!r}) has no tenant_id; pass "
-            "--default-workspace-id to bind legacy sources to a workspace, or "
-            "backfill Source.tenant_id first."
-        )
-
-
-def resolve_source_workspace(
-    source: Source,
-    *,
-    default_workspace_id: uuid.UUID | None,
-) -> uuid.UUID:
-    """Return the effective ``workspace_id`` for a pgvector source.
-
-    Parameters
-    ----------
-    source:
-        The ORM row for the source being migrated.
-    default_workspace_id:
-        Operator-provided fallback for sources whose ``tenant_id`` is
-        null.  When ``None`` and ``source.tenant_id`` is also ``None``,
-        this function raises :class:`MissingWorkspaceError`.
-
-    Raises
-    ------
-    MissingWorkspaceError
-        When neither the source nor the operator provides a workspace.
-    """
-    if source.tenant_id is not None:
-        return source.tenant_id
-    if default_workspace_id is not None:
-        return default_workspace_id
-    raise MissingWorkspaceError(source_id=source.id, source_name=source.name)
-
+from omniscience_index.workspace import (
+    MissingWorkspaceError,
+    resolve_source_workspace,
+)
 
 __all__ = ["MissingWorkspaceError", "resolve_source_workspace"]

--- a/packages/index/src/omniscience_index/workspace.py
+++ b/packages/index/src/omniscience_index/workspace.py
@@ -1,0 +1,85 @@
+"""Workspace-id resolution shared by ingestion and migration paths.
+
+The pgvector schema does not carry a ``workspace_id`` column on
+``sources`` directly — ``Source.tenant_id`` is the multi-tenancy key
+(see ``omniscience_core.auth.workspace.workspace_filter``).
+
+Both the ingestion worker (issue #126) and the legacy pgvector
+migration runner (issue #108) need to derive a non-null
+``workspace_id`` BEFORE invoking any Neo4j / Qdrant adapter — the
+adapters fail closed on a missing ACL marker.
+
+Rationale for living here (not in ``migration/``):
+    The migration package is a one-shot tool kept for legacy installs.
+    The ingestion worker uses the resolver on every document.  Reaching
+    into a private ``migration.workspace`` from production code would
+    couple the live path to the legacy module.  Lifting the helper to
+    ``omniscience_index.workspace`` is the smallest change that keeps
+    the migration runner working (it re-exports from this module) and
+    gives the worker a stable import target.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from omniscience_core.db.models import Source
+
+
+class MissingWorkspaceError(RuntimeError):
+    """Raised when a source cannot be mapped to a workspace.
+
+    Carries the offending ``source_id`` and ``source_name`` so callers
+    can produce a fix-it message naming the problem row.  The ingestion
+    worker catches this, logs ``workspace_resolution_failed``, and
+    surfaces an error result so the broker NAKs the message (and after
+    ``max_deliver`` redeliveries the message lands in the DLQ).
+    """
+
+    def __init__(self, *, source_id: uuid.UUID, source_name: str) -> None:
+        self.source_id = source_id
+        self.source_name = source_name
+        super().__init__(
+            f"Source {source_id} ({source_name!r}) has no tenant_id; backfill "
+            "Source.tenant_id (or, for migration only, pass --default-workspace-id)."
+        )
+
+
+def resolve_source_workspace(
+    source: Source,
+    *,
+    default_workspace_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Return the effective ``workspace_id`` for a source row.
+
+    Resolution order:
+
+    1. ``source.tenant_id`` when set — the canonical workspace marker.
+    2. ``default_workspace_id`` when provided — the migration-time
+       fallback used by ``scripts/migrate_to_hybrid.py``.  Production
+       ingestion MUST NOT pass a default; tenant-less sources are a
+       data-quality bug that the worker should refuse to write past.
+    3. Raise :class:`MissingWorkspaceError`.
+
+    Parameters
+    ----------
+    source:
+        The ORM row for the source being processed.
+    default_workspace_id:
+        Operator-provided fallback for sources whose ``tenant_id`` is
+        null.  Defaults to ``None`` (the production posture: fail
+        closed).  Only the legacy migration tool sets this.
+
+    Raises
+    ------
+    MissingWorkspaceError
+        When neither the source nor the operator provides a workspace.
+    """
+    if source.tenant_id is not None:
+        return source.tenant_id
+    if default_workspace_id is not None:
+        return default_workspace_id
+    raise MissingWorkspaceError(source_id=source.id, source_name=source.name)
+
+
+__all__ = ["MissingWorkspaceError", "resolve_source_workspace"]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -85,6 +85,7 @@ def _make_index_writer(upsert_action: str = "created") -> MagicMock:
     result = MagicMock()
     result.action = upsert_action
     result.chunks_written = 1
+    result.document_id = uuid.uuid4()
 
     writer = MagicMock(spec=IndexWriterProtocol)
     writer.upsert_document = AsyncMock(return_value=result)
@@ -92,31 +93,86 @@ def _make_index_writer(upsert_action: str = "created") -> MagicMock:
     return writer
 
 
-def _make_session_factory() -> MagicMock:
-    """Return a minimal async session factory mock."""
-    session = AsyncMock()
-    session.begin = MagicMock(return_value=session)
-    session.add = MagicMock()
-    session.flush = AsyncMock()
-    session.execute = AsyncMock(
-        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+def _make_graph_store() -> MagicMock:
+    """Return a mock GraphStore for the pipeline / worker tests."""
+    store = MagicMock()
+    store.upsert_graph = AsyncMock(return_value=None)
+    store.delete_tombstoned = AsyncMock(return_value=0)
+    return store
+
+
+def _make_vector_store() -> MagicMock:
+    """Return a mock VectorStore for the pipeline / worker tests."""
+    outcome = MagicMock()
+    outcome.action = "created"
+    outcome.chunks_written = 1
+    outcome.document_id = uuid.uuid4()
+    outcome.doc_version = 1
+
+    store = MagicMock()
+    store.upsert_chunks = AsyncMock(return_value=outcome)
+    store.delete_by_document = AsyncMock(return_value=True)
+    return store
+
+
+def _make_session_factory(source: Any = None) -> MagicMock:
+    """Return a minimal async session factory mock.
+
+    The session yields a mock execute() that defaults to scalar_one_or_none
+    -> ``source`` (a Source row).  Tests that drive workspace resolution
+    pass a Source with an explicit ``tenant_id``.  RunTracker tests still
+    rely on ``None`` for the document lookup; both code paths use the
+    same factory shape.
+    """
+    inner_session = AsyncMock()
+    inner_session.begin = MagicMock(return_value=inner_session)
+    inner_session.add = MagicMock()
+    inner_session.flush = AsyncMock()
+    inner_session.execute = AsyncMock(
+        return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=source))
     )
 
+    # Make the factory() result an async context manager that yields the
+    # inner session (mirrors how the real async_sessionmaker behaves).
+    factory_cm = MagicMock()
+    factory_cm.__aenter__ = AsyncMock(return_value=inner_session)
+    factory_cm.__aexit__ = AsyncMock(return_value=False)
+
     factory = MagicMock()
-    factory.return_value = session
+    factory.return_value = factory_cm
+    factory.session = inner_session  # expose for assertions when needed
     return factory
+
+
+def _make_source(tenant_id: uuid.UUID | None = None, name: str = "test-source") -> Any:
+    """Build a duck-typed Source row carrying the tenant_id needed by ACL."""
+    src = MagicMock()
+    src.id = uuid.uuid4()
+    src.name = name
+    src.tenant_id = tenant_id if tenant_id is not None else uuid.uuid4()
+    return src
 
 
 def _make_pipeline(
     connector: MagicMock | None = None,
     embedding_provider: MagicMock | None = None,
     index_writer: MagicMock | None = None,
+    graph_store: MagicMock | None = None,
+    vector_store: MagicMock | None = None,
 ) -> IngestionPipeline:
     return IngestionPipeline(
         connector=connector or _make_connector(),
         embedding_provider=embedding_provider or _make_embedding_provider(),
         index_writer=index_writer or _make_index_writer(),
+        graph_store=graph_store or _make_graph_store(),
+        vector_store=vector_store or _make_vector_store(),
     )
+
+
+# Default workspace_id used by every pipeline test that does not care
+# about the exact value.  Module-level so the same UUID flows through
+# any helper that wants to assert it round-trips intact.
+_DEFAULT_WORKSPACE_ID: uuid.UUID = uuid.uuid4()
 
 
 def _get_counter_value(counter: Any, labels: dict[str, str]) -> float:
@@ -153,7 +209,9 @@ class TestIngestionPipelineHappyPath:
     async def test_created_document_returns_created_action(self) -> None:
         pipeline = _make_pipeline()
         event = _make_event(action="created")
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.action == "created"
         assert result.source_id == event.source_id
         assert result.external_id == event.external_id
@@ -164,7 +222,9 @@ class TestIngestionPipelineHappyPath:
         writer = _make_index_writer(upsert_action="updated")
         pipeline = _make_pipeline(index_writer=writer)
         event = _make_event(action="updated")
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.action == "updated"
 
     @pytest.mark.asyncio
@@ -172,7 +232,7 @@ class TestIngestionPipelineHappyPath:
         connector = _make_connector()
         pipeline = _make_pipeline(connector=connector)
         event = _make_event()
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         connector.fetch.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -180,7 +240,7 @@ class TestIngestionPipelineHappyPath:
         provider = _make_embedding_provider()
         pipeline = _make_pipeline(embedding_provider=provider)
         event = _make_event()
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         provider.embed.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -188,14 +248,16 @@ class TestIngestionPipelineHappyPath:
         writer = _make_index_writer()
         pipeline = _make_pipeline(index_writer=writer)
         event = _make_event()
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         writer.upsert_document.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_duration_ms_is_positive(self) -> None:
         pipeline = _make_pipeline()
         event = _make_event()
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.duration_ms >= 0.0
 
     @pytest.mark.asyncio
@@ -204,7 +266,7 @@ class TestIngestionPipelineHappyPath:
         writer = _make_index_writer()
         pipeline = _make_pipeline(index_writer=writer)
         event = _make_event(source_id=sid)
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         call_kwargs = writer.upsert_document.call_args.kwargs
         assert call_kwargs["source_id"] == sid
 
@@ -216,7 +278,9 @@ class TestIngestionPipelineHashDedup:
         writer = _make_index_writer(upsert_action="unchanged")
         pipeline = _make_pipeline(index_writer=writer)
         event = _make_event(action="updated")
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.action == "unchanged"
 
     @pytest.mark.asyncio
@@ -226,7 +290,7 @@ class TestIngestionPipelineHashDedup:
         provider = _make_embedding_provider()
         pipeline = _make_pipeline(embedding_provider=provider, index_writer=writer)
         event = _make_event(action="updated")
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         provider.embed.assert_awaited_once()
 
 
@@ -236,7 +300,9 @@ class TestIngestionPipelineDeletedDocument:
         writer = _make_index_writer()
         pipeline = _make_pipeline(index_writer=writer)
         event = _make_event(action="deleted")
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.action == "deleted"
         writer.tombstone.assert_awaited_once_with(event.source_id, event.external_id)
 
@@ -245,7 +311,7 @@ class TestIngestionPipelineDeletedDocument:
         provider = _make_embedding_provider()
         pipeline = _make_pipeline(embedding_provider=provider)
         event = _make_event(action="deleted")
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         provider.embed.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -254,7 +320,9 @@ class TestIngestionPipelineDeletedDocument:
         writer.tombstone = AsyncMock(return_value=False)
         pipeline = _make_pipeline(index_writer=writer)
         event = _make_event(action="deleted")
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.action == "unchanged"
 
 
@@ -265,7 +333,9 @@ class TestIngestionPipelineFetchError:
         connector.fetch = AsyncMock(side_effect=RuntimeError("network timeout"))
         pipeline = _make_pipeline(connector=connector)
         event = _make_event()
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.action == "error"
         assert result.error is not None
         assert "network timeout" in result.error
@@ -281,7 +351,7 @@ class TestIngestionPipelineFetchError:
         before = _get_counter_value(
             INGESTION_ERRORS_TOTAL, {"source_type": source_type, "stage": "fetch"}
         )
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         after = _get_counter_value(
             INGESTION_ERRORS_TOTAL, {"source_type": source_type, "stage": "fetch"}
         )
@@ -294,7 +364,7 @@ class TestIngestionPipelineFetchError:
         provider = _make_embedding_provider()
         pipeline = _make_pipeline(connector=connector, embedding_provider=provider)
         event = _make_event()
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         provider.embed.assert_not_awaited()
 
 
@@ -305,7 +375,9 @@ class TestIngestionPipelineEmbedError:
         provider.embed = AsyncMock(side_effect=RuntimeError("model overloaded"))
         pipeline = _make_pipeline(embedding_provider=provider)
         event = _make_event()
-        result = await pipeline.run(event, config=None, secrets={})
+        result = await pipeline.run(
+            event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID
+        )
         assert result.action == "error"
         assert result.error is not None
 
@@ -320,7 +392,7 @@ class TestIngestionPipelineEmbedError:
         before = _get_counter_value(
             INGESTION_ERRORS_TOTAL, {"source_type": source_type, "stage": "embed"}
         )
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         after = _get_counter_value(
             INGESTION_ERRORS_TOTAL, {"source_type": source_type, "stage": "embed"}
         )
@@ -333,7 +405,7 @@ class TestIngestionPipelineEmbedError:
         writer = _make_index_writer()
         pipeline = _make_pipeline(embedding_provider=provider, index_writer=writer)
         event = _make_event()
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         writer.upsert_document.assert_not_awaited()
 
 
@@ -348,7 +420,7 @@ class TestIngestionMetrics:
         pipeline = _make_pipeline()
         event = _make_event()
         before = _get_histogram_count(INGESTION_STAGE_DURATION_SECONDS, {"stage": "fetch"})
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         after = _get_histogram_count(INGESTION_STAGE_DURATION_SECONDS, {"stage": "fetch"})
         assert after > before
 
@@ -357,7 +429,7 @@ class TestIngestionMetrics:
         pipeline = _make_pipeline()
         event = _make_event()
         before = _get_histogram_count(INGESTION_STAGE_DURATION_SECONDS, {"stage": "embed"})
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         after = _get_histogram_count(INGESTION_STAGE_DURATION_SECONDS, {"stage": "embed"})
         assert after > before
 
@@ -366,7 +438,7 @@ class TestIngestionMetrics:
         pipeline = _make_pipeline()
         event = _make_event()
         before = _get_histogram_count(INGESTION_STAGE_DURATION_SECONDS, {"stage": "index"})
-        await pipeline.run(event, config=None, secrets={})
+        await pipeline.run(event, config=None, secrets={}, workspace_id=_DEFAULT_WORKSPACE_ID)
         after = _get_histogram_count(INGESTION_STAGE_DURATION_SECONDS, {"stage": "index"})
         assert after > before
 
@@ -518,18 +590,25 @@ def _make_worker(
     connector: MagicMock | None = None,
     provider: MagicMock | None = None,
     writer: MagicMock | None = None,
+    graph_store: MagicMock | None = None,
+    vector_store: MagicMock | None = None,
+    source: Any = None,
 ) -> tuple[IngestionWorker, MagicMock]:
     queue_consumer = _make_queue_consumer(events or [])
     registry = _make_connector_registry(connector or _make_connector())
     embedding_provider = provider or _make_embedding_provider()
     index_writer = writer or _make_index_writer()
-    session_factory = _make_session_factory()
+    # Default: tenant-bound source so the worker resolves a workspace.
+    src = source if source is not None else _make_source()
+    session_factory = _make_session_factory(source=src)
 
     worker = IngestionWorker(
         queue_consumer=queue_consumer,
         connector_registry=registry,
         embedding_provider=embedding_provider,
         index_writer=index_writer,
+        graph_store=graph_store or _make_graph_store(),
+        vector_store=vector_store or _make_vector_store(),
         session_factory=session_factory,
     )
     return worker, queue_consumer
@@ -574,6 +653,7 @@ class TestIngestionWorkerHappyPath:
             result = MagicMock()
             result.action = "created"
             result.chunks_written = 1
+            result.document_id = uuid.uuid4()
             return result
 
         writer.upsert_document = AsyncMock(side_effect=_upsert)
@@ -615,7 +695,9 @@ class TestIngestionWorkerErrors:
             connector_registry=_make_connector_registry(connector),
             embedding_provider=_make_embedding_provider(),
             index_writer=_make_index_writer(),
-            session_factory=_make_session_factory(),
+            graph_store=_make_graph_store(),
+            vector_store=_make_vector_store(),
+            session_factory=_make_session_factory(source=_make_source()),
         )
 
         with (
@@ -652,7 +734,9 @@ class TestIngestionWorkerErrors:
             connector_registry=_make_connector_registry(),
             embedding_provider=provider,
             index_writer=_make_index_writer(),
-            session_factory=_make_session_factory(),
+            graph_store=_make_graph_store(),
+            vector_store=_make_vector_store(),
+            session_factory=_make_session_factory(source=_make_source()),
         )
 
         with (

--- a/tests/test_ingestion_e2e.py
+++ b/tests/test_ingestion_e2e.py
@@ -1,0 +1,325 @@
+"""End-to-end ingestion test (issue #126).
+
+Spins up real Neo4j + Qdrant containers via ``testcontainers``, drives a
+single document through the live :class:`IngestionPipeline`, and asserts
+the document is observable in **both** Neo4j (entities) and Qdrant
+(chunks).  Postgres is exercised at the protocol level via a
+hand-rolled in-memory writer so the test stays focused on the new
+three-store fan-out and does not require a database container.
+
+Gating
+------
+
+This test is **opt-in**: it runs only when
+``OMNISCIENCE_RUN_E2E_INGESTION=1``.  The default CI pipeline skips it
+because:
+
+1. Spinning two containers per run is slow.
+2. Some hosted runners cannot pull large container images.
+
+The same gating shape is used by the issue-#104 (Neo4j) and issue-#106
+(Qdrant) contract tests — see ``tests/test_neo4j_store.py`` and
+``tests/test_qdrant_contract.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+
+# Skip the entire module unless the operator opted in.
+_E2E_FLAG: str = "OMNISCIENCE_RUN_E2E_INGESTION"
+if os.environ.get(_E2E_FLAG) != "1":
+    pytest.skip(
+        f"Set {_E2E_FLAG}=1 to run live ingestion E2E.",
+        allow_module_level=True,
+    )
+
+# These imports are guarded by the skip above so a missing
+# ``testcontainers[neo4j,qdrant]`` extra does not break collection.
+pytest.importorskip("testcontainers.qdrant")
+pytest.importorskip("testcontainers.neo4j")
+
+
+from omniscience_index.stores.neo4j_store import (  # noqa: E402  -- gated import
+    Neo4jGraphStore,
+    Neo4jStoreConfig,
+)
+from omniscience_index.stores.qdrant_config import QdrantConfig  # noqa: E402  -- gated
+from omniscience_index.stores.qdrant_store import (  # noqa: E402  -- gated import
+    QdrantVectorStore,
+)
+from omniscience_server.ingestion.events import (  # noqa: E402  -- gated import
+    DocumentChangeEvent,
+)
+from omniscience_server.ingestion.pipeline import (  # noqa: E402  -- gated import
+    IngestionPipeline,
+)
+
+# ---------------------------------------------------------------------------
+# Stub embedding provider
+# ---------------------------------------------------------------------------
+
+
+class _StubEmbedding:
+    """Tiny deterministic embedding provider for E2E tests."""
+
+    dim = 8
+    model_name = "stub-embedding"
+    provider_name = "stub"
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        import math
+
+        out: list[list[float]] = []
+        for t in texts:
+            h = hash(t)
+            raw = [((h >> (i * 4)) & 0xF) / 15.0 for i in range(self.dim)]
+            n = math.sqrt(sum(x * x for x in raw)) or 1.0
+            out.append([x / n for x in raw])
+        return out
+
+    async def close(self) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# In-memory IndexWriter — the test does not run Postgres.
+# ---------------------------------------------------------------------------
+
+
+class _InMemoryIndexWriter:
+    """Minimal in-memory writer satisfying ``IndexWriterProtocol``.
+
+    Records every call so the test can assert all three stores received
+    the document without requiring a Postgres container.  Production
+    semantics (content-hash dedup, document-id stability) are
+    preserved.
+    """
+
+    def __init__(self) -> None:
+        self._documents: dict[tuple[uuid.UUID, str], dict[str, Any]] = {}
+
+    async def upsert_document(
+        self,
+        source_id: uuid.UUID,
+        external_id: str,
+        uri: str,
+        title: str | None,
+        content_hash: str,
+        metadata: dict[str, Any],
+        chunks: list[Any],
+        ingestion_run_id: uuid.UUID | None,
+    ) -> Any:
+        from dataclasses import dataclass
+
+        @dataclass
+        class _Result:
+            action: str
+            document_id: uuid.UUID
+            chunks_written: int
+            doc_version: int
+
+        key = (source_id, external_id)
+        existing = self._documents.get(key)
+        if existing is None:
+            doc_id = uuid.uuid4()
+            self._documents[key] = {
+                "id": doc_id,
+                "content_hash": content_hash,
+                "version": 1,
+            }
+            return _Result(
+                action="created",
+                document_id=doc_id,
+                chunks_written=len(chunks),
+                doc_version=1,
+            )
+        if existing["content_hash"] == content_hash:
+            return _Result(
+                action="unchanged",
+                document_id=existing["id"],
+                chunks_written=0,
+                doc_version=existing["version"],
+            )
+        existing["content_hash"] = content_hash
+        existing["version"] += 1
+        return _Result(
+            action="updated",
+            document_id=existing["id"],
+            chunks_written=len(chunks),
+            doc_version=existing["version"],
+        )
+
+    async def tombstone(self, source_id: uuid.UUID, external_id: str) -> bool:
+        key = (source_id, external_id)
+        if key in self._documents:
+            del self._documents[key]
+            return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Container fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def neo4j_container() -> Any:
+    from testcontainers.neo4j import Neo4jContainer
+
+    with Neo4jContainer(image="neo4j:5.20").with_env("NEO4J_AUTH", "neo4j/test_password") as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def qdrant_container() -> Any:
+    from testcontainers.qdrant import QdrantContainer
+
+    with QdrantContainer(image="qdrant/qdrant:v1.12.4") as c:
+        yield c
+
+
+@pytest_asyncio.fixture()
+async def neo4j_store(neo4j_container: Any) -> AsyncIterator[Neo4jGraphStore]:
+    config = Neo4jStoreConfig(
+        uri=neo4j_container.get_connection_url(),
+        username="neo4j",
+        password="test_password",
+        database="neo4j",
+        max_connection_pool_size=4,
+        connection_acquisition_timeout_seconds=30.0,
+        max_transaction_retry_time_seconds=30.0,
+        default_max_depth=2,
+    )
+    store = Neo4jGraphStore(config=config)
+    await store.connect()
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+@pytest_asyncio.fixture()
+async def qdrant_store(qdrant_container: Any) -> AsyncIterator[QdrantVectorStore]:
+    host = qdrant_container.get_container_host_ip()
+    http_port = int(qdrant_container.get_exposed_port(6333))
+    grpc_port = int(qdrant_container.get_exposed_port(6334))
+    config = QdrantConfig(
+        host=host,
+        grpc_port=grpc_port,
+        http_port=http_port,
+        api_key=None,
+        prefer_grpc=False,
+    )
+    embedding = _StubEmbedding()
+    store = QdrantVectorStore(config=config, embedding_provider=embedding)
+    # Unique collection per test run.
+    store._collection_name = (  # type: ignore[attr-defined]
+        f"omniscience__stub-embedding__d8__t{uuid.uuid4().hex[:8]}"
+    )
+    await store.connect()
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# E2E test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingestion_writes_to_all_three_stores(
+    neo4j_store: Neo4jGraphStore,
+    qdrant_store: QdrantVectorStore,
+) -> None:
+    """One document goes through the worker; all three stores observe it."""
+    from omniscience_connectors.base import Connector, DocumentRef, FetchedDocument
+
+    workspace_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+
+    # ---- mock connector that returns a small Python file -----------------
+
+    class _StubConnector:
+        async def fetch(
+            self,
+            config: Any,
+            secrets: dict[str, str],
+            ref: DocumentRef,
+        ) -> FetchedDocument:
+            return FetchedDocument(
+                ref=ref,
+                content_bytes=b"def greet():\n    return 'hi'\n",
+                content_type="text/x-python",
+            )
+
+    connector: Connector = _StubConnector()  # type: ignore[assignment]
+
+    # ---- graph extractor ------------------------------------------------
+
+    def _stub_extractor(parsed: Any, src_bytes: bytes) -> tuple[list[Any], list[Any]]:
+        from omniscience_parsers.code.graph import ExtractedEntity
+
+        ent = ExtractedEntity(
+            id=uuid.uuid4(),
+            entity_type="function",
+            name="example.greet",
+            display_name="greet",
+            symbol="greet",
+            metadata={},
+        )
+        return [ent], []
+
+    pipeline = IngestionPipeline(
+        connector=connector,
+        embedding_provider=_StubEmbedding(),  # type: ignore[arg-type]
+        index_writer=_InMemoryIndexWriter(),  # type: ignore[arg-type]
+        graph_store=neo4j_store,
+        vector_store=qdrant_store,
+        graph_extractor=_stub_extractor,
+    )
+
+    event = DocumentChangeEvent(
+        source_id=source_id,
+        source_type="git",
+        external_id="example.py",
+        uri="file://example.py",
+        action="created",  # type: ignore[arg-type]
+    )
+
+    # Force the parser to "handle" .py without spinning up tree-sitter
+    # (which is heavyweight and orthogonal to this test's purpose).
+    with patch("omniscience_parsers.TreeSitterParser") as parser_cls:
+        from unittest.mock import MagicMock
+
+        parser = MagicMock()
+        parser.can_handle = MagicMock(return_value=True)
+        parser.parse = MagicMock(return_value=MagicMock())
+        parser_cls.return_value = parser
+
+        result = await pipeline.run(
+            event=event,
+            config=None,
+            secrets={},
+            workspace_id=workspace_id,
+        )
+
+    assert result.action == "created"
+
+    # ---- assert Qdrant received the chunk -------------------------------
+    qdrant_count = await qdrant_store.count(source_id=source_id, workspace_id=workspace_id)
+    assert qdrant_count == 1
+
+    # ---- assert Neo4j received the entity -------------------------------
+    entity = await neo4j_store.get_entity(entity_name="example.greet", workspace_id=workspace_id)
+    assert entity is not None
+    assert entity.kind == "function"

--- a/tests/test_ingestion_three_stores.py
+++ b/tests/test_ingestion_three_stores.py
@@ -1,0 +1,734 @@
+"""Tests for issue #126 — ingestion worker drives Neo4j + Qdrant writes.
+
+Coverage map (per the issue's acceptance criteria):
+
+* Pipeline-side three-store fan-out
+    - ``upsert_document`` (Postgres) called with the placeholder chunks.
+    - ``upsert_chunks`` (Qdrant) called with workspace_id in metadata,
+      chunk lineage fields populated, embedding present.
+    - ``upsert_graph`` (Neo4j) called with workspace_id stamped on
+      every entity's metadata.
+    - Call order: Postgres -> Qdrant -> Neo4j (matches the
+      pipeline's documented sequence in the module docstring).
+
+* ACL invariant
+    - Tenant-less source: worker returns ``action="error"`` with a
+      ``workspace_resolution_failed`` log AND the broker NAK is fired.
+    - Missing source row: same fail-closed outcome (no silent default).
+    - Adapter raises ``ValueError("upsert_graph_missing_workspace_id")``
+      (Neo4j adapter's actual error shape) — propagates as a hard
+      failure; pipeline returns ``action="error"``.
+
+* Partial-failure semantics
+    - Postgres OK + Qdrant raises -> action="error".
+    - Postgres OK + Qdrant OK + Neo4j raises -> action="error".
+
+All tests run with in-memory mocks of the protocols; no real Neo4j /
+Qdrant / Postgres is started.  The opt-in integration test lives in
+``test_ingestion_e2e.py`` and is gated on
+``OMNISCIENCE_RUN_E2E_INGESTION=1``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from omniscience_index.workspace import MissingWorkspaceError
+from omniscience_server.ingestion.events import DocumentChangeEvent
+from omniscience_server.ingestion.pipeline import IngestionPipeline
+from omniscience_server.ingestion.worker import IngestionWorker
+
+# ---------------------------------------------------------------------------
+# Test helpers — keep them local to avoid leaking into the existing
+# tests/test_ingestion.py mock set; those fixtures don't model the
+# three-store fan-out.
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    source_id: uuid.UUID | None = None,
+    source_type: str = "git",
+    external_id: str = "abc/def.py",
+    uri: str = "file://abc/def.py",
+    action: str = "created",
+) -> DocumentChangeEvent:
+    return DocumentChangeEvent(
+        source_id=source_id or uuid.uuid4(),
+        source_type=source_type,
+        external_id=external_id,
+        uri=uri,
+        action=action,  # type: ignore[arg-type]
+    )
+
+
+def _make_connector(content: bytes = b"def foo():\n    pass\n") -> MagicMock:
+    from omniscience_connectors.base import DocumentRef, FetchedDocument
+
+    connector = MagicMock()
+    ref = DocumentRef(external_id="abc/def.py", uri="file://abc/def.py")
+    fetched = FetchedDocument(ref=ref, content_bytes=content, content_type="text/plain")
+    connector.fetch = AsyncMock(return_value=fetched)
+    return connector
+
+
+def _make_embedding_provider(
+    vectors: list[list[float]] | None = None,
+) -> MagicMock:
+    provider = MagicMock()
+    provider.dim = 4
+    provider.model_name = "test-model"
+    provider.provider_name = "test-provider"
+    provider.embed = AsyncMock(return_value=vectors or [[0.1, 0.2, 0.3, 0.4]])
+    return provider
+
+
+def _make_index_writer(action: str = "created") -> MagicMock:
+    result = MagicMock()
+    result.action = action
+    result.chunks_written = 1
+    result.document_id = uuid.uuid4()
+    writer = MagicMock()
+    writer.upsert_document = AsyncMock(return_value=result)
+    writer.tombstone = AsyncMock(return_value=True)
+    return writer
+
+
+def _make_graph_store() -> MagicMock:
+    store = MagicMock()
+    store.upsert_graph = AsyncMock(return_value=None)
+    return store
+
+
+def _make_vector_store() -> MagicMock:
+    outcome = MagicMock()
+    outcome.action = "created"
+    outcome.chunks_written = 1
+    outcome.document_id = uuid.uuid4()
+    outcome.doc_version = 1
+    store = MagicMock()
+    store.upsert_chunks = AsyncMock(return_value=outcome)
+    store.delete_by_document = AsyncMock(return_value=True)
+    return store
+
+
+def _make_pipeline(
+    *,
+    connector: MagicMock | None = None,
+    embedding_provider: MagicMock | None = None,
+    index_writer: MagicMock | None = None,
+    graph_store: MagicMock | None = None,
+    vector_store: MagicMock | None = None,
+    graph_extractor: Any | None = None,
+) -> IngestionPipeline:
+    return IngestionPipeline(
+        connector=connector or _make_connector(),
+        embedding_provider=embedding_provider or _make_embedding_provider(),
+        index_writer=index_writer or _make_index_writer(),
+        graph_store=graph_store or _make_graph_store(),
+        vector_store=vector_store or _make_vector_store(),
+        graph_extractor=graph_extractor,
+    )
+
+
+def _make_session_factory(source: Any | None) -> MagicMock:
+    """Async session factory that yields ``source`` from scalar_one_or_none."""
+    inner_session = AsyncMock()
+    scalar_result = MagicMock()
+    scalar_result.scalar_one_or_none = MagicMock(return_value=source)
+    inner_session.execute = AsyncMock(return_value=scalar_result)
+
+    factory_cm = MagicMock()
+    factory_cm.__aenter__ = AsyncMock(return_value=inner_session)
+    factory_cm.__aexit__ = AsyncMock(return_value=False)
+
+    factory = MagicMock(return_value=factory_cm)
+    return factory
+
+
+def _make_source(tenant_id: uuid.UUID | None) -> Any:
+    src = MagicMock()
+    src.id = uuid.uuid4()
+    src.name = "issue-126-test-source"
+    src.tenant_id = tenant_id
+    return src
+
+
+_WORKSPACE_A: uuid.UUID = uuid.uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline three-store fan-out
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineThreeStoreFanOut:
+    @pytest.mark.asyncio
+    async def test_postgres_qdrant_neo4j_all_called(self) -> None:
+        """The pipeline writes Postgres + Qdrant + Neo4j when entities exist."""
+        index_writer = _make_index_writer()
+        graph_store = _make_graph_store()
+        vector_store = _make_vector_store()
+
+        # Stub graph extractor so _stage_graph reaches the adapter call.
+        def _extractor(parsed: Any, src_bytes: bytes) -> tuple[list[Any], list[Any]]:
+            ent = MagicMock()
+            ent.id = uuid.uuid4()
+            ent.metadata = {}
+            return [ent], []
+
+        # Force can_handle("", ".py") to True via stubbed parser.
+        with patch("omniscience_parsers.TreeSitterParser") as parser_cls:
+            parser = MagicMock()
+            parser.can_handle = MagicMock(return_value=True)
+            parsed_doc = MagicMock()
+            parser.parse = MagicMock(return_value=parsed_doc)
+            parser_cls.return_value = parser
+
+            pipeline = _make_pipeline(
+                index_writer=index_writer,
+                graph_store=graph_store,
+                vector_store=vector_store,
+                graph_extractor=_extractor,
+            )
+            event = _make_event()
+            result = await pipeline.run(
+                event=event,
+                config=None,
+                secrets={},
+                workspace_id=_WORKSPACE_A,
+            )
+
+        assert result.action == "created"
+        index_writer.upsert_document.assert_awaited_once()
+        vector_store.upsert_chunks.assert_awaited_once()
+        graph_store.upsert_graph.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_qdrant_receives_workspace_id_in_metadata(self) -> None:
+        """Qdrant upsert metadata always carries ``workspace_id`` (ADR-0006 §ACL)."""
+        vector_store = _make_vector_store()
+        pipeline = _make_pipeline(vector_store=vector_store)
+        event = _make_event()
+        await pipeline.run(event=event, config=None, secrets={}, workspace_id=_WORKSPACE_A)
+
+        kwargs = vector_store.upsert_chunks.call_args.kwargs
+        assert kwargs["metadata"]["workspace_id"] == str(_WORKSPACE_A)
+        assert kwargs["source_id"] == event.source_id
+        assert kwargs["external_id"] == event.external_id
+
+    @pytest.mark.asyncio
+    async def test_qdrant_payload_contains_lineage_and_embedding(self) -> None:
+        """ChunkPayload carries the embedding + ADR-0006 lineage fields."""
+        vector_store = _make_vector_store()
+        provider = _make_embedding_provider(vectors=[[0.5, 0.6, 0.7, 0.8]])
+        pipeline = _make_pipeline(vector_store=vector_store, embedding_provider=provider)
+        await pipeline.run(event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A)
+
+        kwargs = vector_store.upsert_chunks.call_args.kwargs
+        chunks = kwargs["chunks"]
+        assert len(chunks) == 1
+        chunk = chunks[0]
+        assert chunk["embedding"] == [0.5, 0.6, 0.7, 0.8]
+        assert chunk["embedding_model"] == "test-model"
+        assert chunk["embedding_provider"] == "test-provider"
+        assert chunk["parser_version"] == "placeholder-v0"
+        assert chunk["chunker_strategy"] == "full-content-v0"
+        assert chunk["ord"] == 0
+        assert "text" in chunk
+
+    @pytest.mark.asyncio
+    async def test_qdrant_metadata_includes_content_hash_arg(self) -> None:
+        """``content_hash`` keyword arg passed to Qdrant matches the Postgres hash."""
+        vector_store = _make_vector_store()
+        index_writer = _make_index_writer()
+        pipeline = _make_pipeline(vector_store=vector_store, index_writer=index_writer)
+        await pipeline.run(event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A)
+
+        qdrant_kwargs = vector_store.upsert_chunks.call_args.kwargs
+        pg_kwargs = index_writer.upsert_document.call_args.kwargs
+        assert qdrant_kwargs["content_hash"] == pg_kwargs["content_hash"]
+
+    @pytest.mark.asyncio
+    async def test_neo4j_entities_tagged_with_workspace_id(self) -> None:
+        """Every entity passed to ``upsert_graph`` carries ``workspace_id``."""
+        graph_store = _make_graph_store()
+
+        def _extractor(parsed: Any, src_bytes: bytes) -> tuple[list[Any], list[Any]]:
+            entities = []
+            for _ in range(3):
+                e = MagicMock()
+                e.id = uuid.uuid4()
+                e.metadata = {}
+                entities.append(e)
+            return entities, []
+
+        with patch("omniscience_parsers.TreeSitterParser") as parser_cls:
+            parser = MagicMock()
+            parser.can_handle = MagicMock(return_value=True)
+            parser.parse = MagicMock(return_value=MagicMock())
+            parser_cls.return_value = parser
+
+            pipeline = _make_pipeline(graph_store=graph_store, graph_extractor=_extractor)
+            await pipeline.run(
+                event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A
+            )
+
+        kwargs = graph_store.upsert_graph.call_args.kwargs
+        for ent in kwargs["entities"]:
+            assert ent.metadata["workspace_id"] == str(_WORKSPACE_A)
+
+    @pytest.mark.asyncio
+    async def test_call_order_postgres_then_vector_then_graph(self) -> None:
+        """Pipeline calls Postgres before Qdrant before Neo4j."""
+        order: list[str] = []
+        index_writer = _make_index_writer()
+        graph_store = _make_graph_store()
+        vector_store = _make_vector_store()
+
+        async def _pg_call(**kwargs: Any) -> Any:
+            order.append("postgres")
+            r = MagicMock()
+            r.action = "created"
+            r.document_id = uuid.uuid4()
+            r.chunks_written = 1
+            return r
+
+        async def _qdrant_call(**kwargs: Any) -> Any:
+            order.append("qdrant")
+            o = MagicMock()
+            o.action = "created"
+            o.chunks_written = 1
+            o.document_id = uuid.uuid4()
+            o.doc_version = 1
+            return o
+
+        async def _neo4j_call(**kwargs: Any) -> None:
+            order.append("neo4j")
+
+        index_writer.upsert_document = AsyncMock(side_effect=_pg_call)
+        vector_store.upsert_chunks = AsyncMock(side_effect=_qdrant_call)
+        graph_store.upsert_graph = AsyncMock(side_effect=_neo4j_call)
+
+        def _extractor(parsed: Any, src_bytes: bytes) -> tuple[list[Any], list[Any]]:
+            e = MagicMock()
+            e.id = uuid.uuid4()
+            e.metadata = {}
+            return [e], []
+
+        with patch("omniscience_parsers.TreeSitterParser") as parser_cls:
+            parser = MagicMock()
+            parser.can_handle = MagicMock(return_value=True)
+            parser.parse = MagicMock(return_value=MagicMock())
+            parser_cls.return_value = parser
+
+            pipeline = _make_pipeline(
+                index_writer=index_writer,
+                graph_store=graph_store,
+                vector_store=vector_store,
+                graph_extractor=_extractor,
+            )
+            await pipeline.run(
+                event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A
+            )
+
+        assert order == ["postgres", "qdrant", "neo4j"]
+
+
+# ---------------------------------------------------------------------------
+# ACL invariant — workspace resolution at the worker boundary
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerWorkspaceResolution:
+    def _build_worker(
+        self,
+        *,
+        source: Any,
+    ) -> tuple[IngestionWorker, MagicMock, MagicMock, MagicMock]:
+        from omniscience_connectors.registry import ConnectorRegistry
+
+        registry: ConnectorRegistry = MagicMock(spec=ConnectorRegistry)
+        registry.get = MagicMock(return_value=_make_connector())
+        graph_store = _make_graph_store()
+        vector_store = _make_vector_store()
+        index_writer = _make_index_writer()
+
+        worker = IngestionWorker(
+            queue_consumer=MagicMock(),
+            connector_registry=registry,
+            embedding_provider=_make_embedding_provider(),
+            index_writer=index_writer,
+            graph_store=graph_store,
+            vector_store=vector_store,
+            session_factory=_make_session_factory(source),
+        )
+        return worker, graph_store, vector_store, index_writer
+
+    @pytest.mark.asyncio
+    async def test_tenant_less_source_returns_error_result(self) -> None:
+        """A source with ``tenant_id is None`` must produce ``action='error'``."""
+        source = _make_source(tenant_id=None)
+        worker, graph_store, vector_store, index_writer = self._build_worker(source=source)
+
+        result = await worker.process_document(_make_event())
+
+        assert result.action == "error"
+        assert result.error is not None
+        assert "tenant_id" in result.error
+        # No adapter should have been touched — fail closed BEFORE any I/O.
+        graph_store.upsert_graph.assert_not_awaited()
+        vector_store.upsert_chunks.assert_not_awaited()
+        index_writer.upsert_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_source_row_returns_error_result(self) -> None:
+        """A source row that no longer exists must be treated as missing workspace."""
+        worker, graph_store, vector_store, index_writer = self._build_worker(source=None)
+
+        result = await worker.process_document(_make_event())
+
+        assert result.action == "error"
+        graph_store.upsert_graph.assert_not_awaited()
+        vector_store.upsert_chunks.assert_not_awaited()
+        index_writer.upsert_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolve_workspace_propagates_tenant_id(self) -> None:
+        """The resolved workspace_id is exactly ``Source.tenant_id``."""
+        target = uuid.uuid4()
+        source = _make_source(tenant_id=target)
+        worker, _graph, vector_store, _ = self._build_worker(source=source)
+
+        await worker.process_document(_make_event())
+
+        kwargs = vector_store.upsert_chunks.call_args.kwargs
+        assert kwargs["metadata"]["workspace_id"] == str(target)
+
+    @pytest.mark.asyncio
+    async def test_resolve_workspace_raises_on_missing_workspace(self) -> None:
+        """``_resolve_workspace`` raises ``MissingWorkspaceError`` for tenant-less sources.
+
+        Direct unit test: catches the helper's behaviour even before the
+        process_document call wraps it in an error result.
+        """
+        source = _make_source(tenant_id=None)
+        worker, _, _, _ = self._build_worker(source=source)
+
+        with pytest.raises(MissingWorkspaceError):
+            await worker._resolve_workspace(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Adapter-side ACL rejection
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterAclRejection:
+    @pytest.mark.asyncio
+    async def test_qdrant_missing_workspace_propagates(self) -> None:
+        """Qdrant's ValueError on missing workspace_id surfaces as action='error'."""
+        vector_store = _make_vector_store()
+        vector_store.upsert_chunks = AsyncMock(
+            side_effect=ValueError(
+                "QdrantVectorStore upsert rejected: metadata['workspace_id'] "
+                "is required and must be a non-null UUID (ADR-0006 §ACL)."
+            )
+        )
+        pipeline = _make_pipeline(vector_store=vector_store)
+        result = await pipeline.run(
+            event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A
+        )
+        assert result.action == "error"
+        assert "workspace_id" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_neo4j_missing_workspace_propagates(self) -> None:
+        """Neo4j's ValueError on missing workspace_id surfaces as action='error'."""
+        graph_store = _make_graph_store()
+        graph_store.upsert_graph = AsyncMock(
+            side_effect=ValueError("upsert_graph_missing_workspace_id")
+        )
+
+        def _extractor(parsed: Any, src_bytes: bytes) -> tuple[list[Any], list[Any]]:
+            e = MagicMock()
+            e.id = uuid.uuid4()
+            e.metadata = {}
+            return [e], []
+
+        with patch("omniscience_parsers.TreeSitterParser") as parser_cls:
+            parser = MagicMock()
+            parser.can_handle = MagicMock(return_value=True)
+            parser.parse = MagicMock(return_value=MagicMock())
+            parser_cls.return_value = parser
+
+            pipeline = _make_pipeline(graph_store=graph_store, graph_extractor=_extractor)
+            result = await pipeline.run(
+                event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A
+            )
+
+        assert result.action == "error"
+        assert "workspace" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure semantics
+# ---------------------------------------------------------------------------
+
+
+class TestPartialFailureSemantics:
+    @pytest.mark.asyncio
+    async def test_postgres_ok_qdrant_fails_returns_error(self) -> None:
+        """Postgres write succeeds; Qdrant raises -> pipeline returns 'error'.
+
+        Re-delivery is safe because both writers are idempotent: Postgres
+        dedups by content_hash, Qdrant does the same in its adapter.
+        """
+        index_writer = _make_index_writer()
+        vector_store = _make_vector_store()
+        vector_store.upsert_chunks = AsyncMock(side_effect=RuntimeError("qdrant down"))
+
+        pipeline = _make_pipeline(index_writer=index_writer, vector_store=vector_store)
+        result = await pipeline.run(
+            event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A
+        )
+
+        assert result.action == "error"
+        index_writer.upsert_document.assert_awaited_once()  # Postgres was hit
+        vector_store.upsert_chunks.assert_awaited_once()  # Qdrant was attempted
+
+    @pytest.mark.asyncio
+    async def test_postgres_ok_qdrant_ok_neo4j_fails_returns_error(self) -> None:
+        """Two writes succeed; Neo4j fails -> pipeline returns 'error'."""
+        index_writer = _make_index_writer()
+        vector_store = _make_vector_store()
+        graph_store = _make_graph_store()
+        graph_store.upsert_graph = AsyncMock(side_effect=RuntimeError("neo4j down"))
+
+        def _extractor(parsed: Any, src_bytes: bytes) -> tuple[list[Any], list[Any]]:
+            e = MagicMock()
+            e.id = uuid.uuid4()
+            e.metadata = {}
+            return [e], []
+
+        with patch("omniscience_parsers.TreeSitterParser") as parser_cls:
+            parser = MagicMock()
+            parser.can_handle = MagicMock(return_value=True)
+            parser.parse = MagicMock(return_value=MagicMock())
+            parser_cls.return_value = parser
+
+            pipeline = _make_pipeline(
+                index_writer=index_writer,
+                vector_store=vector_store,
+                graph_store=graph_store,
+                graph_extractor=_extractor,
+            )
+            result = await pipeline.run(
+                event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A
+            )
+
+        assert result.action == "error"
+        index_writer.upsert_document.assert_awaited_once()
+        vector_store.upsert_chunks.assert_awaited_once()
+        graph_store.upsert_graph.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_parser_failure_does_not_abort_ingestion(self) -> None:
+        """Parser/extractor errors stay best-effort — Postgres + Qdrant still succeed."""
+        index_writer = _make_index_writer()
+        vector_store = _make_vector_store()
+
+        def _broken_extractor(parsed: Any, src_bytes: bytes) -> tuple[list[Any], list[Any]]:
+            raise RuntimeError("extractor blew up")
+
+        with patch("omniscience_parsers.TreeSitterParser") as parser_cls:
+            parser = MagicMock()
+            parser.can_handle = MagicMock(return_value=True)
+            parser.parse = MagicMock(return_value=MagicMock())
+            parser_cls.return_value = parser
+
+            pipeline = _make_pipeline(
+                index_writer=index_writer,
+                vector_store=vector_store,
+                graph_extractor=_broken_extractor,
+            )
+            result = await pipeline.run(
+                event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A
+            )
+
+        assert result.action == "created"
+        index_writer.upsert_document.assert_awaited_once()
+        vector_store.upsert_chunks.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Worker NAK behaviour on resolution failure
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerNakOnResolutionFailure:
+    @pytest.mark.asyncio
+    async def test_tenant_less_source_results_in_nak(self) -> None:
+        """The broker NAKs when workspace resolution fails so the DLQ pipeline runs."""
+        from omniscience_connectors.registry import ConnectorRegistry
+
+        registry: ConnectorRegistry = MagicMock(spec=ConnectorRegistry)
+        registry.get = MagicMock(return_value=_make_connector())
+        source = _make_source(tenant_id=None)
+
+        event = _make_event()
+        msg = MagicMock()
+        msg.payload = event
+        msg.ack = AsyncMock()
+        msg.nak = AsyncMock()
+
+        consumer = MagicMock()
+
+        async def _iter() -> Any:
+            yield msg
+
+        consumer.__aiter__ = MagicMock(return_value=_iter())
+        consumer.stop = MagicMock()
+
+        worker = IngestionWorker(
+            queue_consumer=consumer,
+            connector_registry=registry,
+            embedding_provider=_make_embedding_provider(),
+            index_writer=_make_index_writer(),
+            graph_store=_make_graph_store(),
+            vector_store=_make_vector_store(),
+            session_factory=_make_session_factory(source),
+        )
+
+        with (
+            patch.object(worker._run_tracker, "start", AsyncMock(return_value=uuid.uuid4())),
+            patch.object(worker._run_tracker, "record_error", AsyncMock()),
+            patch.object(worker._run_tracker, "finish", AsyncMock()),
+        ):
+            await worker.start()
+
+        msg.nak.assert_awaited_once()
+        msg.ack.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Deletion path also targets Qdrant
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePath:
+    @pytest.mark.asyncio
+    async def test_deleted_action_calls_qdrant_delete(self) -> None:
+        """A 'deleted' event tombstones in Postgres AND Qdrant."""
+        index_writer = _make_index_writer()
+        vector_store = _make_vector_store()
+        pipeline = _make_pipeline(index_writer=index_writer, vector_store=vector_store)
+
+        event = _make_event(action="deleted")
+        result = await pipeline.run(
+            event=event, config=None, secrets={}, workspace_id=_WORKSPACE_A
+        )
+        assert result.action == "deleted"
+        index_writer.tombstone.assert_awaited_once_with(event.source_id, event.external_id)
+        vector_store.delete_by_document.assert_awaited_once()
+        kwargs = vector_store.delete_by_document.call_args.kwargs
+        assert kwargs["workspace_id"] == _WORKSPACE_A
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: assert the worker passes the resolved workspace into the
+# pipeline.run kwargs (catches a regression where the kwarg is dropped).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_passes_workspace_to_pipeline_run() -> None:
+    from omniscience_connectors.registry import ConnectorRegistry
+
+    target = uuid.uuid4()
+    source = _make_source(tenant_id=target)
+
+    registry: ConnectorRegistry = MagicMock(spec=ConnectorRegistry)
+    registry.get = MagicMock(return_value=_make_connector())
+
+    worker = IngestionWorker(
+        queue_consumer=MagicMock(),
+        connector_registry=registry,
+        embedding_provider=_make_embedding_provider(),
+        index_writer=_make_index_writer(),
+        graph_store=_make_graph_store(),
+        vector_store=_make_vector_store(),
+        session_factory=_make_session_factory(source),
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def _capture(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        from omniscience_server.ingestion.events import ProcessResult
+
+        return ProcessResult(
+            source_id=kwargs["event"].source_id,
+            external_id=kwargs["event"].external_id,
+            action="created",
+            duration_ms=1.0,
+        )
+
+    with patch(
+        "omniscience_server.ingestion.worker.IngestionPipeline.run",
+        new=AsyncMock(side_effect=_capture),
+    ):
+        await worker.process_document(_make_event())
+
+    assert captured["workspace_id"] == target
+
+
+# ---------------------------------------------------------------------------
+# Regression guard for ``_make_session_factory``: the call sequence is
+# ``factory()`` -> async-with -> ``execute()``.  call_count == 1 confirms
+# the worker resolves the workspace exactly once per document (no
+# retries inside ``_resolve_workspace``).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_resolved_exactly_once_per_document() -> None:
+    from omniscience_connectors.registry import ConnectorRegistry
+
+    source = _make_source(tenant_id=uuid.uuid4())
+    factory = _make_session_factory(source)
+
+    registry: ConnectorRegistry = MagicMock(spec=ConnectorRegistry)
+    registry.get = MagicMock(return_value=_make_connector())
+
+    worker = IngestionWorker(
+        queue_consumer=MagicMock(),
+        connector_registry=registry,
+        embedding_provider=_make_embedding_provider(),
+        index_writer=_make_index_writer(),
+        graph_store=_make_graph_store(),
+        vector_store=_make_vector_store(),
+        session_factory=factory,
+    )
+
+    await worker.process_document(_make_event())
+    assert factory.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Helper coverage: prove the call_args kwargs exist (avoids accidental
+# regressions to positional args, which would silently break the worker
+# when called by the production app DI wiring).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_worker_calls_index_writer_with_keyword_arguments_only() -> None:
+    pipeline = _make_pipeline()
+    await pipeline.run(event=_make_event(), config=None, secrets={}, workspace_id=_WORKSPACE_A)
+    # If the production code regresses to positional args, .call_args.kwargs
+    # would be empty and the next assertion fails.
+    pg_call: call = pipeline._index_writer.upsert_document.call_args  # type: ignore[attr-defined]
+    assert pg_call.kwargs, "IndexWriter.upsert_document must be called with kwargs"

--- a/tests/test_unblock_ingestion.py
+++ b/tests/test_unblock_ingestion.py
@@ -198,15 +198,37 @@ def _make_worker(
     embedding_provider.provider_name = "test-provider"
 
     index_writer = MagicMock()
+    graph_store = MagicMock()
+    graph_store.upsert_graph = AsyncMock(return_value=None)
+    vector_store = MagicMock()
+    vector_store.upsert_chunks = AsyncMock(return_value=MagicMock(action="created"))
 
-    session_factory = AsyncMock()
-    session_factory.return_value = AsyncMock()
+    # Session factory: return a Source row with a non-null tenant_id so
+    # workspace resolution succeeds.  These tests stub IngestionPipeline.run,
+    # so the only DB interaction is the worker's source lookup.
+    fake_source = MagicMock()
+    fake_source.id = uuid.uuid4()
+    fake_source.name = "unblock-test-source"
+    fake_source.tenant_id = uuid.uuid4()
+
+    inner_session = AsyncMock()
+    scalar_result = MagicMock()
+    scalar_result.scalar_one_or_none = MagicMock(return_value=fake_source)
+    inner_session.execute = AsyncMock(return_value=scalar_result)
+
+    factory_cm = MagicMock()
+    factory_cm.__aenter__ = AsyncMock(return_value=inner_session)
+    factory_cm.__aexit__ = AsyncMock(return_value=False)
+
+    session_factory = MagicMock(return_value=factory_cm)
 
     worker = IngestionWorker(
         queue_consumer=mock_consumer,
         connector_registry=mock_registry,
         embedding_provider=embedding_provider,
         index_writer=index_writer,
+        graph_store=graph_store,
+        vector_store=vector_store,
         session_factory=session_factory,
         secrets_resolver=secrets_resolver,
     )


### PR DESCRIPTION
Closes #126.

## Summary

Restore the three-store invariant the Epic #96 cutover left half-wired: the live ingestion worker now writes Postgres operational metadata (unchanged), Qdrant chunk embeddings, and Neo4j entities/edges for every ingested document. After this PR a fresh v0.2.0 deployment is queryable via the GraphRAG composer without running ``scripts/migrate_to_hybrid.py``.

## Per-document call sequence

```
worker.process_document(event)
  -> _resolve_workspace(event.source_id)             # Source.tenant_id -> workspace_id
  -> pipeline.run(event, ..., workspace_id=ws)
       fetch -> hash_check -> parse -> chunk -> embed
       -> _stage_index   : IndexWriter.upsert_document(...)        # Postgres metadata
       -> _stage_vector  : VectorStore.upsert_chunks(...)          # Qdrant + workspace_id in metadata
       -> _stage_graph   : GraphStore.upsert_graph(...)            # Neo4j + workspace_id stamped on every entity
       -> _stage_link    : EntityLinker.link_entities(...)         # optional
```

The migration runner's call shape is mirrored exactly: ``upsert_chunks`` per document with the same ``ChunkPayload`` lineage fields (ADR-0006); ``upsert_graph`` as the batch path (never the per-row ``upsert_entity``/``upsert_edge``). Postgres / Qdrant / Neo4j are all idempotent on retry.

## ACL invariant

- The worker resolves ``Source.tenant_id`` -> ``workspace_id`` BEFORE any adapter call via ``omniscience_index.workspace.resolve_source_workspace`` (the same helper the migration runner uses).
- Tenant-less or missing source rows produce a structured-log ``workspace_resolution_failed`` and ``ProcessResult(action=\"error\")``; the broker NAKs, the message redelivers, and after ``max_deliver`` lands in the DLQ.
- Adapter-side ACL rejections (``Qdrant: workspace_id required`` / ``Neo4j: upsert_graph_missing_workspace_id``) propagate as hard failures — never swallowed.

## Helper extraction rationale

The workspace resolver was previously private to the migration package. It now lives at ``omniscience_index/workspace.py`` so the live ingestion path imports it without reaching into a one-shot tool's internals. The legacy ``omniscience_index/migration/workspace.py`` re-exports the same names so the migration runner and its 36 tests keep working unchanged.

## Failure modes covered

- Tenant-less source -> error result + NAK (no I/O performed).
- Missing source row -> same fail-closed outcome.
- Adapter raises ``MissingWorkspaceError``-equivalent -> propagates.
- Postgres OK + Qdrant raises -> action=\"error\".
- Postgres OK + Qdrant OK + Neo4j raises -> action=\"error\".
- Parser/extractor failure -> stays best-effort (Postgres + Qdrant still succeed).
- Deletion event -> tombstones in Postgres AND Qdrant.

## Test plan

- [x] ``uv run pytest --no-cov`` passes (1573 passed, 10 skipped vs baseline 1546/16; +27 new tests, fewer skips locally because Docker is available).
- [x] ``uv run mypy apps/ packages/`` clean (153 files, --strict).
- [x] ``uv run ruff check .`` clean.
- [x] ``uv run ruff format --check .`` clean.
- [x] New tests in ``tests/test_ingestion_three_stores.py`` (20 unit tests) cover three-store fan-out, ACL invariant, adapter rejection, and partial-failure semantics.
- [x] Opt-in E2E in ``tests/test_ingestion_e2e.py`` (gated on ``OMNISCIENCE_RUN_E2E_INGESTION=1``) spins Neo4j + Qdrant containers and asserts a single ingested document is observable in both stores.
- [x] Existing migration tests still pass (``tests/test_migration_to_hybrid.py``: 36/36).
- [x] Existing pipeline / worker tests updated and pass (``tests/test_ingestion.py``: 79/79; ``tests/test_unblock_ingestion.py``: 33/33; ``tests/test_entity_linking.py``: 42/42).

## Files changed

- ``apps/server/src/omniscience_server/app.py`` — wire ``graph_store`` + ``vector_store`` into the worker constructor.
- ``apps/server/src/omniscience_server/ingestion/pipeline.py`` — three-store fan-out, workspace_id parameter, new ``_stage_vector``, refactored ``_stage_graph``.
- ``apps/server/src/omniscience_server/ingestion/worker.py`` — workspace resolution per document, new constructor params.
- ``packages/index/src/omniscience_index/workspace.py`` — canonical workspace resolver (new).
- ``packages/index/src/omniscience_index/migration/workspace.py`` — re-export shim for backward compat.
- ``tests/test_ingestion_three_stores.py`` — 20 new unit tests (new).
- ``tests/test_ingestion_e2e.py`` — opt-in integration test (new).
- ``tests/test_ingestion.py``, ``tests/test_unblock_ingestion.py`` — updated for new constructor + kwargs.

## Out of scope (per Lead guardrails)

- ``IndexWriter`` semantics unchanged; still focused on Postgres operational metadata.
- ``Neo4jGraphStore`` / ``QdrantVectorStore`` not modified beyond use.
- ``GraphRAGComposer``, storage protocols, and the migration script untouched.
- No new feature flag — three-store ingestion IS the v0.2.x default after this PR.
- No MCP / REST API contract changes.