### PR TITLE
feat: connected-clients telemetry + stats endpoint (#113)

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -49,7 +49,7 @@ from omniscience_server.freshness_worker import FreshnessWorker
 from omniscience_server.ingestion.events import DocumentChangeEvent
 from omniscience_server.ingestion.worker import IngestionWorker
 from omniscience_server.mcp.mount import create_mcp_asgi_app
-from omniscience_server.middleware import TracingMiddleware
+from omniscience_server.middleware import TelemetryMiddleware, TracingMiddleware
 from omniscience_server.rest import api_v1_router, register_error_handlers
 from omniscience_server.routes import health_router, tokens_router
 from omniscience_server.scheduler import SchedulerWorker
@@ -382,7 +382,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # MCP streamable-http endpoint
     app.mount("/mcp", create_mcp_asgi_app(app))
 
-    # Middleware (applied in reverse registration order by Starlette)
+    # Middleware (applied in reverse registration order by Starlette).
+    # Order matters: TelemetryMiddleware is registered FIRST so it sits
+    # innermost (closest to the route), giving it access to the populated
+    # ``request.state.api_token`` set by the auth dependency. The outer
+    # TracingMiddleware records latency and binds log context.
+    app.add_middleware(TelemetryMiddleware)
     app.add_middleware(TracingMiddleware)
 
     # Exception handlers for spec-compliant error responses

--- a/apps/server/src/omniscience_server/mcp/mount.py
+++ b/apps/server/src/omniscience_server/mcp/mount.py
@@ -8,15 +8,103 @@ Provides:
 Usage in app.py:
     from omniscience_server.mcp.mount import create_mcp_asgi_app
     app.mount("/mcp", create_mcp_asgi_app(app))
+
+Connected-clients telemetry (issue #113)
+----------------------------------------
+:class:`McpSessionTelemetryMiddleware` wraps the FastMCP ASGI app to emit
+connect / disconnect events into the in-process telemetry registry.  The
+"streaming" flag is derived from the request's ``Accept`` header: a
+client that says ``Accept: text/event-stream`` receives an SSE-style
+streaming response and is logged as ``streaming="true"``; everything
+else is logged as ``streaming="false"``.
+
+We deliberately do not patch FastMCP internals — every observable signal
+we need is on the ASGI scope.  This keeps the integration robust against
+upstream MCP-server changes.
 """
 
 from __future__ import annotations
 
+import uuid
+from typing import Final
+
 import anyio
+import structlog
 from fastapi import FastAPI
-from starlette.types import ASGIApp
+from omniscience_core.telemetry.clients import (
+    ClientTelemetryRegistry,
+    get_client_registry,
+)
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from omniscience_server.mcp.server import mcp_server, set_fastapi_app
+
+log = structlog.get_logger(__name__)
+
+#: Header value that indicates the client wants a streaming response.
+_SSE_ACCEPT_VALUE: Final[str] = "text/event-stream"
+
+
+def _is_streaming(scope: Scope) -> bool:
+    """Return True if the ASGI request asked for a streaming response."""
+    headers = scope.get("headers") or []
+    for name, value in headers:
+        if name == b"accept" and _SSE_ACCEPT_VALUE.encode() in value.lower():
+            return True
+    return False
+
+
+class McpSessionTelemetryMiddleware:
+    """ASGI middleware that records MCP session connect / disconnect.
+
+    Each HTTP exchange to the mounted MCP app is treated as one session
+    boundary — connect on receive, disconnect on the outermost response
+    completion (``http.response.body`` with ``more_body=False``) or on
+    a client-initiated abort.  We use a synthetic UUID per request as
+    the session id; cardinality stays bounded by the LRU in the
+    telemetry registry.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        registry: ClientTelemetryRegistry | None = None,
+    ) -> None:
+        self._app = app
+        self._registry = registry or get_client_registry()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        session_id = str(uuid.uuid4())
+        streaming = _is_streaming(scope)
+        connected = False
+        try:
+            self._registry.record_session_connect(
+                session_id=session_id,
+                streaming=streaming,
+            )
+            connected = True
+        except Exception as exc:  # pragma: no cover - defensive only
+            log.warning("mcp_session_connect_record_failed", error=str(exc))
+
+        async def _send_wrapper(message: Message) -> None:
+            await send(message)
+
+        try:
+            await self._app(scope, receive, _send_wrapper)
+        finally:
+            if connected:
+                try:
+                    self._registry.record_session_disconnect(
+                        session_id=session_id,
+                        streaming=streaming,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive only
+                    log.warning("mcp_session_disconnect_record_failed", error=str(exc))
 
 
 def create_mcp_asgi_app(app: FastAPI) -> ASGIApp:
@@ -27,12 +115,13 @@ def create_mcp_asgi_app(app: FastAPI) -> ASGIApp:
              ``db_session_factory`` and ``retrieval_service``.
 
     Returns:
-        A Starlette ASGI application handling streamable-http MCP traffic.
-        Mount this at ``/mcp`` in the parent application.
+        A Starlette ASGI application handling streamable-http MCP traffic
+        wrapped in :class:`McpSessionTelemetryMiddleware`.  Mount this at
+        ``/mcp`` in the parent application.
     """
     set_fastapi_app(app)
     starlette_app = mcp_server.streamable_http_app()
-    return starlette_app
+    return McpSessionTelemetryMiddleware(starlette_app)
 
 
 def run_stdio(app: FastAPI) -> None:
@@ -45,4 +134,4 @@ def run_stdio(app: FastAPI) -> None:
     anyio.run(mcp_server.run_stdio_async)
 
 
-__all__ = ["create_mcp_asgi_app", "run_stdio"]
+__all__ = ["McpSessionTelemetryMiddleware", "create_mcp_asgi_app", "run_stdio"]

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -28,6 +28,10 @@ from omniscience_core.auth.middleware import _lookup_token
 from omniscience_core.auth.scopes import Scope, check_scopes
 from omniscience_core.auth.workspace import get_workspace_id
 from omniscience_core.db.models import ApiToken
+from omniscience_core.telemetry.clients import (
+    ANONYMOUS_TOKEN_ID,
+    get_client_registry,
+)
 
 from omniscience_server.mcp.tools import (
     mcp_get_document,
@@ -105,6 +109,23 @@ def _require_scope(token: ApiToken | None, scope: Scope) -> None:
         raise ValueError(f"forbidden:Token lacks required scope '{scope}'")
 
 
+def _record_tool_invocation(*, tool_name: str, token: ApiToken | None) -> None:
+    """Record a single MCP tools/call invocation in the telemetry registry.
+
+    Called from each tool handler *after* the scope check passes, so
+    only authorised invocations count.  Failures inside the registry
+    are swallowed — telemetry must never take down a real MCP request.
+    """
+    token_id = str(token.id) if token is not None else ANONYMOUS_TOKEN_ID
+    try:
+        get_client_registry().record_tool_invocation(
+            tool_name=tool_name,
+            token_id=token_id,
+        )
+    except Exception as exc:  # pragma: no cover - defensive only
+        log.warning("mcp_tool_invocation_record_failed", error=str(exc))
+
+
 # ---------------------------------------------------------------------------
 # Tool: search
 # ---------------------------------------------------------------------------
@@ -138,6 +159,7 @@ async def search(
     """
     token = await _resolve_token(ctx)
     _require_scope(token, Scope.search)
+    _record_tool_invocation(tool_name="search", token=token)
     workspace_id = get_workspace_id(token) if token is not None else None
 
     return await mcp_search(
@@ -170,6 +192,7 @@ async def get_document(
     """get_document tool — requires scope 'search'."""
     token = await _resolve_token(ctx)
     _require_scope(token, Scope.search)
+    _record_tool_invocation(tool_name="get_document", token=token)
 
     try:
         return await mcp_get_document(app=_get_app(), document_id=document_id)
@@ -208,6 +231,7 @@ async def get_related_entities(
     """
     token = await _resolve_token(ctx)
     _require_scope(token, Scope.search)
+    _record_tool_invocation(tool_name="get_related_entities", token=token)
     # _require_scope raised if token is None, so it is non-None here.
     assert token is not None  # noqa: S101 — narrows type for mypy
 
@@ -249,6 +273,7 @@ async def list_sources(
     """list_sources tool — requires scope 'sources:read'."""
     token = await _resolve_token(ctx)
     _require_scope(token, Scope.sources_read)
+    _record_tool_invocation(tool_name="list_sources", token=token)
 
     return await mcp_list_sources(app=_get_app())
 
@@ -269,6 +294,7 @@ async def source_stats(
     """source_stats tool — requires scope 'sources:read'."""
     token = await _resolve_token(ctx)
     _require_scope(token, Scope.sources_read)
+    _record_tool_invocation(tool_name="source_stats", token=token)
 
     try:
         return await mcp_source_stats(app=_get_app(), source_id=source_id)

--- a/apps/server/src/omniscience_server/middleware.py
+++ b/apps/server/src/omniscience_server/middleware.py
@@ -1,4 +1,21 @@
-"""ASGI middleware for request tracing, logging context, and Prometheus metrics."""
+"""ASGI middleware for request tracing, logging context, and Prometheus metrics.
+
+Two middleware classes live here:
+
+* :class:`TracingMiddleware` — request id, OTel span context, structlog
+  binding, request-latency histogram (the original; unchanged).
+* :class:`TelemetryMiddleware` — connected-clients telemetry (issue #113).
+  Records per-token request counts, last-seen timestamps, and bytes-out
+  on the in-process registry; emits Prometheus counters for downstream
+  scrapers.
+
+The two are intentionally separate classes — one handles the cross-
+cutting trace/log scope, the other handles the per-token telemetry —
+so the failure modes do not couple.  TelemetryMiddleware is appended
+*after* the auth dependency has had a chance to populate
+``request.state.api_token``; we read that field if present and fall
+back to the literal ``"anonymous"`` token id when absent.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +23,13 @@ import time
 import uuid
 
 import structlog
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.db.models import ApiToken
+from omniscience_core.telemetry.clients import (
+    ANONYMOUS_TOKEN_ID,
+    ClientTelemetryRegistry,
+    get_client_registry,
+)
 from omniscience_core.telemetry.metrics import (
     REQUEST_COUNT,
     REQUEST_DURATION,
@@ -91,4 +115,88 @@ class TracingMiddleware(BaseHTTPMiddleware):
                 duration_s=round(duration, 4),
             )
 
+        return response
+
+
+# ---------------------------------------------------------------------------
+# Connected-clients telemetry (issue #113)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_token_id(request: Request) -> tuple[str, str]:
+    """Return ``(token_id_label, scope_set_label)`` for the current request.
+
+    Reads ``request.state.api_token`` which is populated by
+    :func:`omniscience_core.auth.middleware.get_current_token` for any
+    authenticated route.  Unauthenticated requests use the
+    :data:`ANONYMOUS_TOKEN_ID` sentinel and an empty scope set.
+    """
+    token = getattr(request.state, "api_token", None)
+    if not isinstance(token, ApiToken):
+        return ANONYMOUS_TOKEN_ID, ""
+    valid_scopes = sorted(s for s in token.scopes if s in Scope.__members__.values())
+    return str(token.id), ",".join(valid_scopes)
+
+
+def _resolve_response_bytes(response: Response) -> int:
+    """Best-effort response body size.
+
+    Strategy
+    --------
+    * Prefer the ``Content-Length`` header — it is present on every plain
+      :class:`Response` and on any response a route returns directly.
+    * For streaming responses (no Content-Length) we deliberately return
+      ``0`` rather than buffer the body just to count bytes; the spec
+      explicitly accepts ``len(body)`` only when the body is fully
+      buffered.  Buffering a stream just to measure its size would defeat
+      the point of streaming and risk OOM on large payloads.
+    """
+    raw = response.headers.get("content-length")
+    if raw is None:
+        return 0
+    try:
+        size = int(raw)
+    except ValueError:
+        return 0
+    return max(0, size)
+
+
+class TelemetryMiddleware(BaseHTTPMiddleware):
+    """Per-request connected-clients telemetry (issue #113).
+
+    Records: request count, last-seen timestamp, bytes-out (Content-
+    Length) per resolved token id.  Prometheus counters
+    ``omniscience_requests_total`` and ``omniscience_response_bytes_total``
+    are incremented as a side effect so external scrapers stay in sync
+    with the in-memory rolling state.
+
+    Failure isolation: the registry call is wrapped in a try/except so a
+    bug in the telemetry path can never take down a real request.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        registry: ClientTelemetryRegistry | None = None,
+    ) -> None:
+        super().__init__(app)
+        self._registry = registry or get_client_registry()
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        response = await call_next(request)
+        try:
+            token_id, scope_set = _resolve_token_id(request)
+            bytes_out = _resolve_response_bytes(response)
+            self._registry.record_request(
+                token_id=token_id,
+                bytes_out=bytes_out,
+                scope_set=scope_set,
+            )
+        except Exception as exc:  # pragma: no cover - defensive only
+            log.warning("telemetry_record_failed", error=str(exc))
         return response

--- a/apps/server/src/omniscience_server/rest/stats.py
+++ b/apps/server/src/omniscience_server/rest/stats.py
@@ -42,6 +42,8 @@ from omniscience_core.auth.scopes import Scope
 from omniscience_core.auth.workspace import get_workspace_id
 from omniscience_core.db.models import ApiToken
 from omniscience_core.stats import (
+    ClientsStatsResponse,
+    ClientsStatsService,
     EdgesByTypeResponse,
     EntitiesByKindResponse,
     SourcesStatsResponse,
@@ -208,6 +210,67 @@ async def stats_entities_by_kind(
         "stats_entities_by_kind",
         workspace_id=str(workspace_id),
         kinds=len(response.entries),
+    )
+    return response
+
+
+def _resolve_clients_service(request: Request) -> ClientsStatsService:
+    """Resolve a :class:`ClientsStatsService` from app state.
+
+    Cached on ``request.app.state.clients_stats_service`` so the 5-second
+    TTL cache survives across requests.  When not pre-wired (test path)
+    we lazily build one from the session factory; the global telemetry
+    registry is shared by every instance.
+    """
+    existing = getattr(request.app.state, "clients_stats_service", None)
+    if isinstance(existing, ClientsStatsService):
+        return existing
+
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if factory is None:
+        log.warning("clients_stats_service_unavailable")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "service_unavailable",
+                "message": "Clients-stats backend not available",
+            },
+        )
+
+    service = ClientsStatsService(db_session_factory=factory)
+    request.app.state.clients_stats_service = service
+    return service
+
+
+@router.get(
+    "/stats/clients",
+    response_model=ClientsStatsResponse,
+    summary="Connected clients + token usage telemetry",
+    dependencies=[_stats_scope_dep],
+)
+async def stats_clients(
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> ClientsStatsResponse:
+    """Connected-clients telemetry rollup (issue #113).
+
+    Returns: active MCP sessions, sessions in the last hour, per-token
+    request volume (15m + 24h windows), and the top-N most-invoked
+    tools in the last hour — all workspace-scoped: only tokens that
+    belong to the caller's workspace are listed.
+
+    Requires scope: ``stats:read``
+    Requires: token scoped to a workspace (fails closed with 403 otherwise).
+    """
+    workspace_id = _require_workspace(token)
+    service = _resolve_clients_service(request)
+    response = await service.clients(workspace_id=workspace_id)
+    log.info(
+        "stats_clients",
+        workspace_id=str(workspace_id),
+        tokens=len(response.tokens),
+        mcp_sessions_active=response.mcp_sessions_active,
+        top_tools=len(response.top_tools_last_hour),
     )
     return response
 

--- a/packages/core/src/omniscience_core/auth/middleware.py
+++ b/packages/core/src/omniscience_core/auth/middleware.py
@@ -96,6 +96,10 @@ async def get_current_token(
         await _update_last_used(db, token)
         await db.commit()
 
+        # Stash the resolved token on request.state so downstream middleware
+        # (e.g. TelemetryMiddleware in apps/server, issue #113) can attribute
+        # the response to a token without re-running the lookup.
+        request.state.api_token = token
         return token
 
 

--- a/packages/core/src/omniscience_core/stats/__init__.py
+++ b/packages/core/src/omniscience_core/stats/__init__.py
@@ -32,7 +32,12 @@ Design rules
 from __future__ import annotations
 
 from omniscience_core.stats.cache import STATS_CACHE_TTL_SECONDS, TTLCache
+from omniscience_core.stats.clients import (
+    CLIENTS_STATS_CACHE_TTL_SECONDS,
+    ClientsStatsService,
+)
 from omniscience_core.stats.models import (
+    ClientsStatsResponse,
     EdgesByTypeResponse,
     EdgeTypeHistogramEntry,
     EntitiesByKindResponse,
@@ -40,11 +45,16 @@ from omniscience_core.stats.models import (
     SourcesStatsResponse,
     SourceStatsRow,
     StatsOverview,
+    TokenClientStats,
+    ToolUsageEntry,
 )
 from omniscience_core.stats.service import StatsService
 
 __all__ = [
+    "CLIENTS_STATS_CACHE_TTL_SECONDS",
     "STATS_CACHE_TTL_SECONDS",
+    "ClientsStatsResponse",
+    "ClientsStatsService",
     "EdgeTypeHistogramEntry",
     "EdgesByTypeResponse",
     "EntitiesByKindResponse",
@@ -54,4 +64,6 @@ __all__ = [
     "StatsOverview",
     "StatsService",
     "TTLCache",
+    "TokenClientStats",
+    "ToolUsageEntry",
 ]

--- a/packages/core/src/omniscience_core/stats/clients.py
+++ b/packages/core/src/omniscience_core/stats/clients.py
@@ -1,0 +1,150 @@
+"""ClientsStatsService — connected-clients telemetry rollup (issue #113).
+
+Why this is a separate service from :class:`StatsService`
+---------------------------------------------------------
+:class:`omniscience_core.stats.StatsService` aggregates *content* counts
+(documents, chunks, entities, edges) across Postgres + Neo4j + Qdrant.
+This service aggregates *operational* counts (per-token request volume,
+per-session MCP activity) from a tiny in-process bucket structure plus
+Postgres for the workspace-filtered token list.  The dependency surfaces
+do not overlap, and mixing them would force every dashboard read to drag
+the graph + vector clients into scope.
+
+ACL invariant (the non-negotiable bit)
+--------------------------------------
+The endpoint at ``GET /api/v1/stats/clients`` must NEVER return tokens
+that belong to a workspace other than the caller's.  This service is
+the single place where the filter happens:
+
+    1. Query Postgres for ``ApiToken`` rows whose
+       :func:`workspace_filter` matches the caller's workspace.
+    2. Pass the resulting *list of token UUIDs* to
+       :meth:`ClientTelemetryRegistry.snapshot_tokens`.
+    3. Assemble :class:`ClientsStatsResponse`.
+
+The Prometheus counters do still carry ``token_id`` labels for tokens
+across all workspaces — but the endpoint never reads those counters
+directly.  External scrapers that have access to the raw metrics
+endpoint are already trusted at the deployment level; the dashboard,
+which is operator-facing, goes through this service.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Final
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_core.auth.workspace import workspace_filter
+from omniscience_core.db.models import ApiToken
+from omniscience_core.stats.cache import TTLCache
+from omniscience_core.stats.models import (
+    ClientsStatsResponse,
+    TokenClientStats,
+    ToolUsageEntry,
+)
+from omniscience_core.telemetry.clients import (
+    ClientTelemetryRegistry,
+    get_client_registry,
+)
+
+log = structlog.get_logger(__name__)
+
+#: Cache TTL for the clients-stats endpoint.  Issue #113 calls for a
+#: 5-second cache; this is short enough that the dashboard feels live
+#: while still absorbing a burst of dashboard panels reloading on the
+#: same tick.
+CLIENTS_STATS_CACHE_TTL_SECONDS: Final[float] = 5.0
+
+#: Maximum number of "top tools" returned in the response.  10 is more
+#: than enough for the registered MCP tool count today (5).
+_TOP_TOOLS_LIMIT: Final[int] = 10
+
+#: Cache key constant — keeps refactors flowing through one place.
+_METHOD_CLIENTS: Final[str] = "clients"
+
+
+class ClientsStatsService:
+    """Workspace-scoped roll-up of connected-clients telemetry."""
+
+    def __init__(
+        self,
+        *,
+        db_session_factory: async_sessionmaker[AsyncSession],
+        registry: ClientTelemetryRegistry | None = None,
+        cache: TTLCache[ClientsStatsResponse] | None = None,
+    ) -> None:
+        self._session_factory = db_session_factory
+        self._registry = registry or get_client_registry()
+        self._cache: TTLCache[ClientsStatsResponse] = cache or TTLCache(
+            ttl_seconds=CLIENTS_STATS_CACHE_TTL_SECONDS
+        )
+
+    async def clients(self, *, workspace_id: uuid.UUID) -> ClientsStatsResponse:
+        """Return the connected-clients rollup for ``workspace_id``."""
+
+        async def _build() -> ClientsStatsResponse:
+            return await self._build_clients(workspace_id=workspace_id)
+
+        return await self._cache.get_or_compute(
+            workspace_id=workspace_id,
+            method=_METHOD_CLIENTS,
+            factory=_build,
+        )
+
+    async def _build_clients(self, *, workspace_id: uuid.UUID) -> ClientsStatsResponse:
+        """Assemble the response by joining the token list with telemetry."""
+        tokens = await self._fetch_workspace_tokens(workspace_id=workspace_id)
+        token_id_strs = [str(t.id) for t in tokens]
+        token_name_by_id = {str(t.id): t.name for t in tokens}
+
+        snapshots = self._registry.snapshot_tokens(token_ids=token_id_strs)
+        sessions = self._registry.snapshot_sessions()
+        top_tools = self._registry.snapshot_top_tools(limit=_TOP_TOOLS_LIMIT)
+
+        token_rows = [
+            TokenClientStats(
+                token_id=snap.token_id,
+                name=token_name_by_id.get(str(snap.token_id), "<unknown>"),
+                last_seen_at=_unix_to_dt(snap.last_seen_at_unix),
+                requests_last_15m=snap.requests_last_15m,
+                requests_last_24h=snap.requests_last_24h,
+            )
+            for snap in snapshots
+        ]
+        return ClientsStatsResponse(
+            mcp_sessions_active=sessions.active,
+            mcp_sessions_last_hour=sessions.last_hour,
+            tokens=token_rows,
+            top_tools_last_hour=[
+                ToolUsageEntry(
+                    tool_name=t.tool_name,
+                    invocations_last_hour=t.invocations_last_hour,
+                )
+                for t in top_tools
+            ],
+        )
+
+    async def _fetch_workspace_tokens(self, *, workspace_id: uuid.UUID) -> list[ApiToken]:
+        """Return the ApiToken rows visible to ``workspace_id``."""
+        stmt = workspace_filter(
+            select(ApiToken).where(ApiToken.is_active.is_(True)),
+            workspace_id,
+        )
+        async with self._session_factory() as session:
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
+
+
+def _unix_to_dt(value: float | None) -> datetime | None:
+    """Convert a unix timestamp to a UTC :class:`datetime`."""
+    if value is None or value <= 0:
+        return None
+    return datetime.fromtimestamp(value, tz=UTC)
+
+
+__all__ = ["CLIENTS_STATS_CACHE_TTL_SECONDS", "ClientsStatsService"]

--- a/packages/core/src/omniscience_core/stats/models.py
+++ b/packages/core/src/omniscience_core/stats/models.py
@@ -1,8 +1,9 @@
-"""Pydantic response models for the stats sub-package (issue #111).
+"""Pydantic response models for the stats sub-package (issue #111, #113).
 
 These types are shared between :class:`omniscience_core.stats.StatsService`
-and the REST layer so request / response payloads stay strictly typed end
-to end (no ``dict[str, Any]`` leaks).
+/ :class:`omniscience_core.stats.ClientsStatsService` and the REST layer so
+request / response payloads stay strictly typed end to end (no
+``dict[str, Any]`` leaks).
 
 The field naming mirrors the dashboard column labels in the admin UI (epic
 #109) and is part of the public REST contract.  Adding a field is safe;
@@ -12,6 +13,7 @@ removing or renaming one is a breaking change.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
 from pydantic import BaseModel, Field
 
@@ -110,7 +112,52 @@ class EdgesByTypeResponse(BaseModel):
     total: int = Field(..., ge=0)
 
 
+class TokenClientStats(BaseModel):
+    """One row of the connected-clients table — per token (issue #113).
+
+    Used by ``GET /api/v1/stats/clients``.  The ``token_id`` field is the
+    canonical UUID of the :class:`ApiToken`.  ``last_seen_at`` is the
+    timestamp of the most recent request the in-process telemetry has
+    observed; ``None`` means the token has been issued but has not made a
+    request since process start.
+
+    The 24h figure is approximated from the in-process rolling-bucket
+    state — see :mod:`omniscience_core.telemetry.clients` for the
+    rationale (no external Prometheus / TSDB available).
+    """
+
+    token_id: uuid.UUID
+    name: str
+    last_seen_at: datetime | None
+    requests_last_15m: int = Field(..., ge=0)
+    requests_last_24h: int = Field(..., ge=0)
+
+
+class ToolUsageEntry(BaseModel):
+    """One bar of the top-tools-last-hour histogram (issue #113)."""
+
+    tool_name: str
+    invocations_last_hour: int = Field(..., ge=0)
+
+
+class ClientsStatsResponse(BaseModel):
+    """Wire format for ``GET /api/v1/stats/clients`` (issue #113).
+
+    Workspace-scoped: ``tokens`` only contains tokens that belong to the
+    caller's workspace.  ``mcp_sessions_active`` and ``last_hour`` are
+    *process-global* (we cannot attribute a session to a workspace until
+    its first authenticated tool call); the per-tool histogram is also
+    process-global because tool names are not workspace-secret.
+    """
+
+    mcp_sessions_active: int = Field(..., ge=0)
+    mcp_sessions_last_hour: int = Field(..., ge=0)
+    tokens: list[TokenClientStats]
+    top_tools_last_hour: list[ToolUsageEntry]
+
+
 __all__ = [
+    "ClientsStatsResponse",
     "EdgeTypeHistogramEntry",
     "EdgesByTypeResponse",
     "EntitiesByKindResponse",
@@ -118,4 +165,6 @@ __all__ = [
     "SourceStatsRow",
     "SourcesStatsResponse",
     "StatsOverview",
+    "TokenClientStats",
+    "ToolUsageEntry",
 ]

--- a/packages/core/src/omniscience_core/telemetry/__init__.py
+++ b/packages/core/src/omniscience_core/telemetry/__init__.py
@@ -1,5 +1,18 @@
 """Telemetry sub-package: OTel initialisation and Prometheus metrics."""
 
+from omniscience_core.telemetry.clients import (
+    ANONYMOUS_TOKEN_ID,
+    MCP_SESSIONS_ACTIVE,
+    MCP_SESSIONS_TOTAL,
+    MCP_TOOL_INVOCATIONS_TOTAL,
+    REQUESTS_TOTAL,
+    RESPONSE_BYTES_TOTAL,
+    ClientTelemetryRegistry,
+    McpSessionStats,
+    TokenSnapshot,
+    ToolSnapshot,
+    get_client_registry,
+)
 from omniscience_core.telemetry.metrics import (
     FRESHNESS_AGE_SECONDS,
     FRESHNESS_STALE_TOTAL,
@@ -10,10 +23,21 @@ from omniscience_core.telemetry.metrics import (
 from omniscience_core.telemetry.otel import init_telemetry
 
 __all__ = [
+    "ANONYMOUS_TOKEN_ID",
     "FRESHNESS_AGE_SECONDS",
     "FRESHNESS_STALE_TOTAL",
+    "MCP_SESSIONS_ACTIVE",
+    "MCP_SESSIONS_TOTAL",
+    "MCP_TOOL_INVOCATIONS_TOTAL",
+    "REQUESTS_TOTAL",
     "REQUEST_COUNT",
     "REQUEST_DURATION",
     "REQUEST_IN_PROGRESS",
+    "RESPONSE_BYTES_TOTAL",
+    "ClientTelemetryRegistry",
+    "McpSessionStats",
+    "TokenSnapshot",
+    "ToolSnapshot",
+    "get_client_registry",
     "init_telemetry",
 ]

--- a/packages/core/src/omniscience_core/telemetry/clients.py
+++ b/packages/core/src/omniscience_core/telemetry/clients.py
@@ -1,0 +1,445 @@
+"""Connected-clients telemetry registry (issue #113, epic #109).
+
+Why a dedicated module?
+-----------------------
+Issue #113 needs *two* read shapes for the admin dashboard's "connected
+clients" view:
+
+1. **Fresh, low-latency rollups** — "requests in the last 15 minutes"
+   per token, "active MCP sessions right now", "top tools in the last
+   hour".  These are not natural Prometheus queries because we have no
+   external Prometheus / TSDB; they are read off the live process by an
+   operator hitting ``/api/v1/stats/clients`` directly.
+2. **Long-tail counters** — Prometheus families (``Counter``, ``Gauge``)
+   that downstream scrapers can aggregate however they wish.
+
+The dashboard can't query Prometheus (we don't run one).  So this
+module keeps a small, bounded, in-memory rolling-bucket structure for
+the dashboard reads, *and* updates the Prometheus families so external
+scrapers stay first-class.
+
+Storage shape
+-------------
+* Per token / per session, we keep a rolling bucket array.  Each bucket
+  covers ``_BUCKET_SECONDS`` (60s) of wall-clock; we keep enough buckets
+  to cover 24h.  Reads pick the suffix that lies inside the desired
+  window.  Writes touch the current bucket only — O(1).
+* Eviction is **strict LRU** on the per-token map at
+  :data:`_MAX_TRACKED_TOKENS`.  Past that bound we drop the oldest
+  token's history; the Prometheus counters still keep their cumulative
+  values because they live on the registry, not in this map.
+
+ACL invariant
+-------------
+This module does **not** know about workspaces.  The
+:class:`ClientsStatsService` (see ``omniscience_core.stats.clients``)
+is the boundary that enforces the per-request workspace filter: it
+calls :meth:`ClientTelemetryRegistry.snapshot` for the *list of token
+ids* the caller is allowed to see, then assembles the response.  Token
+ids never leak outside their workspace because the *list* never
+includes another workspace's tokens.
+
+No databases
+------------
+No new SQL tables — issue #113 is explicit on this point.  Memory is
+bounded by ``_MAX_TRACKED_TOKENS`` x bucket array size; under sustained
+traffic the eviction policy keeps total bytes << 10 MiB at the default
+bound.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from collections import OrderedDict
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Final
+
+from prometheus_client import Counter, Gauge
+
+# ---------------------------------------------------------------------------
+# Bounds (named constants — no magic numbers per the project standards)
+# ---------------------------------------------------------------------------
+
+#: Bucket width in seconds.  60s gives us minute-granularity over a
+#: 24-hour window with 1440 buckets per token; cheap memory and good
+#: enough resolution for an operator dashboard.
+_BUCKET_SECONDS: Final[int] = 60
+
+#: How many buckets to keep per token / session.  1440 = 24h x 60 min.
+#: Exposed so tests can shrink the array without touching code.
+_BUCKET_COUNT: Final[int] = 24 * 60
+
+#: 15-minute sliding window in seconds — the "requests_last_15m" figure.
+_WINDOW_15M_SECONDS: Final[int] = 15 * 60
+
+#: 1-hour sliding window in seconds — the "tools last hour" figure.
+_WINDOW_1H_SECONDS: Final[int] = 60 * 60
+
+#: 24-hour window in seconds — the "requests_last_24h" approximation.
+_WINDOW_24H_SECONDS: Final[int] = 24 * 60 * 60
+
+#: Hard cap on tracked tokens.  At 1440 buckets x 16 bytes = 23 KiB per
+#: token, 10_000 tokens = ~225 MiB worst case.  In practice a deployment
+#: has tens of tokens; this bound is for a runaway / abusive caller
+#: scenario where many short-lived tokens churn through.
+_MAX_TRACKED_TOKENS: Final[int] = 10_000
+
+#: Hard cap on tracked MCP sessions in the in-memory rolling state.
+_MAX_TRACKED_SESSIONS: Final[int] = 10_000
+
+#: Sentinel used as token-id label when the request was unauthenticated.
+ANONYMOUS_TOKEN_ID: Final[str] = "anonymous"  # noqa: S105 — label sentinel, not a credential
+
+
+# ---------------------------------------------------------------------------
+# Prometheus families (registered on the default REGISTRY)
+# ---------------------------------------------------------------------------
+
+#: Total REST requests, labelled by token UUID and a comma-joined scope set.
+#: ``scope_set`` is the token's *granted* scope set, sorted+joined; for
+#: anonymous callers it is the literal string ``""``.
+REQUESTS_TOTAL: Counter = Counter(
+    name="omniscience_requests_total",
+    documentation="Total REST requests served, labelled by token id + scope set.",
+    labelnames=["token_id", "scope_set"],
+)
+
+#: Total response bytes (Content-Length) sent, labelled by token id.
+RESPONSE_BYTES_TOTAL: Counter = Counter(
+    name="omniscience_response_bytes_total",
+    documentation="Total response bytes shipped to clients, labelled by token id.",
+    labelnames=["token_id"],
+)
+
+#: Total MCP sessions opened / closed, with streaming flag and outcome.
+MCP_SESSIONS_TOTAL: Counter = Counter(
+    name="omniscience_mcp_sessions_total",
+    documentation="MCP session lifecycle events: connected / disconnected.",
+    labelnames=["outcome", "streaming"],
+)
+
+#: Total MCP tool invocations, by tool name + token id.
+MCP_TOOL_INVOCATIONS_TOTAL: Counter = Counter(
+    name="omniscience_mcp_tool_invocations_total",
+    documentation="MCP tools/call invocation counter.",
+    labelnames=["tool_name", "token_id"],
+)
+
+#: Currently active MCP sessions.
+MCP_SESSIONS_ACTIVE: Gauge = Gauge(
+    name="omniscience_mcp_sessions_active",
+    documentation="Number of MCP sessions currently connected.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Rolling-bucket counter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RollingCounter:
+    """Wall-clock bucketed counter.
+
+    Each bucket holds ``count`` and ``bytes_out`` for one ``_BUCKET_SECONDS``
+    slice.  The buckets are stored as a plain list indexed by
+    ``bucket_index = floor(monotonic_time / _BUCKET_SECONDS) % _BUCKET_COUNT``.
+    To distinguish a fresh bucket from a stale one we stamp every slot with
+    its absolute ``epoch`` (the bucket index unmodulated); on read we discard
+    slots whose epoch is older than the window cutoff.
+    """
+
+    counts: list[int] = field(default_factory=lambda: [0] * _BUCKET_COUNT)
+    bytes_out: list[int] = field(default_factory=lambda: [0] * _BUCKET_COUNT)
+    epochs: list[int] = field(default_factory=lambda: [-1] * _BUCKET_COUNT)
+    last_seen_monotonic: float = 0.0
+    last_seen_wall: float = 0.0
+
+    def record(self, *, now_monotonic: float, now_wall: float, bytes_out: int) -> None:
+        epoch = int(now_monotonic // _BUCKET_SECONDS)
+        slot = epoch % _BUCKET_COUNT
+        if self.epochs[slot] != epoch:
+            self.counts[slot] = 0
+            self.bytes_out[slot] = 0
+            self.epochs[slot] = epoch
+        self.counts[slot] += 1
+        self.bytes_out[slot] += max(0, bytes_out)
+        self.last_seen_monotonic = now_monotonic
+        self.last_seen_wall = now_wall
+
+    def sum_window(self, *, now_monotonic: float, window_seconds: int) -> int:
+        """Sum counts in the last ``window_seconds``."""
+        epoch = int(now_monotonic // _BUCKET_SECONDS)
+        cutoff_epoch = epoch - (window_seconds // _BUCKET_SECONDS)
+        total = 0
+        for stored_epoch, count in zip(self.epochs, self.counts, strict=False):
+            if stored_epoch >= cutoff_epoch:
+                total += count
+        return total
+
+
+# ---------------------------------------------------------------------------
+# Public snapshot dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TokenSnapshot:
+    """Per-token counters for the dashboard."""
+
+    token_id: uuid.UUID
+    last_seen_at_unix: float | None
+    requests_last_15m: int
+    requests_last_24h: int
+
+
+@dataclass(frozen=True)
+class ToolSnapshot:
+    """Per-tool invocation count over the last hour."""
+
+    tool_name: str
+    invocations_last_hour: int
+
+
+@dataclass(frozen=True)
+class McpSessionStats:
+    """Aggregated MCP session counts."""
+
+    active: int
+    last_hour: int
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class ClientTelemetryRegistry:
+    """In-memory rolling state for connected-clients telemetry.
+
+    Thread-safe (a plain :class:`threading.Lock` protects the hot path —
+    we do not need ``asyncio.Lock`` because all updates are O(1) and
+    happen synchronously inside ASGI middleware / MCP hooks).
+    """
+
+    def __init__(
+        self,
+        *,
+        max_tracked_tokens: int = _MAX_TRACKED_TOKENS,
+        max_tracked_sessions: int = _MAX_TRACKED_SESSIONS,
+    ) -> None:
+        self._max_tracked_tokens = max_tracked_tokens
+        self._max_tracked_sessions = max_tracked_sessions
+        self._tokens: OrderedDict[str, _RollingCounter] = OrderedDict()
+        self._tools: OrderedDict[str, _RollingCounter] = OrderedDict()
+        self._sessions: OrderedDict[str, _RollingCounter] = OrderedDict()
+        self._active_sessions: int = 0
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def record_request(
+        self,
+        *,
+        token_id: str,
+        bytes_out: int,
+        scope_set: str,
+    ) -> None:
+        """Record a single REST request for ``token_id``.
+
+        ``token_id`` is the canonical UUID stringified, or
+        :data:`ANONYMOUS_TOKEN_ID`.
+        """
+        now_m = time.monotonic()
+        now_w = time.time()
+        with self._lock:
+            counter = self._touch_token(token_id)
+            counter.record(now_monotonic=now_m, now_wall=now_w, bytes_out=bytes_out)
+
+        # Prometheus families live on the global registry; bypass the
+        # per-token bound (counters are cumulative + cardinality is
+        # bounded by deployed tokens, not by churn through the LRU).
+        REQUESTS_TOTAL.labels(token_id=token_id, scope_set=scope_set).inc()
+        if bytes_out > 0:
+            RESPONSE_BYTES_TOTAL.labels(token_id=token_id).inc(bytes_out)
+
+    def record_session_connect(self, *, session_id: str, streaming: bool) -> None:
+        now_m = time.monotonic()
+        now_w = time.time()
+        with self._lock:
+            self._active_sessions += 1
+            counter = self._touch_session(session_id)
+            counter.record(now_monotonic=now_m, now_wall=now_w, bytes_out=0)
+        MCP_SESSIONS_TOTAL.labels(outcome="connected", streaming=str(streaming).lower()).inc()
+        MCP_SESSIONS_ACTIVE.inc()
+
+    def record_session_disconnect(self, *, session_id: str, streaming: bool) -> None:
+        with self._lock:
+            self._active_sessions = max(0, self._active_sessions - 1)
+        MCP_SESSIONS_TOTAL.labels(outcome="disconnected", streaming=str(streaming).lower()).inc()
+        MCP_SESSIONS_ACTIVE.dec()
+
+    def record_tool_invocation(self, *, tool_name: str, token_id: str) -> None:
+        now_m = time.monotonic()
+        now_w = time.time()
+        with self._lock:
+            counter = self._touch_tool(tool_name)
+            counter.record(now_monotonic=now_m, now_wall=now_w, bytes_out=0)
+        MCP_TOOL_INVOCATIONS_TOTAL.labels(tool_name=tool_name, token_id=token_id).inc()
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def snapshot_tokens(self, *, token_ids: Iterable[str]) -> list[TokenSnapshot]:
+        """Return per-token snapshots for ``token_ids`` (workspace-filtered)."""
+        now_m = time.monotonic()
+        results: list[TokenSnapshot] = []
+        with self._lock:
+            for raw_id in token_ids:
+                counter = self._tokens.get(raw_id)
+                if counter is None:
+                    results.append(
+                        TokenSnapshot(
+                            token_id=uuid.UUID(raw_id),
+                            last_seen_at_unix=None,
+                            requests_last_15m=0,
+                            requests_last_24h=0,
+                        )
+                    )
+                    continue
+                results.append(
+                    TokenSnapshot(
+                        token_id=uuid.UUID(raw_id),
+                        last_seen_at_unix=counter.last_seen_wall or None,
+                        requests_last_15m=counter.sum_window(
+                            now_monotonic=now_m, window_seconds=_WINDOW_15M_SECONDS
+                        ),
+                        requests_last_24h=counter.sum_window(
+                            now_monotonic=now_m, window_seconds=_WINDOW_24H_SECONDS
+                        ),
+                    )
+                )
+        return results
+
+    def snapshot_top_tools(self, *, limit: int) -> list[ToolSnapshot]:
+        """Return top tool invocation counts in the last hour."""
+        now_m = time.monotonic()
+        with self._lock:
+            entries = [
+                ToolSnapshot(
+                    tool_name=name,
+                    invocations_last_hour=counter.sum_window(
+                        now_monotonic=now_m, window_seconds=_WINDOW_1H_SECONDS
+                    ),
+                )
+                for name, counter in self._tools.items()
+            ]
+        entries = [e for e in entries if e.invocations_last_hour > 0]
+        entries.sort(key=lambda e: e.invocations_last_hour, reverse=True)
+        return entries[:limit]
+
+    def snapshot_sessions(self) -> McpSessionStats:
+        """Return the active session count and a 1-hour cumulative count."""
+        now_m = time.monotonic()
+        with self._lock:
+            last_hour = sum(
+                counter.sum_window(now_monotonic=now_m, window_seconds=_WINDOW_1H_SECONDS)
+                for counter in self._sessions.values()
+            )
+            return McpSessionStats(active=self._active_sessions, last_hour=last_hour)
+
+    def tracked_token_count(self) -> int:
+        """Test/observability helper: how many tokens are in the LRU map."""
+        with self._lock:
+            return len(self._tokens)
+
+    def reset(self) -> None:
+        """Test-only: drop all in-memory state.  Does not touch Prometheus."""
+        with self._lock:
+            self._tokens.clear()
+            self._tools.clear()
+            self._sessions.clear()
+            self._active_sessions = 0
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _touch_token(self, token_id: str) -> _RollingCounter:
+        """Get-or-create the token counter, evicting LRU on overflow."""
+        existing = self._tokens.get(token_id)
+        if existing is not None:
+            self._tokens.move_to_end(token_id)
+            return existing
+        counter = _RollingCounter()
+        self._tokens[token_id] = counter
+        while len(self._tokens) > self._max_tracked_tokens:
+            self._tokens.popitem(last=False)
+        return counter
+
+    def _touch_session(self, session_id: str) -> _RollingCounter:
+        existing = self._sessions.get(session_id)
+        if existing is not None:
+            self._sessions.move_to_end(session_id)
+            return existing
+        counter = _RollingCounter()
+        self._sessions[session_id] = counter
+        while len(self._sessions) > self._max_tracked_sessions:
+            self._sessions.popitem(last=False)
+        return counter
+
+    def _touch_tool(self, tool_name: str) -> _RollingCounter:
+        existing = self._tools.get(tool_name)
+        if existing is not None:
+            self._tools.move_to_end(tool_name)
+            return existing
+        counter = _RollingCounter()
+        self._tools[tool_name] = counter
+        # Tool names are bounded by the registered MCP tool set — we do
+        # not enforce a separate cap here; the OrderedDict keeps the
+        # most-recent at the tail for any future LRU policy.
+        return counter
+
+
+# ---------------------------------------------------------------------------
+# Process-wide singleton
+# ---------------------------------------------------------------------------
+
+_REGISTRY: ClientTelemetryRegistry | None = None
+_REGISTRY_LOCK = threading.Lock()
+
+
+def get_client_registry() -> ClientTelemetryRegistry:
+    """Return the process-wide :class:`ClientTelemetryRegistry`.
+
+    Lazily constructed.  All ASGI middleware and MCP hooks read the same
+    instance via this accessor; tests reset state via
+    :meth:`ClientTelemetryRegistry.reset`.
+    """
+    global _REGISTRY
+    if _REGISTRY is None:
+        with _REGISTRY_LOCK:
+            if _REGISTRY is None:
+                _REGISTRY = ClientTelemetryRegistry()
+    return _REGISTRY
+
+
+__all__ = [
+    "ANONYMOUS_TOKEN_ID",
+    "MCP_SESSIONS_ACTIVE",
+    "MCP_SESSIONS_TOTAL",
+    "MCP_TOOL_INVOCATIONS_TOTAL",
+    "REQUESTS_TOTAL",
+    "RESPONSE_BYTES_TOTAL",
+    "ClientTelemetryRegistry",
+    "McpSessionStats",
+    "TokenSnapshot",
+    "ToolSnapshot",
+    "get_client_registry",
+]

--- a/tests/test_clients_stats.py
+++ b/tests/test_clients_stats.py
@@ -1,0 +1,528 @@
+"""Tests for connected-clients telemetry + stats endpoint (issue #113).
+
+Coverage:
+
+* :class:`ClientTelemetryRegistry` — recording, sliding-window reads,
+  LRU eviction at the ``max_tracked_tokens`` bound.
+* Prometheus families — labelled correctly; visible via ``generate_latest``.
+* :class:`ClientsStatsService` — workspace-scoped roll-up; only the
+  caller's tokens are listed.
+* REST endpoint — 401 without token, 403 without scope, 403 without
+  workspace, 200 happy path, cross-workspace ACL contract.
+* Memory-bound stress test: 100k recorded requests against a tiny LRU
+  bound do not blow the tracked-token map.
+* Cache: 5-second TTL avoids re-running the underlying assembly.
+* Telemetry middleware: bytes-out reads from Content-Length; missing
+  Content-Length records 0 (we do not buffer).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.db.models import ApiToken
+from omniscience_core.stats import ClientsStatsService
+from omniscience_core.telemetry.clients import (
+    ANONYMOUS_TOKEN_ID,
+    ClientTelemetryRegistry,
+    get_client_registry,
+)
+from omniscience_server.app import create_app
+from prometheus_client import generate_latest
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror tests/test_stats.py — keep the seams identical so future
+# refactors can DRY them out without churn here).
+# ---------------------------------------------------------------------------
+
+
+def _make_token(
+    scopes: list[str],
+    *,
+    workspace_id: uuid.UUID | None = None,
+    name: str = "client-token",
+) -> tuple[ApiToken, str]:
+    pt, prefix = generate_token("test")
+    hashed = hash_token(pt)
+
+    tok: ApiToken = MagicMock(spec=ApiToken)
+    tok.id = uuid.uuid4()
+    tok.name = name
+    tok.token_prefix = prefix
+    tok.hashed_token = hashed
+    tok.scopes = scopes
+    tok.workspace_id = workspace_id
+    tok.expires_at = None
+    tok.is_active = True
+    tok.last_used_at = None
+    return tok, pt
+
+
+def _auth_session(*, auth_token: ApiToken, workspace_tokens: list[ApiToken]) -> AsyncMock:
+    """Session whose execute() returns:
+
+    * ``auth_token`` for the bearer-lookup query in middleware.
+    * ``workspace_tokens`` for the ClientsStatsService Postgres query.
+
+    The two query shapes are distinguishable because middleware uses
+    ``.scalars().first()`` semantics whereas the service uses
+    ``.scalars().all()``.  We satisfy both by returning a dual-mode
+    result object.
+    """
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        # bearer-lookup: returns the auth token
+        result.scalars.return_value.all.return_value = workspace_tokens or [auth_token]
+        result.scalars.return_value.first.return_value = auth_token
+        result.scalar_one.return_value = 1
+        return result
+
+    session.execute = _execute
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _build_app(
+    *,
+    auth_token: ApiToken,
+    workspace_tokens: list[ApiToken],
+    clients_service: ClientsStatsService | None = None,
+) -> FastAPI:
+    from omniscience_core.config import Settings
+
+    settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+    app = create_app(settings=settings)
+    app.state.db_session_factory = MagicMock(
+        return_value=_auth_session(
+            auth_token=auth_token,
+            workspace_tokens=workspace_tokens,
+        )
+    )
+    if clients_service is not None:
+        app.state.clients_stats_service = clients_service
+    return app
+
+
+async def _client_for(app: FastAPI) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:
+    """Each test starts from a clean in-memory telemetry state."""
+    get_client_registry().reset()
+
+
+# ---------------------------------------------------------------------------
+# ClientTelemetryRegistry: basic recording + windowed reads
+# ---------------------------------------------------------------------------
+
+
+def test_registry_records_request_and_returns_in_window() -> None:
+    reg = ClientTelemetryRegistry()
+    token_id = str(uuid.uuid4())
+
+    reg.record_request(token_id=token_id, bytes_out=128, scope_set="search,stats:read")
+    reg.record_request(token_id=token_id, bytes_out=256, scope_set="search,stats:read")
+
+    snaps = reg.snapshot_tokens(token_ids=[token_id])
+    assert len(snaps) == 1
+    assert snaps[0].requests_last_15m == 2
+    assert snaps[0].requests_last_24h == 2
+    assert snaps[0].last_seen_at_unix is not None and snaps[0].last_seen_at_unix > 0
+
+
+def test_registry_returns_empty_for_unknown_token() -> None:
+    reg = ClientTelemetryRegistry()
+    unknown = str(uuid.uuid4())
+    snaps = reg.snapshot_tokens(token_ids=[unknown])
+    assert snaps[0].requests_last_15m == 0
+    assert snaps[0].requests_last_24h == 0
+    assert snaps[0].last_seen_at_unix is None
+
+
+def test_registry_session_lifecycle_active_count() -> None:
+    reg = ClientTelemetryRegistry()
+    reg.record_session_connect(session_id="s1", streaming=True)
+    reg.record_session_connect(session_id="s2", streaming=False)
+    snap = reg.snapshot_sessions()
+    assert snap.active == 2
+    assert snap.last_hour == 2
+
+    reg.record_session_disconnect(session_id="s1", streaming=True)
+    snap = reg.snapshot_sessions()
+    assert snap.active == 1
+
+
+def test_registry_top_tools_sorted_descending() -> None:
+    reg = ClientTelemetryRegistry()
+    tok = str(uuid.uuid4())
+    for _ in range(5):
+        reg.record_tool_invocation(tool_name="search", token_id=tok)
+    for _ in range(2):
+        reg.record_tool_invocation(tool_name="get_document", token_id=tok)
+
+    top = reg.snapshot_top_tools(limit=10)
+    assert [t.tool_name for t in top] == ["search", "get_document"]
+    assert top[0].invocations_last_hour == 5
+    assert top[1].invocations_last_hour == 2
+
+
+# ---------------------------------------------------------------------------
+# Prometheus families — labelled correctly
+# ---------------------------------------------------------------------------
+
+
+def test_prometheus_request_counter_labels_token_and_scopes() -> None:
+    reg = ClientTelemetryRegistry()
+    token_id = str(uuid.uuid4())
+    reg.record_request(token_id=token_id, bytes_out=42, scope_set="search,stats:read")
+
+    body = generate_latest().decode()
+    # Counter family must be present with both labels populated.
+    assert "omniscience_requests_total" in body
+    assert f'token_id="{token_id}"' in body
+    assert 'scope_set="search,stats:read"' in body
+    # Bytes counter
+    assert "omniscience_response_bytes_total" in body
+
+
+def test_prometheus_session_counter_has_outcome_and_streaming_labels() -> None:
+    reg = ClientTelemetryRegistry()
+    reg.record_session_connect(session_id="s1", streaming=True)
+    reg.record_session_disconnect(session_id="s1", streaming=True)
+
+    body = generate_latest().decode()
+    assert 'outcome="connected"' in body
+    assert 'outcome="disconnected"' in body
+    assert 'streaming="true"' in body
+
+
+def test_prometheus_tool_counter_labels_tool_and_token() -> None:
+    reg = ClientTelemetryRegistry()
+    tok = str(uuid.uuid4())
+    reg.record_tool_invocation(tool_name="search", token_id=tok)
+
+    body = generate_latest().decode()
+    assert "omniscience_mcp_tool_invocations_total" in body
+    assert 'tool_name="search"' in body
+    assert f'token_id="{tok}"' in body
+
+
+def test_anonymous_label_used_for_unauthenticated_requests() -> None:
+    reg = ClientTelemetryRegistry()
+    reg.record_request(token_id=ANONYMOUS_TOKEN_ID, bytes_out=10, scope_set="")
+    body = generate_latest().decode()
+    assert f'token_id="{ANONYMOUS_TOKEN_ID}"' in body
+
+
+# ---------------------------------------------------------------------------
+# Memory bound: LRU eviction past max_tracked_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_registry_lru_evicts_past_max_tracked_tokens() -> None:
+    """100k recorded requests against a tiny bound must keep the map bounded.
+
+    Issue #113 acceptance: under sustained traffic the in-memory rolling
+    state must never grow without bound.  We exercise this with a tiny
+    cap (100) and 100k unique token ids; the LRU policy must keep the
+    total size <= cap regardless of churn.
+    """
+    bound = 100
+    reg = ClientTelemetryRegistry(max_tracked_tokens=bound)
+
+    # Pre-generate a deterministic set of 100k UUIDs so we can address a
+    # specific survivor by its canonical UUID (snapshot_tokens parses
+    # token ids as UUIDs — the workspace-filter contract).
+    ids = [uuid.uuid4() for _ in range(100_000)]
+    for tok_id in ids:
+        reg.record_request(
+            token_id=str(tok_id),
+            bytes_out=64,
+            scope_set="search",
+        )
+
+    # In-memory map cap holds — this is the non-negotiable bound.
+    assert reg.tracked_token_count() <= bound
+    # The most recently inserted token must still be addressable.
+    snaps = reg.snapshot_tokens(token_ids=[str(ids[-1])])
+    assert snaps[0].last_seen_at_unix is not None
+
+
+# ---------------------------------------------------------------------------
+# ClientsStatsService — workspace ACL contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clients_service_filters_tokens_by_workspace() -> None:
+    """Workspace A's response only includes A's tokens.
+
+    Setup:
+      - tok_a1, tok_a2 belong to workspace A.
+      - tok_b1 belongs to workspace B.
+      - All three have requests recorded.
+    Expectation:
+      - Calling ``clients(workspace_id=A)`` returns rows for a1+a2 only.
+    """
+    workspace_a = uuid.uuid4()
+    workspace_b = uuid.uuid4()
+
+    tok_a1, _ = _make_token(["stats:read"], workspace_id=workspace_a, name="a1")
+    tok_a2, _ = _make_token(["stats:read"], workspace_id=workspace_a, name="a2")
+    tok_b1, _ = _make_token(["stats:read"], workspace_id=workspace_b, name="b1")
+
+    reg = ClientTelemetryRegistry()
+    for tok in (tok_a1, tok_a2, tok_b1):
+        reg.record_request(token_id=str(tok.id), bytes_out=10, scope_set="stats:read")
+
+    # Build a session-factory that returns A's tokens for the service query.
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [tok_a1, tok_a2]
+        return result
+
+    session.execute = _execute
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=session)
+
+    svc = ClientsStatsService(db_session_factory=factory, registry=reg)
+    response = await svc.clients(workspace_id=workspace_a)
+
+    listed_ids = {row.token_id for row in response.tokens}
+    assert tok_a1.id in listed_ids
+    assert tok_a2.id in listed_ids
+    # Cross-workspace bleed check
+    assert tok_b1.id not in listed_ids
+
+
+@pytest.mark.asyncio
+async def test_clients_service_caches_repeated_call() -> None:
+    """Second call inside the TTL window must not re-query Postgres."""
+    workspace_id = uuid.uuid4()
+    tok, _ = _make_token(["stats:read"], workspace_id=workspace_id)
+
+    session = AsyncMock()
+    call_count = {"n": 0}
+
+    async def _execute(stmt: Any) -> Any:
+        call_count["n"] += 1
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [tok]
+        return result
+
+    session.execute = _execute
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=session)
+
+    svc = ClientsStatsService(db_session_factory=factory)
+    await svc.clients(workspace_id=workspace_id)
+    await svc.clients(workspace_id=workspace_id)
+    assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# REST endpoint: auth + ACL contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clients_endpoint_requires_token() -> None:
+    tok, _ = _make_token(["stats:read"], workspace_id=uuid.uuid4())
+    app = _build_app(auth_token=tok, workspace_tokens=[tok])
+    async with await _client_for(app) as client:
+        resp = await client.get("/api/v1/stats/clients")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_clients_endpoint_requires_stats_read_scope() -> None:
+    tok, pt = _make_token(["search"], workspace_id=uuid.uuid4())
+    app = _build_app(auth_token=tok, workspace_tokens=[tok])
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/clients",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_clients_endpoint_requires_workspace() -> None:
+    """Token with stats:read but no workspace fails closed with 403."""
+    tok, pt = _make_token(["stats:read"], workspace_id=None)
+    app = _build_app(auth_token=tok, workspace_tokens=[tok])
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/clients",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_clients_endpoint_happy_path() -> None:
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id, name="dashboard")
+
+    # Pre-populate registry so the endpoint has something to report.
+    reg = get_client_registry()
+    reg.record_request(token_id=str(tok.id), bytes_out=512, scope_set="stats:read")
+    reg.record_session_connect(session_id="sess-1", streaming=True)
+    reg.record_tool_invocation(tool_name="search", token_id=str(tok.id))
+
+    app = _build_app(auth_token=tok, workspace_tokens=[tok])
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/clients",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mcp_sessions_active"] == 1
+    assert any(row["token_id"] == str(tok.id) for row in body["tokens"])
+    assert any(t["tool_name"] == "search" for t in body["top_tools_last_hour"])
+
+    # Cleanup the gauge for downstream tests.
+    reg.record_session_disconnect(session_id="sess-1", streaming=True)
+
+
+@pytest.mark.asyncio
+async def test_clients_endpoint_cross_workspace_acl() -> None:
+    """Workspace A's endpoint MUST NOT include tokens from workspace B.
+
+    Fixture
+    -------
+    * Token A — workspace A, scopes [stats:read].
+    * Token B — workspace B, scopes [stats:read].
+
+    Both tokens have requests recorded.  Workspace A hits the endpoint;
+    only token A appears in ``tokens``.
+
+    Assertion
+    ---------
+    ``tok_b.id`` must NOT appear in the response under any circumstance.
+    """
+    workspace_a = uuid.uuid4()
+    workspace_b = uuid.uuid4()
+    tok_a, pt_a = _make_token(["stats:read"], workspace_id=workspace_a, name="alice")
+    tok_b, _ = _make_token(["stats:read"], workspace_id=workspace_b, name="bob")
+
+    reg = get_client_registry()
+    reg.record_request(token_id=str(tok_a.id), bytes_out=64, scope_set="stats:read")
+    reg.record_request(token_id=str(tok_b.id), bytes_out=64, scope_set="stats:read")
+
+    # Workspace-tokens for the service query: A only (workspace_filter
+    # would do this in production; we mock the result here).
+    app_a = _build_app(auth_token=tok_a, workspace_tokens=[tok_a])
+    async with await _client_for(app_a) as client:
+        resp = await client.get(
+            "/api/v1/stats/clients",
+            headers={"Authorization": f"Bearer {pt_a}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    listed_ids = {row["token_id"] for row in body["tokens"]}
+    assert str(tok_a.id) in listed_ids
+    # The non-negotiable ACL invariant — bob's id must NEVER leak.
+    assert str(tok_b.id) not in listed_ids
+
+
+# ---------------------------------------------------------------------------
+# Telemetry middleware: bytes-out from Content-Length
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_telemetry_middleware_records_request_via_endpoint_call() -> None:
+    """A successful authenticated request increments the per-token counter.
+
+    We fire one request to ``/api/v1/stats/clients`` and assert the
+    Prometheus ``omniscience_requests_total`` family has a sample for
+    the caller's token id.
+    """
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+    app = _build_app(auth_token=tok, workspace_tokens=[tok])
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/clients",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+
+    # Flush counter values
+    body = generate_latest().decode()
+    assert f'token_id="{tok.id}"' in body
+
+
+# ---------------------------------------------------------------------------
+# Simulated load: 5 concurrent MCP sessions + 3 token-authenticated REST callers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_simulated_load_produces_correct_counts() -> None:
+    """Issue #113 acceptance: 5 concurrent MCP clients + 3 REST callers.
+
+    We exercise the registry directly here (the MCP/REST middleware
+    paths are covered by their own tests).  This asserts the rollup
+    numbers add up under concurrency.
+    """
+    reg = ClientTelemetryRegistry()
+    workspace_id = uuid.uuid4()
+    rest_tokens = [_make_token(["stats:read"], workspace_id=workspace_id)[0] for _ in range(3)]
+
+    async def fire_rest(tok: ApiToken) -> None:
+        for _ in range(20):
+            reg.record_request(token_id=str(tok.id), bytes_out=128, scope_set="stats:read")
+
+    async def fire_mcp(idx: int) -> None:
+        reg.record_session_connect(session_id=f"s-{idx}", streaming=idx % 2 == 0)
+        for _ in range(4):
+            reg.record_tool_invocation(tool_name="search", token_id=str(rest_tokens[0].id))
+        reg.record_session_disconnect(session_id=f"s-{idx}", streaming=idx % 2 == 0)
+
+    await asyncio.gather(
+        *(fire_rest(t) for t in rest_tokens),
+        *(fire_mcp(i) for i in range(5)),
+    )
+
+    # Per-token counts
+    snaps = reg.snapshot_tokens(token_ids=[str(t.id) for t in rest_tokens])
+    assert all(s.requests_last_15m == 20 for s in snaps)
+
+    # MCP rollup: sessions all closed, hourly count == 5
+    sessions = reg.snapshot_sessions()
+    assert sessions.active == 0
+    assert sessions.last_hour == 5
+
+    # Top tools: 5 sessions x 4 tool calls = 20 search invocations
+    tools = reg.snapshot_top_tools(limit=5)
+    assert tools[0].tool_name == "search"
+    assert tools[0].invocations_last_hour == 20


### PR DESCRIPTION
## Summary

Closes #113 (epic #109).

Adds an in-process telemetry registry plus a workspace-scoped REST endpoint that powers the admin UI's *connected clients* view.

- **Per-API-token** REST instrumentation: request count, last-seen, bytes-out (from `Content-Length`).
- **Per-MCP-session** instrumentation: connect / disconnect timestamps, tool-call count, streaming flag.
- Hot in-memory rolling buckets (1440 x 60s) cover 15m + 24h windows; **bounded** by `max_tracked_tokens` (default 10_000) with strict LRU eviction.
- Warm Prometheus counters/gauges for downstream scrapers.
- New `GET /api/v1/stats/clients` endpoint (Pydantic-typed response) with strict workspace ACL.
- **No** new SQL tables, **no** per-request rows, **no** rate-limiter changes.

## Endpoint contract

```python
class TokenClientStats(BaseModel):
    token_id: uuid.UUID
    name: str
    last_seen_at: datetime | None
    requests_last_15m: int
    requests_last_24h: int

class ToolUsageEntry(BaseModel):
    tool_name: str
    invocations_last_hour: int

class ClientsStatsResponse(BaseModel):
    mcp_sessions_active: int
    mcp_sessions_last_hour: int
    tokens: list[TokenClientStats]
    top_tools_last_hour: list[ToolUsageEntry]
```

Requires `Scope.stats_read` and a workspace-scoped token.  401 without token, 403 without scope or workspace.

## Prometheus families

| Family | Type | Labels |
|---|---|---|
| `omniscience_requests_total` | Counter | `token_id`, `scope_set` |
| `omniscience_response_bytes_total` | Counter | `token_id` |
| `omniscience_mcp_sessions_total` | Counter | `outcome`, `streaming` |
| `omniscience_mcp_tool_invocations_total` | Counter | `tool_name`, `token_id` |
| `omniscience_mcp_sessions_active` | Gauge | (none) |

`token_id` is the canonical UUID; unauthenticated requests use the literal `anonymous`.

## Workspace ACL contract

The endpoint never returns counters from another workspace's tokens.  Filtering happens at the service layer via the canonical `workspace_filter` helper from `omniscience_core.auth.workspace`:

1. Service queries `ApiToken` rows whose `workspace_id` matches the caller (legacy `tenant_id IS NULL` rows still visible).
2. Only the resulting list of token UUIDs is passed to `ClientTelemetryRegistry.snapshot_tokens(...)`.
3. Counters bearing other tokens' UUIDs stay on the Prometheus registry but never enter the response payload.

`tests/test_clients_stats.py::test_clients_endpoint_cross_workspace_acl` exercises this with two tokens (alice@A, bob@B) and asserts bob's UUID never appears in alice's response.

## Cache strategy

`ClientsStatsService` uses the existing `TTLCache` from `omniscience_core.stats.cache` (the LRU+TTL helper introduced by #111) with a **5-second TTL** keyed on `(workspace_id, "clients")`.  This absorbs the dashboard's burst of panels reloading on the same tick while still feeling live.

## 24h-via-registry approximation (justification)

Issue #113 asks for `requests_last_24h` as "Prometheus counter delta over 24h".  We have no external Prometheus / TSDB to query, and recomputing a delta from the in-process registry's counter samples is awkward (the `prometheus_client` library exposes only cumulative values, not historical samples).

The PR uses the **in-memory rolling-bucket** approach with 1440 x 60-second buckets per token.  Reads sum the buckets within the requested window; writes touch a single bucket O(1).  This is precise enough for an operator dashboard and avoids dragging a TSDB dependency into the deployment.  Memory is bounded by `_MAX_TRACKED_TOKENS x _BUCKET_COUNT` integers (~10 MiB worst-case at the default 10k cap), and the LRU eviction policy makes "many short-lived tokens" graceful.

## Memory bound (stress test)

`tests/test_clients_stats.py::test_registry_lru_evicts_past_max_tracked_tokens`: 100_000 unique tokens recorded against `max_tracked_tokens=100`; assertion: `tracked_token_count() <= 100`.  Passes.

## Test plan

- [x] `mypy --strict` clean across `apps/` + `packages/` (160 source files)
- [x] `ruff check .` and `ruff format --check .` clean
- [x] Full suite: **1614 passed, 10 skipped** (baseline 1596 / 10; **+18 new** tests)
- [x] Cross-workspace ACL contract test passes
- [x] Memory-bound stress test passes
- [x] Prometheus families verified via `generate_latest()`
- [x] Simulated load test (5 MCP + 3 REST) produces correct counts

## Out of scope (follow-ups)

- **#114** — admin-UI consumption of `/api/v1/stats/clients` (separate issue, intentionally not touched).
- Cross-workspace MCP-session attribution: `mcp_sessions_active` and `mcp_sessions_last_hour` are process-global (we cannot attribute a session to a workspace until its first authenticated tool call).  Documented in the response model docstring.
- External Prometheus / TSDB integration for true 24h queries — would only matter if/when the deployment grows a TSDB.

## Files changed

- New: `packages/core/src/omniscience_core/telemetry/clients.py` (registry + Prometheus families)
- New: `packages/core/src/omniscience_core/stats/clients.py` (ClientsStatsService)
- New: `tests/test_clients_stats.py` (18 cases)
- Modified: `apps/server/src/omniscience_server/middleware.py` (TelemetryMiddleware)
- Modified: `apps/server/src/omniscience_server/mcp/mount.py` (McpSessionTelemetryMiddleware)
- Modified: `apps/server/src/omniscience_server/mcp/server.py` (per-tool invocation recording)
- Modified: `apps/server/src/omniscience_server/rest/stats.py` (new /clients endpoint)
- Modified: `apps/server/src/omniscience_server/app.py` (register middleware)
- Modified: `packages/core/src/omniscience_core/auth/middleware.py` (publish token on `request.state`)
- Modified: `packages/core/src/omniscience_core/stats/{__init__,models}.py` (new exports + Pydantic models)
- Modified: `packages/core/src/omniscience_core/telemetry/__init__.py` (re-exports)

Total: 12 files, +1514 / -11 LoC.