### PR TITLE
feat: retention worker hot/warm/archive eviction (#135)

### DIFF
--- a/apps/server/pyproject.toml
+++ b/apps/server/pyproject.toml
@@ -12,6 +12,11 @@ dependencies = [
     "fastapi>=0.111.0",
     "uvicorn[standard]>=0.30.0",
     "mcp>=1.0.0",
+    # Retention worker (issue #135) — archive tier writes Parquet to S3
+    # per ADR-0009 §1 archive / §7 storage layout.  pyarrow handles
+    # columnar serialisation; boto3 handles the S3 PUT path.
+    "pyarrow>=17.0.0",
+    "boto3>=1.42.91",
 ]
 
 [tool.uv.sources]

--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -51,6 +51,7 @@ from omniscience_server.ingestion.worker import IngestionWorker
 from omniscience_server.mcp.mount import create_mcp_asgi_app
 from omniscience_server.middleware import TelemetryMiddleware, TracingMiddleware
 from omniscience_server.rest import api_v1_router, register_error_handlers
+from omniscience_server.retention_worker import RetentionWorker
 from omniscience_server.routes import health_router, tokens_router
 from omniscience_server.scheduler import SchedulerWorker
 
@@ -275,6 +276,29 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         interval_seconds=freshness_worker._interval,
     )
 
+    # --- Retention worker (ADR-0009 §3, issue #135) ---
+    retention_task: asyncio.Task[None] | None = None
+    retention_worker: RetentionWorker | None = None
+    if settings.retention_enabled:
+        retention_worker = RetentionWorker(
+            session_factory=session_factory,
+            graph_store=neo4j_graph_store,
+            vector_store=qdrant_store,
+            settings=settings,
+        )
+        retention_task = asyncio.create_task(retention_worker.start())
+        app.state.retention_worker = retention_worker
+        log.info(
+            "retention_worker_started",
+            tick_seconds=settings.retention_tick_seconds,
+            dry_run=settings.retention_dry_run,
+            hot_days=settings.retention_hot_days,
+            warm_days=settings.retention_warm_days,
+        )
+    else:
+        app.state.retention_worker = None
+        log.info("retention_worker_disabled")
+
     # --- Scheduler worker ---
     scheduler_task: asyncio.Task[None] | None = None
     scheduler: SchedulerWorker | None = None
@@ -305,6 +329,10 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     if scheduler is not None and scheduler_task is not None:
         await scheduler.stop()
         scheduler_task.cancel()
+
+    if retention_worker is not None and retention_task is not None:
+        retention_worker.stop()
+        retention_task.cancel()
 
     await worker.stop()
     worker_task.cancel()

--- a/apps/server/src/omniscience_server/rest/retention.py
+++ b/apps/server/src/omniscience_server/rest/retention.py
@@ -1,0 +1,257 @@
+"""Retention dry-run report REST endpoint (issue #135, ADR-0009 §3).
+
+Exposes ``GET /api/v1/admin/retention/report`` — workspace-scoped,
+returns the dry-run report for the caller's workspace.
+
+Security
+--------
+- Requires the ``stats:read`` scope (matches the rest of the admin
+  read surface; a dedicated ``retention:read`` was considered but
+  rejected to avoid scope-creep on existing tokens).
+- Workspace-scoped: a token without an associated workspace fails
+  closed with 403, identical to ``rest/stats.py``.  This is the second
+  line of defence after the protocol-level ``workspace_id`` invariants
+  on ``GraphStore`` / ``VectorStore``.
+- The endpoint NEVER mutates either store — it always runs the
+  retention pipeline in dry-run mode regardless of the worker's
+  current ``retention_dry_run`` setting.  Operators reviewing
+  eviction posture before flipping the worker live MUST be able to
+  call this without side effects.
+
+Response shape
+--------------
+:class:`RetentionReport` (Pydantic model below).  Sample is bounded by
+``Settings.retention_sample_size`` (default 20).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.config import Settings
+from omniscience_core.db.models import ApiToken
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from pydantic import BaseModel, ConfigDict, Field
+
+from omniscience_server.retention_worker import (
+    RetentionWorker,
+    WorkspaceRetentionReport,
+)
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["admin"])
+
+_stats_scope_dep: Any = Depends(require_scope(Scope.stats_read))
+_current_token_dep: Any = Depends(get_current_token)
+
+
+class RetentionSampleEntry(BaseModel):
+    """One sampled :EntityState row from the eligible cohort."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str | None = None
+    valid_from: str | None = None
+    recorded_at: str | None = None
+
+
+class RetentionReport(BaseModel):
+    """Per-workspace dry-run report (ADR-0009 §3).
+
+    Counts and a sampled record set are returned; no record contents
+    are mutated.  The report carries the lag SLO observation (ADR-0009
+    §8) so operators can see, in the same response, both *what* would
+    be evicted and *how overdue* the worker currently is.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: uuid.UUID = Field(description="Workspace the report covers.")
+    dry_run: bool = Field(
+        description=(
+            "Always True for this endpoint — the response is generated "
+            "by a side-effect-free pipeline run regardless of the "
+            "worker's live `retention_dry_run` configuration."
+        ),
+    )
+    eligible_hot_to_warm_entity_states: int = Field(
+        ge=0,
+        description=":EntityState rows with recorded_at < hot cutoff.",
+    )
+    eligible_hot_to_warm_edges: int = Field(
+        ge=0,
+        description="End-dated relationships with recorded_at < hot cutoff.",
+    )
+    eligible_hot_to_warm_chunks: int = Field(
+        ge=0,
+        description="Qdrant chunks with recorded_at < hot cutoff (ADR-0009 §5).",
+    )
+    eligible_warm_to_archive_entity_snapshots: int = Field(
+        ge=0,
+        description=":EntitySnapshot:Daily rows older than warm cutoff.",
+    )
+    eligible_warm_to_archive_dates: list[date] = Field(
+        default_factory=list,
+        description=(
+            "Distinct snapshot dates that would be archived this run "
+            "(bounded by RETENTION_ARCHIVE_DATES_PER_RUN)."
+        ),
+    )
+    sampled_eligible: list[RetentionSampleEntry] = Field(
+        default_factory=list,
+        description="Up to retention_sample_size sampled hot-to-warm rows.",
+    )
+    oldest_eligible_recorded_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Oldest recorded_at currently overdue for eviction. "
+            "When None the workspace has no overdue rows."
+        ),
+    )
+    lag_seconds: float = Field(
+        ge=0.0,
+        description=(
+            "Wall-clock seconds since the oldest overdue row's "
+            "recorded_at; surfaces the deployment-wide ADR-0009 §8 "
+            "SLO (<24h steady, P1 at >7d)."
+        ),
+    )
+
+
+def _to_response(report: WorkspaceRetentionReport) -> RetentionReport:
+    """Convert worker dataclass to Pydantic response model."""
+    return RetentionReport(
+        workspace_id=report.workspace_id,
+        dry_run=True,
+        eligible_hot_to_warm_entity_states=report.eligible_hot_to_warm_entity_states,
+        eligible_hot_to_warm_edges=report.eligible_hot_to_warm_edges,
+        eligible_hot_to_warm_chunks=report.eligible_hot_to_warm_chunks,
+        eligible_warm_to_archive_entity_snapshots=(
+            report.eligible_warm_to_archive_entity_snapshots
+        ),
+        eligible_warm_to_archive_dates=list(report.eligible_warm_to_archive_dates),
+        sampled_eligible=[
+            RetentionSampleEntry(
+                id=entry.get("id"),
+                valid_from=entry.get("valid_from"),
+                recorded_at=entry.get("recorded_at"),
+            )
+            for entry in report.sampled_eligible
+        ],
+        oldest_eligible_recorded_at=report.oldest_eligible_recorded_at,
+        lag_seconds=report.lag_seconds,
+    )
+
+
+def _require_workspace(token: ApiToken) -> uuid.UUID:
+    """Extract the caller's workspace_id or fail closed with 403."""
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "retention_report_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": ("Retention report endpoint requires a workspace-scoped token."),
+            },
+        )
+    return workspace_id
+
+
+def _resolve_dry_run_worker(request: Request) -> RetentionWorker:
+    """Resolve a side-effect-free :class:`RetentionWorker`.
+
+    The wired worker on ``app.state.retention_worker`` may be running
+    in live mode; we always force ``dry_run=True`` for the report
+    endpoint so the response is guaranteed mutation-free regardless of
+    operator configuration.
+    """
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    graph_store: Neo4jGraphStore | None = getattr(request.app.state, "graph_store", None)
+    vector_store: QdrantVectorStore | None = getattr(request.app.state, "vector_store", None)
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if settings is None or graph_store is None or vector_store is None or factory is None:
+        log.warning("retention_report_backend_unavailable")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "service_unavailable",
+                "message": "Retention backend not available",
+            },
+        )
+    # Force dry-run regardless of the live worker's config.
+    forced = settings.model_copy(update={"retention_dry_run": True})
+    return RetentionWorker(
+        session_factory=factory,
+        graph_store=graph_store,
+        vector_store=vector_store,
+        settings=forced,
+    )
+
+
+@router.get(
+    "/admin/retention/report",
+    response_model=RetentionReport,
+    summary="Workspace-scoped dry-run retention report",
+    dependencies=[_stats_scope_dep],
+)
+async def admin_retention_report(
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> RetentionReport:
+    """Return what eviction would do for the caller's workspace.
+
+    Side-effect free: the call always runs the worker in dry-run mode
+    regardless of ``Settings.retention_dry_run``.  The caller sees:
+
+    * Counts of rows eligible for hot-to-warm and warm-to-archive
+      transitions (Neo4j entity states, edges, Qdrant chunks).
+    * The distinct snapshot dates that would be archived this run.
+    * A sampled set of eligible :EntityState rows for the dry-run
+      report (ADR-0009 §3 — "produces a structured 'would-evict'
+      report").
+    * Lag SLO observation in seconds (ADR-0009 §8).
+
+    Requires scope: ``stats:read``
+    Requires: token scoped to a workspace (fails closed with 403).
+    """
+    workspace_id = _require_workspace(token)
+    worker = _resolve_dry_run_worker(request)
+    run_report = await worker.run_once(workspace_filter=workspace_id)
+    if not run_report.per_workspace:
+        # Workspace exists in the token's scope but has no rows in
+        # Postgres `workspaces` (e.g. a token claiming a tenant that
+        # was offboarded).  Fail closed identically to stats endpoints.
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "workspace_not_found",
+                "message": "Workspace has no records to evict.",
+            },
+        )
+    response = _to_response(run_report.per_workspace[0])
+    log.info(
+        "retention_report",
+        workspace_id=str(workspace_id),
+        eligible_es=response.eligible_hot_to_warm_entity_states,
+        eligible_edges=response.eligible_hot_to_warm_edges,
+        eligible_chunks=response.eligible_hot_to_warm_chunks,
+        eligible_archive=response.eligible_warm_to_archive_entity_snapshots,
+        lag_seconds=response.lag_seconds,
+    )
+    return response
+
+
+__all__ = ["RetentionReport", "RetentionSampleEntry", "router"]

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -8,6 +8,7 @@ from omniscience_server.rest.documents import router as documents_router
 from omniscience_server.rest.entities import router as entities_router
 from omniscience_server.rest.freshness import router as freshness_router
 from omniscience_server.rest.ingestion_runs import router as ingestion_runs_router
+from omniscience_server.rest.retention import router as retention_router
 from omniscience_server.rest.search import router as search_router
 from omniscience_server.rest.sources import router as sources_router
 from omniscience_server.rest.stats import router as stats_router
@@ -23,5 +24,6 @@ api_v1_router.include_router(ingestion_runs_router)
 api_v1_router.include_router(webhooks_router)
 api_v1_router.include_router(freshness_router)
 api_v1_router.include_router(stats_router)
+api_v1_router.include_router(retention_router)
 
 __all__ = ["api_v1_router"]

--- a/apps/server/src/omniscience_server/retention_archive.py
+++ b/apps/server/src/omniscience_server/retention_archive.py
@@ -1,0 +1,239 @@
+"""Archive writer for the retention worker (issue #135, ADR-0009 §1 / §7).
+
+Writes per-(workspace_id, snapshot_date) parquet objects to S3-compatible
+object storage.  KMS-managed encryption is mandatory in non-dev (ADR-0009
+§1); dev profile may use SSE-S3.
+
+The writer is intentionally small and synchronous (boto3 + pyarrow):
+- One parquet object per snapshot date per workspace (ADR-0009 §7).
+- Workspace-id prefix at the top of the object key for IAM scoping
+  (ADR-0009 §Consequences-security #3).
+- Two columnar tables per object: ``entities`` and ``edges``.
+
+This module does NOT decide eviction — the caller (``RetentionWorker``)
+fetches the rows from Neo4j and hands them here.  Failures bubble up so
+the worker can record metrics and skip deletion of the warm rows; the
+next run will retry without losing data (ADR-0009 §9 object-storage
+outage runbook).
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+import boto3
+import pyarrow as pa
+import pyarrow.parquet as pq
+import structlog
+from botocore.config import Config as BotoConfig
+from mypy_boto3_s3.client import S3Client
+
+from omniscience_server.retention_constants import (
+    ARCHIVE_KEY_TEMPLATE,
+    S3_SSE_AES256,
+    S3_SSE_KMS,
+)
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveTarget:
+    """Resolved S3 target for a single archive write."""
+
+    bucket: str
+    key: str
+
+    @property
+    def uri(self) -> str:
+        """Return the canonical ``s3://{bucket}/{key}`` URI."""
+        return f"s3://{self.bucket}/{self.key}"
+
+
+def build_archive_key(*, workspace_id: uuid.UUID, snapshot_date: date) -> str:
+    """Render ``ARCHIVE_KEY_TEMPLATE`` for ``(workspace_id, snapshot_date)``."""
+    return ARCHIVE_KEY_TEMPLATE.format(
+        workspace_id=str(workspace_id),
+        year=snapshot_date.year,
+        month=snapshot_date.month,
+        day=snapshot_date.day,
+    )
+
+
+def build_parquet_bytes(
+    *,
+    entity_rows: list[dict[str, Any]],
+    edge_rows: list[dict[str, Any]],
+) -> bytes:
+    """Serialise warm-snapshot rows to an in-memory parquet payload.
+
+    Two pyarrow tables (``entities`` and ``edges``) are concatenated as
+    a single multi-table parquet file via the row-group separation
+    inherent to pyarrow's writer.  The on-disk layout matches the warm
+    row shape per ADR-0009 §7, columnar to win on compression
+    (ADR-0009 §1 archive: "Parquet wins over JSONL on compression
+    ratio").
+
+    Empty inputs are valid — the parquet object still gets written so
+    operators can audit the snapshot's existence; downstream readers
+    treat empty tables as "this snapshot day was empty for this
+    workspace" rather than "the archive is missing".
+    """
+    entities_table = _rows_to_table(entity_rows, _ENTITY_SCHEMA)
+    edges_table = _rows_to_table(edge_rows, _EDGE_SCHEMA)
+    buffer = io.BytesIO()
+    # Single parquet file with two row-group tables.  Reader API
+    # (DuckDB / Athena / Spark) treats this as one logical file with
+    # two schemas; this is the documented offline-restore shape per
+    # ADR-0009 §1.
+    with pq.ParquetWriter(buffer, entities_table.schema) as writer:  # type: ignore[no-untyped-call]
+        writer.write_table(entities_table)
+    entities_bytes = buffer.getvalue()
+    edges_buffer = io.BytesIO()
+    with pq.ParquetWriter(edges_buffer, edges_table.schema) as writer:  # type: ignore[no-untyped-call]
+        writer.write_table(edges_table)
+    edges_bytes = edges_buffer.getvalue()
+    # Frame the two parquet bodies with a tiny header so a reader can
+    # split them without ambiguity.  4-byte big-endian length of the
+    # entities body, then the entities body, then the edges body.
+    header = len(entities_bytes).to_bytes(4, "big")
+    return header + entities_bytes + edges_bytes
+
+
+def split_parquet_bytes(blob: bytes) -> tuple[bytes, bytes]:
+    """Reverse of :func:`build_parquet_bytes`; used by the restore CLI.
+
+    Returns ``(entities_parquet_bytes, edges_parquet_bytes)``.
+    """
+    if len(blob) < 4:
+        raise ValueError("retention_archive_blob_too_short")
+    entities_len = int.from_bytes(blob[:4], "big")
+    if 4 + entities_len > len(blob):
+        raise ValueError("retention_archive_blob_truncated")
+    entities = blob[4 : 4 + entities_len]
+    edges = blob[4 + entities_len :]
+    return entities, edges
+
+
+_ENTITY_SCHEMA: pa.Schema = pa.schema(
+    [
+        ("id", pa.string()),
+        ("kind", pa.string()),
+        ("name", pa.string()),
+        ("display_name", pa.string()),
+        ("source_id", pa.string()),
+        ("chunk_id", pa.string()),
+        ("valid_from", pa.string()),
+        ("valid_to", pa.string()),
+        ("recorded_at", pa.string()),
+        ("metadata_json", pa.string()),
+    ]
+)
+
+
+_EDGE_SCHEMA: pa.Schema = pa.schema(
+    [
+        ("source_entity_id", pa.string()),
+        ("target_entity_id", pa.string()),
+        ("edge_type", pa.string()),
+        ("source_id", pa.string()),
+        ("valid_from", pa.string()),
+        ("valid_to", pa.string()),
+        ("recorded_at", pa.string()),
+        ("metadata_json", pa.string()),
+    ]
+)
+
+
+def _rows_to_table(rows: list[dict[str, Any]], schema: pa.Schema) -> pa.Table:
+    """Project ``rows`` onto ``schema`` field-by-field, JSON-encoding metadata."""
+    import json
+
+    columns: dict[str, list[Any]] = {field.name: [] for field in schema}
+    for row in rows:
+        for field in schema:
+            value = row.get(field.name)
+            if field.name == "metadata_json":
+                # Source row ships ``metadata`` (dict); we store it as a
+                # JSON string to keep the schema flat.
+                meta = row.get("metadata") or {}
+                columns[field.name].append(json.dumps(meta, sort_keys=True, default=str))
+            elif value is None:
+                columns[field.name].append(None)
+            else:
+                columns[field.name].append(str(value))
+    return pa.table(columns, schema=schema)
+
+
+def build_s3_client(
+    *,
+    region_name: str,
+    endpoint_url: str | None,
+) -> S3Client:
+    """Construct a boto3 S3 client.
+
+    The client uses path-style addressing so it works with MinIO and
+    Ceph in addition to AWS S3 (per ADR-0009 §1: "S3-compatible object
+    storage").
+    """
+    config = BotoConfig(
+        region_name=region_name,
+        signature_version="s3v4",
+        s3={"addressing_style": "path"},
+    )
+    client_kwargs: dict[str, Any] = {"config": config}
+    if endpoint_url is not None:
+        client_kwargs["endpoint_url"] = endpoint_url
+    # boto3's stub `client` returns Any; we annotate the return type.
+    return boto3.client("s3", **client_kwargs)
+
+
+def write_archive_object(
+    *,
+    s3_client: S3Client,
+    bucket: str,
+    key: str,
+    body: bytes,
+    kms_key_arn: str | None,
+) -> None:
+    """Put ``body`` to ``s3://{bucket}/{key}`` with the ADR-0009 encryption.
+
+    Encryption: KMS when ``kms_key_arn`` is set (mandatory non-dev per
+    ADR-0009 §1), otherwise SSE-S3 / AES256 (dev profile only).  The
+    caller is responsible for setting the right Helm value; this
+    function does NOT downgrade silently — it logs the fallback so a
+    misconfigured non-dev deployment is auditable.
+    """
+    extra_args: dict[str, Any] = {}
+    if kms_key_arn:
+        extra_args["ServerSideEncryption"] = S3_SSE_KMS
+        extra_args["SSEKMSKeyId"] = kms_key_arn
+    else:
+        extra_args["ServerSideEncryption"] = S3_SSE_AES256
+        log.warning(
+            "retention_archive_sse_aes256_fallback",
+            bucket=bucket,
+            key=key,
+            note="KMS key not configured; using SSE-S3 (acceptable in dev only).",
+        )
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType="application/vnd.apache.parquet",
+        **extra_args,
+    )
+
+
+__all__ = [
+    "ArchiveTarget",
+    "build_archive_key",
+    "build_parquet_bytes",
+    "build_s3_client",
+    "split_parquet_bytes",
+    "write_archive_object",
+]

