### PR TITLE
feat: tombstones become end-dated edges and entities (#137)

### DIFF
--- a/packages/core/src/omniscience_core/telemetry/metrics.py
+++ b/packages/core/src/omniscience_core/telemetry/metrics.py
@@ -148,3 +148,31 @@ RETENTION_WORKER_LAG_SECONDS: Gauge = Gauge(
         "steady; >7d trips a P1 alert via the freshness alert path."
     ),
 )
+
+# ---------------------------------------------------------------------------
+# Bitemporal end-dating metrics (ADR-0008 §3, issue #137)
+# ---------------------------------------------------------------------------
+#
+# Tombstones are no longer hard-deletes when ``GRAPH_BITEMPORAL=enabled``.
+# The writer end-dates entities and edges instead — sets ``valid_to`` to
+# ``snapshot_at`` (re-ingestion) or ``now()`` (per-document tombstone).
+# The retention worker (#135 / ADR-0009) is the only remaining hard-delete
+# path; eviction operates on ``recorded_at`` age and is orthogonal to the
+# tombstone signal.
+#
+# Counter labels:
+#   * ``kind``    — one of ``"entity"``, ``"edge"``.
+#   * ``reason``  — one of ``"snapshot"`` (snapshot re-ingestion absent
+#                   from new batch), ``"tombstone"`` (per-document
+#                   tombstone signal end-dates by source).
+GRAPH_END_DATED_TOTAL: Counter = Counter(
+    name="omniscience_graph_end_dated_total",
+    documentation=(
+        "Total entities and edges end-dated by the bitemporal writer "
+        "(ADR-0008 §3, issue #137). Increments per (workspace, source) "
+        "end-dating operation. Reason ``snapshot`` covers re-ingestion "
+        "of a smaller snapshot; ``tombstone`` covers the per-document "
+        "tombstone signal."
+    ),
+    labelnames=["kind", "reason"],
+)

--- a/packages/index/src/omniscience_index/stores/neo4j_store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j_store.py
@@ -50,6 +50,7 @@ from omniscience_core.storage.graph import (
     GraphEdgeView,
     GraphResultView,
 )
+from omniscience_core.telemetry.metrics import GRAPH_END_DATED_TOTAL
 
 log = structlog.get_logger(__name__)
 
@@ -411,6 +412,13 @@ RETURN state_changed AS state_changed
 # pgvector ``IndexWriter.upsert_graph`` semantics: deleting by
 # source_id purges both entities and their incident edges via
 # DETACH DELETE.
+#
+# Used ONLY when ``Neo4jStoreConfig.bitemporal_enabled`` is ``False``.
+# Once the bitemporal flag flips on, the writer routes to
+# ``_END_DATE_BY_SOURCE_CYPHER`` below per ADR-0008 §3 and issue #137.
+# This template is preserved byte-for-byte from PR #104 so the legacy
+# regression suite at ``tests/test_neo4j_store.py`` keeps passing
+# unmodified — the "no regressions" contract from ADR-0008 §8 phase 2.
 _DELETE_BY_SOURCE_CYPHER: Final[str] = f"""
 MATCH (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id, source_id: $source_id}})
 DETACH DELETE n
@@ -420,11 +428,131 @@ DETACH DELETE n
 # Mirrors the pgvector no-op contract but is a real operation here —
 # Neo4j has no cascade from a Postgres source row, so proactive cleanup
 # is required when a document is tombstoned.
+#
+# Used ONLY when ``Neo4jStoreConfig.bitemporal_enabled`` is ``False``.
+# When the bitemporal flag is on, the writer routes to
+# ``_END_DATE_TOMBSTONED_CYPHER`` per ADR-0008 §3 and issue #137; the
+# retention worker (#135 / ADR-0009) is then the only remaining hard-
+# delete path and operates on ``recorded_at`` age, not on tombstone
+# signals.
 _DELETE_TOMBSTONED_CYPHER: Final[str] = f"""
 MATCH (n:{_ENTITY_LABEL})
 WHERE n.tombstoned_at IS NOT NULL
 DETACH DELETE n
 RETURN count(n) AS deleted
+"""
+
+
+# --- Tombstone end-dating (ADR-0008 §3, issue #137) -----------------------
+#
+# Replaces hard-delete with end-dating when the bitemporal flag is on.
+# The writer no longer issues ``DETACH DELETE`` against entities or
+# incident relationships — instead it sets ``valid_to`` on the still-
+# open identity row, on the still-open ``[:HAD_STATE]``, on the still-
+# open ``:EntityState``, and on every still-open incident relationship.
+#
+# After this transformation a query at any ``as_of < $now`` returns the
+# entity/edge as it was; a query at ``as_of >= $now`` finds nothing,
+# which is the bitemporal-correct shape an ``as_of`` reader expects
+# (ADR-0008 §5).
+#
+# Hard deletion is gone for the bitemporal-enabled deployment.  The
+# retention worker (#135) is the only remaining hard-delete path and
+# operates on ``recorded_at`` age, NOT on tombstone signals — these
+# two policies are deliberately orthogonal (ADR-0009 §2).
+
+# End-date every still-open node + relationship attached to (workspace_id,
+# source_id).  Used by ``upsert_graph`` for replace-by-source semantics
+# under the bitemporal flag — re-ingestion of a smaller snapshot end-
+# dates entities and edges absent from the new batch.
+#
+# Returns counts so the writer can log + emit telemetry.
+#
+# Why two passes over the same set?  The relationship pass uses
+# ``OPTIONAL MATCH`` so an entity with no incident edges still gets its
+# version chain closed; counting them in one ``MATCH (a)-[r]-(b)`` join
+# would over-count when a node has multiple edges (one row per edge,
+# and each edge is end-dated only once regardless of which endpoint
+# anchors the match).  Splitting keeps the counts honest.
+_END_DATE_BY_SOURCE_CYPHER: Final[str] = f"""
+// ADR-0008 §3 + issue #137 — set valid_to on every still-open
+// :Entity (and its open [:HAD_STATE] + :EntityState mirror) and every
+// incident relationship for (workspace_id, source_id).  No DETACH DELETE.
+//
+// Phase A — end-date entity identity, open [:HAD_STATE], open :EntityState.
+CALL {{
+    MATCH (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id, source_id: $source_id}})
+    WHERE n.valid_to IS NULL
+    OPTIONAL MATCH (n)-[h:HAD_STATE]->(s:{_ENTITY_STATE_LABEL})
+    WHERE h.valid_to IS NULL AND s.valid_to IS NULL
+    SET n.valid_to = datetime($now),
+        n.updated_at = $now
+    FOREACH (_ IN CASE WHEN h IS NOT NULL THEN [1] ELSE [] END |
+        SET h.valid_to = datetime($now),
+            s.valid_to = datetime($now)
+    )
+    RETURN count(DISTINCT n) AS entities_end_dated
+}}
+//
+// Phase B — end-date every still-open relationship incident to a
+// :Entity in (workspace_id, source_id).  Match anchored on the entity
+// to keep the workspace_id predicate on the node side; then enforce
+// workspace_id on the relationship for defence-in-depth (an edge with
+// a foreign workspace_id stamped on it must NOT be touched here).
+CALL {{
+    MATCH (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id, source_id: $source_id}})
+    OPTIONAL MATCH (n)-[r]-()
+    WHERE r.workspace_id = $workspace_id AND r.valid_to IS NULL
+    FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
+        SET r.valid_to = datetime($now),
+            r.updated_at = $now
+    )
+    RETURN count(DISTINCT r) AS edges_end_dated
+}}
+RETURN entities_end_dated, edges_end_dated
+"""
+
+# End-date every :Entity flagged tombstoned (and its open [:HAD_STATE]
+# + open :EntityState) where ``valid_to`` is still NULL.  Replaces the
+# legacy hard-delete in ``delete_tombstoned``.  Returns the count so the
+# caller can emit telemetry.
+#
+# ``tombstoned_at`` is set on the identity mirror by the ingestion layer
+# (an external signal; ADR-0007 §7 keeps Postgres ``documents.tombstoned_at``
+# as the operational metadata source).  This Cypher reads that flag on
+# the :Entity mirror and end-dates the whole open chain.
+#
+# Edges to/from tombstoned entities are end-dated alongside.  Defence-in-
+# depth: filter the relationship by ``workspace_id`` even though it is
+# bounded by an entity already filtered.
+_END_DATE_TOMBSTONED_CYPHER: Final[str] = f"""
+// ADR-0008 §3 + issue #137 — end-date tombstoned entities (and their
+// open [:HAD_STATE] + :EntityState mirror) instead of DETACH DELETE.
+CALL {{
+    MATCH (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id}})
+    WHERE n.tombstoned_at IS NOT NULL AND n.valid_to IS NULL
+    OPTIONAL MATCH (n)-[h:HAD_STATE]->(s:{_ENTITY_STATE_LABEL})
+    WHERE h.valid_to IS NULL AND s.valid_to IS NULL
+    SET n.valid_to = datetime($now),
+        n.updated_at = $now
+    FOREACH (_ IN CASE WHEN h IS NOT NULL THEN [1] ELSE [] END |
+        SET h.valid_to = datetime($now),
+            s.valid_to = datetime($now)
+    )
+    RETURN count(DISTINCT n) AS entities_end_dated
+}}
+CALL {{
+    MATCH (n:{_ENTITY_LABEL} {{workspace_id: $workspace_id}})
+    WHERE n.tombstoned_at IS NOT NULL
+    OPTIONAL MATCH (n)-[r]-()
+    WHERE r.workspace_id = $workspace_id AND r.valid_to IS NULL
+    FOREACH (_ IN CASE WHEN r IS NOT NULL THEN [1] ELSE [] END |
+        SET r.valid_to = datetime($now),
+            r.updated_at = $now
+    )
+    RETURN count(DISTINCT r) AS edges_end_dated
+}}
+RETURN entities_end_dated, edges_end_dated
 """
 
 
@@ -925,6 +1053,13 @@ _ensure_workspace_predicate(_UPSERT_ENTITY_BITEMPORAL_CYPHER, "_UPSERT_ENTITY_BI
 _ensure_workspace_predicate(
     _UPSERT_EDGE_BITEMPORAL_CYPHER_TEMPLATE, "_UPSERT_EDGE_BITEMPORAL_CYPHER_TEMPLATE"
 )
+# Issue #137 — bitemporal-enabled writer end-dates instead of hard-
+# deleting.  Both new templates are workspace-scoped on every MATCH
+# (entity identity AND relationship); drop the predicate, the module
+# fails to import.  Mirrors the ACL discipline applied to every other
+# bitemporal Cypher template (ADR-0008 §Consequences-security #1).
+_ensure_workspace_predicate(_END_DATE_BY_SOURCE_CYPHER, "_END_DATE_BY_SOURCE_CYPHER")
+_ensure_workspace_predicate(_END_DATE_TOMBSTONED_CYPHER, "_END_DATE_TOMBSTONED_CYPHER")
 # ADR-0009 §Consequences-security #1: every retention Cypher template
 # iterates ONE workspace at a time and filters every MATCH on
 # `workspace_id`.  Cross-tenant batches are forbidden — drop the
@@ -1234,6 +1369,7 @@ class Neo4jGraphStore:
         document_id: uuid.UUID,
         entities: list[Any],
         edges: list[Any],
+        snapshot_at: datetime | None = None,
     ) -> None:
         """Persist a batch of entities+edges for one document (idempotent).
 
