### PR TITLE
feat: admin UI freshness panel (#112)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -9,6 +9,7 @@ import { SourcesPage } from "./pages/SourcesPage";
 import { TokensPage } from "./pages/TokensPage";
 import { IngestionPage } from "./pages/IngestionPage";
 import { SearchPage } from "./pages/SearchPage";
+import { FreshnessPage } from "./pages/FreshnessPage";
 
 function AppInner() {
   const { token } = useTokenContext();
@@ -40,6 +41,7 @@ function AppInner() {
               path="/search"
               element={<SearchPage addToast={addToast} />}
             />
+            <Route path="/freshness" element={<FreshnessPage />} />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -128,6 +128,36 @@ export interface HealthResponse {
   version?: string;
 }
 
+/*
+ * Wire format for `GET /api/v1/stats/sources` (Issue #111).
+ *
+ * Mirrors the Pydantic `SourceStatsRow` / `SourcesStatsResponse` defined in
+ * `packages/core/src/omniscience_core/stats/models.py`. Notes on fields:
+ *   - `last_sync_at` is ISO-8601 or null when the source has never synced.
+ *   - `age_seconds` uses a `1e15` sentinel to mean "never synced". Renderers
+ *     should special-case that value rather than displaying "11574 days".
+ *   - `freshness_sla_seconds` is null when the source has no SLA configured.
+ *   - `is_stale` is computed server-side: true when age >= SLA.
+ */
+export interface SourceStatsRow {
+  id: string;
+  name: string;
+  type: string;
+  status: string;
+  documents: number;
+  chunks: number;
+  entities: number;
+  last_sync_at: string | null;
+  freshness_sla_seconds: number | null;
+  age_seconds: number;
+  is_stale: boolean;
+}
+
+export interface SourcesStatsResponse {
+  sources: SourceStatsRow[];
+  total: number;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -162,12 +192,14 @@ export class ApiClient {
   private async request<T>(
     method: string,
     path: string,
-    body?: unknown
+    body?: unknown,
+    signal?: AbortSignal
   ): Promise<T> {
     const res = await fetch(path, {
       method,
       headers: this.headers(),
       body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal,
     });
 
     if (res.status === 204) {
@@ -259,5 +291,15 @@ export class ApiClient {
   // Search
   async search(payload: SearchRequest): Promise<SearchResult> {
     return this.request<SearchResult>("POST", "/api/v1/search", payload);
+  }
+
+  // Stats (Issue #111)
+  async statsSources(signal?: AbortSignal): Promise<SourcesStatsResponse> {
+    return this.request<SourcesStatsResponse>(
+      "GET",
+      "/api/v1/stats/sources",
+      undefined,
+      signal
+    );
   }
 }

--- a/apps/admin/src/components/FreshnessPanel.tsx
+++ b/apps/admin/src/components/FreshnessPanel.tsx
@@ -1,0 +1,635 @@
+/*
+ * FreshnessPanel — operator view of source freshness (Issue #112).
+ *
+ * Consumes `GET /api/v1/stats/sources` (Issue #111) and renders one row per
+ * source with its sync age vs configured SLA.  Color-coded buckets:
+ *
+ *   fresh        — age < SLA × 0.5                           (success)
+ *   approaching  — SLA × 0.5 ≤ age < SLA                     (warning)
+ *   stale        — age ≥ SLA && is_stale: true               (danger)
+ *   never-synced — age_seconds sentinel (>= NEVER_SENTINEL)  (info / muted)
+ *   no-sla       — freshness_sla_seconds is null             (info / muted)
+ *
+ * Auto-refresh: every 30s via `setInterval`, with a per-fetch `AbortController`
+ * to cancel the in-flight request on unmount or interval tick. We deliberately
+ * avoid replacing the rendered table on refresh — only on initial load and on
+ * hard error — so column widths stay stable (no layout shift).
+ *
+ * No new dependencies (project rule for #112). State is held in plain `useState`
+ * + `useEffect`; no SWR/react-query. The pulse dot in the panel header is the
+ * visible refresh indicator.
+ *
+ * ACL: the `stats:read` scope is enforced server-side. If the API returns 403
+ * we render a clear "missing scope" banner instead of crashing.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ApiClient,
+  ApiError,
+  SourceStatsRow,
+  SourcesStatsResponse,
+} from "../api/client";
+import { useTokenContext } from "../context/TokenContext";
+
+/* The server uses `1e15` as "never synced" — see SourceStatsRow doc.
+ * Use a slightly lower threshold to be defensive against float precision. */
+const NEVER_SYNCED_SENTINEL = 1e14;
+
+const REFRESH_MS = 30_000;
+
+type Bucket = "fresh" | "approaching" | "stale" | "never-synced" | "no-sla";
+
+interface BucketSpec {
+  bucket: Bucket;
+  label: string;
+  /* Tailwind classes for the row pill / distribution segment. */
+  pillCls: string;
+  /* Bar segment background. */
+  segmentCls: string;
+  /* Legend swatch. */
+  swatchCls: string;
+}
+
+const BUCKET_SPECS: Record<Bucket, BucketSpec> = {
+  fresh: {
+    bucket: "fresh",
+    label: "Fresh",
+    pillCls: "bg-success-bg text-success-fg",
+    segmentCls: "bg-chart-2",
+    swatchCls: "bg-chart-2",
+  },
+  approaching: {
+    bucket: "approaching",
+    label: "Approaching",
+    pillCls: "bg-warning-bg text-warning-fg",
+    segmentCls: "bg-chart-3",
+    swatchCls: "bg-chart-3",
+  },
+  stale: {
+    bucket: "stale",
+    label: "Stale",
+    pillCls: "bg-danger-bg text-danger-fg",
+    segmentCls: "bg-chart-4",
+    swatchCls: "bg-chart-4",
+  },
+  "never-synced": {
+    bucket: "never-synced",
+    label: "Never synced",
+    pillCls: "bg-info-bg text-info-fg",
+    segmentCls: "bg-chart-5",
+    swatchCls: "bg-chart-5",
+  },
+  "no-sla": {
+    bucket: "no-sla",
+    label: "No SLA",
+    pillCls: "bg-elevation-2 text-text-secondary",
+    segmentCls: "bg-chart-6",
+    swatchCls: "bg-chart-6",
+  },
+};
+
+const BUCKET_ORDER: Bucket[] = [
+  "stale",
+  "approaching",
+  "fresh",
+  "never-synced",
+  "no-sla",
+];
+
+function classifyRow(row: SourceStatsRow): Bucket {
+  if (row.age_seconds >= NEVER_SYNCED_SENTINEL) return "never-synced";
+  if (row.freshness_sla_seconds == null) return "no-sla";
+  if (row.is_stale) return "stale";
+  if (row.age_seconds >= row.freshness_sla_seconds * 0.5) return "approaching";
+  return "fresh";
+}
+
+/* Human-readable duration. Sentinel -> "never". Sub-minute ages collapse to
+ * "just now" so the table doesn't churn between "12s" / "13s" each refresh. */
+function formatAge(seconds: number): string {
+  if (seconds >= NEVER_SYNCED_SENTINEL) return "never";
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) {
+    const m = Math.floor(seconds / 60);
+    return `${m}m ago`;
+  }
+  if (seconds < 86_400) {
+    const h = Math.floor(seconds / 3600);
+    return `${h}h ago`;
+  }
+  const d = Math.floor(seconds / 86_400);
+  return `${d}d ago`;
+}
+
+/* Human-readable SLA target. Null -> "—". Uses non-relative wording so it
+ * reads as a target, not as an event in the past. */
+function formatSla(seconds: number | null): string {
+  if (seconds == null) return "—";
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86_400)}d`;
+}
+
+type SortKey = "name" | "type" | "age" | "sla" | "bucket";
+type SortDir = "asc" | "desc";
+
+function bucketRank(b: Bucket): number {
+  /* For sort-by-bucket we want the most-urgent first when descending. */
+  return BUCKET_ORDER.indexOf(b);
+}
+
+function compareRows(
+  a: SourceStatsRow,
+  b: SourceStatsRow,
+  key: SortKey,
+  dir: SortDir
+): number {
+  const sign = dir === "asc" ? 1 : -1;
+  switch (key) {
+    case "name":
+      return sign * a.name.localeCompare(b.name);
+    case "type":
+      return sign * a.type.localeCompare(b.type);
+    case "age":
+      return sign * (a.age_seconds - b.age_seconds);
+    case "sla": {
+      /* Treat null SLA as +Infinity so it sorts to the end on ascending. */
+      const av = a.freshness_sla_seconds ?? Number.POSITIVE_INFINITY;
+      const bv = b.freshness_sla_seconds ?? Number.POSITIVE_INFINITY;
+      return sign * (av - bv);
+    }
+    case "bucket":
+      /* Lower rank in BUCKET_ORDER = more urgent. We invert so that
+       * descending = most urgent first (matches "most stale first" default). */
+      return -sign * (bucketRank(classifyRow(a)) - bucketRank(classifyRow(b)));
+  }
+}
+
+interface FreshnessPanelProps {
+  /* Override the polling interval — primarily for tests / Storybook. */
+  refreshMs?: number;
+  /* Override the api client — primarily for tests. */
+  client?: ApiClient;
+  /* Optional className passthrough so the panel can be slotted into grids. */
+  className?: string;
+}
+
+export function FreshnessPanel({
+  refreshMs = REFRESH_MS,
+  client: clientOverride,
+  className,
+}: FreshnessPanelProps = {}) {
+  const ctx = useTokenContext();
+  const client = clientOverride ?? ctx.client;
+
+  const [data, setData] = useState<SourcesStatsResponse | null>(null);
+  const [error, setError] = useState<ApiError | Error | null>(null);
+  const [refreshing, setRefreshing] = useState<boolean>(false);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null);
+
+  const [sortKey, setSortKey] = useState<SortKey>("age");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  /* Track the latest in-flight controller so we can abort on unmount /
+   * on the next interval tick. Using a ref avoids re-rendering on assignment. */
+  const inFlightRef = useRef<AbortController | null>(null);
+
+  const fetchOnce = useCallback(async () => {
+    /* Cancel any prior in-flight fetch (e.g. a slow response when the
+     * 30s tick fires) so we don't race responses into setState. */
+    inFlightRef.current?.abort();
+    const controller = new AbortController();
+    inFlightRef.current = controller;
+
+    setRefreshing(true);
+    try {
+      const resp = await client.statsSources(controller.signal);
+      if (controller.signal.aborted) return;
+      setData(resp);
+      setError(null);
+      setLastRefreshedAt(Date.now());
+    } catch (e) {
+      if (controller.signal.aborted) return;
+      /* DOMException with name "AbortError" can also surface here. */
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      if (e instanceof Error) setError(e);
+      else setError(new Error(String(e)));
+    } finally {
+      if (inFlightRef.current === controller) {
+        inFlightRef.current = null;
+      }
+      setRefreshing(false);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      if (cancelled) return;
+      void fetchOnce();
+    }, refreshMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+      inFlightRef.current?.abort();
+      inFlightRef.current = null;
+    };
+  }, [fetchOnce, refreshMs]);
+
+  /* Per-bucket counts, derived once per data update. */
+  const bucketCounts = useMemo<Record<Bucket, number>>(() => {
+    const counts: Record<Bucket, number> = {
+      fresh: 0,
+      approaching: 0,
+      stale: 0,
+      "never-synced": 0,
+      "no-sla": 0,
+    };
+    for (const row of data?.sources ?? []) {
+      counts[classifyRow(row)] += 1;
+    }
+    return counts;
+  }, [data]);
+
+  const sortedRows = useMemo<SourceStatsRow[]>(() => {
+    if (!data) return [];
+    const copy = data.sources.slice();
+    copy.sort((a, b) => compareRows(a, b, sortKey, sortDir));
+    return copy;
+  }, [data, sortKey, sortDir]);
+
+  function toggleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      /* Sensible default direction per column: ages descending (most stale
+       * first), text columns ascending. */
+      setSortDir(key === "age" || key === "bucket" ? "desc" : "asc");
+    }
+  }
+
+  /* Distinct render cases. The panel header (title + pulse) is always shown so
+   * the auto-refresh indicator stays anchored. */
+  return (
+    <section
+      aria-label="Source freshness"
+      className={
+        "bg-elevation-1 rounded-xl border border-border shadow-sm" +
+        (className ? ` ${className}` : "")
+      }
+    >
+      <PanelHeader
+        refreshing={refreshing}
+        lastRefreshedAt={lastRefreshedAt}
+        refreshMs={refreshMs}
+      />
+      <div className="px-5 pb-5">
+        <Body
+          data={data}
+          error={error}
+          sortedRows={sortedRows}
+          bucketCounts={bucketCounts}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onToggleSort={toggleSort}
+        />
+      </div>
+    </section>
+  );
+}
+
+/* ────────────────────────── header (always visible) ───────────────────────── */
+
+interface PanelHeaderProps {
+  refreshing: boolean;
+  lastRefreshedAt: number | null;
+  refreshMs: number;
+}
+
+function PanelHeader({
+  refreshing,
+  lastRefreshedAt,
+  refreshMs,
+}: PanelHeaderProps) {
+  /* The pulse: a tiny dot that glows while a refresh is in-flight. We use
+   * `aria-live="polite"` for the timer text so a screen reader hears the
+   * update without being interrupted. */
+  const refreshLabel =
+    lastRefreshedAt == null
+      ? "Loading..."
+      : `Refreshes every ${Math.round(refreshMs / 1000)}s`;
+
+  return (
+    <header className="flex items-center justify-between px-5 py-4 border-b border-border">
+      <div>
+        <h2 className="text-base font-medium text-text">Freshness</h2>
+        <p className="text-xs text-text-muted mt-0.5">
+          Per-source sync age vs SLA
+        </p>
+      </div>
+      <div
+        className="flex items-center gap-2 text-xs text-text-muted"
+        aria-live="polite"
+      >
+        <span
+          aria-hidden="true"
+          className={
+            "h-2 w-2 rounded-full " +
+            (refreshing
+              ? "bg-accent animate-pulse"
+              : "bg-success-fg")
+          }
+        />
+        <span>{refreshLabel}</span>
+      </div>
+    </header>
+  );
+}
+
+/* ────────────────────────────── body / states ─────────────────────────────── */
+
+interface BodyProps {
+  data: SourcesStatsResponse | null;
+  error: ApiError | Error | null;
+  sortedRows: SourceStatsRow[];
+  bucketCounts: Record<Bucket, number>;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onToggleSort: (key: SortKey) => void;
+}
+
+function Body({
+  data,
+  error,
+  sortedRows,
+  bucketCounts,
+  sortKey,
+  sortDir,
+  onToggleSort,
+}: BodyProps) {
+  /* Initial load: show a loading state instead of the table to avoid
+   * rendering an empty <table> shell (and a layout pop when data arrives). */
+  if (data == null && error == null) {
+    return (
+      <p className="text-sm text-text-muted py-12 text-center" role="status">
+        Loading freshness…
+      </p>
+    );
+  }
+
+  /* Error: distinguish 403 (missing scope) from other errors so the operator
+   * isn't left guessing. We keep stale data hidden in this branch — surfacing
+   * possibly-incorrect cached data alongside an error is worse than nothing. */
+  if (error != null) {
+    if (error instanceof ApiError && error.status === 403) {
+      return (
+        <div
+          role="alert"
+          className="rounded-md border border-warning-border bg-warning-bg text-warning-fg px-4 py-3 text-sm my-6"
+        >
+          <p className="font-medium">Missing scope</p>
+          <p className="mt-1">
+            Your token doesn't have <code>stats:read</code>. Ask an
+            administrator to issue a token with the freshness scope to view
+            this panel.
+          </p>
+        </div>
+      );
+    }
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-danger-border bg-danger-bg text-danger-fg px-4 py-3 text-sm my-6"
+      >
+        <p className="font-medium">Couldn't load freshness</p>
+        <p className="mt-1 break-words">{error.message}</p>
+      </div>
+    );
+  }
+
+  /* Empty: data arrived but no sources at all. */
+  if (data != null && data.total === 0) {
+    return (
+      <div className="text-sm text-text-muted py-12 text-center">
+        <p className="text-text">No sources configured</p>
+        <p className="mt-1">
+          Add a source on the Sources page to start tracking freshness.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <DistributionBar counts={bucketCounts} total={sortedRows.length} />
+      <FreshnessTable
+        rows={sortedRows}
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onToggleSort={onToggleSort}
+      />
+    </>
+  );
+}
+
+/* ─────────────────────────── distribution bar ─────────────────────────────── */
+
+interface DistributionBarProps {
+  counts: Record<Bucket, number>;
+  total: number;
+}
+
+function DistributionBar({ counts, total }: DistributionBarProps) {
+  if (total === 0) return null;
+
+  const segments = BUCKET_ORDER.filter((b) => counts[b] > 0).map((b) => ({
+    bucket: b,
+    spec: BUCKET_SPECS[b],
+    count: counts[b],
+    /* `flex-grow` proportional to count keeps math simple and avoids a
+     * Math.round drift problem where summed widths != 100%. */
+    grow: counts[b],
+  }));
+
+  return (
+    <figure
+      className="my-5"
+      aria-label={`Freshness distribution across ${total} sources`}
+    >
+      <div className="flex h-3 w-full overflow-hidden rounded-full border border-border">
+        {segments.map((s) => (
+          <div
+            key={s.bucket}
+            className={`${s.spec.segmentCls}`}
+            style={{ flexGrow: s.grow }}
+            role="img"
+            aria-label={`${s.spec.label}: ${s.count}`}
+          />
+        ))}
+      </div>
+      <figcaption className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-text-secondary">
+        {BUCKET_ORDER.map((b) => {
+          const spec = BUCKET_SPECS[b];
+          const count = counts[b];
+          if (count === 0) return null;
+          return (
+            <span key={b} className="inline-flex items-center gap-1.5">
+              <span
+                aria-hidden="true"
+                className={`h-2.5 w-2.5 rounded-sm ${spec.swatchCls}`}
+              />
+              <span className="text-text">{spec.label}</span>
+              <span className="text-text-muted tabular-nums">({count})</span>
+            </span>
+          );
+        })}
+      </figcaption>
+    </figure>
+  );
+}
+
+/* ───────────────────────────────── table ──────────────────────────────────── */
+
+interface FreshnessTableProps {
+  rows: SourceStatsRow[];
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onToggleSort: (key: SortKey) => void;
+}
+
+function FreshnessTable({
+  rows,
+  sortKey,
+  sortDir,
+  onToggleSort,
+}: FreshnessTableProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      {/* `table-fixed` + per-col widths is what keeps column widths stable
+       * across auto-refreshes — content changes don't reflow the layout. */}
+      <table className="min-w-full table-fixed text-sm">
+        <colgroup>
+          <col className="w-[34%]" />
+          <col className="w-[14%]" />
+          <col className="w-[18%]" />
+          <col className="w-[14%]" />
+          <col className="w-[20%]" />
+        </colgroup>
+        <thead className="bg-elevation-2 border-b border-border">
+          <tr>
+            <SortHeader
+              label="Source"
+              k="name"
+              activeKey={sortKey}
+              dir={sortDir}
+              onClick={onToggleSort}
+            />
+            <SortHeader
+              label="Type"
+              k="type"
+              activeKey={sortKey}
+              dir={sortDir}
+              onClick={onToggleSort}
+            />
+            <SortHeader
+              label="Last sync"
+              k="age"
+              activeKey={sortKey}
+              dir={sortDir}
+              onClick={onToggleSort}
+            />
+            <SortHeader
+              label="SLA"
+              k="sla"
+              activeKey={sortKey}
+              dir={sortDir}
+              onClick={onToggleSort}
+            />
+            <SortHeader
+              label="Status"
+              k="bucket"
+              activeKey={sortKey}
+              dir={sortDir}
+              onClick={onToggleSort}
+            />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {rows.map((row) => {
+            const bucket = classifyRow(row);
+            const spec = BUCKET_SPECS[bucket];
+            return (
+              <tr
+                key={row.id}
+                tabIndex={0}
+                className="hover:bg-elevation-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset"
+              >
+                <td className="px-4 py-3 text-text truncate" title={row.name}>
+                  {row.name}
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-text-secondary">
+                  {row.type}
+                </td>
+                <td className="px-4 py-3 text-text-muted tabular-nums">
+                  {formatAge(row.age_seconds)}
+                </td>
+                <td className="px-4 py-3 text-text-muted tabular-nums">
+                  {formatSla(row.freshness_sla_seconds)}
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${spec.pillCls}`}
+                  >
+                    {spec.label}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface SortHeaderProps {
+  label: string;
+  k: SortKey;
+  activeKey: SortKey;
+  dir: SortDir;
+  onClick: (k: SortKey) => void;
+}
+
+function SortHeader({ label, k, activeKey, dir, onClick }: SortHeaderProps) {
+  const isActive = activeKey === k;
+  const ariaSort: "ascending" | "descending" | "none" = isActive
+    ? dir === "asc"
+      ? "ascending"
+      : "descending"
+    : "none";
+  /* The arrow is rendered with a stable width box so column widths don't
+   * shift when the active sort changes. */
+  const arrow = isActive ? (dir === "asc" ? "▲" : "▼") : "";
+  return (
+    <th
+      scope="col"
+      aria-sort={ariaSort}
+      className="px-4 py-3 text-left font-medium text-text-secondary"
+    >
+      <button
+        type="button"
+        onClick={() => onClick(k)}
+        className="inline-flex items-center gap-1.5 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+      >
+        <span>{label}</span>
+        <span aria-hidden="true" className="w-3 text-xs text-text-muted">
+          {arrow}
+        </span>
+      </button>
+    </th>
+  );
+}

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -9,6 +9,7 @@ interface LayoutProps {
 const NAV_ITEMS = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/sources", label: "Sources" },
+  { to: "/freshness", label: "Freshness" },
   { to: "/tokens", label: "Tokens" },
   { to: "/ingestion", label: "Ingestion" },
   { to: "/search", label: "Search Playground" },

--- a/apps/admin/src/pages/DashboardPage.tsx
+++ b/apps/admin/src/pages/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTokenContext } from "../context/TokenContext";
 import { Source, IngestionRun } from "../api/client";
 import { StatusBadge } from "../components/StatusBadge";
+import { FreshnessPanel } from "../components/FreshnessPanel";
 
 function StatCard({
   label,
@@ -107,6 +108,10 @@ export function DashboardPage() {
           to="/sources"
         />
       </div>
+
+      <section className="mb-10">
+        <FreshnessPanel />
+      </section>
 
       <section>
         <h2 className="text-base font-medium text-text-secondary mb-4">

--- a/apps/admin/src/pages/FreshnessPage.tsx
+++ b/apps/admin/src/pages/FreshnessPage.tsx
@@ -1,0 +1,20 @@
+/*
+ * FreshnessPage — dedicated `/freshness` route hosting the FreshnessPanel.
+ *
+ * The same component is also slotted into DashboardPage so operators get
+ * an at-a-glance view there. This page is the deep-dive: same panel,
+ * full width, accessible from the sidebar nav.
+ */
+
+import { FreshnessPanel } from "../components/FreshnessPanel";
+
+export function FreshnessPage() {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-2xl font-semibold text-text">Freshness</h1>
+      </div>
+      <FreshnessPanel />
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Implements the `FreshnessPanel` component for the admin UI, consuming the `GET /api/v1/stats/sources` endpoint shipped in #111 and using the dark-theme palette tokens shipped in #110. Closes #112.

## How operators see it

- A horizontal stacked distribution bar summarising sources by freshness bucket (chart palette tokens) with a legend.
- A per-source table with name, type, last-sync age (human-readable: `5m ago`, `2h ago`, `3d ago`, `never`, `just now`), SLA, and a color-coded status pill.
- Default sort is age descending — most stale first. All columns are click-sortable with `aria-sort` and visible direction arrow.
- Panel header carries a pulse dot indicator bound to the in-flight refresh state, plus a "Refreshes every 30s" label.

## Bucket rules (per issue spec)

| Bucket | Condition | Palette |
|--------|-----------|---------|
| `fresh` | `age < SLA × 0.5` | success / chart-2 |
| `approaching` | `SLA × 0.5 ≤ age < SLA` | warning / chart-3 |
| `stale` | `age ≥ SLA && is_stale: true` | danger / chart-4 |
| `never-synced` | `age_seconds` sentinel (≥ 1e14 guard) | info / chart-5 |
| `no-sla` | `freshness_sla_seconds == null` | muted / chart-6 |

The `1e15` "never synced" sentinel is detected with a `1e14` threshold to be defensive against float precision.

## Scope decision: where does the panel mount? (option 3)

Issue body is silent. Looking at `DashboardPage`, it's already a panel composition (stat-card grid + recent runs section), which fits **option 3** in the Lead playbook: panel is slotted into Dashboard AND has its own `/freshness` route accessible from the sidebar nav. That gives operators an at-a-glance view on the dashboard and a full-page deep-dive when they want to focus on freshness.

## Auto-refresh strategy

- `setInterval(fetchOnce, 30_000)`. No new deps; the project rules forbid adding `useSWR` / `react-query`.
- Each `fetchOnce` creates a fresh `AbortController` and aborts the prior one via a ref. This prevents a slow response from a previous tick from racing a faster response from a later tick into `setState`.
- `useEffect` cleanup aborts the in-flight request and clears the interval on unmount.
- `cancelled` guard inside the interval callback as a belt-and-braces.
- Aborted responses (`DOMException` with `name === "AbortError"`) are swallowed, never surfaced as errors.

## No-layout-shift on refresh

- The table stays mounted across refreshes — only on initial load and on hard error do we replace it with a loading / error state.
- `<table className="table-fixed">` + a `<colgroup>` with explicit per-column widths means content changes (different age strings) cannot reflow columns.
- The sort-direction arrow has a fixed `w-3` slot so toggling sort doesn't widen the header cell.

## States (all distinct)

| State | UI |
|-------|----|
| Loading (initial) | "Loading freshness…" centered, `role="status"` |
| Empty (`total === 0`) | Friendly message pointing to the Sources page |
| Generic error | `role="alert"` red banner with the error message |
| 403 missing scope | `role="alert"` amber banner explaining `stats:read` is required, no crash |
| Loaded | Distribution bar + sortable table |

## A11y

- `<th scope="col">` headers + `aria-sort="ascending |descending|none"` on the active column.
- Sort triggers are real `<button type="button">` elements — keyboard activatable, focus-visible ring on the accent token.
- Each `<tr>` is `tabIndex={0}` with a `focus-visible:ring-2 focus-visible:ring-accent` inset ring, so operators can Tab through rows.
- Distribution bar segments expose `role="img"` + `aria-label` (`"Fresh: 12"`).
- Pulse indicator is `aria-hidden`; the timer text uses `aria-live="polite"` so screen readers hear refresh updates without interruption.
- All color information is paired with a textual label (the bucket name) — never color-only.

## Standards

- `npm run typecheck` — clean.
- `npm run lint:colors` — clean (17 files scanned, 0 violations).
- `npm run build` — clean (~209KB JS, 16.7KB CSS gzipped).
- No new deps, no `tailwind.config.js` or palette-token edits.
- No raw hex, no `bg-white` / `text-gray-*`.

## Files changed (LoC)

- `apps/admin/src/components/FreshnessPanel.tsx` — new (635 LoC, well-commented)
- `apps/admin/src/pages/FreshnessPage.tsx` — new (20 LoC)
- `apps/admin/src/api/client.ts` — adds `SourceStatsRow`, `SourcesStatsResponse`, `statsSources(signal?)` and threads an `AbortSignal` through the private `request()` helper (+44 / -1)
- `apps/admin/src/App.tsx` — registers `/freshness` route (+2)
- `apps/admin/src/components/Layout.tsx` — adds `Freshness` nav item (+1)
- `apps/admin/src/pages/DashboardPage.tsx` — slots `<FreshnessPanel />` between stat cards and recent runs (+5)

## Manual smoke

Verified locally (the four acceptance scenarios + the 403 path):

1. **Empty state** — token authenticated, no sources configured: friendly empty message.
2. **All fresh** — recent syncs all under SLA × 0.5: green pills, single-segment bar.
3. **Mixed** — fresh + approaching + stale + never-synced + no-sla: full color spread, distribution bar shows all segments proportional, default sort lands stale rows first.
4. **All stale** — every row red.
5. **Auto-refresh** — pulse dot animates while fetching; column widths unchanged across ticks.
6. **403 path** — token without `stats:read`: amber "missing scope" banner, no crash.
7. **Keyboard** — Tab cycles through nav, sort buttons, then table rows; focus-visible ring on accent token visible at every stop.

## Scope guardrails respected

- No "trigger re-sync" button (lives on Sources).
- No historical freshness chart.
- No new dependencies.
- No backend / endpoint shape changes.
- No palette-token changes.