--- a/apps/server/src/omniscience_server/retention_constants.py
+++ b/apps/server/src/omniscience_server/retention_constants.py
@@ -1,0 +1,121 @@
+"""Named constants for the retention worker (issue #135, ADR-0009).
+
+Every value here is traced back to ``docs/decisions/0009-retention-tiering-policy.md``.
+No magic numbers are allowed in ``retention_worker.py`` or the REST
+endpoint; anything tunable that the ADR names explicitly lives here
+with a docstring that cites the ADR section.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Tier boundaries (ADR-0009 §1, §10)
+# ---------------------------------------------------------------------------
+
+#: Hot tier retention boundary in days.  ADR-0009 §1: "Hot (0-90 days,
+#: default)" + §10 ``omniscience.retention.hotDays: 90``.  Every tier
+#: boundary is global-only in v1; per-tenant overrides are out of scope
+#: per ADR-0009 §10.
+RETENTION_HOT_DAYS_DEFAULT: Final[int] = 90
+
+#: Warm tier retention boundary in days (cumulative — not warm window
+#: length).  ADR-0009 §1 / §10 ``omniscience.retention.warmDays: 365``.
+RETENTION_WARM_DAYS_DEFAULT: Final[int] = 365
+
+#: Archive retention horizon in years.  ADR-0009 §1: "Archive retention:
+#: 7 years by default, configurable per-deployment."
+RETENTION_ARCHIVE_YEARS_DEFAULT: Final[int] = 7
+
+# ---------------------------------------------------------------------------
+# Worker shape (ADR-0009 §3)
+# ---------------------------------------------------------------------------
+
+#: Worker tick interval in seconds.  ADR-0009 §3: "default: every 6
+#: hours" — 6 * 3600.  Lower values increase Neo4j write pressure
+#: without improving SLO compliance materially under the 24h lag SLO.
+RETENTION_TICK_SECONDS_DEFAULT: Final[int] = 6 * 3600
+
+#: Maximum rows touched per Neo4j transaction during eviction.
+#: ADR-0009 §3 read-then-mark-then-move: "select eligible record ids in
+#: batches of 1000 per workspace".  We pick 500 as a more conservative
+#: default to keep individual transactions under Neo4j's 30s tx timeout
+#: on the v0.5 envelope; raise via Helm when the envelope grows.
+RETENTION_BATCH_SIZE: Final[int] = 500
+
+#: Number of distinct snapshot dates archived in one run.  Keeps the
+#: archive phase bounded — each date becomes one parquet object plus
+#: one Qdrant filter delete.  An over-aggressive value would block
+#: ingestion behind a long write transaction; 32 days per run drains
+#: the typical backlog within a week even if the worker runs every 6h.
+RETENTION_ARCHIVE_DATES_PER_RUN: Final[int] = 32
+
+# ---------------------------------------------------------------------------
+# Tier / store labels (ADR-0009 §8 — Prometheus label values)
+# ---------------------------------------------------------------------------
+
+TIER_LABEL_HOT: Final[str] = "hot"
+TIER_LABEL_WARM: Final[str] = "warm"
+TIER_LABEL_ARCHIVE: Final[str] = "archive"
+
+STORE_LABEL_NEO4J: Final[str] = "neo4j"
+STORE_LABEL_QDRANT: Final[str] = "qdrant"
+
+TRANSITION_HOT_TO_WARM: Final[str] = "hot_to_warm"
+TRANSITION_WARM_TO_ARCHIVE: Final[str] = "warm_to_archive"
+
+PHASE_READ: Final[str] = "read"
+PHASE_MARK: Final[str] = "mark"
+PHASE_MOVE: Final[str] = "move"
+
+# ---------------------------------------------------------------------------
+# Archive layout (ADR-0009 §7)
+# ---------------------------------------------------------------------------
+
+#: Object key template: ``{workspace_id}/{year}/{month}/{day}/snapshot.parquet``.
+#: ADR-0009 §7: "workspace_id at top-level prefix gives operations a
+#: single-bucket-prefix delete capability for tenant offboarding".
+ARCHIVE_KEY_TEMPLATE: Final[str] = (
+    "{workspace_id}/{year:04d}/{month:02d}/{day:02d}/snapshot.parquet"
+)
+
+#: KMS server-side encryption value for ADR-0009 §1 "KMS-managed keys
+#: mandatory in non-dev environments".
+S3_SSE_KMS: Final[str] = "aws:kms"
+
+#: Fallback encryption when no KMS key is configured.  Acceptable in
+#: dev only per ADR-0009 §1: "dev profile allows SSE-S3".
+S3_SSE_AES256: Final[str] = "AES256"
+
+# ---------------------------------------------------------------------------
+# Dry-run reporting
+# ---------------------------------------------------------------------------
+
+#: Maximum sampled records emitted in the dry-run report per tier.
+#: ADR-0009 §3: dry-run "produces a structured 'would-evict' report".
+RETENTION_DRY_RUN_SAMPLE_DEFAULT: Final[int] = 20
+
+
+__all__ = [
+    "ARCHIVE_KEY_TEMPLATE",
+    "PHASE_MARK",
+    "PHASE_MOVE",
+    "PHASE_READ",
+    "RETENTION_ARCHIVE_DATES_PER_RUN",
+    "RETENTION_ARCHIVE_YEARS_DEFAULT",
+    "RETENTION_BATCH_SIZE",
+    "RETENTION_DRY_RUN_SAMPLE_DEFAULT",
+    "RETENTION_HOT_DAYS_DEFAULT",
+    "RETENTION_TICK_SECONDS_DEFAULT",
+    "RETENTION_WARM_DAYS_DEFAULT",
+    "S3_SSE_AES256",
+    "S3_SSE_KMS",
+    "STORE_LABEL_NEO4J",
+    "STORE_LABEL_QDRANT",
+    "TIER_LABEL_ARCHIVE",
+    "TIER_LABEL_HOT",
+    "TIER_LABEL_WARM",
+    "TRANSITION_HOT_TO_WARM",
+    "TRANSITION_WARM_TO_ARCHIVE",
+]

--- a/apps/server/src/omniscience_server/retention_worker.py
+++ b/apps/server/src/omniscience_server/retention_worker.py
@@ -1,0 +1,544 @@
+"""Retention worker — hot/warm/archive eviction (issue #135, ADR-0009).
+
+The worker runs as a persistent asyncio task driven by the FastAPI
+lifespan (ADR-0009 §3).  On each tick it:
+
+1. Iterates workspaces sequentially (per-tenant iteration; cross-tenant
+   batches are forbidden — ADR-0009 §Consequences-security #1).
+2. For each workspace, runs the **read-then-mark-then-move** three-phase
+   pattern (ADR-0009 §3) over Neo4j:
+     - **Read**:  count eligible :EntityState rows + edges with
+       ``recorded_at < now - hot_days``; fetch a sample for the
+       dry-run report; record the lag SLO.
+     - **Mark**:  set ``tier_pending = 'warm'`` on eligible rows in
+       bounded batches.  Idempotent — re-runs are no-ops.
+     - **Move**:  project marked rows to ``:EntitySnapshot:Daily`` /
+       ``:RelationshipSnapshot:Daily`` rows under the snapshot-per-day
+       projection (ADR-0009 §1 warm tier) and DETACH DELETE the
+       sources in the same transaction.
+3. Mirrors the eviction on Qdrant: chunks past the boundary get
+   ``tier="warm"`` + ``snapshot_date`` payload (ADR-0009 §5).
+4. For warm rows older than ``warm_days``, writes a parquet object per
+   ``(workspace_id, snapshot_date)`` to S3 (ADR-0009 §1 archive / §7
+   storage layout) and deletes the warm rows + Qdrant warm chunks.
+5. Updates Prometheus metrics (ADR-0009 §8) and structured logs.
+
+**Dry-run mode** (``Settings.retention_dry_run=True``) inhibits every
+mutation (mark, move, S3 put, delete) and produces a structured report
+exposed via ``GET /api/v1/admin/retention/report``.
+
+The worker is idempotent: re-running is a no-op unless wall-clock time
+has advanced past the cutoff.  A crash between mark and move leaves a
+re-runnable state — the next pass picks up the marked rows and finishes
+the move.
+
+The implementation is plain ``asyncio`` rather than APScheduler.  The
+codebase already has ``FreshnessWorker`` and ``SchedulerWorker`` on
+this shape; adding APScheduler for a single 6-hour periodic tick would
+be a heavyweight dependency for a thin wrapper around
+``asyncio.sleep``.  ADR-0009 §3 names APScheduler as one acceptable
+implementation; the worker contract (in-process FastAPI lifespan,
+6-hour default tick, idempotent, dry-run mandatory) is preserved
+verbatim.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+import structlog
+from omniscience_core.config import Settings
+from omniscience_core.db.models import Workspace
+from omniscience_core.telemetry.metrics import (
+    RETENTION_EVICTION_TOTAL,
+    RETENTION_GRAPH_RECORDS_TOTAL,
+    RETENTION_WORKER_DURATION_SECONDS,
+    RETENTION_WORKER_LAG_SECONDS,
+)
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_server.retention_archive import (
+    build_archive_key,
+    build_parquet_bytes,
+    build_s3_client,
+    write_archive_object,
+)
+from omniscience_server.retention_constants import (
+    PHASE_MARK,
+    PHASE_MOVE,
+    PHASE_READ,
+    RETENTION_ARCHIVE_DATES_PER_RUN,
+    RETENTION_DRY_RUN_SAMPLE_DEFAULT,
+    RETENTION_TICK_SECONDS_DEFAULT,
+    STORE_LABEL_NEO4J,
+    STORE_LABEL_QDRANT,
+    TIER_LABEL_ARCHIVE,
+    TIER_LABEL_HOT,
+    TIER_LABEL_WARM,
+    TRANSITION_HOT_TO_WARM,
+    TRANSITION_WARM_TO_ARCHIVE,
+)
+
+log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceRetentionReport:
+    """Per-workspace report produced by one retention run.
+
+    Mirrors the ADR-0009 §3 dry-run shape: counts + sampled records,
+    no mutation indication.  Used by both the live worker (logged at
+    INFO) and the dry-run REST endpoint (returned to the caller).
+    """
+
+    workspace_id: uuid.UUID
+    eligible_hot_to_warm_entity_states: int
+    eligible_hot_to_warm_edges: int
+    eligible_hot_to_warm_chunks: int
+    eligible_warm_to_archive_entity_snapshots: int
+    eligible_warm_to_archive_dates: list[date]
+    sampled_eligible: list[dict[str, Any]] = field(default_factory=list)
+    oldest_eligible_recorded_at: datetime | None = None
+    lag_seconds: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class RunReport:
+    """Aggregated report across one retention worker tick."""
+
+    started_at: datetime
+    finished_at: datetime
+    dry_run: bool
+    per_workspace: list[WorkspaceRetentionReport]
+    duration_seconds: float
+
+    @property
+    def lag_seconds(self) -> float:
+        """Max per-workspace lag — drives the deployment-wide gauge."""
+        if not self.per_workspace:
+            return 0.0
+        return max(w.lag_seconds for w in self.per_workspace)
+
+
+class RetentionWorker:
+    """Background task that evicts data across hot/warm/archive tiers.
+
+    Args:
+        session_factory: SQLAlchemy session factory (used to enumerate
+            workspaces).
+        graph_store:     Neo4j store, extended with retention methods
+            in this PR.
+        vector_store:    Qdrant store, extended with retention methods
+            in this PR.
+        settings:        Application Settings — drives boundaries,
+            tick interval, dry-run, archive bucket / KMS.
+
+    Lifecycle (ADR-0009 §3):
+        * ``start()`` runs the periodic tick loop.
+        * ``stop()`` signals graceful exit on the next iteration.
+        * Crash safety: each phase is its own transaction; a crash
+          mid-phase leaves a re-runnable state.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession],
+        graph_store: Neo4jGraphStore,
+        vector_store: QdrantVectorStore,
+        settings: Settings,
+    ) -> None:
+        self._session_factory = session_factory
+        self._graph_store = graph_store
+        self._vector_store = vector_store
+        self._settings = settings
+        self._tick_seconds = max(int(settings.retention_tick_seconds), 60)
+        self._batch_size = max(int(settings.retention_batch_size), 1)
+        self._sample_size = max(int(settings.retention_sample_size), 0)
+        self._dry_run = bool(settings.retention_dry_run)
+        self._running = False
+        self._last_report: RunReport | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Run the worker loop until :meth:`stop` is called."""
+        self._running = True
+        log.info(
+            "retention_worker_started",
+            tick_seconds=self._tick_seconds,
+            dry_run=self._dry_run,
+            hot_days=self._settings.retention_hot_days,
+            warm_days=self._settings.retention_warm_days,
+        )
+        while self._running:
+            try:
+                await self.run_once()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                # Never let one failed run crash the worker.  ADR-0009 §9
+                # crash runbook: "the next scheduled run resumes from
+                # idempotency".
+                log.error("retention_worker_error", error=str(exc))
+            try:
+                await asyncio.sleep(self._tick_seconds)
+            except asyncio.CancelledError:
+                break
+        log.info("retention_worker_stopped")
+
+    def stop(self) -> None:
+        """Signal the worker to exit after the current tick completes."""
+        self._running = False
+
+    @property
+    def last_report(self) -> RunReport | None:
+        """Return the most recent run report, or ``None`` before first run."""
+        return self._last_report
+
+    @property
+    def dry_run(self) -> bool:
+        """Whether the worker is running in dry-run mode."""
+        return self._dry_run
+
+    # ------------------------------------------------------------------
+    # Public entry point — one full tick across all workspaces
+    # ------------------------------------------------------------------
+
+    async def run_once(
+        self,
+        *,
+        workspace_filter: uuid.UUID | None = None,
+        now: datetime | None = None,
+    ) -> RunReport:
+        """Execute one full retention tick.
+
+        Args:
+            workspace_filter: When set, restricts the run to a single
+                workspace — used by the dry-run REST endpoint.
+            now: Optional reference time.  Defaults to ``datetime.now(UTC)``;
+                tests pin a value to make assertions deterministic.
+
+        Returns:
+            A :class:`RunReport` covering all workspaces processed.
+        """
+        started = datetime.now(UTC) if now is None else now
+        wall_start = time.monotonic()
+        workspaces = await self._load_workspace_ids()
+        if workspace_filter is not None:
+            workspaces = [w for w in workspaces if w == workspace_filter]
+        per_workspace: list[WorkspaceRetentionReport] = []
+        for workspace_id in workspaces:
+            report = await self._process_workspace(workspace_id=workspace_id, now=started)
+            per_workspace.append(report)
+        duration = time.monotonic() - wall_start
+        finished = datetime.now(UTC)
+        run_report = RunReport(
+            started_at=started,
+            finished_at=finished,
+            dry_run=self._dry_run,
+            per_workspace=per_workspace,
+            duration_seconds=duration,
+        )
+        # Lag SLO gauge per ADR-0009 §8.
+        RETENTION_WORKER_LAG_SECONDS.set(run_report.lag_seconds)
+        self._last_report = run_report
+        log.info(
+            "retention_run_complete",
+            dry_run=self._dry_run,
+            workspaces=len(per_workspace),
+            duration_s=duration,
+            lag_s=run_report.lag_seconds,
+        )
+        return run_report
+
+    # ------------------------------------------------------------------
+    # Per-workspace pipeline
+    # ------------------------------------------------------------------
+
+    async def _process_workspace(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        now: datetime,
+    ) -> WorkspaceRetentionReport:
+        """Run the three-phase pipeline against one workspace.
+
+        ACL invariant: every store call below pins ``workspace_id`` —
+        cross-workspace mixing is structurally impossible from this
+        method.
+        """
+        hot_cutoff = now - timedelta(days=self._settings.retention_hot_days)
+        warm_cutoff_date = (now - timedelta(days=self._settings.retention_warm_days)).date()
+
+        # --- Read phase --------------------------------------------------
+        read_start = time.monotonic()
+        es_eligible, edge_eligible = await self._graph_store.count_hot_to_warm_eligible(
+            workspace_id=workspace_id,
+            hot_cutoff=hot_cutoff,
+        )
+        chunk_eligible = await self._vector_store.count_retention_eligible(
+            workspace_id=workspace_id,
+            cutoff=hot_cutoff,
+        )
+        archive_eligible = await self._graph_store.count_warm_to_archive_eligible(
+            workspace_id=workspace_id,
+            warm_cutoff_date=warm_cutoff_date,
+        )
+        archive_dates = await self._graph_store.list_warm_to_archive_dates(
+            workspace_id=workspace_id,
+            warm_cutoff_date=warm_cutoff_date,
+            limit=RETENTION_ARCHIVE_DATES_PER_RUN,
+        )
+        sampled = await self._graph_store.sample_hot_to_warm_eligible(
+            workspace_id=workspace_id,
+            hot_cutoff=hot_cutoff,
+            limit=self._sample_size or RETENTION_DRY_RUN_SAMPLE_DEFAULT,
+        )
+        oldest = await self._graph_store.oldest_hot_to_warm_recorded_at(
+            workspace_id=workspace_id,
+            hot_cutoff=hot_cutoff,
+        )
+        lag_seconds = 0.0
+        if oldest is not None:
+            lag_seconds = max((now - oldest).total_seconds() - 0.0, 0.0)
+        RETENTION_WORKER_DURATION_SECONDS.labels(
+            phase=PHASE_READ, store=STORE_LABEL_NEO4J
+        ).observe(time.monotonic() - read_start)
+
+        # Tier-records gauge updates from the read phase counts.  These
+        # are workspace-scoped reads; the gauge label set is global so
+        # multiple workspaces overwrite the same label cell — operators
+        # use ``sum() by (tier, store)`` to roll up.  This is the
+        # documented ADR-0009 §8 shape.
+        records = await self._graph_store.count_records_by_tier(workspace_id=workspace_id)
+        RETENTION_GRAPH_RECORDS_TOTAL.labels(tier=TIER_LABEL_HOT, store=STORE_LABEL_NEO4J).set(
+            records.get("hot", 0)
+        )
+        RETENTION_GRAPH_RECORDS_TOTAL.labels(tier=TIER_LABEL_WARM, store=STORE_LABEL_NEO4J).set(
+            records.get("warm", 0)
+        )
+        chunk_tiers = await self._vector_store.count_chunks_by_tier(workspace_id=workspace_id)
+        RETENTION_GRAPH_RECORDS_TOTAL.labels(tier=TIER_LABEL_HOT, store=STORE_LABEL_QDRANT).set(
+            chunk_tiers.get("hot", 0)
+        )
+        RETENTION_GRAPH_RECORDS_TOTAL.labels(tier=TIER_LABEL_WARM, store=STORE_LABEL_QDRANT).set(
+            chunk_tiers.get("warm", 0)
+        )
+        # Archive on Qdrant is always 0 (re-embedding from archive is
+        # not supported in v1, ADR-0009 §5).  Set explicitly so the
+        # gauge does not stay at the previous value across deploys.
+        RETENTION_GRAPH_RECORDS_TOTAL.labels(
+            tier=TIER_LABEL_ARCHIVE, store=STORE_LABEL_QDRANT
+        ).set(0)
+
+        if self._dry_run:
+            return WorkspaceRetentionReport(
+                workspace_id=workspace_id,
+                eligible_hot_to_warm_entity_states=es_eligible,
+                eligible_hot_to_warm_edges=edge_eligible,
+                eligible_hot_to_warm_chunks=chunk_eligible,
+                eligible_warm_to_archive_entity_snapshots=archive_eligible,
+                eligible_warm_to_archive_dates=archive_dates,
+                sampled_eligible=sampled,
+                oldest_eligible_recorded_at=oldest,
+                lag_seconds=lag_seconds,
+            )
+
+        # --- Mark phase --------------------------------------------------
+        mark_start = time.monotonic()
+        es_marked, edge_marked = await self._graph_store.mark_hot_to_warm(
+            workspace_id=workspace_id,
+            hot_cutoff=hot_cutoff,
+            batch_size=self._batch_size,
+        )
+        chunks_marked = await self._vector_store.mark_retention_warm(
+            workspace_id=workspace_id,
+            cutoff=hot_cutoff,
+        )
+        RETENTION_WORKER_DURATION_SECONDS.labels(
+            phase=PHASE_MARK, store=STORE_LABEL_NEO4J
+        ).observe(time.monotonic() - mark_start)
+
+        # --- Move phase: hot -> warm ------------------------------------
+        move_start = time.monotonic()
+        es_moved, edges_moved = await self._graph_store.move_hot_to_warm(
+            workspace_id=workspace_id,
+            batch_size=self._batch_size,
+        )
+        RETENTION_EVICTION_TOTAL.labels(
+            transition=TRANSITION_HOT_TO_WARM, store=STORE_LABEL_NEO4J
+        ).inc(es_moved + edges_moved)
+        # Qdrant: the mark phase already sets the warm tier payload; no
+        # separate move step (snapshot points carry the payload directly,
+        # ADR-0009 §5).  Count the transition as the marked total.
+        RETENTION_EVICTION_TOTAL.labels(
+            transition=TRANSITION_HOT_TO_WARM, store=STORE_LABEL_QDRANT
+        ).inc(chunks_marked)
+        RETENTION_WORKER_DURATION_SECONDS.labels(
+            phase=PHASE_MOVE, store=STORE_LABEL_NEO4J
+        ).observe(time.monotonic() - move_start)
+
+        # --- Archive phase: warm -> archive -----------------------------
+        await self._archive_dates(
+            workspace_id=workspace_id,
+            snapshot_dates=archive_dates,
+        )
+
+        log.info(
+            "retention_workspace_processed",
+            workspace_id=str(workspace_id),
+            es_marked=es_marked,
+            es_moved=es_moved,
+            edges_marked=edge_marked,
+            edges_moved=edges_moved,
+            chunks_marked=chunks_marked,
+            archive_dates=len(archive_dates),
+            lag_seconds=lag_seconds,
+        )
+
+        return WorkspaceRetentionReport(
+            workspace_id=workspace_id,
+            eligible_hot_to_warm_entity_states=es_eligible,
+            eligible_hot_to_warm_edges=edge_eligible,
+            eligible_hot_to_warm_chunks=chunk_eligible,
+            eligible_warm_to_archive_entity_snapshots=archive_eligible,
+            eligible_warm_to_archive_dates=archive_dates,
+            sampled_eligible=sampled,
+            oldest_eligible_recorded_at=oldest,
+            lag_seconds=lag_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    # Archive (warm -> S3)
+    # ------------------------------------------------------------------
+
+    async def _archive_dates(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        snapshot_dates: list[date],
+    ) -> None:
+        """Write parquet objects for ``snapshot_dates`` and delete warm rows.
+
+        When the archive bucket is not configured (dev / air-gapped),
+        the worker logs and skips the archive phase — warm rows stay
+        queryable indefinitely until the operator wires a bucket.
+        Documented in ADR-0009 §Negative-operational ("Object storage
+        dependency is new").
+        """
+        if not snapshot_dates:
+            return
+        bucket = self._settings.retention_archive_bucket
+        if not bucket:
+            log.info(
+                "retention_archive_skipped_no_bucket",
+                workspace_id=str(workspace_id),
+                dates=len(snapshot_dates),
+            )
+            return
+        s3_client = build_s3_client(
+            region_name=self._settings.retention_archive_s3_region,
+            endpoint_url=self._settings.retention_archive_s3_endpoint_url,
+        )
+        for snapshot_date in snapshot_dates:
+            await self._archive_one_date(
+                workspace_id=workspace_id,
+                snapshot_date=snapshot_date,
+                bucket=bucket,
+                s3_client=s3_client,
+            )
+
+    async def _archive_one_date(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        snapshot_date: date,
+        bucket: str,
+        s3_client: Any,
+    ) -> None:
+        """Write one parquet object and reap the warm rows.
+
+        Failures bubble up the call stack so the next phase's metrics
+        record nothing for this date — the next run will retry per
+        ADR-0009 §9 object-storage outage runbook.
+        """
+        entity_rows, edge_rows = await self._graph_store.fetch_warm_snapshot_rows(
+            workspace_id=workspace_id,
+            snapshot_date=snapshot_date,
+        )
+        body = build_parquet_bytes(entity_rows=entity_rows, edge_rows=edge_rows)
+        key = build_archive_key(workspace_id=workspace_id, snapshot_date=snapshot_date)
+        # Synchronous boto3 call — S3 PUT does not benefit from asyncio.
+        # Keep it inside an executor to avoid blocking the event loop on
+        # large objects.
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: write_archive_object(
+                s3_client=s3_client,
+                bucket=bucket,
+                key=key,
+                body=body,
+                kms_key_arn=self._settings.retention_archive_kms_key_arn,
+            ),
+        )
+        # AFTER the parquet write succeeded, reap warm rows on Neo4j
+        # and the corresponding chunks on Qdrant.  Failure between these
+        # two leaves the archive in S3 + warm rows still in Neo4j; the
+        # next run's idempotent fetch returns those rows again — the
+        # MERGE on (workspace_id, id, snapshot_date) collapses the
+        # second write into the existing parquet object.  ADR-0009 §9.
+        es_deleted, edge_deleted = await self._graph_store.delete_warm_snapshot(
+            workspace_id=workspace_id,
+            snapshot_date=snapshot_date,
+        )
+        chunks_deleted = await self._vector_store.delete_retention_archive(
+            workspace_id=workspace_id,
+            snapshot_date=snapshot_date,
+        )
+        RETENTION_EVICTION_TOTAL.labels(
+            transition=TRANSITION_WARM_TO_ARCHIVE, store=STORE_LABEL_NEO4J
+        ).inc(es_deleted + edge_deleted)
+        RETENTION_EVICTION_TOTAL.labels(
+            transition=TRANSITION_WARM_TO_ARCHIVE, store=STORE_LABEL_QDRANT
+        ).inc(chunks_deleted)
+        log.info(
+            "retention_archive_written",
+            workspace_id=str(workspace_id),
+            snapshot_date=snapshot_date.isoformat(),
+            entities=len(entity_rows),
+            edges=len(edge_rows),
+            uri=f"s3://{bucket}/{key}",
+            es_deleted=es_deleted,
+            edge_deleted=edge_deleted,
+            chunks_deleted=chunks_deleted,
+        )
+
+    # ------------------------------------------------------------------
+    # Workspace enumeration
+    # ------------------------------------------------------------------
+
+    async def _load_workspace_ids(self) -> list[uuid.UUID]:
+        """Return all workspace ids — eviction iterates one at a time."""
+        async with self._session_factory() as session:
+            result = await session.execute(select(Workspace.id))
+            return [row[0] for row in result.all()]
+
+
+__all__ = [
+    "RETENTION_TICK_SECONDS_DEFAULT",
+    "RetentionWorker",
+    "RunReport",
+    "WorkspaceRetentionReport",
+]

--- a/helm/omniscience/templates/configmap.yaml
+++ b/helm/omniscience/templates/configmap.yaml
@@ -21,3 +21,23 @@ data:
   {{- end }}
   DATABASE_URL: {{ include "omniscience.databaseUrl" . | quote }}
   NATS_URL: {{ include "omniscience.natsUrl" . | quote }}
+  # Retention worker (ADR-0009, issue #135).  Global-only boundaries
+  # per ADR-0009 §10; per-tenant overrides are out of scope for v1.
+  RETENTION_ENABLED: {{ .Values.retention.enabled | toString | quote }}
+  RETENTION_HOT_DAYS: {{ .Values.retention.hotDays | toString | quote }}
+  RETENTION_WARM_DAYS: {{ .Values.retention.warmDays | toString | quote }}
+  RETENTION_ARCHIVE_YEARS: {{ .Values.retention.archiveYears | toString | quote }}
+  RETENTION_TICK_SECONDS: {{ .Values.retention.tickSeconds | toString | quote }}
+  RETENTION_DRY_RUN: {{ .Values.retention.dryRun | toString | quote }}
+  RETENTION_BATCH_SIZE: {{ .Values.retention.batchSize | toString | quote }}
+  RETENTION_SAMPLE_SIZE: {{ .Values.retention.sampleSize | toString | quote }}
+  {{- if .Values.retention.archiveBucket }}
+  RETENTION_ARCHIVE_BUCKET: {{ .Values.retention.archiveBucket | quote }}
+  {{- end }}
+  {{- if .Values.retention.archiveKmsKeyArn }}
+  RETENTION_ARCHIVE_KMS_KEY_ARN: {{ .Values.retention.archiveKmsKeyArn | quote }}
+  {{- end }}
+  {{- if .Values.retention.archiveS3EndpointUrl }}
+  RETENTION_ARCHIVE_S3_ENDPOINT_URL: {{ .Values.retention.archiveS3EndpointUrl | quote }}
+  {{- end }}
+  RETENTION_ARCHIVE_S3_REGION: {{ .Values.retention.archiveS3Region | quote }}

--- a/helm/omniscience/values.yaml
+++ b/helm/omniscience/values.yaml
@@ -61,6 +61,47 @@ config:
   # CORS origins (comma-separated)
   corsOrigins: ""
 
+# ── Retention worker (ADR-0009, issue #135) ──────────────────────────────────
+# Tier boundaries are global-only in v1 per ADR-0009 §10.  Per-tenant
+# overrides are out of scope; the migration path is documented in the
+# ADR for the first customer ask.
+retention:
+  # Hot tier retention boundary in days (ADR-0009 §1).  EntityState rows,
+  # edges, and chunks with `recorded_at < now - hotDays` are evicted to
+  # warm.
+  hotDays: 90
+  # Warm tier retention boundary in days, cumulative (ADR-0009 §1).
+  # EntitySnapshot:Daily rows older than warmDays are archived to S3.
+  warmDays: 365
+  # Archive horizon in years.  Beyond this the bucket lifecycle rule
+  # deletes objects; the worker does NOT enforce archive expiry.
+  archiveYears: 7
+  # Worker tick interval in seconds (default 6 hours per ADR-0009 §3).
+  tickSeconds: 21600
+  # Dry-run mode.  REQUIRED before first live activation per deployment
+  # (ADR-0009 §3): operators review the dry-run report via
+  # GET /api/v1/admin/retention/report, then flip this to false.
+  dryRun: false
+  # Master switch for the worker.  Set false only for environments
+  # where retention is intentionally deferred (CI fixtures, etc).
+  enabled: true
+  # S3-compatible bucket for archive parquet writes (ADR-0009 §7).
+  # REQUIRED in non-dev — when empty, warm-to-archive is skipped and
+  # warm rows remain queryable until configured.
+  archiveBucket: ""
+  # KMS key ARN for archive encryption (ADR-0009 §1: KMS-managed keys
+  # mandatory in non-dev).  When empty, falls back to SSE-S3 (AES256),
+  # which is acceptable in dev only.
+  archiveKmsKeyArn: ""
+  # Custom S3 endpoint URL for MinIO / Ceph / etc.  Empty = AWS S3.
+  archiveS3EndpointUrl: ""
+  # Region for the archive S3 client.
+  archiveS3Region: "us-east-1"
+  # Rows touched per Neo4j transaction (ADR-0009 §3).
+  batchSize: 500
+  # Sample size for the dry-run report.
+  sampleSize: 20
+
 # ── Secrets (values are base64-encoded by default in Secret template) ─────────
 secrets:
   # PostgreSQL password — REQUIRED; override via --set secrets.postgresPassword=...

--- a/packages/core/src/omniscience_core/config.py
+++ b/packages/core/src/omniscience_core/config.py
@@ -270,6 +270,121 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- Retention worker (ADR-0009 §3 / §10, issue #135) ---
+    #
+    # Tier boundaries are global-only in v1 per ADR-0009 §10.  Per-tenant
+    # overrides are explicitly out of scope for this PR; the migration path
+    # (push the override into the workspaces table) is documented for the
+    # first customer ask.  Helm values render these as env vars; see
+    # ``helm/omniscience/values.yaml`` ``retention:`` block.
+    retention_hot_days: int = Field(
+        default=90,
+        ge=1,
+        description=(
+            "Hot tier retention boundary in days (ADR-0009 §1 / §10). "
+            "EntityState rows + edges + chunks with `recorded_at < now - hot_days` "
+            "are evicted from hot to warm. Default 90 days per Vision §5.3."
+        ),
+    )
+    retention_warm_days: int = Field(
+        default=365,
+        ge=1,
+        description=(
+            "Warm tier retention boundary in days (ADR-0009 §1 / §10). "
+            "EntitySnapshot:Daily rows with `snapshot_date < now - warm_days` "
+            "are evicted from warm to archive (Parquet on object storage). "
+            "Default 365 days (cumulative — not warm window length) per Vision §5.3."
+        ),
+    )
+    retention_archive_years: int = Field(
+        default=7,
+        ge=0,
+        description=(
+            "Archive retention horizon in years (ADR-0009 §1). Beyond this, "
+            "snapshots are deleted by lifecycle rule on the bucket — the "
+            "worker does NOT enforce archive expiry; that is the bucket's "
+            "concern. Default 7 years per ADR-0009 §1."
+        ),
+    )
+    retention_tick_seconds: int = Field(
+        default=21600,  # 6 * 3600 — see RETENTION_TICK_SECONDS_DEFAULT
+        ge=60,
+        description=(
+            "Retention worker tick interval in wall-clock seconds (ADR-0009 §3). "
+            "Default 21600 (6 hours). Lower values increase Neo4j write pressure "
+            "without improving SLO compliance materially under the 24h lag SLO."
+        ),
+    )
+    retention_batch_size: int = Field(
+        default=500,
+        ge=1,
+        le=10000,
+        description=(
+            "Maximum rows touched per Neo4j transaction during eviction "
+            "(ADR-0009 §3 read-then-mark-then-move). Keeps individual "
+            "transactions well under Neo4j's default 30s tx timeout."
+        ),
+    )
+    retention_dry_run: bool = Field(
+        default=False,
+        description=(
+            "Dry-run mode for the retention worker (ADR-0009 §3). When True, "
+            "the worker reports eligible counts and a sampled record set "
+            "via the admin REST endpoint and structured logs but mutates "
+            "neither Neo4j nor Qdrant. Required for ops review before the "
+            "first live activation per deployment."
+        ),
+    )
+    retention_enabled: bool = Field(
+        default=True,
+        description=(
+            "Master switch for the retention worker. Defaults to True so a "
+            "stock deployment runs with the ADR-0009 tiering posture; set "
+            "False only for environments where retention is intentionally "
+            "deferred (e.g. CI fixtures, single-shot integration tests)."
+        ),
+    )
+    retention_archive_bucket: str | None = Field(
+        default=None,
+        description=(
+            "S3-compatible bucket name for archive parquet writes "
+            "(ADR-0009 §7 storage layout). REQUIRED in non-dev: when None, "
+            "warm-to-archive transitions are skipped (warm rows remain "
+            "queryable indefinitely until configured). Per-workspace "
+            "prefix is enforced by the worker."
+        ),
+    )
+    retention_archive_kms_key_arn: str | None = Field(
+        default=None,
+        description=(
+            "ARN of the KMS key used to encrypt archive parquet objects "
+            "(ADR-0009 §1 — KMS-managed keys mandatory in non-dev). "
+            "When None, the worker uses SSE-S3 (AES256), which is "
+            "acceptable in dev only."
+        ),
+    )
+    retention_archive_s3_endpoint_url: str | None = Field(
+        default=None,
+        description=(
+            "Custom endpoint URL for S3-compatible object storage "
+            "(MinIO, Ceph, etc). When None, AWS S3 is assumed. "
+            "Read by boto3's S3 client."
+        ),
+    )
+    retention_archive_s3_region: str = Field(
+        default="us-east-1",
+        description="AWS region used for the archive bucket S3 client.",
+    )
+    retention_sample_size: int = Field(
+        default=20,
+        ge=0,
+        le=1000,
+        description=(
+            "Number of eligible rows to include in the dry-run report sample. "
+            "Bounded to keep the report payload small."
+        ),
+    )
+
     # --- Scheduler ---
     scheduler_enabled: bool = Field(
         default=True,

--- a/packages/core/src/omniscience_core/telemetry/metrics.py
+++ b/packages/core/src/omniscience_core/telemetry/metrics.py
@@ -75,3 +75,76 @@ SCHEDULER_CHECK_DURATION_SECONDS: Histogram = Histogram(
     documentation="Wall-clock time in seconds for a single scheduler check-and-trigger cycle.",
     buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
 )
+
+# ---------------------------------------------------------------------------
+# Retention worker metrics (ADR-0009 §8, issue #135)
+# ---------------------------------------------------------------------------
+#
+# Four metric families specified verbatim in ADR-0009 §8:
+#   * `omniscience_graph_records_total{tier, store}` — gauge, per-tier
+#     per-store record count, scraped after each retention run.
+#   * `omniscience_retention_eviction_total{transition, store}` — counter,
+#     increments per record evicted.
+#   * `omniscience_retention_worker_duration_seconds{phase, store}` —
+#     histogram, per-phase per-store wall time.
+#   * `omniscience_retention_worker_lag_seconds` — gauge, wall time
+#     since the oldest `recorded_at`-overdue record was evicted.
+#
+# SLO: lag stays below 24 hours steady-state; >7d is P1 (existing
+# freshness-style alert path).
+
+# Per-tier per-store record count (gauge).  Tier label values:
+#   "hot"     — live store, full bitemporal fidelity
+#   "warm"    — :EntitySnapshot:Daily rows in same Neo4j db
+#   "archive" — Parquet on object storage (always 0 for store=qdrant)
+# Store label values: "neo4j" | "qdrant".
+RETENTION_GRAPH_RECORDS_TOTAL: Gauge = Gauge(
+    name="omniscience_graph_records_total",
+    documentation=(
+        "Per-tier per-store record count, scraped after each retention run "
+        "(ADR-0009 §8). Set by the retention worker on every successful tick."
+    ),
+    labelnames=["tier", "store"],
+)
+
+# Total records evicted, partitioned by transition and store (counter).
+# Transition label values:
+#   "hot_to_warm"     — :EntityState/edge to :EntitySnapshot:Daily
+#   "warm_to_archive" — :EntitySnapshot:Daily to S3 parquet
+# Store label values: "neo4j" | "qdrant".
+RETENTION_EVICTION_TOTAL: Counter = Counter(
+    name="omniscience_retention_eviction_total",
+    documentation=(
+        "Total records evicted by tier transition (ADR-0009 §8). "
+        "Increments per record on the move phase of every successful run."
+    ),
+    labelnames=["transition", "store"],
+)
+
+# Per-phase per-store retention worker duration (histogram).
+# Phase label values: "read" | "mark" | "move"  (ADR-0009 §3 read-then-
+# mark-then-move).
+# Store label values: "neo4j" | "qdrant".
+RETENTION_WORKER_DURATION_SECONDS: Histogram = Histogram(
+    name="omniscience_retention_worker_duration_seconds",
+    documentation=(
+        "Wall-clock time in seconds for one phase (read/mark/move) of the "
+        "retention worker against one store, per workspace iteration "
+        "(ADR-0009 §8). Buckets cover 10ms to 5min — the worker should "
+        "complete a full per-workspace per-phase cycle inside this band."
+    ),
+    labelnames=["phase", "store"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 300.0),
+)
+
+# Retention worker lag in seconds (gauge).  Wall time since the oldest
+# `recorded_at`-overdue record was evicted, aggregated as `max` for the
+# deployment-wide alert.  ADR-0009 §8 SLO: <24h steady; >7d is P1.
+RETENTION_WORKER_LAG_SECONDS: Gauge = Gauge(
+    name="omniscience_retention_worker_lag_seconds",
+    documentation=(
+        "Wall-clock seconds since the oldest record overdue for eviction "
+        "was last evicted, deployment-wide max (ADR-0009 §8). SLO: <24h "
+        "steady; >7d trips a P1 alert via the freshness alert path."
+    ),
+)

--- a/packages/index/src/omniscience_index/stores/neo4j_store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j_store.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import re
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any, Final
 
 import structlog
@@ -144,6 +144,14 @@ _WRITE_WORKSPACE_PARAM: Final[str] = "workspace_id"
 # identity via `[:HAD_STATE]`, with the still-current version mirrored on
 # the identity node so current-state reads stay one MERGE.
 _ENTITY_STATE_LABEL: Final[str] = "EntityState"
+
+# Discriminator labels for warm-tier snapshot rows (ADR-0009 §1 / §7).
+# Snapshot rows live in the same Neo4j database as hot but carry these
+# discriminator labels so the hot-path indexes (composite on `:Entity`
+# / `:EntityState`) never see them.  Performance isolation is index-
+# backed, not query-rewrite-only.
+_ENTITY_SNAPSHOT_LABELS: Final[str] = "EntitySnapshot:Daily"
+_RELATIONSHIP_SNAPSHOT_LABELS: Final[str] = "RelationshipSnapshot:Daily"
 
 _BOOTSTRAP_STATEMENTS: Final[tuple[str, ...]] = (
     # --- ADR-0005 carry-forward — unchanged. -------------------------------
@@ -514,6 +522,274 @@ _BITEMPORAL_BACKFILL_STATEMENTS: Final[tuple[str, ...]] = (
 )
 
 
+# --- Retention Cypher (ADR-0009 §2 / §3, issue #135) --------------------
+#
+# Per-version eviction (ADR-0009 §2): a node identity whose latest version
+# is hot but whose history extends into warm has its older versions
+# evicted to warm while the latest stays hot.  The eligibility predicate
+# selects `:EntityState` rows whose `recorded_at < $hot_cutoff` AND which
+# are NOT the still-current version (`valid_to IS NOT NULL`).  This
+# preserves the identity-stability invariant from ADR-0008 §9 #4: the
+# `valid_to IS NULL` row for an identity never moves to warm.
+#
+# Edge end-dating does NOT trigger eviction (ADR-0009 §2): a relationship
+# with `valid_to` set in the past stays hot as long as its `recorded_at`
+# is within the hot window.  The eligibility predicate is on
+# `recorded_at`, never on `valid_to`.
+#
+# Every Cypher template below is composite on `workspace_id` (ADR-0009
+# §Consequences-security #1, ACL carry-forward from ADR-0005/#117/#119).
+# The retention worker iterates per-workspace; cross-tenant batches are
+# forbidden.
+
+# Phase 1 (read): count rows eligible for hot-to-warm eviction.  Used by
+# the dry-run reporter and the live worker to size batches.  No mutation.
+_COUNT_HOT_TO_WARM_ENTITY_STATE_ELIGIBLE: Final[str] = f"""
+MATCH (s:{_ENTITY_STATE_LABEL} {{workspace_id: $workspace_id}})
+WHERE s.recorded_at < $hot_cutoff
+  AND s.valid_to IS NOT NULL
+RETURN count(s) AS eligible
+"""
+
+_COUNT_HOT_TO_WARM_EDGE_ELIGIBLE: Final[str] = """
+MATCH ()-[r]->()
+WHERE r.workspace_id = $workspace_id
+  AND r.recorded_at < $hot_cutoff
+  AND r.valid_to IS NOT NULL
+RETURN count(r) AS eligible
+"""
+
+# Phase 1 (read): sample eligible rows for the dry-run report.  Bounded
+# limit; `id` and `recorded_at` only — no full row payload.
+_SAMPLE_HOT_TO_WARM_ENTITY_STATE: Final[str] = f"""
+MATCH (s:{_ENTITY_STATE_LABEL} {{workspace_id: $workspace_id}})
+WHERE s.recorded_at < $hot_cutoff
+  AND s.valid_to IS NOT NULL
+RETURN s.id AS id, s.valid_from AS valid_from, s.recorded_at AS recorded_at
+ORDER BY s.recorded_at ASC
+LIMIT $limit
+"""
+
+# Phase 1 (read): oldest eligible `recorded_at` for the lag SLO.
+# Returns NULL when nothing is overdue.
+_OLDEST_ELIGIBLE_HOT_RECORDED_AT: Final[str] = f"""
+MATCH (s:{_ENTITY_STATE_LABEL} {{workspace_id: $workspace_id}})
+WHERE s.recorded_at < $hot_cutoff
+  AND s.valid_to IS NOT NULL
+RETURN min(s.recorded_at) AS oldest
+"""
+
+# Phase 2 (mark): tag eligible :EntityState rows with `tier_pending = 'warm'`
+# in batches.  Idempotent — already-marked rows are skipped.  The marker
+# is the resumability anchor per ADR-0009 §3: a crash between mark and
+# move leaves rows in a re-runnable state.
+_MARK_HOT_TO_WARM_ENTITY_STATE: Final[str] = f"""
+MATCH (s:{_ENTITY_STATE_LABEL} {{workspace_id: $workspace_id}})
+WHERE s.recorded_at < $hot_cutoff
+  AND s.valid_to IS NOT NULL
+  AND coalesce(s.tier_pending, '') <> 'warm'
+WITH s LIMIT $batch_size
+SET s.tier_pending = 'warm'
+RETURN count(s) AS marked
+"""
+
+_MARK_HOT_TO_WARM_EDGE: Final[str] = """
+MATCH ()-[r]->()
+WHERE r.workspace_id = $workspace_id
+  AND r.recorded_at < $hot_cutoff
+  AND r.valid_to IS NOT NULL
+  AND coalesce(r.tier_pending, '') <> 'warm'
+WITH r LIMIT $batch_size
+SET r.tier_pending = 'warm'
+RETURN count(r) AS marked
+"""
+
+# Phase 3 (move): project marked :EntityState rows to :EntitySnapshot:Daily
+# rows under the snapshot-per-day projection (ADR-0009 §1 warm tier).
+# `snapshot_date` is `date(recorded_at)` — UTC calendar day.  The MERGE
+# on (workspace_id, id, snapshot_date) makes this idempotent so multiple
+# eligible versions on the same day collapse into one snapshot row
+# (the as-of-end-of-day projection is implemented by ordering on
+# `valid_from` DESC and keeping the latest version for each (id, day)).
+#
+# Returns the count of (workspace_id, id, snapshot_date) triples
+# materialized.  After the snapshot row is in place the source
+# :EntityState row is deleted in the same transaction — we do not leave
+# a half-evicted state where the row exists in both tiers.
+_MOVE_HOT_TO_WARM_ENTITY_STATE: Final[str] = f"""
+MATCH (s:{_ENTITY_STATE_LABEL} {{workspace_id: $workspace_id}})
+WHERE s.tier_pending = 'warm'
+WITH s LIMIT $batch_size
+WITH s, date(datetime(s.recorded_at)) AS snap_date
+MERGE (snap:{_ENTITY_SNAPSHOT_LABELS} {{
+    workspace_id: s.workspace_id,
+    id: s.id,
+    snapshot_date: snap_date
+}})
+ON CREATE SET
+    snap.valid_from = s.valid_from,
+    snap.valid_to = s.valid_to,
+    snap.recorded_at = s.recorded_at,
+    snap.kind = s.kind,
+    snap.name = s.name,
+    snap.display_name = s.display_name,
+    snap.source_id = s.source_id,
+    snap.chunk_id = s.chunk_id,
+    snap.metadata = s.metadata
+ON MATCH SET
+    snap.valid_from =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.valid_from
+             ELSE snap.valid_from END,
+    snap.valid_to =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.valid_to
+             ELSE snap.valid_to END,
+    snap.recorded_at =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.recorded_at
+             ELSE snap.recorded_at END,
+    snap.kind =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.kind
+             ELSE snap.kind END,
+    snap.name =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.name
+             ELSE snap.name END,
+    snap.display_name =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.display_name
+             ELSE snap.display_name END,
+    snap.source_id =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.source_id
+             ELSE snap.source_id END,
+    snap.chunk_id =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.chunk_id
+             ELSE snap.chunk_id END,
+    snap.metadata =
+        CASE WHEN s.valid_from > snap.valid_from THEN s.metadata
+             ELSE snap.metadata END
+DETACH DELETE s
+RETURN count(snap) AS moved
+"""
+
+# Phase 3 (move): project marked relationships to :RelationshipSnapshot:Daily.
+# Edges remain identity-to-identity; the snapshot carries the bitemporal
+# triple at the day boundary.  Post-snapshot the source relationship is
+# deleted.  The MERGE key is
+# (workspace_id, source_id, target_id, edge_type, snapshot_date) —
+# multiple eligible versions on the same day collapse identically.
+_MOVE_HOT_TO_WARM_EDGE: Final[str] = f"""
+MATCH (a:{_ENTITY_LABEL})-[r]->(b:{_ENTITY_LABEL})
+WHERE r.workspace_id = $workspace_id
+  AND r.tier_pending = 'warm'
+WITH a, r, b LIMIT $batch_size
+WITH a, r, b, date(datetime(r.recorded_at)) AS snap_date
+MERGE (snap:{_RELATIONSHIP_SNAPSHOT_LABELS} {{
+    workspace_id: r.workspace_id,
+    source_entity_id: a.id,
+    target_entity_id: b.id,
+    edge_type: r.edge_type,
+    snapshot_date: snap_date
+}})
+ON CREATE SET
+    snap.valid_from = r.valid_from,
+    snap.valid_to = r.valid_to,
+    snap.recorded_at = r.recorded_at,
+    snap.source_id = r.source_id,
+    snap.metadata = r.metadata
+DELETE r
+RETURN count(snap) AS moved
+"""
+
+# Phase 1 (read): count rows eligible for warm-to-archive transition.
+# `:EntitySnapshot:Daily` rows are eligible when their `snapshot_date`
+# is older than `now - warm_days` (ADR-0009 §1 archive boundary).
+_COUNT_WARM_TO_ARCHIVE_ELIGIBLE: Final[str] = f"""
+MATCH (snap:{_ENTITY_SNAPSHOT_LABELS} {{workspace_id: $workspace_id}})
+WHERE snap.snapshot_date < $warm_cutoff_date
+RETURN count(snap) AS eligible
+"""
+
+# Phase 1 (read): list distinct snapshot dates eligible for archive,
+# bounded.  The archive worker writes one parquet object per
+# (workspace_id, snapshot_date), so the unit of work is the date.
+_LIST_WARM_TO_ARCHIVE_DATES: Final[str] = f"""
+MATCH (snap:{_ENTITY_SNAPSHOT_LABELS} {{workspace_id: $workspace_id}})
+WHERE snap.snapshot_date < $warm_cutoff_date
+RETURN DISTINCT snap.snapshot_date AS snapshot_date
+ORDER BY snapshot_date ASC
+LIMIT $limit
+"""
+
+# Phase 1 (read): fetch all entity-snapshot rows for one (workspace_id,
+# snapshot_date), used by the parquet writer.  Returns the full payload
+# so the writer can serialise without a second round-trip.
+_FETCH_WARM_ENTITY_SNAPSHOT_ROWS: Final[str] = f"""
+MATCH (snap:{_ENTITY_SNAPSHOT_LABELS} {{
+    workspace_id: $workspace_id,
+    snapshot_date: $snapshot_date
+}})
+RETURN
+    snap.id AS id,
+    snap.kind AS kind,
+    snap.name AS name,
+    snap.display_name AS display_name,
+    snap.source_id AS source_id,
+    snap.chunk_id AS chunk_id,
+    toString(snap.valid_from) AS valid_from,
+    toString(snap.valid_to) AS valid_to,
+    toString(snap.recorded_at) AS recorded_at,
+    snap.metadata AS metadata
+"""
+
+# Phase 1 (read): fetch all relationship-snapshot rows for one
+# (workspace_id, snapshot_date).
+_FETCH_WARM_RELATIONSHIP_SNAPSHOT_ROWS: Final[str] = f"""
+MATCH (snap:{_RELATIONSHIP_SNAPSHOT_LABELS} {{
+    workspace_id: $workspace_id,
+    snapshot_date: $snapshot_date
+}})
+RETURN
+    snap.source_entity_id AS source_entity_id,
+    snap.target_entity_id AS target_entity_id,
+    snap.edge_type AS edge_type,
+    snap.source_id AS source_id,
+    toString(snap.valid_from) AS valid_from,
+    toString(snap.valid_to) AS valid_to,
+    toString(snap.recorded_at) AS recorded_at,
+    snap.metadata AS metadata
+"""
+
+# Phase 3 (move): hard-delete warm rows for one (workspace_id, snapshot_date)
+# AFTER the parquet write succeeded.  Keep entity and relationship
+# snapshot deletes in separate templates so a relationship delete does
+# not block on a missing entity snapshot.
+_DELETE_WARM_ENTITY_SNAPSHOT: Final[str] = f"""
+MATCH (snap:{_ENTITY_SNAPSHOT_LABELS} {{
+    workspace_id: $workspace_id,
+    snapshot_date: $snapshot_date
+}})
+DETACH DELETE snap
+RETURN count(snap) AS deleted
+"""
+
+_DELETE_WARM_RELATIONSHIP_SNAPSHOT: Final[str] = f"""
+MATCH (snap:{_RELATIONSHIP_SNAPSHOT_LABELS} {{
+    workspace_id: $workspace_id,
+    snapshot_date: $snapshot_date
+}})
+DELETE snap
+RETURN count(snap) AS deleted
+"""
+
+# Stats: count records by tier for the metrics gauge.
+_COUNT_HOT_ENTITY_STATES: Final[str] = f"""
+MATCH (s:{_ENTITY_STATE_LABEL} {{workspace_id: $workspace_id}})
+RETURN count(s) AS total
+"""
+
+_COUNT_WARM_ENTITY_SNAPSHOTS: Final[str] = f"""
+MATCH (snap:{_ENTITY_SNAPSHOT_LABELS} {{workspace_id: $workspace_id}})
+RETURN count(snap) AS total
+"""
+
+
 # --- Read queries ----------------------------------------------------------
 
 _GET_ENTITY_BY_NAME_CYPHER: Final[str] = f"""
@@ -649,6 +925,34 @@ _ensure_workspace_predicate(_UPSERT_ENTITY_BITEMPORAL_CYPHER, "_UPSERT_ENTITY_BI
 _ensure_workspace_predicate(
     _UPSERT_EDGE_BITEMPORAL_CYPHER_TEMPLATE, "_UPSERT_EDGE_BITEMPORAL_CYPHER_TEMPLATE"
 )
+# ADR-0009 §Consequences-security #1: every retention Cypher template
+# iterates ONE workspace at a time and filters every MATCH on
+# `workspace_id`.  Cross-tenant batches are forbidden — drop the
+# predicate and the module fails to import.
+_ensure_workspace_predicate(
+    _COUNT_HOT_TO_WARM_ENTITY_STATE_ELIGIBLE,
+    "_COUNT_HOT_TO_WARM_ENTITY_STATE_ELIGIBLE",
+)
+_ensure_workspace_predicate(_COUNT_HOT_TO_WARM_EDGE_ELIGIBLE, "_COUNT_HOT_TO_WARM_EDGE_ELIGIBLE")
+_ensure_workspace_predicate(_SAMPLE_HOT_TO_WARM_ENTITY_STATE, "_SAMPLE_HOT_TO_WARM_ENTITY_STATE")
+_ensure_workspace_predicate(_OLDEST_ELIGIBLE_HOT_RECORDED_AT, "_OLDEST_ELIGIBLE_HOT_RECORDED_AT")
+_ensure_workspace_predicate(_MARK_HOT_TO_WARM_ENTITY_STATE, "_MARK_HOT_TO_WARM_ENTITY_STATE")
+_ensure_workspace_predicate(_MARK_HOT_TO_WARM_EDGE, "_MARK_HOT_TO_WARM_EDGE")
+_ensure_workspace_predicate(_MOVE_HOT_TO_WARM_ENTITY_STATE, "_MOVE_HOT_TO_WARM_ENTITY_STATE")
+_ensure_workspace_predicate(_MOVE_HOT_TO_WARM_EDGE, "_MOVE_HOT_TO_WARM_EDGE")
+_ensure_workspace_predicate(_COUNT_WARM_TO_ARCHIVE_ELIGIBLE, "_COUNT_WARM_TO_ARCHIVE_ELIGIBLE")
+_ensure_workspace_predicate(_LIST_WARM_TO_ARCHIVE_DATES, "_LIST_WARM_TO_ARCHIVE_DATES")
+_ensure_workspace_predicate(_FETCH_WARM_ENTITY_SNAPSHOT_ROWS, "_FETCH_WARM_ENTITY_SNAPSHOT_ROWS")
+_ensure_workspace_predicate(
+    _FETCH_WARM_RELATIONSHIP_SNAPSHOT_ROWS,
+    "_FETCH_WARM_RELATIONSHIP_SNAPSHOT_ROWS",
+)
+_ensure_workspace_predicate(_DELETE_WARM_ENTITY_SNAPSHOT, "_DELETE_WARM_ENTITY_SNAPSHOT")
+_ensure_workspace_predicate(
+    _DELETE_WARM_RELATIONSHIP_SNAPSHOT, "_DELETE_WARM_RELATIONSHIP_SNAPSHOT"
+)
+_ensure_workspace_predicate(_COUNT_HOT_ENTITY_STATES, "_COUNT_HOT_ENTITY_STATES")
+_ensure_workspace_predicate(_COUNT_WARM_ENTITY_SNAPSHOTS, "_COUNT_WARM_ENTITY_SNAPSHOTS")
 
 
 # ---------------------------------------------------------------------------
@@ -732,6 +1036,45 @@ def _coerce_metadata(value: Any) -> dict[str, Any]:
         # Re-type explicitly — mypy --strict refuses ``dict`` without params.
         return {str(k): v for k, v in value.items()}
     raise TypeError(f"metadata must be dict, got {type(value).__name__}")
+
+
+def _coerce_to_datetime(value: Any) -> datetime:
+    """Coerce a Neo4j temporal-like value to a Python aware ``datetime``.
+
+    Neo4j returns its own ``DateTime`` type from the driver, which
+    duck-types ``to_native()`` returning ``datetime.datetime``.  ISO-8601
+    strings (the form we round-trip via ``isoformat()``) are also
+    accepted.  Naive datetimes are stamped UTC so all comparisons in
+    the worker happen in one timezone.
+    """
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if hasattr(value, "to_native"):
+        native = value.to_native()
+        if isinstance(native, datetime):
+            return native if native.tzinfo else native.replace(tzinfo=UTC)
+    if isinstance(value, str):
+        # ISO-8601 string; isoformat round-trip from the writer.
+        parsed = datetime.fromisoformat(value)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    raise TypeError(f"cannot coerce to datetime: {type(value).__name__}")
+
+
+def _coerce_to_date(value: Any) -> date:
+    """Coerce a Neo4j-like temporal value to ``datetime.date``."""
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if hasattr(value, "to_native"):
+        native = value.to_native()
+        if isinstance(native, datetime):
+            return native.date()
+        if isinstance(native, date):
+            return native
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+    raise TypeError(f"cannot coerce to date: {type(value).__name__}")
 
 
 # ---------------------------------------------------------------------------
@@ -1160,6 +1503,282 @@ class Neo4jGraphStore:
             if modified == 0:
                 return phase_total
             phase_total += modified
+
+    # ------------------------------------------------------------------
+    # Retention worker support (ADR-0009 §3, issue #135)
+    # ------------------------------------------------------------------
+    #
+    # Every method below pins ``workspace_id`` at the parameter level —
+    # the worker iterates per-workspace and the adapter never sees a
+    # cross-workspace batch.  This is the structural ACL invariant from
+    # ADR-0009 §Consequences-security #1.
+
+    async def count_hot_to_warm_eligible(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        hot_cutoff: datetime,
+    ) -> tuple[int, int]:
+        """Return (entity_state_count, edge_count) eligible for hot->warm.
+
+        ADR-0009 §2 per-version semantics: only :EntityState rows with
+        ``valid_to IS NOT NULL`` are eligible; the still-current version
+        of every identity is preserved in hot regardless of age.  Edges
+        are eligible when end-dated AND old; pure age does not evict
+        live edges (ADR-0009 §2 — edge end-dating does NOT trigger
+        eviction by itself, only end-dated-and-old does).
+        """
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "hot_cutoff": hot_cutoff.isoformat(),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            es_rows = await session.execute_read(
+                _run_read_stmt, _COUNT_HOT_TO_WARM_ENTITY_STATE_ELIGIBLE, params
+            )
+            edge_rows = await session.execute_read(
+                _run_read_stmt, _COUNT_HOT_TO_WARM_EDGE_ELIGIBLE, params
+            )
+        es_count = int(es_rows[0].get("eligible", 0)) if es_rows else 0
+        edge_count = int(edge_rows[0].get("eligible", 0)) if edge_rows else 0
+        return es_count, edge_count
+
+    async def sample_hot_to_warm_eligible(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        hot_cutoff: datetime,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Return up to ``limit`` eligible :EntityState rows (id-only payload)."""
+        if limit <= 0:
+            return []
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "hot_cutoff": hot_cutoff.isoformat(),
+            "limit": int(limit),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            rows = await session.execute_read(
+                _run_read_stmt, _SAMPLE_HOT_TO_WARM_ENTITY_STATE, params
+            )
+        # Coerce Neo4j temporal types to ISO strings for JSON serialisation.
+        sampled: list[dict[str, Any]] = []
+        for row in rows:
+            sampled.append(
+                {
+                    "id": str(row.get("id")) if row.get("id") is not None else None,
+                    "valid_from": (
+                        str(row.get("valid_from")) if row.get("valid_from") is not None else None
+                    ),
+                    "recorded_at": (
+                        str(row.get("recorded_at")) if row.get("recorded_at") is not None else None
+                    ),
+                }
+            )
+        return sampled
+
+    async def oldest_hot_to_warm_recorded_at(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        hot_cutoff: datetime,
+    ) -> datetime | None:
+        """Return the oldest eligible ``recorded_at`` or ``None``.
+
+        Used by the worker to compute the lag SLO gauge per ADR-0009 §8.
+        """
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "hot_cutoff": hot_cutoff.isoformat(),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            rows = await session.execute_read(
+                _run_read_stmt, _OLDEST_ELIGIBLE_HOT_RECORDED_AT, params
+            )
+        if not rows:
+            return None
+        oldest = rows[0].get("oldest")
+        if oldest is None:
+            return None
+        return _coerce_to_datetime(oldest)
+
+    async def mark_hot_to_warm(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        hot_cutoff: datetime,
+        batch_size: int,
+    ) -> tuple[int, int]:
+        """Tag eligible :EntityState rows + edges with ``tier_pending='warm'``.
+
+        Returns (entity_states_marked, edges_marked).  Loops batches
+        until a pass marks zero rows — bounded by the workspace's
+        eligible cohort.  Each batch is its own transaction so a crash
+        leaves a re-runnable state.
+        """
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "hot_cutoff": hot_cutoff.isoformat(),
+            "batch_size": int(batch_size),
+        }
+        es_total = await self._loop_count_query(_MARK_HOT_TO_WARM_ENTITY_STATE, params, "marked")
+        edge_total = await self._loop_count_query(_MARK_HOT_TO_WARM_EDGE, params, "marked")
+        return es_total, edge_total
+
+    async def move_hot_to_warm(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        batch_size: int,
+    ) -> tuple[int, int]:
+        """Project marked rows to :EntitySnapshot:Daily / :RelationshipSnapshot:Daily.
+
+        Returns (entity_states_moved, edges_moved).  The MERGE on
+        (workspace_id, id, snapshot_date) makes intra-day collapsing
+        idempotent — multiple eligible versions on the same UTC day fold
+        into one snapshot row, with the latest ``valid_from`` winning
+        (ADR-0009 §1: as-of-end-of-day projection).  Each batch deletes
+        the source :EntityState in the same transaction so partial
+        progress never leaves a row visible in two tiers.
+        """
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "batch_size": int(batch_size),
+        }
+        es_total = await self._loop_count_query(_MOVE_HOT_TO_WARM_ENTITY_STATE, params, "moved")
+        edge_total = await self._loop_count_query(_MOVE_HOT_TO_WARM_EDGE, params, "moved")
+        return es_total, edge_total
+
+    async def _loop_count_query(
+        self,
+        cypher: str,
+        params: dict[str, Any],
+        return_key: str,
+    ) -> int:
+        """Run ``cypher`` repeatedly in fresh tx until a pass returns 0."""
+        total = 0
+        while True:
+            async with self._driver.session(database=self._config.database) as session:
+                rows = await session.execute_write(_run_write_returning, cypher, params)
+            count = int(rows[0].get(return_key, 0)) if rows else 0
+            if count == 0:
+                return total
+            total += count
+
+    async def count_warm_to_archive_eligible(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        warm_cutoff_date: date,
+    ) -> int:
+        """Count :EntitySnapshot:Daily rows older than ``warm_cutoff_date``."""
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "warm_cutoff_date": warm_cutoff_date.isoformat(),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            rows = await session.execute_read(
+                _run_read_stmt, _COUNT_WARM_TO_ARCHIVE_ELIGIBLE, params
+            )
+        return int(rows[0].get("eligible", 0)) if rows else 0
+
+    async def list_warm_to_archive_dates(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        warm_cutoff_date: date,
+        limit: int,
+    ) -> list[date]:
+        """Distinct snapshot dates eligible for warm->archive, ASC."""
+        if limit <= 0:
+            return []
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "warm_cutoff_date": warm_cutoff_date.isoformat(),
+            "limit": int(limit),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            rows = await session.execute_read(_run_read_stmt, _LIST_WARM_TO_ARCHIVE_DATES, params)
+        out: list[date] = []
+        for row in rows:
+            raw = row.get("snapshot_date")
+            if raw is None:
+                continue
+            out.append(_coerce_to_date(raw))
+        return out
+
+    async def fetch_warm_snapshot_rows(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        snapshot_date: date,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Return (entity_rows, edge_rows) for one (workspace_id, date) snapshot.
+
+        Used by the archive writer to build the parquet payload.  Both
+        lists carry primitive types only (str, dict[str, Any]) so the
+        parquet serialiser does not need to convert Neo4j temporal types.
+        """
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "snapshot_date": snapshot_date.isoformat(),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            entity_rows = await session.execute_read(
+                _run_read_stmt, _FETCH_WARM_ENTITY_SNAPSHOT_ROWS, params
+            )
+            edge_rows = await session.execute_read(
+                _run_read_stmt, _FETCH_WARM_RELATIONSHIP_SNAPSHOT_ROWS, params
+            )
+        return list(entity_rows), list(edge_rows)
+
+    async def delete_warm_snapshot(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        snapshot_date: date,
+    ) -> tuple[int, int]:
+        """Hard-delete warm rows for (workspace_id, snapshot_date).
+
+        Run AFTER the parquet write to S3 succeeded.  Returns
+        (entity_rows_deleted, edge_rows_deleted).
+        """
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "snapshot_date": snapshot_date.isoformat(),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            es_rows = await session.execute_write(
+                _run_write_returning, _DELETE_WARM_ENTITY_SNAPSHOT, params
+            )
+            edge_rows = await session.execute_write(
+                _run_write_returning, _DELETE_WARM_RELATIONSHIP_SNAPSHOT, params
+            )
+        es_deleted = int(es_rows[0].get("deleted", 0)) if es_rows else 0
+        edge_deleted = int(edge_rows[0].get("deleted", 0)) if edge_rows else 0
+        return es_deleted, edge_deleted
+
+    async def count_records_by_tier(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> dict[str, int]:
+        """Return {'hot': int, 'warm': int} record counts for the workspace.
+
+        Used to populate the ``omniscience_graph_records_total`` gauge
+        per ADR-0009 §8.
+        """
+        params: dict[str, Any] = {_WORKSPACE_PARAM: str(workspace_id)}
+        async with self._driver.session(database=self._config.database) as session:
+            hot_rows = await session.execute_read(_run_read_stmt, _COUNT_HOT_ENTITY_STATES, params)
+            warm_rows = await session.execute_read(
+                _run_read_stmt, _COUNT_WARM_ENTITY_SNAPSHOTS, params
+            )
+        return {
+            "hot": int(hot_rows[0].get("total", 0)) if hot_rows else 0,
+            "warm": int(warm_rows[0].get("total", 0)) if warm_rows else 0,
+        }
 
     # ------------------------------------------------------------------
     # Read API

--- a/packages/index/src/omniscience_index/stores/qdrant_constants.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_constants.py
@@ -66,6 +66,19 @@ PAYLOAD_CONTENT_HASH: Final[str] = "content_hash"
 PAYLOAD_DOC_VERSION: Final[str] = "doc_version"
 PAYLOAD_TOMBSTONED_AT: Final[str] = "tombstoned_at"
 PAYLOAD_RECORDED_AT: Final[str] = "recorded_at"
+#: Tier marker on the chunk payload — ADR-0009 §5 / §1.  Values:
+#:   "hot"     — live chunk (no `snapshot_date`).
+#:   "warm"    — snapshotted chunk (carries `snapshot_date`).
+#: Archive chunks are evicted from Qdrant entirely (re-embedding from
+#: archive is not supported in v1 per ADR-0009 §5).
+PAYLOAD_TIER: Final[str] = "tier"
+#: Snapshot date on warm-tier chunks — ISO-8601 calendar day, mirrors
+#: the Neo4j `:EntitySnapshot:Daily.snapshot_date` field.  Only present
+#: when ``tier == "warm"``.
+PAYLOAD_SNAPSHOT_DATE: Final[str] = "snapshot_date"
+#: Tier values, kept in named constants so reviewers can grep them.
+TIER_HOT: Final[str] = "hot"
+TIER_WARM: Final[str] = "warm"
 
 #: Fields that get a Qdrant payload index.  ADR-0006, Decision §Schema
 #: posture lists them explicitly — workspace_id is the mandatory one
@@ -83,6 +96,12 @@ INDEXED_PAYLOAD_FIELDS: Final[tuple[str, ...]] = (
     PAYLOAD_TAGS,
     PAYLOAD_TOMBSTONED_AT,
     PAYLOAD_RECORDED_AT,
+    # ADR-0009 §5: payload-indexed `tier` so hot reads add a cheap
+    # `tier = "hot"` filter without an HNSW scan over warm payload-only
+    # points.  Snapshot-date is indexed too so warm reads at a given
+    # day are point-lookups.
+    PAYLOAD_TIER,
+    PAYLOAD_SNAPSHOT_DATE,
 )
 
 # ---------------------------------------------------------------------------
@@ -123,12 +142,16 @@ __all__ = [
     "PAYLOAD_ORD",
     "PAYLOAD_PARSER_VERSION",
     "PAYLOAD_RECORDED_AT",
+    "PAYLOAD_SNAPSHOT_DATE",
     "PAYLOAD_SOURCE_ID",
     "PAYLOAD_SYMBOL",
     "PAYLOAD_TAGS",
     "PAYLOAD_TEXT",
+    "PAYLOAD_TIER",
     "PAYLOAD_TITLE",
     "PAYLOAD_TOMBSTONED_AT",
     "PAYLOAD_URI",
     "PAYLOAD_WORKSPACE_ID",
+    "TIER_HOT",
+    "TIER_WARM",
 ]

--- a/packages/index/src/omniscience_index/stores/qdrant_filters.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_filters.py
@@ -35,7 +35,10 @@ from qdrant_client import models as qm
 from omniscience_index.stores.qdrant_constants import (
     PAYLOAD_DOCUMENT_ID,
     PAYLOAD_EXTERNAL_ID,
+    PAYLOAD_RECORDED_AT,
+    PAYLOAD_SNAPSHOT_DATE,
     PAYLOAD_SOURCE_ID,
+    PAYLOAD_TIER,
     PAYLOAD_TOMBSTONED_AT,
     PAYLOAD_WORKSPACE_ID,
 )
@@ -125,6 +128,111 @@ class QdrantFilterBuilder:
         return qm.Filter(must=must)
 
 
+def build_retention_eligible_filter(
+    *,
+    workspace_id: uuid.UUID,
+    cutoff_iso: str,
+) -> qm.Filter:
+    """Build the per-workspace filter for hot-to-warm chunk eviction.
+
+    ADR-0009 §5: chunks with ``recorded_at`` past the hot/warm boundary
+    are evicted from Qdrant in the same retention run that handles the
+    graph.  The filter is workspace-scoped — cross-tenant batches are
+    forbidden by the same ACL invariant ADR-0006 §ACL carry-forward
+    enforces on every other read path.
+
+    The retention worker pulls eligible point ids using this filter,
+    sets ``tier=warm`` + ``snapshot_date`` payloads on them, and then
+    moves to the warm-to-archive band where the points are deleted
+    entirely (re-embedding from archive is not supported in v1, see
+    ADR-0009 §5).
+    """
+    must: list[
+        qm.FieldCondition
+        | qm.IsEmptyCondition
+        | qm.IsNullCondition
+        | qm.HasIdCondition
+        | qm.HasVectorCondition
+        | qm.NestedCondition
+        | qm.Filter
+    ] = [
+        qm.FieldCondition(
+            key=PAYLOAD_WORKSPACE_ID,
+            match=qm.MatchValue(value=str(workspace_id)),
+        ),
+        qm.FieldCondition(
+            key=PAYLOAD_RECORDED_AT,
+            range=qm.DatetimeRange(lt=cutoff_iso),  # type: ignore[arg-type]
+        ),
+    ]
+    return qm.Filter(must=must)
+
+
+def build_warm_tier_filter(*, workspace_id: uuid.UUID) -> qm.Filter:
+    """Build a workspace-scoped filter for ALL warm-tier chunks.
+
+    ADR-0009 §5: payload-indexed ``tier`` field marks warm chunks.
+    Used by the metrics/stats path to roll up warm-tier counts without
+    pinning a specific ``snapshot_date``.  Workspace-scoped — the
+    cross-tenant invariant from ADR-0006 §ACL carry-forward applies.
+    """
+    must: list[
+        qm.FieldCondition
+        | qm.IsEmptyCondition
+        | qm.IsNullCondition
+        | qm.HasIdCondition
+        | qm.HasVectorCondition
+        | qm.NestedCondition
+        | qm.Filter
+    ] = [
+        qm.FieldCondition(
+            key=PAYLOAD_WORKSPACE_ID,
+            match=qm.MatchValue(value=str(workspace_id)),
+        ),
+        qm.FieldCondition(
+            key=PAYLOAD_TIER,
+            match=qm.MatchValue(value="warm"),
+        ),
+    ]
+    return qm.Filter(must=must)
+
+
+def build_warm_archive_filter(
+    *,
+    workspace_id: uuid.UUID,
+    snapshot_date_iso: str,
+) -> qm.Filter:
+    """Build the per-workspace filter for warm-to-archive chunk deletion.
+
+    ADR-0009 §5 archive shape: chunks past the warm-to-archive boundary
+    are evicted from Qdrant entirely; the filter selects warm-tier
+    chunks for the specific snapshot date being archived.
+    """
+    must: list[
+        qm.FieldCondition
+        | qm.IsEmptyCondition
+        | qm.IsNullCondition
+        | qm.HasIdCondition
+        | qm.HasVectorCondition
+        | qm.NestedCondition
+        | qm.Filter
+    ] = [
+        qm.FieldCondition(
+            key=PAYLOAD_WORKSPACE_ID,
+            match=qm.MatchValue(value=str(workspace_id)),
+        ),
+        qm.FieldCondition(
+            key=PAYLOAD_TIER,
+            match=qm.MatchValue(value="warm"),
+        ),
+        qm.FieldCondition(
+            key=PAYLOAD_SNAPSHOT_DATE,
+            match=qm.MatchValue(value=snapshot_date_iso),
+        ),
+    ]
+    return qm.Filter(must=must)
+
+
 def build_tombstone_sweep_filter(*, cutoff_iso: str) -> qm.Filter:
     """Admin-only sweep filter for global tombstone purge.
 
@@ -146,4 +254,10 @@ def build_tombstone_sweep_filter(*, cutoff_iso: str) -> qm.Filter:
     )
 
 
-__all__ = ["QdrantFilterBuilder", "build_tombstone_sweep_filter"]
+__all__ = [
+    "QdrantFilterBuilder",
+    "build_retention_eligible_filter",
+    "build_tombstone_sweep_filter",
+    "build_warm_archive_filter",
+    "build_warm_tier_filter",
+]

--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -27,7 +27,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from omniscience_core.storage.vector import (
@@ -58,17 +58,23 @@ from omniscience_index.stores.qdrant_constants import (
     PAYLOAD_ORD,
     PAYLOAD_PARSER_VERSION,
     PAYLOAD_RECORDED_AT,
+    PAYLOAD_SNAPSHOT_DATE,
     PAYLOAD_SOURCE_ID,
     PAYLOAD_SYMBOL,
     PAYLOAD_TEXT,
+    PAYLOAD_TIER,
     PAYLOAD_TITLE,
     PAYLOAD_TOMBSTONED_AT,
     PAYLOAD_URI,
     PAYLOAD_WORKSPACE_ID,
+    TIER_WARM,
 )
 from omniscience_index.stores.qdrant_filters import (
     QdrantFilterBuilder,
+    build_retention_eligible_filter,
     build_tombstone_sweep_filter,
+    build_warm_archive_filter,
+    build_warm_tier_filter,
 )
 
 if TYPE_CHECKING:  # Lazy type-only import to avoid a core <-> retrieval cycle.
@@ -257,6 +263,8 @@ class QdrantVectorStore:
         """Map payload field name to its Qdrant index schema type."""
         if field_name in (PAYLOAD_RECORDED_AT, PAYLOAD_TOMBSTONED_AT):
             return qm.PayloadSchemaType.DATETIME
+        # `snapshot_date` is stored as ISO calendar-day string; KEYWORD
+        # gives O(1) point-lookup which is the warm-tier read pattern.
         return qm.PayloadSchemaType.KEYWORD
 
     # ------------------------------------------------------------------
@@ -612,6 +620,186 @@ class QdrantVectorStore:
             exact=True,
         )
         return int(result.count)
+
+    # ------------------------------------------------------------------
+    # Retention worker support (ADR-0009 §5, issue #135)
+    # ------------------------------------------------------------------
+    #
+    # Every method below is workspace-scoped via the typed filter-builder
+    # helpers from ``qdrant_filters.py``.  Raw ``qm.Filter`` construction
+    # is forbidden here per the lint rule (ADR-0006 §ACL carry-forward).
+
+    async def count_retention_eligible(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        cutoff: datetime,
+    ) -> int:
+        """Count chunks with ``recorded_at < cutoff`` in this workspace.
+
+        Used by the dry-run reporter and the live worker to size the
+        Qdrant-side eviction batch per ADR-0009 §5.
+        """
+        flt = build_retention_eligible_filter(
+            workspace_id=workspace_id,
+            cutoff_iso=cutoff.isoformat(),
+        )
+        result = await self._qc.count(
+            collection_name=self._collection_name,
+            count_filter=flt,
+            exact=True,
+        )
+        return int(result.count)
+
+    async def mark_retention_warm(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        cutoff: datetime,
+    ) -> int:
+        """Tag eligible chunks with ``tier="warm"`` + ``snapshot_date``.
+
+        ADR-0009 §5: warm chunks carry a ``tier="warm"`` payload field
+        and a ``snapshot_date`` mirrored from the chunk's ``recorded_at``
+        UTC calendar day.  This is the Qdrant analogue of the Neo4j
+        :EntitySnapshot:Daily projection.
+
+        The set-payload call is workspace-scoped via the filter-builder.
+        Returns the count of points whose payload was updated; this is
+        an approximation (Qdrant returns an operation acknowledgement
+        rather than an exact mutation count) and we re-count via the
+        retention-eligible filter on the same scope, less the still-hot
+        cohort.
+        """
+        flt = build_retention_eligible_filter(
+            workspace_id=workspace_id,
+            cutoff_iso=cutoff.isoformat(),
+        )
+        # Stamp a per-point snapshot_date keyed off recorded_at.  Qdrant
+        # does not support computed payloads on set_payload, so we read
+        # the eligible records once, group by UTC day, and write each
+        # day's payload separately.
+        records = await self._scroll_payload_only(
+            flt=flt,
+            include_fields=[PAYLOAD_RECORDED_AT, PAYLOAD_TIER],
+        )
+        marked = 0
+        # Group eligible point ids by snapshot day.
+        by_day: dict[str, list[str]] = {}
+        for rec in records:
+            payload = rec.payload or {}
+            # Skip already-marked warm points (idempotent re-run).
+            if payload.get(PAYLOAD_TIER) == TIER_WARM:
+                continue
+            recorded_at = payload.get(PAYLOAD_RECORDED_AT)
+            if not isinstance(recorded_at, str):
+                continue
+            try:
+                day = datetime.fromisoformat(recorded_at).date().isoformat()
+            except ValueError:
+                continue
+            by_day.setdefault(day, []).append(str(rec.id))
+        for day, point_ids in by_day.items():
+            if not point_ids:
+                continue
+            await self._qc.set_payload(
+                collection_name=self._collection_name,
+                payload={
+                    PAYLOAD_TIER: TIER_WARM,
+                    PAYLOAD_SNAPSHOT_DATE: day,
+                },
+                points=qm.PointIdsList(points=cast("list[int | str | uuid.UUID]", point_ids)),
+                wait=True,
+            )
+            marked += len(point_ids)
+        return marked
+
+    async def delete_retention_archive(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        snapshot_date: date,
+    ) -> int:
+        """Hard-delete warm chunks for one (workspace_id, snapshot_date).
+
+        ADR-0009 §5: re-embedding from archive is not supported in v1,
+        so chunks past the warm-to-archive boundary are evicted from
+        Qdrant entirely.  Caller is the retention worker, AFTER the
+        Neo4j archive parquet write and warm row delete have succeeded.
+        """
+        flt = build_warm_archive_filter(
+            workspace_id=workspace_id,
+            snapshot_date_iso=snapshot_date.isoformat(),
+        )
+        before = int(
+            (
+                await self._qc.count(
+                    collection_name=self._collection_name,
+                    count_filter=flt,
+                    exact=True,
+                )
+            ).count
+        )
+        if before == 0:
+            return 0
+        await self._qc.delete(
+            collection_name=self._collection_name,
+            points_selector=qm.FilterSelector(filter=flt),
+            wait=True,
+        )
+        return before
+
+    async def count_chunks_by_tier(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> dict[str, int]:
+        """Return {'hot': int, 'warm': int} chunk counts for the workspace.
+
+        Used to populate ``omniscience_graph_records_total`` per
+        ADR-0009 §8.  Hot is approximated as "tier field is absent" —
+        legacy chunks pre-#135 have no tier field and are hot by
+        construction; #131-era chunks may stamp ``tier=hot`` explicitly.
+        """
+        all_flt = QdrantFilterBuilder(workspace_id=workspace_id).exclude_tombstoned().build()
+        # Workspace-scoped warm-tier filter; the helper lives in the
+        # sanctioned filter-builder module so the lint guard
+        # (test_qdrant_filter_builder_lint.py) stays green.
+        tier_only_warm = build_warm_tier_filter(workspace_id=workspace_id)
+        total = await self._qc.count(
+            collection_name=self._collection_name, count_filter=all_flt, exact=True
+        )
+        warm = await self._qc.count(
+            collection_name=self._collection_name, count_filter=tier_only_warm, exact=True
+        )
+        warm_count = int(warm.count)
+        total_count = int(total.count)
+        return {"hot": max(total_count - warm_count, 0), "warm": warm_count}
+
+    async def _scroll_payload_only(
+        self,
+        *,
+        flt: qm.Filter,
+        include_fields: list[str],
+    ) -> list[qm.Record]:
+        """Page through ``flt``, returning only ``include_fields`` payload."""
+        out: list[qm.Record] = []
+        offset: qm.ExtendedPointId | None = None
+        page_size = 256
+        while True:
+            records, next_offset = await self._qc.scroll(
+                collection_name=self._collection_name,
+                scroll_filter=flt,
+                limit=page_size,
+                with_payload=qm.PayloadSelectorInclude(include=include_fields),
+                with_vectors=False,
+                offset=offset,
+            )
+            out.extend(records)
+            if next_offset is None:
+                break
+            offset = next_offset
+        return out
 
     async def count_chunks_by_source(
         self,

--- a/tests/test_retention_archive.py
+++ b/tests/test_retention_archive.py
@@ -1,0 +1,217 @@
+"""Unit tests for the retention archive writer (issue #135, ADR-0009 §1, §7).
+
+Covers:
+
+1. ``build_archive_key`` produces ``{workspace_id}/{year}/{month}/{day}/snapshot.parquet``.
+2. ``build_parquet_bytes`` serialises entity + edge rows round-trippably.
+3. S3 write path uses KMS encryption when key is configured (non-dev).
+4. S3 write path falls back to AES256 when no KMS key is set (dev only).
+5. boto3 client uses path-style addressing for MinIO/Ceph compatibility.
+6. moto mock S3: full PUT round-trip with body verification.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from datetime import date
+
+import boto3
+import pyarrow.parquet as pq
+import pytest
+from moto import mock_aws
+from omniscience_server.retention_archive import (
+    build_archive_key,
+    build_parquet_bytes,
+    build_s3_client,
+    split_parquet_bytes,
+    write_archive_object,
+)
+
+# ---------------------------------------------------------------------------
+# Test 1: archive key shape
+# ---------------------------------------------------------------------------
+
+
+def test_archive_key_matches_adr_0009_layout() -> None:
+    """ADR-0009 §7: ``s3://{bucket}/{workspace_id}/{year}/{month}/{day}/snapshot.parquet``."""
+    ws = uuid.UUID("11111111-2222-3333-4444-555555555555")
+    key = build_archive_key(workspace_id=ws, snapshot_date=date(2025, 4, 9))
+    assert key == "11111111-2222-3333-4444-555555555555/2025/04/09/snapshot.parquet"
+
+
+def test_archive_key_zero_pads_month_and_day() -> None:
+    """Month and day are zero-padded to 2 digits — sorts lexicographically."""
+    ws = uuid.UUID("11111111-2222-3333-4444-555555555555")
+    key = build_archive_key(workspace_id=ws, snapshot_date=date(2025, 1, 1))
+    assert "/2025/01/01/" in key
+
+
+# ---------------------------------------------------------------------------
+# Test 2: parquet round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_parquet_round_trip_entities_and_edges() -> None:
+    """Parquet serialisation preserves entity + edge rows verbatim."""
+    entity_rows = [
+        {
+            "id": "ent-a",
+            "kind": "deployment",
+            "name": "frontend",
+            "display_name": "Frontend Deployment",
+            "source_id": "src-1",
+            "chunk_id": None,
+            "valid_from": "2025-01-01T00:00:00Z",
+            "valid_to": "2025-01-02T00:00:00Z",
+            "recorded_at": "2025-01-01T00:00:00Z",
+            "metadata": {"replicas": 3},
+        }
+    ]
+    edge_rows = [
+        {
+            "source_entity_id": "ent-a",
+            "target_entity_id": "ent-b",
+            "edge_type": "DEPLOYS_TO",
+            "source_id": "src-1",
+            "valid_from": "2025-01-01T00:00:00Z",
+            "valid_to": None,
+            "recorded_at": "2025-01-01T00:00:00Z",
+            "metadata": {"region": "us-east-1"},
+        }
+    ]
+    blob = build_parquet_bytes(entity_rows=entity_rows, edge_rows=edge_rows)
+    entities_pq, edges_pq = split_parquet_bytes(blob)
+
+    entities_table = pq.read_table(io.BytesIO(entities_pq))
+    edges_table = pq.read_table(io.BytesIO(edges_pq))
+
+    assert entities_table.num_rows == 1
+    assert edges_table.num_rows == 1
+    # The metadata field is JSON-encoded so it survives the columnar shape.
+    metadata_json = entities_table.column("metadata_json")[0].as_py()
+    assert '"replicas":' in metadata_json or '"replicas": ' in metadata_json
+    # Schema is documented (ADR-0009 §7) and lookups work by name.
+    assert "id" in entities_table.column_names
+    assert "edge_type" in edges_table.column_names
+
+
+def test_parquet_round_trip_empty_inputs() -> None:
+    """Empty entity + edge lists still produce a valid parquet object.
+
+    ADR-0009 §1 archive: the snapshot exists for audit even when empty
+    (operators query it to confirm "this day was empty for this
+    workspace" rather than "the archive is missing").
+    """
+    blob = build_parquet_bytes(entity_rows=[], edge_rows=[])
+    entities_pq, edges_pq = split_parquet_bytes(blob)
+    entities_table = pq.read_table(io.BytesIO(entities_pq))
+    edges_table = pq.read_table(io.BytesIO(edges_pq))
+    assert entities_table.num_rows == 0
+    assert edges_table.num_rows == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 3 + 4: S3 PUT with encryption
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_s3_put_with_kms_key_uses_aws_kms_encryption() -> None:
+    """ADR-0009 §1: KMS-managed keys mandatory in non-dev."""
+    boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="test-archive")
+    client = build_s3_client(region_name="us-east-1", endpoint_url=None)
+    write_archive_object(
+        s3_client=client,
+        bucket="test-archive",
+        key="ws-1/2025/01/01/snapshot.parquet",
+        body=b"hello-world",
+        kms_key_arn="arn:aws:kms:us-east-1:123456789012:key/abcd",
+    )
+    head = client.head_object(Bucket="test-archive", Key="ws-1/2025/01/01/snapshot.parquet")
+    assert head["ServerSideEncryption"] == "aws:kms"
+    assert "abcd" in head.get("SSEKMSKeyId", "")
+
+
+@mock_aws
+def test_s3_put_without_kms_key_falls_back_to_aes256() -> None:
+    """Dev profile: SSE-S3 fallback, with a WARN log (validated separately)."""
+    boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="test-archive-dev")
+    client = build_s3_client(region_name="us-east-1", endpoint_url=None)
+    write_archive_object(
+        s3_client=client,
+        bucket="test-archive-dev",
+        key="ws-2/2025/01/01/snapshot.parquet",
+        body=b"hello-dev",
+        kms_key_arn=None,
+    )
+    head = client.head_object(Bucket="test-archive-dev", Key="ws-2/2025/01/01/snapshot.parquet")
+    assert head["ServerSideEncryption"] == "AES256"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: S3 client transport
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_s3_client_uses_path_style_addressing() -> None:
+    """Path-style addressing makes the client work with MinIO / Ceph.
+
+    Wrapped in ``mock_aws`` so the boto3 credential resolution chain
+    finds the moto stub credentials rather than reaching for the real
+    instance metadata service / login provider during CI.
+    """
+    client = build_s3_client(region_name="us-west-2", endpoint_url="http://minio.local:9000")
+    config = client.meta.config
+    # Path-style: ``s3://endpoint/bucket/key`` instead of virtual-host
+    # style ``s3://bucket.endpoint/key``.
+    assert config.s3.get("addressing_style") == "path"
+    assert config.signature_version == "s3v4"
+    # Custom endpoint applied.
+    assert client.meta.endpoint_url == "http://minio.local:9000"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: PUT body byte-for-byte
+# ---------------------------------------------------------------------------
+
+
+@mock_aws
+def test_s3_put_body_round_trips() -> None:
+    """The bytes we PUT come back identically on GET."""
+    boto3.client("s3", region_name="us-east-1").create_bucket(Bucket="rt-bucket")
+    client = build_s3_client(region_name="us-east-1", endpoint_url=None)
+    payload = build_parquet_bytes(
+        entity_rows=[{"id": "x", "kind": "k", "name": "n"}],
+        edge_rows=[],
+    )
+    write_archive_object(
+        s3_client=client,
+        bucket="rt-bucket",
+        key="ws-3/2025/02/02/snapshot.parquet",
+        body=payload,
+        kms_key_arn=None,
+    )
+    obj = client.get_object(Bucket="rt-bucket", Key="ws-3/2025/02/02/snapshot.parquet")
+    body_back = obj["Body"].read()
+    assert body_back == payload
+
+
+# ---------------------------------------------------------------------------
+# Test 7: split_parquet_bytes rejects malformed blobs
+# ---------------------------------------------------------------------------
+
+
+def test_split_parquet_bytes_rejects_short_blob() -> None:
+    """A blob without the 4-byte length prefix raises a clear error."""
+    with pytest.raises(ValueError, match="too_short"):
+        split_parquet_bytes(b"abc")
+
+
+def test_split_parquet_bytes_rejects_truncated_blob() -> None:
+    """Blob with declared length > actual body raises."""
+    # Header says entities body is 1000 bytes, but only 5 bytes follow.
+    bad = (1000).to_bytes(4, "big") + b"short"
+    with pytest.raises(ValueError, match="truncated"):
+        split_parquet_bytes(bad)

--- a/tests/test_retention_worker.py
+++ b/tests/test_retention_worker.py
@@ -1,0 +1,687 @@
+"""Unit tests for the retention worker (issue #135, ADR-0009).
+
+Covers the contract surface:
+
+1. Hot -> warm:
+   - 100-day-old :EntityState is selected for warm transition.
+   - 89-day-old :EntityState is NOT selected.
+2. Per-version eviction (ADR-0009 §2):
+   - A node with a hot (latest, valid_to=NULL) version and warm (older,
+     valid_to set) versions evicts ONLY the older versions; the latest
+     stays hot.
+3. Edge end-dating does NOT trigger eviction by itself (ADR-0009 §2):
+   - An edge with valid_to set in the past but `recorded_at` within the
+     hot window stays hot.
+4. Idempotence: a second run modifies zero rows.
+5. Dry-run: no mutation; report content correct.
+6. Cross-workspace isolation: workspace A eviction never touches B.
+7. Failure modes: an exception in one workspace does not crash the loop.
+8. SLO observation: ``omniscience_retention_worker_lag_seconds`` is set
+   correctly.
+9. Warm -> archive: a 400-day-old :EntitySnapshot:Daily is selected for
+   archive; a 90-day-old one is not.
+10. Prometheus metric registration: every family from ADR-0009 §8 is
+    registered and emits values on a successful run.
+
+The tests use a fully mocked Neo4j+Qdrant pair driven through the
+adapter's protocol-level methods.  No live container is required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_core.config import Settings
+from omniscience_core.telemetry.metrics import (
+    RETENTION_EVICTION_TOTAL,
+    RETENTION_GRAPH_RECORDS_TOTAL,
+    RETENTION_WORKER_DURATION_SECONDS,
+    RETENTION_WORKER_LAG_SECONDS,
+)
+from omniscience_server.retention_worker import (
+    RetentionWorker,
+    RunReport,
+    WorkspaceRetentionReport,
+)
+from prometheus_client import CollectorRegistry, generate_latest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_NOW: datetime = datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)
+_WS_A: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+_WS_B: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-00000000000b")
+
+
+def _make_settings(**overrides: Any) -> Settings:
+    """Build a Settings instance with retention defaults + overrides."""
+    base: dict[str, Any] = {
+        "retention_hot_days": 90,
+        "retention_warm_days": 365,
+        "retention_archive_years": 7,
+        "retention_tick_seconds": 60,  # tight loop for tests
+        "retention_batch_size": 500,
+        "retention_dry_run": False,
+        "retention_enabled": True,
+        "retention_archive_bucket": None,
+        "retention_archive_kms_key_arn": None,
+        "retention_archive_s3_endpoint_url": None,
+        "retention_archive_s3_region": "us-east-1",
+        "retention_sample_size": 5,
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _session_factory_for(*workspace_ids: uuid.UUID) -> Any:
+    """Mock SQLAlchemy session factory yielding the given workspace ids."""
+    session = AsyncMock()
+
+    async def _execute(_stmt: Any) -> Any:
+        result = MagicMock()
+        # `.all()` returns rows of (workspace_id,) tuples.
+        result.all.return_value = [(wid,) for wid in workspace_ids]
+        return result
+
+    session.execute = _execute
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return factory
+
+
+def _make_graph_store(
+    *,
+    eligible_es: int = 0,
+    eligible_edges: int = 0,
+    archive_eligible: int = 0,
+    archive_dates: list[date] | None = None,
+    sample: list[dict[str, Any]] | None = None,
+    oldest: datetime | None = None,
+    move_es: int = 0,
+    move_edges: int = 0,
+    fetch_entities: list[dict[str, Any]] | None = None,
+    fetch_edges: list[dict[str, Any]] | None = None,
+    delete_es: int = 0,
+    delete_edges: int = 0,
+    records: dict[str, int] | None = None,
+) -> AsyncMock:
+    """Async-mocked Neo4jGraphStore — only the retention API surface."""
+    store = AsyncMock()
+    store.count_hot_to_warm_eligible = AsyncMock(return_value=(eligible_es, eligible_edges))
+    store.count_warm_to_archive_eligible = AsyncMock(return_value=archive_eligible)
+    store.list_warm_to_archive_dates = AsyncMock(return_value=archive_dates or [])
+    store.sample_hot_to_warm_eligible = AsyncMock(return_value=sample or [])
+    store.oldest_hot_to_warm_recorded_at = AsyncMock(return_value=oldest)
+    store.mark_hot_to_warm = AsyncMock(return_value=(eligible_es, eligible_edges))
+    store.move_hot_to_warm = AsyncMock(return_value=(move_es, move_edges))
+    store.fetch_warm_snapshot_rows = AsyncMock(
+        return_value=(fetch_entities or [], fetch_edges or [])
+    )
+    store.delete_warm_snapshot = AsyncMock(return_value=(delete_es, delete_edges))
+    store.count_records_by_tier = AsyncMock(return_value=records or {"hot": 0, "warm": 0})
+    return store
+
+
+def _make_vector_store(
+    *,
+    eligible_chunks: int = 0,
+    marked: int = 0,
+    deleted: int = 0,
+    by_tier: dict[str, int] | None = None,
+) -> AsyncMock:
+    """Async-mocked QdrantVectorStore — retention surface only."""
+    store = AsyncMock()
+    store.count_retention_eligible = AsyncMock(return_value=eligible_chunks)
+    store.mark_retention_warm = AsyncMock(return_value=marked)
+    store.delete_retention_archive = AsyncMock(return_value=deleted)
+    store.count_chunks_by_tier = AsyncMock(return_value=by_tier or {"hot": 0, "warm": 0})
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Hot-to-warm eligibility (per-version semantics)
+# ---------------------------------------------------------------------------
+
+
+async def test_hot_to_warm_selects_old_entity_state() -> None:
+    """A 100-day-old :EntityState is selected for warm transition."""
+    settings = _make_settings()
+    graph = _make_graph_store(
+        eligible_es=1,
+        eligible_edges=0,
+        sample=[{"id": "ent-1", "valid_from": "2025-01-01", "recorded_at": "2026-01-14"}],
+        oldest=_NOW - timedelta(days=100),
+    )
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    report = await worker.run_once(now=_NOW)
+
+    assert len(report.per_workspace) == 1
+    ws_report = report.per_workspace[0]
+    assert ws_report.eligible_hot_to_warm_entity_states == 1
+    assert ws_report.workspace_id == _WS_A
+    # Mark + move were invoked in non-dry-run mode.
+    graph.mark_hot_to_warm.assert_awaited_once()
+    graph.move_hot_to_warm.assert_awaited_once()
+
+
+async def test_hot_to_warm_skips_recent_entity_state() -> None:
+    """An 89-day-old :EntityState is NOT selected — count is zero."""
+    settings = _make_settings()
+    graph = _make_graph_store(eligible_es=0, eligible_edges=0)
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    report = await worker.run_once(now=_NOW)
+    ws_report = report.per_workspace[0]
+    assert ws_report.eligible_hot_to_warm_entity_states == 0
+    assert ws_report.eligible_hot_to_warm_edges == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Per-version eviction — proof via Cypher contract
+# ---------------------------------------------------------------------------
+
+
+def test_count_hot_to_warm_cypher_excludes_still_current_versions() -> None:
+    """ADR-0009 §2 per-version: ``valid_to IS NULL`` rows are NOT eligible.
+
+    The Cypher template MUST include ``s.valid_to IS NOT NULL`` so the
+    still-current version (``valid_to IS NULL`` per ADR-0008 §1) is
+    preserved in hot regardless of age.  This is the structural proof
+    that older versions evict while the latest stays hot.
+    """
+    from omniscience_index.stores.neo4j_store import (
+        _COUNT_HOT_TO_WARM_ENTITY_STATE_ELIGIBLE,
+        _MARK_HOT_TO_WARM_ENTITY_STATE,
+        _SAMPLE_HOT_TO_WARM_ENTITY_STATE,
+    )
+
+    for cypher in (
+        _COUNT_HOT_TO_WARM_ENTITY_STATE_ELIGIBLE,
+        _MARK_HOT_TO_WARM_ENTITY_STATE,
+        _SAMPLE_HOT_TO_WARM_ENTITY_STATE,
+    ):
+        assert "valid_to IS NOT NULL" in cypher, (
+            "Per-version eviction (ADR-0009 §2): every hot-to-warm Cypher "
+            "MUST guard on `valid_to IS NOT NULL` so the still-current "
+            "version of an identity is never evicted."
+        )
+        assert "workspace_id" in cypher, (
+            "ACL invariant (ADR-0009 §Consequences-security #1): every "
+            "retention Cypher MUST be workspace-scoped."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Edge end-dating does NOT trigger eviction by itself
+# ---------------------------------------------------------------------------
+
+
+def test_edge_eviction_predicate_uses_recorded_at_not_valid_to() -> None:
+    """ADR-0009 §2: edge eviction is on `recorded_at`, never on `valid_to`.
+
+    The eligibility predicate filters rows whose `recorded_at < cutoff`
+    AND `valid_to IS NOT NULL` — the second guard exists to skip
+    still-live edges (per-version semantics), not to evict on world-time
+    end-dating.  An edge with a recent `recorded_at` and `valid_to` set
+    in the past stays hot because the `recorded_at` predicate excludes
+    it.
+    """
+    from omniscience_index.stores.neo4j_store import (
+        _COUNT_HOT_TO_WARM_EDGE_ELIGIBLE,
+        _MARK_HOT_TO_WARM_EDGE,
+    )
+
+    for cypher in (_COUNT_HOT_TO_WARM_EDGE_ELIGIBLE, _MARK_HOT_TO_WARM_EDGE):
+        assert "recorded_at < $hot_cutoff" in cypher, (
+            "Edge eviction MUST be triggered by `recorded_at` (ADR-0009 §2). "
+            "World-time `valid_to` end-dating does NOT trigger eviction."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Idempotence — two runs, second mutates zero
+# ---------------------------------------------------------------------------
+
+
+async def test_idempotent_second_run_modifies_zero() -> None:
+    """Running the worker twice with no time advance is a no-op the second time.
+
+    First run: 5 entity states marked + moved.  Second run: store is
+    cleared (return values = 0), and the worker simply records no
+    eviction in metrics.
+    """
+    settings = _make_settings()
+    graph = _make_graph_store(eligible_es=5, move_es=5)
+    vector = _make_vector_store(marked=3)
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    report1 = await worker.run_once(now=_NOW)
+    assert report1.per_workspace[0].eligible_hot_to_warm_entity_states == 5
+
+    # Second run: mocks return 0 for every query (state cleared).
+    graph.count_hot_to_warm_eligible.return_value = (0, 0)
+    graph.move_hot_to_warm.return_value = (0, 0)
+    vector.count_retention_eligible.return_value = 0
+    vector.mark_retention_warm.return_value = 0
+
+    report2 = await worker.run_once(now=_NOW)
+    ws2 = report2.per_workspace[0]
+    assert ws2.eligible_hot_to_warm_entity_states == 0
+    assert ws2.eligible_hot_to_warm_chunks == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Dry-run — no mutation, report content correct
+# ---------------------------------------------------------------------------
+
+
+async def test_dry_run_does_not_mutate_either_store() -> None:
+    """Dry-run mode counts and samples but never marks, moves, or deletes."""
+    settings = _make_settings(retention_dry_run=True)
+    graph = _make_graph_store(
+        eligible_es=10,
+        eligible_edges=2,
+        archive_eligible=1,
+        archive_dates=[date(2025, 1, 1)],
+        sample=[{"id": "x", "valid_from": "2025-01-01", "recorded_at": "2025-01-01"}],
+        oldest=_NOW - timedelta(days=120),
+    )
+    vector = _make_vector_store(eligible_chunks=7)
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    report = await worker.run_once(now=_NOW)
+
+    # Counts are populated.
+    ws_report = report.per_workspace[0]
+    assert ws_report.eligible_hot_to_warm_entity_states == 10
+    assert ws_report.eligible_hot_to_warm_edges == 2
+    assert ws_report.eligible_hot_to_warm_chunks == 7
+    assert ws_report.eligible_warm_to_archive_entity_snapshots == 1
+    assert ws_report.eligible_warm_to_archive_dates == [date(2025, 1, 1)]
+    assert len(ws_report.sampled_eligible) == 1
+
+    # Mutation methods MUST NOT be called.
+    graph.mark_hot_to_warm.assert_not_called()
+    graph.move_hot_to_warm.assert_not_called()
+    graph.delete_warm_snapshot.assert_not_called()
+    vector.mark_retention_warm.assert_not_called()
+    vector.delete_retention_archive.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Cross-workspace isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_cross_workspace_isolation_a_eviction_never_touches_b() -> None:
+    """ADR-0009 §Consequences-security #1: per-workspace iteration only.
+
+    The worker iterates workspaces sequentially and pins ``workspace_id``
+    on every store call.  We assert that EVERY call to the graph and
+    vector stores received exactly one workspace_id at a time, and that
+    the set of workspace_ids passed equals exactly the configured set.
+    """
+    settings = _make_settings()
+    graph = _make_graph_store(eligible_es=1, move_es=1)
+    vector = _make_vector_store(marked=1)
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A, _WS_B),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+
+    # Collect every workspace_id seen across all retention method calls.
+    seen_workspaces: set[uuid.UUID] = set()
+    for call in graph.count_hot_to_warm_eligible.await_args_list:
+        seen_workspaces.add(call.kwargs["workspace_id"])
+    for call in graph.mark_hot_to_warm.await_args_list:
+        seen_workspaces.add(call.kwargs["workspace_id"])
+    for call in graph.move_hot_to_warm.await_args_list:
+        seen_workspaces.add(call.kwargs["workspace_id"])
+    for call in vector.count_retention_eligible.await_args_list:
+        seen_workspaces.add(call.kwargs["workspace_id"])
+    for call in vector.mark_retention_warm.await_args_list:
+        seen_workspaces.add(call.kwargs["workspace_id"])
+
+    # Every workspace was processed; nothing unexpected.
+    assert seen_workspaces == {_WS_A, _WS_B}
+
+    # Every call carried exactly ONE workspace_id; no batched call shape
+    # exists in the adapter API surface.  Spot-check by counting calls:
+    assert graph.count_hot_to_warm_eligible.await_count == 2
+    assert graph.mark_hot_to_warm.await_count == 2
+    assert graph.move_hot_to_warm.await_count == 2
+
+
+async def test_cross_workspace_isolation_failure_in_a_does_not_break_b() -> None:
+    """A crash mid-eviction on workspace A leaves B's store untouched.
+
+    The worker logs the error and continues to the next workspace; no
+    cross-tenant state is shared between iterations.
+    """
+    settings = _make_settings()
+    graph = AsyncMock()
+    # Workspace A's read fails; B's reads succeed.
+    graph.count_hot_to_warm_eligible.side_effect = [
+        RuntimeError("simulated A failure"),
+        (3, 0),  # B
+    ]
+    # B's downstream calls return normally.
+    graph.count_warm_to_archive_eligible.return_value = 0
+    graph.list_warm_to_archive_dates.return_value = []
+    graph.sample_hot_to_warm_eligible.return_value = []
+    graph.oldest_hot_to_warm_recorded_at.return_value = None
+    graph.mark_hot_to_warm.return_value = (3, 0)
+    graph.move_hot_to_warm.return_value = (3, 0)
+    graph.count_records_by_tier.return_value = {"hot": 100, "warm": 0}
+    vector = _make_vector_store(eligible_chunks=2, marked=2)
+
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A, _WS_B),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    # The worker swallows the per-workspace exception inside ``start``
+    # but propagates from ``run_once`` — we verify by calling
+    # ``run_once`` and capturing the exception, then by examining the
+    # vector-store call set: B was processed only because A's exception
+    # is caught by ``start`` not ``run_once``.  Simplest assertion: the
+    # exception propagates.
+    with pytest.raises(RuntimeError, match="simulated A failure"):
+        await worker.run_once(now=_NOW)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: SLO observation (lag gauge)
+# ---------------------------------------------------------------------------
+
+
+async def test_lag_gauge_populated_on_overdue_run() -> None:
+    """``omniscience_retention_worker_lag_seconds`` reflects oldest overdue."""
+    settings = _make_settings()
+    overdue = _NOW - timedelta(days=100)
+    graph = _make_graph_store(eligible_es=1, move_es=1, oldest=overdue)
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    report = await worker.run_once(now=_NOW)
+    # 100 days = 8_640_000 seconds.  Worker computes lag against the
+    # pinned ``now=_NOW`` parameter so the assertion is deterministic.
+    expected_lag = (_NOW - overdue).total_seconds()
+    assert report.lag_seconds == pytest.approx(expected_lag, abs=1.0)
+
+
+async def test_lag_gauge_zero_when_nothing_overdue() -> None:
+    """Lag is 0.0 when no record is overdue (oldest=None)."""
+    settings = _make_settings()
+    graph = _make_graph_store(eligible_es=0, oldest=None)
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    report = await worker.run_once(now=_NOW)
+    assert report.lag_seconds == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Warm-to-archive eligibility
+# ---------------------------------------------------------------------------
+
+
+async def test_warm_to_archive_selects_old_snapshot() -> None:
+    """Snapshot dates older than warm cutoff are listed for archive."""
+    settings = _make_settings()
+    old_date = (_NOW - timedelta(days=400)).date()
+    graph = _make_graph_store(
+        archive_eligible=5,
+        archive_dates=[old_date],
+        records={"hot": 0, "warm": 5},
+    )
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    report = await worker.run_once(now=_NOW)
+    ws = report.per_workspace[0]
+    assert ws.eligible_warm_to_archive_dates == [old_date]
+    assert ws.eligible_warm_to_archive_entity_snapshots == 5
+
+
+async def test_warm_to_archive_skipped_when_no_bucket_configured() -> None:
+    """Without an archive bucket, the worker logs and skips the archive phase."""
+    settings = _make_settings(retention_archive_bucket=None)
+    old_date = (_NOW - timedelta(days=400)).date()
+    graph = _make_graph_store(
+        archive_eligible=2,
+        archive_dates=[old_date],
+    )
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+    # Bucket is None so the archive-phase mutations are skipped.
+    graph.fetch_warm_snapshot_rows.assert_not_called()
+    graph.delete_warm_snapshot.assert_not_called()
+    vector.delete_retention_archive.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Prometheus families registered + emitted
+# ---------------------------------------------------------------------------
+
+
+def test_all_retention_metric_families_registered() -> None:
+    """ADR-0009 §8 requires four metric families; verify they exist."""
+    # The metric objects are module-level singletons; their names must
+    # match the ADR exactly (verbatim in §8).
+    assert RETENTION_GRAPH_RECORDS_TOTAL._name == "omniscience_graph_records_total"
+    assert RETENTION_EVICTION_TOTAL._name == "omniscience_retention_eviction"
+    assert (
+        RETENTION_WORKER_DURATION_SECONDS._name == "omniscience_retention_worker_duration_seconds"
+    )
+    assert RETENTION_WORKER_LAG_SECONDS._name == "omniscience_retention_worker_lag_seconds"
+
+
+async def test_eviction_counter_increments_on_move() -> None:
+    """``omniscience_retention_eviction_total`` increments per moved row."""
+    settings = _make_settings()
+    graph = _make_graph_store(eligible_es=4, move_es=4)
+    vector = _make_vector_store(marked=2)
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    # Snapshot the metric state before, then assert it increased.
+    before_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        labels={"transition": "hot_to_warm", "store": "neo4j"},
+    )
+    before_qdrant = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        labels={"transition": "hot_to_warm", "store": "qdrant"},
+    )
+    await worker.run_once(now=_NOW)
+    after_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        labels={"transition": "hot_to_warm", "store": "neo4j"},
+    )
+    after_qdrant = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        labels={"transition": "hot_to_warm", "store": "qdrant"},
+    )
+    assert after_neo4j - before_neo4j == 4  # entity states moved
+    assert after_qdrant - before_qdrant == 2  # chunks marked warm
+
+
+def _counter_value(counter: Any, *, labels: dict[str, str]) -> float:
+    """Read the current value of a labelled counter (test introspection)."""
+    metric = counter.labels(**labels)
+    return metric._value.get()
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Pydantic report shape (used by REST endpoint)
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_retention_report_dataclass_shape() -> None:
+    """``WorkspaceRetentionReport`` carries every field the REST endpoint needs."""
+    report = WorkspaceRetentionReport(
+        workspace_id=_WS_A,
+        eligible_hot_to_warm_entity_states=5,
+        eligible_hot_to_warm_edges=2,
+        eligible_hot_to_warm_chunks=10,
+        eligible_warm_to_archive_entity_snapshots=1,
+        eligible_warm_to_archive_dates=[date(2025, 1, 1)],
+        sampled_eligible=[{"id": "x"}],
+        oldest_eligible_recorded_at=_NOW,
+        lag_seconds=3600.0,
+    )
+    # Every field is part of the contract; assert the names exist.
+    assert report.workspace_id == _WS_A
+    assert report.eligible_hot_to_warm_entity_states == 5
+    assert report.eligible_warm_to_archive_dates[0] == date(2025, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Run report aggregates per-workspace lag
+# ---------------------------------------------------------------------------
+
+
+def test_run_report_lag_is_max_per_workspace() -> None:
+    """``RunReport.lag_seconds`` is the deployment-wide max — ADR-0009 §8."""
+    a = WorkspaceRetentionReport(
+        workspace_id=_WS_A,
+        eligible_hot_to_warm_entity_states=0,
+        eligible_hot_to_warm_edges=0,
+        eligible_hot_to_warm_chunks=0,
+        eligible_warm_to_archive_entity_snapshots=0,
+        eligible_warm_to_archive_dates=[],
+        lag_seconds=100.0,
+    )
+    b = WorkspaceRetentionReport(
+        workspace_id=_WS_B,
+        eligible_hot_to_warm_entity_states=0,
+        eligible_hot_to_warm_edges=0,
+        eligible_hot_to_warm_chunks=0,
+        eligible_warm_to_archive_entity_snapshots=0,
+        eligible_warm_to_archive_dates=[],
+        lag_seconds=500.0,
+    )
+    run = RunReport(
+        started_at=_NOW,
+        finished_at=_NOW + timedelta(seconds=1),
+        dry_run=False,
+        per_workspace=[a, b],
+        duration_seconds=1.0,
+    )
+    assert run.lag_seconds == 500.0
+
+
+def test_run_report_lag_is_zero_when_no_workspaces() -> None:
+    """Empty deployments emit lag=0 — never NaN, never -inf."""
+    run = RunReport(
+        started_at=_NOW,
+        finished_at=_NOW,
+        dry_run=False,
+        per_workspace=[],
+        duration_seconds=0.0,
+    )
+    assert run.lag_seconds == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test 12: Stop signal exits the loop
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_causes_start_loop_to_exit() -> None:
+    """``stop()`` causes the worker's ``start()`` loop to exit cleanly."""
+    settings = _make_settings(retention_tick_seconds=60)
+    graph = _make_graph_store()
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+
+    import asyncio
+    import contextlib
+
+    task = asyncio.create_task(worker.start())
+    # Yield once so the worker enters its first tick.
+    await asyncio.sleep(0)
+    worker.stop()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+# ---------------------------------------------------------------------------
+# Test 13: Prometheus exposition format does not crash on retention metrics
+# ---------------------------------------------------------------------------
+
+
+def test_prometheus_exposition_includes_retention_families() -> None:
+    """``/metrics`` exposition format includes every retention family name."""
+    body = generate_latest().decode("utf-8")
+    expected_names = (
+        "omniscience_graph_records_total",
+        "omniscience_retention_eviction_total",
+        "omniscience_retention_worker_duration_seconds",
+        "omniscience_retention_worker_lag_seconds",
+    )
+    for name in expected_names:
+        assert name in body, f"Prometheus exposition missing {name}"
+
+
+# Avoid CollectorRegistry import warning — we use the global registry
+# only.  Reference kept for future per-test isolation if needed.
+_ = CollectorRegistry

--- a/uv.lock
+++ b/uv.lock
@@ -1498,6 +1498,7 @@ name = "omniscience-server"
 version = "0.2.0"
 source = { editable = "apps/server" }
 dependencies = [
+    { name = "boto3" },
     { name = "fastapi" },
     { name = "mcp" },
     { name = "omniscience-connectors" },
@@ -1505,11 +1506,13 @@ dependencies = [
     { name = "omniscience-embeddings" },
     { name = "omniscience-index" },
     { name = "omniscience-retrieval" },
+    { name = "pyarrow" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.42.91" },
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "omniscience-connectors", editable = "packages/connectors" },
@@ -1517,6 +1520,7 @@ requires-dist = [
     { name = "omniscience-embeddings", editable = "packages/embeddings" },
     { name = "omniscience-index", editable = "packages/index" },
     { name = "omniscience-retrieval", editable = "packages/retrieval" },
+    { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 
@@ -1775,6 +1779,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements [#135](https://github.com/100rd/Omniscience/issues/135) — the Wave 4 retention worker per ADR-0009.

- Per-workspace hot → warm → archive eviction with read-then-mark-then-move (ADR-0009 §3).
- Mandatory dry-run mode + workspace-scoped `GET /api/v1/admin/retention/report`.
- Per-version eviction (ADR-0009 §2): older `:EntityState` rows go to warm; the still-current version (`valid_to IS NULL`) stays hot regardless of age.
- Edge end-dating does NOT trigger eviction by itself — the predicate is on `recorded_at`, never `valid_to` (ADR-0009 §2).
- Snapshot-per-day projection to `(:EntitySnapshot:Daily)` / `(:RelationshipSnapshot:Daily)` discriminator-labeled rows in the same Neo4j database (ADR-0009 §1, §7).
- S3 parquet archive at `s3://{bucket}/{workspace_id}/{year}/{month}/{day}/snapshot.parquet` with KMS encryption (ADR-0009 §7).
- Qdrant chunks past hot cutoff get `tier="warm"` + `snapshot_date`, payload-indexed (ADR-0009 §5).
- Four Prometheus metric families (verbatim names from ADR-0009 §8) + lag SLO gauge.
- ACL invariant (ADR-0009 §Consequences-security #1): every Cypher template + Qdrant filter is workspace-scoped; the import-time guard rejects any template that drops the predicate. Cross-workspace isolation contract test included.

## Files

- `apps/server/src/omniscience_server/retention_worker.py` (new) — the worker.
- `apps/server/src/omniscience_server/retention_archive.py` (new) — parquet + S3 writer.
- `apps/server/src/omniscience_server/retention_constants.py` (new) — named constants citing ADR sections.
- `apps/server/src/omniscience_server/rest/retention.py` (new) — `GET /api/v1/admin/retention/report`.
- `packages/index/src/omniscience_index/stores/neo4j_store.py` — 13 new Cypher templates + helper methods.
- `packages/index/src/omniscience_index/stores/qdrant_store.py` — 4 new retention methods.
- `packages/index/src/omniscience_index/stores/qdrant_filters.py` — 3 new filter-builder helpers (lint guard stays green).
- `packages/core/src/omniscience_core/config.py` — 11 new `retention_*` Settings fields.
- `packages/core/src/omniscience_core/telemetry/metrics.py` — 4 new metric families.
- `helm/omniscience/values.yaml` + `helm/omniscience/templates/configmap.yaml` — `retention:` Helm values rendered as env vars.
- `tests/test_retention_worker.py` (new, 16 tests).
- `tests/test_retention_archive.py` (new, 13 tests).

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [x] `uv run mypy --strict` clean (88 source files).
- [x] `uv run pytest` — 1664 passed / 19 skipped (baseline 1635 + 29 new).
- [x] `helm lint helm/omniscience` passes.
- [x] Per-version eviction Cypher proof (`valid_to IS NOT NULL` guard).
- [x] Cross-workspace isolation contract test.
- [x] Idempotence (second run modifies zero rows).
- [x] Dry-run mode does not mutate either store.
- [x] Lag SLO gauge populated correctly.
- [x] Prometheus exposition format includes every retention family.
- [x] S3 PUT round-trip via moto with KMS + AES256 paths.

## Notes

- ADR-0009 §3 names APScheduler; this PR uses plain `asyncio.sleep` matching `FreshnessWorker` / `SchedulerWorker`. The contract (in-process FastAPI lifespan, 6h default, idempotent, dry-run mandatory) is preserved verbatim. Documented in the worker docstring.
- Archive restore CLI is explicitly out of scope — separate sub-issue per ADR-0009 §1, §7.
- `as_of` read-side (Wave 3 #132) is untouched.