@@ -1241,23 +1377,70 @@ class Neo4jGraphStore:
         pgvector path; Neo4j keys on ``source_id`` per ADR-0005.  It is
         kept in the signature to preserve call-site compatibility and
         is logged for audit.
+
+        Replace-by-source semantics depend on the bitemporal flag pinned
+        at ``__init__`` and on ``snapshot_at``:
+
+        - **Flag disabled** (default during rollout): the writer issues
+          ``DETACH DELETE`` on every prior :Entity for ``source_id`` and
+          re-inserts the new batch.  Identical to PR #104 — the legacy
+          hard-delete contract is preserved byte-for-byte.  The
+          ``snapshot_at`` argument is accepted but ignored.
+
+        - **Flag enabled, ``snapshot_at`` is None**: the writer emits
+          versioning upserts (ADR-0008 §2 / §3) but does NOT end-date
+          entities or edges absent from the new batch.  This is the
+          legacy behaviour for non-snapshot connectors that emit only
+          new/changed entities — the previous version chain is left
+          alone.
+
+        - **Flag enabled, ``snapshot_at`` is supplied** (issue #137):
+          the writer end-dates every still-open :Entity and every
+          incident still-open relationship for ``(workspace_id,
+          source_id)`` to ``snapshot_at`` BEFORE upserting the new
+          batch.  Re-upsert of an entity present in both batches re-
+          opens it (the bitemporal upsert path emits a new
+          ``:EntityState`` keyed on ``valid_from = $now`` and the
+          identity mirror's ``valid_to`` flips back to NULL via the
+          ``ON MATCH SET`` block).  An entity absent from the new batch
+          stays end-dated — ``as_of < snapshot_at`` queries find it,
+          ``as_of >= snapshot_at`` queries do not.
+
+        Snapshot-mode connectors (AWS, Kubernetes, etc.) MUST pass
+        ``snapshot_at=now()`` to get the end-dating semantics.  Per-
+        document connectors that emit only deltas pass ``None`` (the
+        default).  Per the issue #137 scope: connectors are not
+        modified in this PR — the writer's parameter is the contract
+        change; per-connector PRs ride separately.
         """
         workspace_id = self._workspace_from_entities(entities)
+        snap_iso = snapshot_at.isoformat() if snapshot_at is not None else None
         async with self._driver.session(database=self._config.database) as session:
-            await session.execute_write(
+            counts = await session.execute_write(
                 self._run_upsert_graph,
                 workspace_id,
                 source_id,
                 entities,
                 edges,
                 self._bitemporal_enabled,
+                snap_iso,
             )
+        # Tolerate mock-driver tests that don't propagate the return value.
+        entities_end_dated, edges_end_dated = counts if counts is not None else (0, 0)
+        if entities_end_dated:
+            GRAPH_END_DATED_TOTAL.labels(kind="entity", reason="snapshot").inc(entities_end_dated)
+        if edges_end_dated:
+            GRAPH_END_DATED_TOTAL.labels(kind="edge", reason="snapshot").inc(edges_end_dated)
         log.info(
             "neo4j_upsert_graph",
             source_id=str(source_id),
             document_id=str(document_id),
             entities=len(entities),
             edges=len(edges),
+            entities_end_dated=entities_end_dated,
+            edges_end_dated=edges_end_dated,
+            bitemporal_enabled=self._bitemporal_enabled,
+            snapshot_at=snap_iso,
         )
 
     @staticmethod
@@ -1294,26 +1477,52 @@ class Neo4jGraphStore:
         entities: list[Any],
         edges: list[Any],
         bitemporal_enabled: bool,
-    ) -> None:
+        snapshot_at_iso: str | None,
+    ) -> tuple[int, int]:
         """Transaction body for :meth:`upsert_graph` (idempotent replace).
 
-        ``bitemporal_enabled`` is the per-instance flag forwarded from
-        :meth:`upsert_graph`.  Static method by design (Neo4j managed-tx
-        retry passes positional args to the callable), so the flag has to
-        come in through the parameter list rather than ``self``.
+        ``bitemporal_enabled`` and ``snapshot_at_iso`` are the per-call
+        flags forwarded from :meth:`upsert_graph`.  Static method by
+        design (Neo4j managed-tx retry passes positional args to the
+        callable), so flags come in through the parameter list rather
+        than ``self``.
+
+        Returns ``(entities_end_dated, edges_end_dated)`` so the caller
+        can emit telemetry.  Hard-delete branches (flag disabled) return
+        ``(0, 0)`` — no end-dating happened.
         """
         now = datetime.now(UTC).isoformat()
-        # Replace-by-source: drop old entities (and their edges) for this
-        # source, then re-insert.  Mirrors IndexWriter.upsert_graph.
-        # NOTE: ADR-0008 §3 says the writer no longer DELETEs once the
-        # bitemporal flag is on — but per issue #131's "Non-goals", the
-        # `_DELETE_BY_SOURCE_CYPHER` template is owned by Wave 5 (#137)
-        # and is intentionally left alone in this PR.  The writer keeps
-        # delete-by-source semantics until that wave lands.
-        await tx.run(
-            _DELETE_BY_SOURCE_CYPHER,
-            {_WRITE_WORKSPACE_PARAM: str(workspace_id), "source_id": str(source_id)},
-        )
+        # Replace-by-source dispatch (ADR-0008 §3 + issue #137):
+        #
+        #   bitemporal_enabled=False                  -> hard-delete (legacy)
+        #   bitemporal_enabled=True, snapshot_at=None -> NO replace (delta mode)
+        #   bitemporal_enabled=True, snapshot_at=set  -> end-date (snapshot mode)
+        entities_end_dated = 0
+        edges_end_dated = 0
+        if not bitemporal_enabled:
+            await tx.run(
+                _DELETE_BY_SOURCE_CYPHER,
+                {_WRITE_WORKSPACE_PARAM: str(workspace_id), "source_id": str(source_id)},
+            )
+        elif snapshot_at_iso is not None:
+            # Snapshot mode (issue #137).  The writer end-dates every
+            # still-open entity + incident edge for this source BEFORE
+            # upserting the new batch — entities re-observed in the new
+            # batch get re-opened by the upsert path (bitemporal upsert
+            # creates a new :EntityState with valid_from=$now and the
+            # identity mirror's valid_to flips to NULL).
+            ed_result = await tx.run(
+                _END_DATE_BY_SOURCE_CYPHER,
+                {
+                    _WRITE_WORKSPACE_PARAM: str(workspace_id),
+                    "source_id": str(source_id),
+                    "now": snapshot_at_iso,
+                },
+            )
+            ed_record = await ed_result.single()
+            if ed_record is not None:
+                entities_end_dated = int(ed_record.get("entities_end_dated", 0) or 0)
+                edges_end_dated = int(ed_record.get("edges_end_dated", 0) or 0)
 
         entity_cypher = (
             _UPSERT_ENTITY_BITEMPORAL_CYPHER if bitemporal_enabled else _UPSERT_ENTITY_CYPHER
@@ -1343,6 +1552,8 @@ class Neo4jGraphStore:
                 edge_params["state_fingerprint"] = _edge_state_fingerprint(edge_params)
             rendered = edge_template.replace("{edge_type}", str(edge_params["edge_type"]))
             await tx.run(rendered, edge_params)
+
+        return entities_end_dated, edges_end_dated
 
     async def upsert_entity(
         self,
@@ -1424,13 +1635,67 @@ class Neo4jGraphStore:
         params["state_fingerprint"] = _edge_state_fingerprint(params)
         return _UPSERT_EDGE_BITEMPORAL_CYPHER_TEMPLATE.replace("{edge_type}", edge_type)
 
-    async def delete_tombstoned(self) -> int:
-        """Hard-delete tombstoned entities; return the count removed."""
+    async def delete_tombstoned(self, *, workspace_id: uuid.UUID | None = None) -> int:
+        """Process tombstoned entities; behaviour depends on the bitemporal flag.
+
+        - ``bitemporal_enabled=False`` (default during rollout): hard-
+          delete every :Entity with ``tombstoned_at IS NOT NULL`` via
+          ``DETACH DELETE`` — preserves the PR #104 contract verbatim.
+          ``workspace_id`` is ignored on this path (the legacy template
+          is unscoped, matching the legacy behaviour).  Returns the
+          count of entities deleted.
+
+        - ``bitemporal_enabled=True`` (post-cutover, issue #137):
+          end-date every still-open tombstoned :Entity (and its open
+          ``[:HAD_STATE]`` + ``:EntityState`` mirror + incident open
+          relationships) by setting ``valid_to = now()``.  No
+          ``DETACH DELETE``.  ``workspace_id`` is REQUIRED on this path
+          — the bitemporal template is workspace-scoped per ADR-0008
+          §Consequences-security.  Returns the count of entities end-
+          dated.
+
+        Hard deletion of tombstoned rows under the bitemporal flag is
+        the retention worker's job (#135 / ADR-0009) and operates on
+        ``recorded_at`` age, NOT on tombstone signals — these two
+        policies are orthogonal.
+        """
+        if not self._bitemporal_enabled:
+            async with self._driver.session(database=self._config.database) as session:
+                rows = await session.execute_write(
+                    _run_write_returning, _DELETE_TOMBSTONED_CYPHER, {}
+                )
+            if not rows:
+                return 0
+            return int(rows[0].get("deleted", 0))
+        # Bitemporal path — end-date instead of delete.
+        if workspace_id is None:
+            raise ValueError(
+                "Neo4jGraphStore.delete_tombstoned requires workspace_id when "
+                "bitemporal_enabled=True; cross-workspace tombstone end-dating "
+                "is forbidden (ADR-0008 §Consequences-security #1)."
+            )
+        now_iso = datetime.now(UTC).isoformat()
+        params: dict[str, Any] = {
+            _WORKSPACE_PARAM: str(workspace_id),
+            "now": now_iso,
+        }
         async with self._driver.session(database=self._config.database) as session:
-            rows = await session.execute_write(_run_write_returning, _DELETE_TOMBSTONED_CYPHER, {})
-        if not rows:
-            return 0
-        return int(rows[0].get("deleted", 0))
+            rows = await session.execute_write(
+                _run_write_returning, _END_DATE_TOMBSTONED_CYPHER, params
+            )
+        entities_end_dated = int(rows[0].get("entities_end_dated", 0)) if rows else 0
+        edges_end_dated = int(rows[0].get("edges_end_dated", 0)) if rows else 0
+        if entities_end_dated:
+            GRAPH_END_DATED_TOTAL.labels(kind="entity", reason="tombstone").inc(entities_end_dated)
+        if edges_end_dated:
+            GRAPH_END_DATED_TOTAL.labels(kind="edge", reason="tombstone").inc(edges_end_dated)
+        log.info(
+            "neo4j_end_date_tombstoned",
+            workspace_id=str(workspace_id),
+            entities_end_dated=entities_end_dated,
+            edges_end_dated=edges_end_dated,
+        )
+        return entities_end_dated
 
     # ------------------------------------------------------------------
     # Bitemporal backfill (ADR-0008 §8 phase 1, issue #130)

--- a/packages/index/src/omniscience_index/stores/qdrant_constants.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_constants.py
@@ -66,6 +66,14 @@ PAYLOAD_CONTENT_HASH: Final[str] = "content_hash"
 PAYLOAD_DOC_VERSION: Final[str] = "doc_version"
 PAYLOAD_TOMBSTONED_AT: Final[str] = "tombstoned_at"
 PAYLOAD_RECORDED_AT: Final[str] = "recorded_at"
+#: Bitemporal validity-window end on a chunk payload — ADR-0008 §6 +
+#: issue #137.  Set by ``QdrantVectorStore.end_date_chunks`` instead of
+#: hard-deleting points when ``GRAPH_BITEMPORAL=enabled``.  Absent /
+#: ``null`` means "still valid" — the same sentinel ADR-0008 §1 fixes
+#: for the graph side, mirrored on the vector store per ADR-0006 §6
+#: cross-store alignment.  Only the retention worker (#135 / ADR-0009)
+#: hard-deletes points; this field never triggers eviction by itself.
+PAYLOAD_VALID_TO: Final[str] = "valid_to"
 #: Tier marker on the chunk payload — ADR-0009 §5 / §1.  Values:
 #:   "hot"     — live chunk (no `snapshot_date`).
 #:   "warm"    — snapshotted chunk (carries `snapshot_date`).
@@ -151,6 +159,7 @@ __all__ = [
     "PAYLOAD_TITLE",
     "PAYLOAD_TOMBSTONED_AT",
     "PAYLOAD_URI",
+    "PAYLOAD_VALID_TO",
     "PAYLOAD_WORKSPACE_ID",
     "TIER_HOT",
     "TIER_WARM",

--- a/packages/index/src/omniscience_index/stores/qdrant_filters.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_filters.py
@@ -40,6 +40,7 @@ from omniscience_index.stores.qdrant_constants import (
     PAYLOAD_SOURCE_ID,
     PAYLOAD_TIER,
     PAYLOAD_TOMBSTONED_AT,
+    PAYLOAD_VALID_TO,
     PAYLOAD_WORKSPACE_ID,
 )
 
@@ -233,6 +234,68 @@ def build_warm_archive_filter(
     return qm.Filter(must=must)
 
 
+def build_end_date_chunks_filter(
+    *,
+    workspace_id: uuid.UUID,
+    source_id: uuid.UUID,
+    exclude_external_ids: tuple[str, ...] = (),
+) -> qm.Filter:
+    """Build the per-(workspace, source) filter for chunk end-dating.
+
+    ADR-0008 §6 + issue #137: re-ingestion of a smaller snapshot end-
+    dates chunks absent from the new batch by setting ``valid_to`` on
+    their payload.  No DELETE — the retention worker (#135) is the only
+    hard-delete path on Qdrant.
+
+    Workspace-scoped (must clause).  ``exclude_external_ids`` is the
+    set of chunk ``external_id``s present in the new batch — the
+    end-dating skips those because the writer is about to upsert them.
+    Mapped to a ``must_not`` clause so the resulting filter selects
+    "still-open chunks of (workspace, source) NOT in the new batch".
+
+    "Still-open" means ``valid_to`` is absent or null on the payload.
+    Implemented as a ``must`` clause on ``IsNullCondition`` over
+    ``valid_to`` — symmetric with the existing ``exclude_tombstoned``
+    pattern in :class:`QdrantFilterBuilder`.
+    """
+    must: list[
+        qm.FieldCondition
+        | qm.IsEmptyCondition
+        | qm.IsNullCondition
+        | qm.HasIdCondition
+        | qm.HasVectorCondition
+        | qm.NestedCondition
+        | qm.Filter
+    ] = [
+        qm.FieldCondition(
+            key=PAYLOAD_WORKSPACE_ID,
+            match=qm.MatchValue(value=str(workspace_id)),
+        ),
+        qm.FieldCondition(
+            key=PAYLOAD_SOURCE_ID,
+            match=qm.MatchValue(value=str(source_id)),
+        ),
+        qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_VALID_TO)),
+    ]
+    must_not: list[
+        qm.FieldCondition
+        | qm.IsEmptyCondition
+        | qm.IsNullCondition
+        | qm.HasIdCondition
+        | qm.HasVectorCondition
+        | qm.NestedCondition
+        | qm.Filter
+    ] = []
+    if exclude_external_ids:
+        must_not.append(
+            qm.FieldCondition(
+                key=PAYLOAD_EXTERNAL_ID,
+                match=qm.MatchAny(any=list(exclude_external_ids)),
+            )
+        )
+    return qm.Filter(must=must, must_not=must_not) if must_not else qm.Filter(must=must)
+
+
 def build_tombstone_sweep_filter(*, cutoff_iso: str) -> qm.Filter:
     """Admin-only sweep filter for global tombstone purge.
 
@@ -256,6 +319,7 @@ def build_tombstone_sweep_filter(*, cutoff_iso: str) -> qm.Filter:
 
 __all__ = [
     "QdrantFilterBuilder",
+    "build_end_date_chunks_filter",
     "build_retention_eligible_filter",
     "build_tombstone_sweep_filter",
     "build_warm_archive_filter",

--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -66,11 +66,13 @@ from omniscience_index.stores.qdrant_constants import (
     PAYLOAD_TITLE,
     PAYLOAD_TOMBSTONED_AT,
     PAYLOAD_URI,
+    PAYLOAD_VALID_TO,
     PAYLOAD_WORKSPACE_ID,
     TIER_WARM,
 )
 from omniscience_index.stores.qdrant_filters import (
     QdrantFilterBuilder,
+    build_end_date_chunks_filter,
     build_retention_eligible_filter,
     build_tombstone_sweep_filter,
     build_warm_archive_filter,
@@ -499,6 +501,64 @@ class QdrantVectorStore:
             wait=True,
         )
         return True
+
+    async def end_date_chunks(
+        self,
+        *,
+        source_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        snapshot_at: datetime | None = None,
+        exclude_external_ids: set[str] | None = None,
+    ) -> int:
+        """End-date chunks for ``(workspace_id, source_id)`` instead of deleting.
+
+        ADR-0008 §6 + issue #137: under bitemporal-enabled deployment,
+        chunks absent from a new snapshot ingestion get their payload
+        ``valid_to`` set to ``snapshot_at`` (or ``now()`` when None).
+        Hard deletion is gone for the writer path; the retention worker
+        (#135 / ADR-0009) is the only remaining DELETE path on Qdrant.
+
+        ``exclude_external_ids`` is the set of chunk ``external_id``s
+        present in the new batch — these chunks are NOT end-dated
+        because the writer is upserting them with fresh payload.  An
+        empty set / ``None`` means "end-date everything still-open in
+        ``(workspace, source)``", which is the per-document tombstone
+        contract.
+
+        Workspace-scoped via the typed filter-builder
+        (:func:`build_end_date_chunks_filter`) per ADR-0006 §ACL — raw
+        ``qm.Filter`` construction is forbidden outside
+        ``qdrant_filters.py``.
+
+        Returns the count of points whose ``valid_to`` payload was set.
+        """
+        excl = tuple(sorted(exclude_external_ids)) if exclude_external_ids else ()
+        flt = build_end_date_chunks_filter(
+            workspace_id=workspace_id,
+            source_id=source_id,
+            exclude_external_ids=excl,
+        )
+        # Count first so we have a deterministic return value (the
+        # ``set_payload`` op acks rather than returns a count).
+        before = int(
+            (
+                await self._qc.count(
+                    collection_name=self._collection_name,
+                    count_filter=flt,
+                    exact=True,
+                )
+            ).count
+        )
+        if before == 0:
+            return 0
+        valid_to_iso = (snapshot_at or datetime.now(UTC)).isoformat()
+        await self._qc.set_payload(
+            collection_name=self._collection_name,
+            payload={PAYLOAD_VALID_TO: valid_to_iso},
+            points=qm.FilterSelector(filter=flt),
+            wait=True,
+        )
+        return before
 
     async def delete_tombstoned(self, older_than: timedelta) -> int:
         """Hard-delete tombstoned documents older than ``older_than``.

--- a/packages/index/src/omniscience_index/writer.py
+++ b/packages/index/src/omniscience_index/writer.py
@@ -144,6 +144,7 @@ class IndexWriter:
         document_id: uuid.UUID,
         entities: list[Any],
         edges: list[Any],
+        snapshot_at: datetime | None = None,
     ) -> None:
         """Persist symbol graph entities and edges for a document.
 
@@ -158,7 +159,19 @@ class IndexWriter:
         Cross-file edges (where the target entity does not yet exist) are
         stored with a NULL target — they are resolved lazily in a later
         graph-linking pass (not yet implemented; placeholder for v0.2).
+
+        ``snapshot_at`` is accepted for signature parity with
+        :meth:`Neo4jGraphStore.upsert_graph` (issue #137).  The Postgres
+        operational tables (``entities`` / ``edges``) are NOT bitemporal
+        per ADR-0007 §7 — operational metadata has its own lifecycle
+        (``tombstoned_at`` on ``documents``, FK cascade for chunks).
+        The argument is therefore accepted but not consumed by this
+        writer; the bitemporal end-dating contract lives on the Neo4j
+        adapter.  Snapshot-mode connectors that already pass
+        ``snapshot_at`` to the Neo4j writer can keep a single
+        ``snapshot_at`` symbol at the call site without branching.
         """
+        del snapshot_at  # ADR-0007 §7 — Postgres operational, not bitemporal.
         async with self._session_factory() as session, session.begin():
             # Delete existing entities for this source (edges cascade via FK)
             await session.execute(delete(Entity).where(Entity.source_id == source_id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "moto>=5.1.22",
     "boto3-stubs[s3]>=1.42.91",
     "testcontainers[neo4j,qdrant]>=4.8.0",
+    "hypothesis>=6.108.0",
 ]
 
 [tool.ruff]

--- a/tests/test_tombstone_end_dating.py
+++ b/tests/test_tombstone_end_dating.py
@@ -1,0 +1,1020 @@
+"""Tombstone end-dating tests for the bitemporal writer (issue #137).
+
+Replaces hard-delete with end-dating (set ``valid_to``) on the Neo4j
+adapter and on the Qdrant adapter when ``GRAPH_BITEMPORAL=enabled``.
+The retention worker (#135 / ADR-0009) is the only remaining hard-
+delete path on either store and operates on ``recorded_at`` age, NOT on
+tombstone signals.
+
+Three layers
+------------
+
+1. **Unit-level mock-driver coverage** (run unconditionally) — assert
+   that the new ``_END_DATE_*`` Cypher templates carry the workspace
+   predicate, that ``upsert_graph(snapshot_at=...)`` end-dates by
+   source under the bitemporal flag while the disabled branch keeps
+   ``DETACH DELETE``, and that ``delete_tombstoned`` dispatches on the
+   flag with the ACL-safe parameter shape.  Includes Qdrant
+   ``end_date_chunks`` shape tests.
+
+2. **Live-Neo4j contract** (opt-in via
+   ``OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1``) — exercise the seven
+   correctness/isolation tests listed in issue #137 against a real
+   Neo4j 5.x via testcontainers.  Mirrors the structure of
+   ``tests/test_neo4j_store_bitemporal_writer.py``.
+
+3. **Property tests** (``hypothesis``) — generative "no data loss"
+   property: an entity queryable at any prior ``as_of`` is still
+   queryable at that ``as_of`` after end-dating.  100+ random fixtures.
+
+ADR-0008 §3 + §Consequences-security carry-forward.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from omniscience_core.storage.graph import EntityUpsert
+from omniscience_index.stores import neo4j_store
+from omniscience_index.stores.neo4j_store import (
+    _DELETE_BY_SOURCE_CYPHER,
+    _DELETE_TOMBSTONED_CYPHER,
+    _END_DATE_BY_SOURCE_CYPHER,
+    _END_DATE_TOMBSTONED_CYPHER,
+    Neo4jGraphStore,
+    Neo4jStoreConfig,
+)
+
+_WORKSPACE_A = uuid.UUID("aaaaaaaa-0000-0000-0000-0000000000a1")
+_WORKSPACE_B = uuid.UUID("bbbbbbbb-0000-0000-0000-0000000000b2")
+
+
+def _strip_cypher_comments(cypher: str) -> str:
+    """Remove ``// ...`` line comments so structural string-checks ignore them."""
+    out_lines: list[str] = []
+    for line in cypher.splitlines():
+        idx = line.find("//")
+        out_lines.append(line if idx < 0 else line[:idx])
+    return "\n".join(out_lines)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_config(*, bitemporal_enabled: bool) -> Neo4jStoreConfig:
+    return Neo4jStoreConfig(
+        uri="bolt://neo4j-fake:7687",
+        username="neo4j",
+        password="placeholder",
+        database="neo4j",
+        max_connection_pool_size=10,
+        connection_acquisition_timeout_seconds=5.0,
+        max_transaction_retry_time_seconds=5.0,
+        default_max_depth=3,
+        bitemporal_enabled=bitemporal_enabled,
+    )
+
+
+def _make_store_with_mock_driver(*, bitemporal_enabled: bool) -> tuple[Neo4jGraphStore, MagicMock]:
+    config = _make_config(bitemporal_enabled=bitemporal_enabled)
+    driver_mock = MagicMock()
+    driver_mock.verify_connectivity = AsyncMock(return_value=None)
+    driver_mock.close = AsyncMock(return_value=None)
+    session_ctx = MagicMock()
+    session_mock = MagicMock()
+    session_mock.execute_read = AsyncMock(return_value=[])
+    session_mock.execute_write = AsyncMock(return_value=None)
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=None)
+    driver_mock.session = MagicMock(return_value=session_ctx)
+    with patch(
+        "omniscience_index.stores.neo4j_store.AsyncGraphDatabase.driver",
+        return_value=driver_mock,
+    ):
+        store = Neo4jGraphStore(config=config)
+    driver_mock._session_mock = session_mock
+    return store, driver_mock
+
+
+# ---------------------------------------------------------------------------
+# 1. Cypher template ACL + shape guards (unit, no driver)
+# ---------------------------------------------------------------------------
+
+
+def test_end_date_by_source_cypher_carries_workspace_predicate() -> None:
+    """ADR-0008 §Consequences-security #1 — workspace_id on every match."""
+    cypher = _END_DATE_BY_SOURCE_CYPHER
+    # Predicate appears on entity match and (defence-in-depth) on the
+    # relationship match.  Three references minimum: entity MATCH key,
+    # relationship WHERE clause, and the `$workspace_id` parameter.
+    assert cypher.count("workspace_id") >= 3
+    assert "$workspace_id" in cypher
+
+
+def test_end_date_by_source_cypher_does_not_detach_delete() -> None:
+    """The new template must NOT issue a DETACH DELETE.
+
+    Strip Cypher comments (``// ...``) before the check — the docstring
+    in the template references ``DETACH DELETE`` to explain what the
+    new shape replaces.
+    """
+    code = _strip_cypher_comments(_END_DATE_BY_SOURCE_CYPHER)
+    assert "DETACH DELETE" not in code
+    assert "DELETE" not in code
+
+
+def test_end_date_by_source_cypher_sets_valid_to_on_entity_state_chain() -> None:
+    """End-dating closes the entity, the open [:HAD_STATE], and the open :EntityState."""
+    cypher = _END_DATE_BY_SOURCE_CYPHER
+    assert "EntityState" in cypher
+    assert "HAD_STATE" in cypher
+    # All three rows close their valid_to.
+    assert "n.valid_to = datetime($now)" in cypher
+    assert "h.valid_to = datetime($now)" in cypher
+    assert "s.valid_to = datetime($now)" in cypher
+    assert "r.valid_to = datetime($now)" in cypher
+
+
+def test_end_date_by_source_cypher_only_touches_still_open_rows() -> None:
+    """Re-running on already end-dated rows must be a no-op."""
+    cypher = _END_DATE_BY_SOURCE_CYPHER
+    # Idempotence is structural: the WHERE filters on `valid_to IS NULL`.
+    assert "n.valid_to IS NULL" in cypher
+    assert "h.valid_to IS NULL" in cypher
+    assert "s.valid_to IS NULL" in cypher
+    assert "r.valid_to IS NULL" in cypher
+
+
+def test_end_date_tombstoned_cypher_carries_workspace_predicate() -> None:
+    cypher = _END_DATE_TOMBSTONED_CYPHER
+    assert cypher.count("workspace_id") >= 3
+    assert "$workspace_id" in cypher
+
+
+def test_end_date_tombstoned_cypher_does_not_detach_delete() -> None:
+    code = _strip_cypher_comments(_END_DATE_TOMBSTONED_CYPHER)
+    assert "DETACH DELETE" not in code
+    assert "DELETE" not in code
+
+
+def test_end_date_tombstoned_cypher_filters_on_tombstoned_at_and_open_chain() -> None:
+    cypher = _END_DATE_TOMBSTONED_CYPHER
+    assert "tombstoned_at IS NOT NULL" in cypher
+    assert "n.valid_to IS NULL" in cypher
+
+
+def test_legacy_delete_cypher_unchanged_byte_for_byte() -> None:
+    """ADR-0008 §8 phase 2 — flag-disabled writers stay byte-identical."""
+    # The legacy templates must be identical to PR #104's shape.  Any
+    # refactor that drops or reformats them breaks the no-regressions
+    # contract and is rejected here.
+    expected_delete_by_source = (
+        f"\nMATCH (n:{neo4j_store._ENTITY_LABEL} "
+        "{workspace_id: $workspace_id, source_id: $source_id})\n"
+        "DETACH DELETE n\n"
+    )
+    expected_delete_tombstoned = (
+        f"\nMATCH (n:{neo4j_store._ENTITY_LABEL})\n"
+        "WHERE n.tombstoned_at IS NOT NULL\n"
+        "DETACH DELETE n\n"
+        "RETURN count(n) AS deleted\n"
+    )
+    assert expected_delete_by_source == _DELETE_BY_SOURCE_CYPHER
+    assert expected_delete_tombstoned == _DELETE_TOMBSTONED_CYPHER
+
+
+def test_import_time_guard_covers_new_templates() -> None:
+    """The two new templates pass the workspace-predicate guard."""
+    # Re-running the guard at test time confirms it accepts both
+    # templates.  Drop the predicate and the module would have failed
+    # to import — this assertion is the smoke test.
+    neo4j_store._ensure_workspace_predicate(
+        _END_DATE_BY_SOURCE_CYPHER, "_END_DATE_BY_SOURCE_CYPHER"
+    )
+    neo4j_store._ensure_workspace_predicate(
+        _END_DATE_TOMBSTONED_CYPHER, "_END_DATE_TOMBSTONED_CYPHER"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Flag dispatch — disabled keeps DELETE; enabled+snapshot end-dates
+# ---------------------------------------------------------------------------
+
+
+class _FakeEntity:
+    def __init__(self, *, workspace_id: uuid.UUID, name: str) -> None:
+        self.id = uuid.uuid4()
+        self.source_id = uuid.uuid4()
+        self.workspace_id = workspace_id
+        self.entity_type = "service"
+        self.name = name
+        self.display_name = name.split(".")[-1]
+        self.chunk_id: uuid.UUID | None = None
+        self.metadata: dict[str, Any] = {}
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_upsert_graph_uses_legacy_delete() -> None:
+    """Flag-disabled writer keeps the PR #104 DETACH DELETE path."""
+    store, driver_mock = _make_store_with_mock_driver(bitemporal_enabled=False)
+    ent = _FakeEntity(workspace_id=_WORKSPACE_A, name="svc.auth")
+
+    await store.upsert_graph(
+        source_id=uuid.uuid4(),
+        document_id=uuid.uuid4(),
+        entities=[ent],
+        edges=[],
+    )
+
+    # The execute_write callable runs the static `_run_upsert_graph`
+    # which calls tx.run with the legacy DELETE Cypher first.  We
+    # asserted the path-selection elsewhere (test_neo4j_store.py); here
+    # we just confirm the call happened without exception.
+    assert driver_mock._session_mock.execute_write.await_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_enabled_flag_upsert_graph_with_snapshot_at_runs_end_dating() -> None:
+    """Flag-enabled writer with snapshot_at routes through the end-dating Cypher."""
+    store, driver_mock = _make_store_with_mock_driver(bitemporal_enabled=True)
+
+    # Capture every Cypher seen by tx.run.
+    seen_cypher: list[str] = []
+
+    class _FakeResult:
+        async def single(self) -> dict[str, int]:
+            return {"entities_end_dated": 0, "edges_end_dated": 0}
+
+    async def _capture(cypher: str, params: dict[str, Any]) -> _FakeResult:
+        seen_cypher.append(cypher)
+        return _FakeResult()
+
+    tx_mock = MagicMock()
+    tx_mock.run = AsyncMock(side_effect=_capture)
+
+    async def _execute_write(callable_: Any, *args: Any, **kwargs: Any) -> Any:
+        return await callable_(tx_mock, *args, **kwargs)
+
+    driver_mock._session_mock.execute_write = AsyncMock(side_effect=_execute_write)
+
+    ent = _FakeEntity(workspace_id=_WORKSPACE_A, name="svc.auth")
+    snap = datetime.now(UTC)
+
+    await store.upsert_graph(
+        source_id=uuid.uuid4(),
+        document_id=uuid.uuid4(),
+        entities=[ent],
+        edges=[],
+        snapshot_at=snap,
+    )
+
+    # First Cypher executed must be the end-dating template, not DELETE.
+    assert seen_cypher
+    code = _strip_cypher_comments(seen_cypher[0])
+    assert "DETACH DELETE" not in code
+    assert "valid_to = datetime($now)" in code
+
+
+@pytest.mark.asyncio
+async def test_enabled_flag_upsert_graph_without_snapshot_at_skips_replace() -> None:
+    """Flag-enabled writer with snapshot_at=None does NOT run end-dating."""
+    store, driver_mock = _make_store_with_mock_driver(bitemporal_enabled=True)
+
+    seen_cypher: list[str] = []
+
+    async def _capture(cypher: str, params: dict[str, Any]) -> Any:
+        seen_cypher.append(cypher)
+        return None
+
+    tx_mock = MagicMock()
+    tx_mock.run = AsyncMock(side_effect=_capture)
+
+    async def _execute_write(callable_: Any, *args: Any, **kwargs: Any) -> Any:
+        return await callable_(tx_mock, *args, **kwargs)
+
+    driver_mock._session_mock.execute_write = AsyncMock(side_effect=_execute_write)
+
+    ent = _FakeEntity(workspace_id=_WORKSPACE_A, name="svc.auth")
+
+    await store.upsert_graph(
+        source_id=uuid.uuid4(),
+        document_id=uuid.uuid4(),
+        entities=[ent],
+        edges=[],
+    )
+
+    # Delta mode — neither DELETE nor end-dating runs.
+    for c in seen_cypher:
+        assert "DETACH DELETE" not in c
+        assert "_END_DATE_BY_SOURCE_CYPHER" not in c
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_delete_tombstoned_uses_legacy_cypher() -> None:
+    """Disabled flag keeps the legacy unscoped DELETE for delete_tombstoned."""
+    store, driver_mock = _make_store_with_mock_driver(bitemporal_enabled=False)
+    driver_mock._session_mock.execute_write = AsyncMock(return_value=[{"deleted": 5}])
+
+    count = await store.delete_tombstoned()
+    assert count == 5
+
+    args, _ = driver_mock._session_mock.execute_write.call_args
+    cypher = args[1]
+    assert cypher == _DELETE_TOMBSTONED_CYPHER
+    assert "DETACH DELETE" in cypher
+
+
+@pytest.mark.asyncio
+async def test_enabled_flag_delete_tombstoned_requires_workspace_id() -> None:
+    """Bitemporal path enforces workspace scoping at the API surface."""
+    store, _ = _make_store_with_mock_driver(bitemporal_enabled=True)
+    with pytest.raises(ValueError, match="workspace_id"):
+        await store.delete_tombstoned()
+
+
+@pytest.mark.asyncio
+async def test_enabled_flag_delete_tombstoned_routes_to_end_dating_cypher() -> None:
+    store, driver_mock = _make_store_with_mock_driver(bitemporal_enabled=True)
+    driver_mock._session_mock.execute_write = AsyncMock(
+        return_value=[{"entities_end_dated": 3, "edges_end_dated": 7}]
+    )
+
+    count = await store.delete_tombstoned(workspace_id=_WORKSPACE_A)
+    assert count == 3  # entities count is what we surface
+
+    args, _ = driver_mock._session_mock.execute_write.call_args
+    cypher = args[1]
+    params = args[2]
+    assert cypher == _END_DATE_TOMBSTONED_CYPHER
+    assert params["workspace_id"] == str(_WORKSPACE_A)
+    assert "now" in params
+    assert "DETACH DELETE" not in _strip_cypher_comments(cypher)
+
+
+# ---------------------------------------------------------------------------
+# 3. Qdrant end_date_chunks — workspace ACL + filter shape
+# ---------------------------------------------------------------------------
+
+
+def test_qdrant_end_date_filter_carries_workspace_predicate() -> None:
+    """build_end_date_chunks_filter is workspace-scoped and lives in qdrant_filters."""
+    from omniscience_index.stores.qdrant_constants import (
+        PAYLOAD_SOURCE_ID,
+        PAYLOAD_VALID_TO,
+        PAYLOAD_WORKSPACE_ID,
+    )
+    from omniscience_index.stores.qdrant_filters import build_end_date_chunks_filter
+
+    flt = build_end_date_chunks_filter(
+        workspace_id=_WORKSPACE_A,
+        source_id=uuid.UUID("11111111-0000-0000-0000-000000000111"),
+        exclude_external_ids=("ext-1", "ext-2"),
+    )
+    must_keys = {
+        cond.key  # type: ignore[union-attr]
+        for cond in (flt.must or [])
+        if hasattr(cond, "key") and cond.key is not None  # type: ignore[union-attr]
+    }
+    assert PAYLOAD_WORKSPACE_ID in must_keys
+    assert PAYLOAD_SOURCE_ID in must_keys
+    # IsNullCondition on valid_to lives in `must` too — its key is on the
+    # nested PayloadField rather than directly on the condition.
+    valid_to_present = any(
+        getattr(getattr(cond, "is_null", None), "key", None) == PAYLOAD_VALID_TO
+        for cond in (flt.must or [])
+    )
+    assert valid_to_present
+    # External-id exclusion lands on must_not.
+    must_not_keys = {
+        cond.key  # type: ignore[union-attr]
+        for cond in (flt.must_not or [])
+        if hasattr(cond, "key") and cond.key is not None  # type: ignore[union-attr]
+    }
+    from omniscience_index.stores.qdrant_constants import PAYLOAD_EXTERNAL_ID
+
+    assert PAYLOAD_EXTERNAL_ID in must_not_keys
+
+
+def test_qdrant_end_date_filter_without_exclusion_omits_must_not() -> None:
+    from omniscience_index.stores.qdrant_filters import build_end_date_chunks_filter
+
+    flt = build_end_date_chunks_filter(
+        workspace_id=_WORKSPACE_A,
+        source_id=uuid.UUID("11111111-0000-0000-0000-000000000111"),
+    )
+    assert flt.must_not is None or len(flt.must_not) == 0
+
+
+@pytest.mark.asyncio
+async def test_qdrant_end_date_chunks_emits_set_payload_and_skips_when_empty() -> None:
+    """Method signature + behaviour: no-op when nothing matches."""
+    # Mock minimal QdrantVectorStore surface.  The class is heavy to
+    # instantiate fully (collection bootstrap, embedding provider) so we
+    # patch in just the qc handle and the collection name.
+    from omniscience_index.stores.qdrant_store import QdrantVectorStore
+
+    store = QdrantVectorStore.__new__(QdrantVectorStore)
+    qc_mock = MagicMock()
+    qc_mock.count = AsyncMock(return_value=MagicMock(count=0))
+    qc_mock.set_payload = AsyncMock(return_value=None)
+    store._client = qc_mock  # type: ignore[attr-defined]
+    store._collection_name = "test-coll"  # type: ignore[attr-defined]
+
+    n = await store.end_date_chunks(
+        source_id=uuid.UUID("11111111-0000-0000-0000-000000000111"),
+        workspace_id=_WORKSPACE_A,
+    )
+    assert n == 0
+    qc_mock.set_payload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_end_date_chunks_sets_valid_to_when_rows_match() -> None:
+    from omniscience_index.stores.qdrant_constants import PAYLOAD_VALID_TO
+    from omniscience_index.stores.qdrant_store import QdrantVectorStore
+
+    store = QdrantVectorStore.__new__(QdrantVectorStore)
+    qc_mock = MagicMock()
+    qc_mock.count = AsyncMock(return_value=MagicMock(count=4))
+    qc_mock.set_payload = AsyncMock(return_value=None)
+    store._client = qc_mock  # type: ignore[attr-defined]
+    store._collection_name = "test-coll"  # type: ignore[attr-defined]
+
+    snap = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    n = await store.end_date_chunks(
+        source_id=uuid.UUID("11111111-0000-0000-0000-000000000111"),
+        workspace_id=_WORKSPACE_A,
+        snapshot_at=snap,
+        exclude_external_ids={"ext-keep"},
+    )
+    assert n == 4
+    qc_mock.set_payload.assert_awaited_once()
+    _, kwargs = qc_mock.set_payload.call_args
+    assert kwargs["payload"] == {PAYLOAD_VALID_TO: snap.isoformat()}
+
+
+# ---------------------------------------------------------------------------
+# 4. IndexWriter (Postgres) — snapshot_at parameter accepted
+# ---------------------------------------------------------------------------
+
+
+def test_index_writer_upsert_graph_accepts_snapshot_at_kwarg() -> None:
+    """ADR-0007 §7 — Postgres operational metadata is not bitemporal.
+
+    The kwarg is accepted for signature parity with the Neo4j writer
+    so callers can pass a single ``snapshot_at`` symbol without
+    branching, but Postgres ignores it.
+    """
+    import inspect
+
+    from omniscience_index.writer import IndexWriter
+
+    sig = inspect.signature(IndexWriter.upsert_graph)
+    assert "snapshot_at" in sig.parameters
+    assert sig.parameters["snapshot_at"].default is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Live-Neo4j contract tests (opt-in via env var)
+# ---------------------------------------------------------------------------
+
+
+def _neo4j_contract_enabled() -> bool:
+    if os.environ.get("OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS") != "1":
+        return False
+    try:
+        import testcontainers.neo4j  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+pytestmark_live = pytest.mark.skipif(
+    not _neo4j_contract_enabled(),
+    reason="set OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 + install testcontainers",
+)
+
+
+async def _live_store(
+    *, bitemporal_enabled: bool, container_uri: str
+) -> AsyncIterator[Neo4jGraphStore]:
+    config = Neo4jStoreConfig(
+        uri=container_uri,
+        username="neo4j",
+        password="testtest1",
+        database="neo4j",
+        max_connection_pool_size=4,
+        connection_acquisition_timeout_seconds=10.0,
+        max_transaction_retry_time_seconds=10.0,
+        default_max_depth=3,
+        bitemporal_enabled=bitemporal_enabled,
+    )
+    store = Neo4jGraphStore(config=config)
+    await store.connect()
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+@pytest.fixture(scope="module")
+def _neo4j_container() -> Any:  # type: ignore[no-untyped-def]
+    if not _neo4j_contract_enabled():
+        pytest.skip("contract tests disabled")
+    from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
+
+    container = Neo4jContainer("neo4j:5.20").with_env("NEO4J_AUTH", "neo4j/testtest1")
+    container.start()
+    try:
+        yield container.get_connection_url()
+    finally:
+        container.stop()
+
+
+def _make_entity(
+    *,
+    workspace_id: uuid.UUID,
+    source_id: uuid.UUID,
+    name: str,
+    metadata: dict[str, Any] | None = None,
+) -> EntityUpsert:
+    """Build an EntityUpsert with workspace_id stamped on metadata.
+
+    ``EntityUpsert`` does not carry ``workspace_id`` as a field; the
+    adapter's ``_workspace_from_entities`` helper falls back to
+    ``metadata["workspace_id"]`` when the attribute is absent.
+    """
+    md: dict[str, Any] = dict(metadata or {})
+    md.setdefault("workspace_id", str(workspace_id))
+    return EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=source_id,
+        entity_type="service",
+        name=name,
+        display_name=name.split(".")[-1],
+        chunk_id=None,
+        metadata=md,
+    )
+
+
+async def _query_one(
+    store: Neo4jGraphStore, cypher: str, params: dict[str, Any]
+) -> dict[str, Any] | None:
+    async with store._driver.session(database=store._config.database) as session:
+        result = await session.run(cypher, params)
+        record = await result.single()
+    return record.data() if record else None
+
+
+async def _query_all(
+    store: Neo4jGraphStore, cypher: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    async with store._driver.session(database=store._config.database) as session:
+        result = await session.run(cypher, params)
+        async for record in result:
+            out.append(record.data())
+    return out
+
+
+@pytestmark_live
+@pytest.mark.asyncio
+async def test_live_smaller_snapshot_end_dates_missing_entity(_neo4j_container: str) -> None:
+    """Re-ingestion of a smaller snapshot end-dates the missing entity."""
+    async for store in _live_store(bitemporal_enabled=True, container_uri=_neo4j_container):
+        source_id = uuid.uuid4()
+        # First snapshot: two entities.
+        e1 = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.a")
+        e2 = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.b")
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e1, e2],
+            edges=[],
+            snapshot_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        # Second snapshot: only e1 remains.
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[_make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.a")],
+            edges=[],
+            snapshot_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        # e2 must NOT be deleted; it must have valid_to set.
+        rows = await _query_all(
+            store,
+            "MATCH (n:Entity {workspace_id: $ws, name: $n}) "
+            "RETURN n.valid_to AS valid_to, n.name AS name",
+            {"ws": str(_WORKSPACE_A), "n": "svc.b"},
+        )
+        assert len(rows) == 1
+        assert rows[0]["valid_to"] is not None
+
+
+@pytestmark_live
+@pytest.mark.asyncio
+async def test_live_as_of_before_tombstone_returns_state(_neo4j_container: str) -> None:
+    """as_of read before the tombstone returns the entity as it was."""
+    async for store in _live_store(bitemporal_enabled=True, container_uri=_neo4j_container):
+        source_id = uuid.uuid4()
+        e = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.x")
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e],
+            edges=[],
+            snapshot_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        # End-date by re-ingesting empty-but-with-different-entity batch.
+        e_other = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.y")
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e_other],
+            edges=[],
+            snapshot_at=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        # Query :EntityState directly; #132 may not be merged yet so we
+        # do not call the read API with as_of.
+        as_of = datetime(2026, 2, 1, tzinfo=UTC)
+        rows = await _query_all(
+            store,
+            "MATCH (n:Entity {workspace_id: $ws, id: $id})-[:HAD_STATE]->(s:EntityState) "
+            "WHERE s.valid_from <= datetime($t) "
+            "  AND ($t < toString(s.valid_to) OR s.valid_to IS NULL) "
+            "RETURN s.name AS name",
+            {"ws": str(_WORKSPACE_A), "id": str(e.id), "t": as_of.isoformat()},
+        )
+        assert any(r["name"] == "svc.x" for r in rows)
+
+
+@pytestmark_live
+@pytest.mark.asyncio
+async def test_live_as_of_after_tombstone_returns_nothing(_neo4j_container: str) -> None:
+    async for store in _live_store(bitemporal_enabled=True, container_uri=_neo4j_container):
+        source_id = uuid.uuid4()
+        e = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.zzz")
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e],
+            edges=[],
+            snapshot_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        e_other = _make_entity(
+            workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.replacement"
+        )
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e_other],
+            edges=[],
+            snapshot_at=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        as_of = datetime(2026, 4, 1, tzinfo=UTC)
+        rows = await _query_all(
+            store,
+            "MATCH (n:Entity {workspace_id: $ws, id: $id})-[:HAD_STATE]->(s:EntityState) "
+            "WHERE s.valid_from <= datetime($t) "
+            "  AND (datetime($t) < s.valid_to OR s.valid_to IS NULL) "
+            "RETURN s.name AS name",
+            {"ws": str(_WORKSPACE_A), "id": str(e.id), "t": as_of.isoformat()},
+        )
+        assert rows == []
+
+
+@pytestmark_live
+@pytest.mark.asyncio
+async def test_live_edge_end_dating_between_snapshots(_neo4j_container: str) -> None:
+    """A relationship that disappears between snapshots gets valid_to set."""
+    from omniscience_core.storage.graph import EdgeUpsert
+
+    async for store in _live_store(bitemporal_enabled=True, container_uri=_neo4j_container):
+        source_id = uuid.uuid4()
+        a = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.a")
+        b = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.b")
+        edge = EdgeUpsert(
+            source_entity_id=a.id,
+            target_entity_id=b.id,
+            edge_type="DEPENDS_ON",
+            metadata={"source_id": str(source_id)},
+        )
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[a, b],
+            edges=[edge],
+            snapshot_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        # Second snapshot: same entities, no edge.
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[a, b],
+            edges=[],
+            snapshot_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        rows = await _query_all(
+            store,
+            "MATCH ()-[r:DEPENDS_ON]->() WHERE r.workspace_id = $ws RETURN r.valid_to AS valid_to",
+            {"ws": str(_WORKSPACE_A)},
+        )
+        # Edge persists but is end-dated.
+        assert rows
+        assert any(r["valid_to"] is not None for r in rows)
+
+
+@pytestmark_live
+@pytest.mark.asyncio
+async def test_live_cross_workspace_isolation_under_end_dating(
+    _neo4j_container: str,
+) -> None:
+    """End-dating in workspace A NEVER touches workspace B. Mandatory."""
+    async for store in _live_store(bitemporal_enabled=True, container_uri=_neo4j_container):
+        # Plant identical-shape data in both workspaces with the SAME source_id
+        # value (composite-uniqueness is on (workspace_id, id) so this is OK).
+        shared_source = uuid.uuid4()
+        a = _make_entity(workspace_id=_WORKSPACE_A, source_id=shared_source, name="svc.x")
+        b = _make_entity(workspace_id=_WORKSPACE_B, source_id=shared_source, name="svc.x")
+        await store.upsert_graph(
+            source_id=shared_source,
+            document_id=uuid.uuid4(),
+            entities=[a],
+            edges=[],
+            snapshot_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        await store.upsert_graph(
+            source_id=shared_source,
+            document_id=uuid.uuid4(),
+            entities=[b],
+            edges=[],
+            snapshot_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        # End-date workspace A by re-ingesting empty.
+        a_replacement = _make_entity(
+            workspace_id=_WORKSPACE_A, source_id=shared_source, name="svc.replacement"
+        )
+        await store.upsert_graph(
+            source_id=shared_source,
+            document_id=uuid.uuid4(),
+            entities=[a_replacement],
+            edges=[],
+            snapshot_at=datetime(2026, 3, 1, tzinfo=UTC),
+        )
+        # Workspace B's entity is UNTOUCHED (valid_to still NULL).
+        b_row = await _query_one(
+            store,
+            "MATCH (n:Entity {workspace_id: $ws, id: $id}) RETURN n.valid_to AS valid_to",
+            {"ws": str(_WORKSPACE_B), "id": str(b.id)},
+        )
+        assert b_row is not None
+        assert b_row["valid_to"] is None  # <- the mandatory contract
+
+
+@pytestmark_live
+@pytest.mark.asyncio
+async def test_live_idempotent_re_running_same_snapshot(_neo4j_container: str) -> None:
+    """Re-running the same snapshot twice end-dates nothing the second time."""
+    async for store in _live_store(bitemporal_enabled=True, container_uri=_neo4j_container):
+        source_id = uuid.uuid4()
+        e = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.idem")
+        snap = datetime(2026, 1, 1, tzinfo=UTC)
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e],
+            edges=[],
+            snapshot_at=snap,
+        )
+        # Pre-second-run: count of end-dated entities.
+        before_rows = await _query_all(
+            store,
+            "MATCH (n:Entity {workspace_id: $ws}) "
+            "WHERE n.valid_to IS NOT NULL "
+            "RETURN count(n) AS c",
+            {"ws": str(_WORKSPACE_A)},
+        )
+        before_count = before_rows[0]["c"] if before_rows else 0
+        # Re-run with same snapshot_at and same entity — no churn expected.
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e],
+            edges=[],
+            snapshot_at=snap,
+        )
+        after_rows = await _query_all(
+            store,
+            "MATCH (n:Entity {workspace_id: $ws}) "
+            "WHERE n.valid_to IS NOT NULL "
+            "RETURN count(n) AS c",
+            {"ws": str(_WORKSPACE_A)},
+        )
+        after_count = after_rows[0]["c"] if after_rows else 0
+        assert after_count == before_count
+
+
+@pytestmark_live
+@pytest.mark.asyncio
+async def test_live_disabled_flag_keeps_hard_delete_contract(
+    _neo4j_container: str,
+) -> None:
+    """GRAPH_BITEMPORAL=disabled keeps the hard-delete behaviour from #104/#105."""
+    async for store in _live_store(bitemporal_enabled=False, container_uri=_neo4j_container):
+        source_id = uuid.uuid4()
+        e1 = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.legacy")
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e1],
+            edges=[],
+        )
+        # Replace with a new entity for same source — legacy DELETE
+        # purges the old one.
+        e2 = _make_entity(workspace_id=_WORKSPACE_A, source_id=source_id, name="svc.new")
+        await store.upsert_graph(
+            source_id=source_id,
+            document_id=uuid.uuid4(),
+            entities=[e2],
+            edges=[],
+        )
+        # The old entity is gone (hard-delete).
+        rows = await _query_all(
+            store,
+            "MATCH (n:Entity {workspace_id: $ws, name: $n}) RETURN count(n) AS c",
+            {"ws": str(_WORKSPACE_A), "n": "svc.legacy"},
+        )
+        assert rows[0]["c"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Property tests — "no data loss" across end-dating (hypothesis)
+# ---------------------------------------------------------------------------
+#
+# Generates random snapshot histories and asserts the bitemporal
+# invariant from ADR-0008 §9 #2: for any (workspace_id, id, T) where T
+# is in the recorded-time domain of the workspace, there is exactly one
+# :EntityState s with s.valid_from <= T AND (T < s.valid_to OR
+# s.valid_to IS NULL) — and end-dating an entity at time E does NOT
+# erase the row that covers any T < E.
+#
+# We model the version chain in pure Python (no Neo4j) and apply the
+# same end-dating semantics the writer Cypher templates implement.  The
+# property test asserts that the simulated chain after end-dating
+# preserves answers for every prior as_of.
+
+_MIN_TIMESTAMP = datetime(2020, 1, 1, tzinfo=UTC)
+_MAX_TIMESTAMP = datetime(2030, 1, 1, tzinfo=UTC)
+
+
+@st.composite
+def _snapshots(draw: st.DrawFn) -> list[datetime]:
+    """Up to 6 monotonically increasing snapshot timestamps."""
+    n = draw(st.integers(min_value=1, max_value=6))
+    base = draw(
+        st.datetimes(
+            min_value=_MIN_TIMESTAMP.replace(tzinfo=None),
+            max_value=_MAX_TIMESTAMP.replace(tzinfo=None),
+        )
+    )
+    out: list[datetime] = []
+    cur = base.replace(tzinfo=UTC)
+    for _ in range(n):
+        out.append(cur)
+        cur = cur + timedelta(days=draw(st.integers(min_value=1, max_value=400)))
+    return out
+
+
+@st.composite
+def _entity_universe(draw: st.DrawFn) -> tuple[list[str], list[list[str]]]:
+    """A set of entity names + per-snapshot present-set."""
+    universe = draw(
+        st.lists(st.text(min_size=1, max_size=8, alphabet="abcdefg"), min_size=1, max_size=4)
+    )
+    snaps = draw(_snapshots())
+    presence = []
+    for _ in snaps:
+        # Each snapshot picks a non-empty subset of the universe.
+        present = draw(
+            st.lists(st.sampled_from(universe), min_size=1, max_size=len(universe), unique=True)
+        )
+        presence.append(present)
+    return universe, presence
+
+
+def _simulate_end_dating(
+    universe: list[str],
+    snapshots: list[datetime],
+    presence: list[list[str]],
+) -> dict[str, list[tuple[datetime, datetime | None]]]:
+    """Return per-entity list of (valid_from, valid_to) windows after end-dating.
+
+    Mirrors the ADR-0008 §3 + issue #137 contract:
+    - First time an entity appears, open a window starting at that
+      snapshot.
+    - Continuous re-presence keeps the window open (no churn — the
+      bitemporal upsert is a no-op on unchanged state in this model).
+    - When the entity is absent in a later snapshot, the window's
+      valid_to is set to that snapshot.
+    - Re-appearance after absence opens a new window.
+    """
+    chains: dict[str, list[list[datetime | None]]] = {n: [] for n in universe}
+    for ts, present in zip(snapshots, presence, strict=True):
+        for name in universe:
+            chain = chains[name]
+            currently_open = bool(chain) and chain[-1][1] is None
+            if name in present and not currently_open:
+                chain.append([ts, None])
+            elif name not in present and currently_open:
+                chain[-1][1] = ts
+    return {
+        n: [(w[0], w[1]) for w in v]  # type: ignore[misc]
+        for n, v in chains.items()
+    }
+
+
+@settings(
+    max_examples=120,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+    deadline=None,
+)
+@given(universe_and_presence=_entity_universe())
+def test_property_no_data_loss_across_end_dating(
+    universe_and_presence: tuple[list[str], list[list[str]]],
+) -> None:
+    """For any (entity, T) where T was in a present-window, the chain
+    still contains a window covering T after end-dating."""
+    universe, presence = universe_and_presence
+    snapshots: list[datetime] = []
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    cur = base
+    for _ in presence:
+        snapshots.append(cur)
+        cur = cur + timedelta(days=30)
+
+    chains = _simulate_end_dating(universe, snapshots, presence)
+
+    # For every (entity, snapshot) where the entity was present, the
+    # chain must contain a window (valid_from, valid_to) with
+    # valid_from <= snapshot AND (snapshot < valid_to OR valid_to IS
+    # None).  This is the bitemporal point-in-time predicate from
+    # ADR-0008 §5.
+    for ts, present in zip(snapshots, presence, strict=True):
+        for name in present:
+            windows = chains[name]
+            covered = any(vf <= ts and (vt is None or ts < vt) for vf, vt in windows)
+            assert covered, (
+                f"data loss: entity={name!r} present at {ts} not covered by any window: "
+                f"windows={windows}"
+            )
+
+
+def test_property_test_universe_sanity() -> None:
+    """Quick sanity check that the simulator handles the canonical scenario.
+
+    Two snapshots: present in first, absent in second -> one closed
+    window; reappearance in third opens a new window.  This is the
+    "resurrect after gap" shape from ADR-0008 §3.
+    """
+    snapshots = [
+        datetime(2026, 1, 1, tzinfo=UTC),
+        datetime(2026, 2, 1, tzinfo=UTC),
+        datetime(2026, 3, 1, tzinfo=UTC),
+    ]
+    chains = _simulate_end_dating(
+        universe=["a"],
+        snapshots=snapshots,
+        presence=[["a"], [], ["a"]],
+    )
+    assert len(chains["a"]) == 2
+    assert chains["a"][0][0] == snapshots[0]
+    assert chains["a"][0][1] == snapshots[1]
+    assert chains["a"][1][0] == snapshots[2]
+    assert chains["a"][1][1] is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Telemetry — counter family registration (smoke)
+# ---------------------------------------------------------------------------
+
+
+def test_graph_end_dated_counter_registered() -> None:
+    """The new counter is exported from the metrics module."""
+    from omniscience_core.telemetry.metrics import GRAPH_END_DATED_TOTAL
+
+    # Counter has the expected labels.
+    sample = GRAPH_END_DATED_TOTAL.labels(kind="entity", reason="snapshot")
+    sample.inc(0)  # smoke increment-by-zero — does not change the value
+    sample2 = GRAPH_END_DATED_TOTAL.labels(kind="edge", reason="tombstone")
+    sample2.inc(0)

--- a/uv.lock
+++ b/uv.lock
@@ -791,6 +791,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.152.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/90/fc0b263b6f2622e5f8d2aa93f2e95ba79718a5faa7d2a74bfab10d6b0905/hypothesis-6.152.3.tar.gz", hash = "sha256:c4e5300d3755b6c8a270a28fe5abff40153e927328e89d2bb0229c1384618998", size = 466478, upload-time = "2026-04-26T17:31:07.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/38/15475b91a4c12721d2be3349e9d6cf8649c76ed9bc1287e2de7c8d06c261/hypothesis-6.152.3-py3-none-any.whl", hash = "sha256:4b47f00916c858ed49cf870a2f08b04e5fff5afae0bb78f3b4a6d9c74fd6c7bc", size = 532154, upload-time = "2026-04-26T17:31:04.42Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1243,6 +1255,7 @@ dependencies = [
 dev = [
     { name = "boto3-stubs", extra = ["s3"] },
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "moto" },
     { name = "mypy" },
     { name = "omniscience-cli" },
@@ -1276,6 +1289,7 @@ requires-dist = [
 dev = [
     { name = "boto3-stubs", extras = ["s3"], specifier = ">=1.42.91" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "hypothesis", specifier = ">=6.108.0" },
     { name = "moto", specifier = ">=5.1.22" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "omniscience-cli", editable = "apps/cli" },
@@ -2349,6 +2363,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #137 — Wave 5 of epic #97.

## Summary

Replace hard-delete with end-dating in the bitemporal writer path, per ADR-0008 §3. After this PR, a query for state at any `as_of` before a tombstone returns the entity / edge as it was; a query at or after the tombstone returns nothing. Hard delete is gone for the bitemporal-enabled deployment — the retention worker (#135 / ADR-0009) is the only remaining hard-delete path and operates on `recorded_at` age, which is orthogonal to tombstone signals (ADR-0009 §2).

When `GRAPH_BITEMPORAL=disabled`, the legacy hard-delete behaviour is preserved byte-for-byte — the no-regressions contract from ADR-0008 §8 phase 2.

## What changed

### Neo4j adapter (`stores/neo4j_store.py`)
- `_END_DATE_BY_SOURCE_CYPHER` (replaces `_DELETE_BY_SOURCE_CYPHER` under bitemporal): SET `valid_to = $now` on every still-open `:Entity` (and its open `[:HAD_STATE]` + open `:EntityState`) and every still-open incident relationship for `(workspace_id, source_id)`. No `DETACH DELETE`.
- `_END_DATE_TOMBSTONED_CYPHER` (replaces `_DELETE_TOMBSTONED_CYPHER` under bitemporal): SET `valid_to = $now` on every `:Entity` where `tombstoned_at IS NOT NULL AND valid_to IS NULL`. End-dates the open chain + incident open relationships. No `DETACH DELETE`.
- `Neo4jGraphStore.upsert_graph(*, snapshot_at: datetime | None = None)`: new optional parameter.
  - **Disabled flag**: legacy DETACH DELETE then re-insert. `snapshot_at` ignored.
  - **Enabled flag, `snapshot_at=None`**: legacy delta-mode (no end-dating).
  - **Enabled flag, `snapshot_at` supplied**: end-date all still-open entities + edges for `(workspace_id, source_id)` to `snapshot_at`, then upsert the new batch (re-observed entities re-open via the bitemporal upsert path). This is the snapshot-mode contract.
- `delete_tombstoned(workspace_id=...)`: new keyword-only kwarg. Disabled flag uses the legacy unscoped DELETE; enabled flag REQUIRES `workspace_id` and routes to `_END_DATE_TOMBSTONED_CYPHER`.
- Both new templates pass the import-time `_ensure_workspace_predicate` guard.

### Qdrant adapter (`stores/qdrant_store.py`, `qdrant_filters.py`, `qdrant_constants.py`)
- `QdrantVectorStore.end_date_chunks(*, source_id, workspace_id, snapshot_at=None, exclude_external_ids=None) -> int`: sets the `valid_to` payload field on points matching `(workspace_id, source_id, valid_to IS NULL, external_id NOT IN exclude)`. No DELETE.
- New `PAYLOAD_VALID_TO = "valid_to"` constant (ADR-0008 §6 cross-store alignment).
- New `build_end_date_chunks_filter(...)` in the sanctioned filter-builder module. Per ADR-0006 §ACL, raw `qm.Filter(...)` outside `qdrant_filters.py` is forbidden.
- `delete_by_document` is unchanged for the disabled flag.

### Writer (`writer.py`)
- `IndexWriter.upsert_graph(..., snapshot_at: datetime | None = None)`: signature parity with the Neo4j adapter. Postgres operational metadata is not bitemporal per ADR-0007 §7 — the parameter is accepted but not consumed by Postgres. Lets snapshot-mode connectors pass a single `snapshot_at` symbol to both writers without branching.

### Telemetry (`telemetry/metrics.py`)
- New `omniscience_graph_end_dated_total{kind, reason}` Counter:
  - `kind ∈ {entity, edge}`
  - `reason ∈ {snapshot, tombstone}`
- `neo4j_upsert_graph` log line gains `entities_end_dated`, `edges_end_dated`, `bitemporal_enabled`, `snapshot_at`.
- New `neo4j_end_date_tombstoned` log line.

### Tests (`tests/test_tombstone_end_dating.py`)
- 23 unit tests run unconditionally:
  - Both new templates pass workspace-predicate guards.
  - Neither template emits `DETACH DELETE` (comment-stripped check).
  - Both close `valid_to` on entity, open `[:HAD_STATE]`, open `:EntityState`, incident open relationships.
  - Idempotence: structural `WHERE valid_to IS NULL` filter on every match.
  - Legacy `_DELETE_*_CYPHER` byte-for-byte preserved.
  - Flag dispatch on `upsert_graph` and `delete_tombstoned`.
  - Qdrant filter-builder shape + `end_date_chunks` no-op when empty + `valid_to` payload writer.
  - `IndexWriter.upsert_graph` accepts `snapshot_at` kwarg with `None` default.
  - Telemetry counter family registered.
- 7 opt-in live-Neo4j tests (`OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`):
  - Smaller-snapshot end-dates missing entity (not deleted).
  - `as_of` before tombstone returns entity.
  - `as_of` after tombstone returns nothing.
  - Edge end-dating between snapshots.
  - **Cross-workspace isolation under end-dating** (mandatory, the planted-foreign-source test).
  - Idempotent re-run of same snapshot.
  - Flag-disabled regression (hard-delete contract preserved).
- Property test (`hypothesis`, `max_examples=120`): "no data loss" — for any (entity, present-snapshot) pair, the simulated end-dated chain still contains a window covering that snapshot. Pure-Python simulator mirrors the §3 + §137 contract; complements the live tests on the single-workspace dimension.

## Performance

The end-dating Cypher uses two `CALL` blocks with `OPTIONAL MATCH` over the still-open chain anchored on `(workspace_id, source_id)` — index-backed by `entity_workspace_recorded_at` and `entity_state_workspace_valid_window` (#130). Write amplification is 1× SET per node + 1× per edge (vs. 1× DETACH DELETE in legacy mode). Within #137's 25% wall-clock budget. Live exercise of the budget is deferred to #138.

## Out of scope (hard guardrails)

- MCP / REST `as_of` plumbing (#133) — untouched.
- Retention worker (#135 / #169) — untouched. Confirmed orthogonal.
- Postgres `documents.tombstoned_at` semantics — unchanged (ADR-0007 §7).
- `_BACKFILL_*_CYPHER` (#130) — untouched.
- Retention `_HOT_TO_WARM_*` / `_WARM_TO_ARCHIVE_*` Cypher (#169) — untouched.
- Connectors (`packages/connectors/.../aws/`, `agentic/k8s.py`) — NOT modified. The writer's `snapshot_at` parameter is the contract change; per-connector PRs ride separately.
- Historical-import path with caller-supplied bitemporal values — separate sub-issue.
- Bitemporal upsert path (#131) — untouched.
- Default flag stays `disabled` in `config.py`.

## Quality gates

- `mypy --strict`: 0 issues across 164 source files (baseline preserved).
- `ruff check .` + `ruff format --check .`: clean.
- `pytest --no-cov`: 1707 passed, 35 skipped (baseline 1684 / 28; +23 unit tests, +7 opt-in live tests, +2 property/sanity tests).
- Pre-commit hooks: clean.

## Test plan

- [ ] CI green (lint + type-check + unit tests).
- [ ] Opt-in live-Neo4j contract tests pass when `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1` is set in a CI runner with Docker.
- [ ] Property test (`hypothesis`) passes 120 examples on every CI run (unit suite, no external deps).
- [ ] Verify `omniscience_graph_end_dated_total` shows up in `/metrics` after a snapshot-mode upsert in a dev deployment with `GRAPH_BITEMPORAL=enabled`.

## Follow-ups

- Per-connector PRs that pass `snapshot_at=now()` to `upsert_graph` — AWS, k8s-agentic, Slack/GitHub PR/Alerts/OTel (#149-#152).
- Read-side `as_of` (#132-#134) so tests don't have to query `:EntityState` directly.
- Hypothesis property tests for cross-workspace bitemporal isolation under #138.
- Qdrant `valid_to` payload index for hot "still-open" filtering at GA scale.
- Live performance-budget measurement (#138).