### PR TITLE
feat: retention metrics dashboard, alerts, admin UI (#136)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -10,6 +10,7 @@ import { TokensPage } from "./pages/TokensPage";
 import { IngestionPage } from "./pages/IngestionPage";
 import { SearchPage } from "./pages/SearchPage";
 import { FreshnessPage } from "./pages/FreshnessPage";
+import { RetentionPage } from "./pages/RetentionPage";
 
 function AppInner() {
   const { token } = useTokenContext();
@@ -42,6 +43,7 @@ function AppInner() {
               element={<SearchPage addToast={addToast} />}
             />
             <Route path="/freshness" element={<FreshnessPage />} />
+            <Route path="/retention" element={<RetentionPage />} />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -236,6 +236,71 @@ export interface ClientsStatsResponse {
   top_tools_last_hour: ToolUsageEntry[];
 }
 
+/*
+ * Wire format for `GET /api/v1/admin/retention/status` (Issue #136, ADR-0009 §8).
+ *
+ * Mirrors the Pydantic `RetentionStatus`. All counts are scoped to the
+ * caller's workspace; the response carries IDs and counts only — no
+ * entity bodies, no chunk text (ACL invariant from ADR-0009 §Consequences-
+ * security).
+ *
+ * `last_run_at` is null when the worker has not completed its first
+ * tick since process start — the admin UI renders that as "never run"
+ * rather than displaying a stale value.
+ */
+export interface RetentionStatusResponse {
+  workspace_id: string;
+  neo4j_hot: number;
+  neo4j_warm: number;
+  qdrant_hot: number;
+  qdrant_warm: number;
+  last_run_at: string | null;
+  lag_seconds: number;
+  dry_run: boolean;
+}
+
+/*
+ * Wire format for the dry-run `GET /api/v1/admin/retention/report`
+ * (Issue #135, ADR-0009 §3). Returned when an operator wants to
+ * preview what the next worker tick would evict without mutating any
+ * store. Sample size is bounded by `Settings.retention_sample_size`
+ * (default 20).
+ */
+export interface RetentionSampleEntry {
+  id: string | null;
+  valid_from: string | null;
+  recorded_at: string | null;
+}
+
+export interface RetentionReportResponse {
+  workspace_id: string;
+  dry_run: boolean;
+  eligible_hot_to_warm_entity_states: number;
+  eligible_hot_to_warm_edges: number;
+  eligible_hot_to_warm_chunks: number;
+  eligible_warm_to_archive_entity_snapshots: number;
+  eligible_warm_to_archive_dates: string[];
+  sampled_eligible: RetentionSampleEntry[];
+  oldest_eligible_recorded_at: string | null;
+  lag_seconds: number;
+}
+
+/*
+ * Wire format for `POST /api/v1/admin/retention/run-now` (Issue #136).
+ * 202 Accepted with a server-generated `run_id`; the run executes
+ * synchronously inside the request handler and is scoped to the
+ * caller's workspace by the structural ACL invariant on the worker.
+ */
+export interface RetentionRunNowResponse {
+  run_id: string;
+  workspace_id: string;
+  started_at: string;
+  finished_at: string;
+  duration_seconds: number;
+  dry_run: boolean;
+  lag_seconds: number;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -417,6 +482,36 @@ export class ApiClient {
       "/api/v1/stats/clients",
       undefined,
       signal
+    );
+  }
+
+  // Retention admin (Issue #136, ADR-0009)
+  async retentionStatus(
+    signal?: AbortSignal
+  ): Promise<RetentionStatusResponse> {
+    return this.request<RetentionStatusResponse>(
+      "GET",
+      "/api/v1/admin/retention/status",
+      undefined,
+      signal
+    );
+  }
+
+  async retentionReport(
+    signal?: AbortSignal
+  ): Promise<RetentionReportResponse> {
+    return this.request<RetentionReportResponse>(
+      "GET",
+      "/api/v1/admin/retention/report",
+      undefined,
+      signal
+    );
+  }
+
+  async retentionRunNow(): Promise<RetentionRunNowResponse> {
+    return this.request<RetentionRunNowResponse>(
+      "POST",
+      "/api/v1/admin/retention/run-now"
     );
   }
 }

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/sources", label: "Sources" },
   { to: "/freshness", label: "Freshness" },
+  { to: "/retention", label: "Retention" },
   { to: "/tokens", label: "Tokens" },
   { to: "/ingestion", label: "Ingestion" },
   { to: "/search", label: "Search Playground" },

--- a/apps/admin/src/components/dashboard/RetentionPanel.tsx
+++ b/apps/admin/src/components/dashboard/RetentionPanel.tsx
@@ -1,0 +1,201 @@
+/*
+ * RetentionPanel — compact retention summary on the dashboard
+ * (Issue #136 § "wire into the dashboard home page (#114) as a card").
+ *
+ * The dashboard card shows hot/warm/archive totals + lag indicator
+ * with a link to /retention for the deep-dive page. Refresh cadence
+ * is 30s — matches the issue's call-out and fits the OverviewHeader
+ * cadence so the dashboard stays visually coherent.
+ *
+ * The card is intentionally read-only. Action buttons (Run now / Dry
+ * run report) live exclusively on /retention so the dashboard surface
+ * stays scannable. Operators following the link from the card to the
+ * deep-dive page get the full set of affordances + per-tenant table.
+ */
+
+import { Link } from "react-router-dom";
+import { ApiClient, RetentionStatusResponse } from "../../api/client";
+import { useTokenContext } from "../../context/TokenContext";
+import { usePanelFetch } from "../../hooks/usePanelFetch";
+import { PanelBody, PanelFrame } from "./PanelFrame";
+import { PanelErrorBoundary } from "./PanelErrorBoundary";
+
+const REFRESH_MS = 30_000;
+
+/* SLO thresholds in seconds — kept synchronised with the Prometheus
+ * alert rules in `monitoring/prometheus/alerts/retention.yaml`. */
+const LAG_WARNING_SECONDS = 86_400; // 24h
+const LAG_CRITICAL_SECONDS = 604_800; // 7d
+
+type LagBucket = "ok" | "warning" | "critical" | "never";
+
+interface BucketSpec {
+  label: string;
+  pillCls: string;
+}
+
+const LAG_BUCKETS: Record<LagBucket, BucketSpec> = {
+  ok: { label: "Within 24h SLO", pillCls: "bg-success-bg text-success-fg" },
+  warning: { label: ">24h", pillCls: "bg-warning-bg text-warning-fg" },
+  critical: { label: ">7d (P1)", pillCls: "bg-danger-bg text-danger-fg" },
+  never: { label: "Not run yet", pillCls: "bg-info-bg text-info-fg" },
+};
+
+function classifyLag(s: RetentionStatusResponse): LagBucket {
+  if (s.last_run_at == null) return "never";
+  if (s.lag_seconds > LAG_CRITICAL_SECONDS) return "critical";
+  if (s.lag_seconds > LAG_WARNING_SECONDS) return "warning";
+  return "ok";
+}
+
+function formatLag(seconds: number): string {
+  if (seconds <= 0) return "0s";
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86_400)}d`;
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString();
+}
+
+interface Props {
+  client?: ApiClient;
+  refreshMs?: number;
+}
+
+export function RetentionPanel({
+  client: clientOverride,
+  refreshMs = REFRESH_MS,
+}: Props = {}) {
+  const ctx = useTokenContext();
+  const client = clientOverride ?? ctx.client;
+
+  const { data, error, refreshing, lastRefreshedAt } =
+    usePanelFetch<RetentionStatusResponse>(
+      (signal) => client.retentionStatus(signal),
+      refreshMs
+    );
+
+  return (
+    <PanelFrame
+      title="Retention"
+      subtitle="Hot / warm / archive totals & lag SLO"
+      refreshing={refreshing}
+      lastRefreshedAt={lastRefreshedAt}
+      refreshMs={refreshMs}
+    >
+      <PanelErrorBoundary panelTitle="Retention">
+        <PanelBody
+          data={data}
+          error={error}
+          isEmpty={() => false /* totals always render even at zero */}
+          emptyTitle=""
+          emptyHint=""
+          skeleton={<CardSkeleton />}
+        >
+          {(d) => <Card data={d} />}
+        </PanelBody>
+      </PanelErrorBoundary>
+    </PanelFrame>
+  );
+}
+
+function Card({ data }: { data: RetentionStatusResponse }) {
+  const bucket = classifyLag(data);
+  const spec = LAG_BUCKETS[bucket];
+  const totalHot = data.neo4j_hot + data.qdrant_hot;
+  const totalWarm = data.neo4j_warm + data.qdrant_warm;
+  /* Archive count is not surfaced via /status (Qdrant is always 0 by
+   * design — re-embedding from archive is unsupported in v1 per
+   * ADR-0009 §5; Neo4j archive lives outside the live store entirely
+   * per ADR-0009 §1). The card displays "—" so operators know to
+   * follow the link to /retention for the dry-run report which lists
+   * eligible-for-archive snapshot dates. */
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-3 gap-3">
+        <Tile label="Hot" value={totalHot} colorVar="--chart-1" />
+        <Tile label="Warm" value={totalWarm} colorVar="--chart-2" />
+        <Tile label="Archive" value={null} colorVar="--chart-3" />
+      </div>
+
+      <div className="flex items-center justify-between rounded-md border border-border bg-elevation-2 px-3 py-2">
+        <div className="flex flex-col">
+          <span className="text-xs text-text-muted uppercase tracking-wide">
+            Lag SLO
+          </span>
+          <span className="text-sm text-text tabular-nums">
+            {data.last_run_at == null ? "no runs yet" : formatLag(data.lag_seconds)}
+          </span>
+        </div>
+        <span
+          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${spec.pillCls}`}
+        >
+          {spec.label}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between text-xs text-text-muted">
+        <span>
+          {data.dry_run ? "Dry-run mode" : "Live mode"}
+        </span>
+        <Link
+          to="/retention"
+          className="text-accent hover:text-accent-hover hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
+        >
+          View retention →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+interface TileProps {
+  label: string;
+  value: number | null;
+  colorVar: string;
+}
+
+function Tile({ label, value, colorVar }: TileProps) {
+  return (
+    <div className="bg-elevation-2 rounded-lg border border-border px-3 py-2.5">
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 rounded-full"
+          style={{ backgroundColor: `var(${colorVar})` }}
+        />
+        <span className="text-xs text-text-muted uppercase tracking-wide">
+          {label}
+        </span>
+      </div>
+      <p className="text-xl font-semibold text-text mt-1 tabular-nums">
+        {value == null ? "—" : formatCount(value)}
+      </p>
+    </div>
+  );
+}
+
+function CardSkeleton() {
+  return (
+    <div className="space-y-4" aria-hidden="true">
+      <div className="grid grid-cols-3 gap-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-elevation-2 rounded-lg border border-border px-3 py-2.5 motion-safe:animate-pulse"
+          >
+            <div className="h-3 w-12 bg-elevation-1 rounded" />
+            <div className="h-6 w-16 bg-elevation-1 rounded mt-2" />
+          </div>
+        ))}
+      </div>
+      <div className="h-12 rounded-md border border-border bg-elevation-2 motion-safe:animate-pulse" />
+      <span className="sr-only" role="status">
+        Loading retention…
+      </span>
+    </div>
+  );
+}

--- a/apps/admin/src/components/dashboard/Sparkline.tsx
+++ b/apps/admin/src/components/dashboard/Sparkline.tsx
@@ -1,0 +1,142 @@
+/*
+ * Sparkline — hand-rolled SVG mini chart (Issue #136).
+ *
+ * Used by the Retention page to render an at-a-glance trend for each
+ * of the four ADR-0009 §8 metrics. Per Issue #114's "no charting
+ * heavyweights" rule we add zero new npm dependencies and keep the
+ * implementation tiny — the bundle delta budget for #136 is the same
+ * as for #114.
+ *
+ * A11y notes
+ * ----------
+ *   - The SVG carries a `role="img"` and `aria-label` describing the
+ *     metric + current value; screen readers get a meaningful summary
+ *     without rendering the visualisation.
+ *   - Color comes from the chart palette tokens defined in
+ *     tailwind.config.js — never raw hex.
+ *   - Static SVG, no animation; satisfies prefers-reduced-motion by
+ *     construction.
+ *
+ * Empty / single-point safety
+ * ---------------------------
+ *   - 0 points  → renders an inert placeholder strip.
+ *   - 1 point   → renders a single dot at the midline (no spurious
+ *     line connecting one point to nothing).
+ *   - all-equal → renders a flat line at the midline.
+ */
+
+interface SparklineProps {
+  /* Numeric series, in chronological order. Newest sample LAST so the
+   * line trends rightward (the conventional reading order). */
+  values: number[];
+  /* Accessible label — "Lag (s) trend over the last hour" etc. */
+  caption: string;
+  /* Width / height in CSS pixels. Defaults match the dashboard card
+   * shape; the page-level metric cards override for a wider canvas. */
+  width?: number;
+  height?: number;
+  /* Stroke color CSS variable — defaults to the chart-1 palette token.
+   * Callers pass `--chart-2` etc. to differentiate concurrent
+   * sparklines without leaving the palette. */
+  strokeVar?: string;
+}
+
+const DEFAULT_WIDTH = 120;
+const DEFAULT_HEIGHT = 32;
+
+export function Sparkline({
+  values,
+  caption,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  strokeVar = "--chart-1",
+}: SparklineProps) {
+  if (values.length === 0) {
+    return (
+      <svg
+        role="img"
+        aria-label={`${caption} (no data yet)`}
+        width={width}
+        height={height}
+        className="block"
+      >
+        <line
+          x1={0}
+          y1={height / 2}
+          x2={width}
+          y2={height / 2}
+          stroke="var(--text-muted)"
+          strokeOpacity={0.3}
+          strokeDasharray="2 3"
+          strokeWidth={1}
+        />
+      </svg>
+    );
+  }
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  const xStep = values.length > 1 ? width / (values.length - 1) : 0;
+
+  /* Map each value to an SVG y coordinate. With range == 0 we draw a
+   * flat line at the vertical midpoint — a no-op series should look
+   * stable, not collapsed to the top or bottom. */
+  const yFor = (v: number): number => {
+    if (range === 0) return height / 2;
+    /* Pad 2px top/bottom so the stroke does not clip at extremes. */
+    const usable = height - 4;
+    return 2 + ((max - v) / range) * usable;
+  };
+
+  if (values.length === 1) {
+    return (
+      <svg
+        role="img"
+        aria-label={`${caption} (current ${values[0]})`}
+        width={width}
+        height={height}
+        className="block"
+      >
+        <circle
+          cx={width / 2}
+          cy={yFor(values[0])}
+          r={2.5}
+          fill={`var(${strokeVar})`}
+        />
+      </svg>
+    );
+  }
+
+  const points = values
+    .map((v, i) => `${(i * xStep).toFixed(2)},${yFor(v).toFixed(2)}`)
+    .join(" ");
+
+  const last = values[values.length - 1];
+  return (
+    <svg
+      role="img"
+      aria-label={`${caption} (current ${last})`}
+      width={width}
+      height={height}
+      className="block"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke={`var(${strokeVar})`}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Trailing dot anchors the eye on the latest sample — the
+       * conventional sparkline endpoint emphasis. */}
+      <circle
+        cx={(values.length - 1) * xStep}
+        cy={yFor(last)}
+        r={2}
+        fill={`var(${strokeVar})`}
+      />
+    </svg>
+  );
+}

--- a/apps/admin/src/pages/DashboardPage.tsx
+++ b/apps/admin/src/pages/DashboardPage.tsx
@@ -39,6 +39,7 @@ import { ClientsPanel } from "../components/dashboard/ClientsPanel";
 import { DeltaStrip } from "../components/dashboard/DeltaStrip";
 import { OverviewHeader } from "../components/dashboard/OverviewHeader";
 import { PanelErrorBoundary } from "../components/dashboard/PanelErrorBoundary";
+import { RetentionPanel } from "../components/dashboard/RetentionPanel";
 import { SchemaVolumePanel } from "../components/dashboard/SchemaVolumePanel";
 import { SourcesPanel } from "../components/dashboard/SourcesPanel";
 import { FreshnessPanel } from "../components/FreshnessPanel";
@@ -82,6 +83,16 @@ export function DashboardPage() {
           <PanelErrorBoundary panelTitle="Freshness">
             <FreshnessPanel />
           </PanelErrorBoundary>
+        </div>
+        {/*
+         * RetentionPanel (Issue #136) — compact retention card on the
+         * dashboard with a link to the deep-dive /retention page. Sits
+         * full-width below the 7/5 splits to keep the lag SLO visible
+         * without competing with Sources / Freshness for vertical
+         * attention.
+         */}
+        <div className="xl:col-span-12">
+          <RetentionPanel />
         </div>
       </div>
     </div>

--- a/apps/admin/src/pages/RetentionPage.tsx
+++ b/apps/admin/src/pages/RetentionPage.tsx
@@ -1,0 +1,671 @@
+/*
+ * RetentionPage — dedicated `/retention` deep-dive (Issue #136, ADR-0009 §8).
+ *
+ * Shows the four ADR-0009 §8 metrics with sparklines + current values,
+ * a per-tenant tier table (one row in v1 — the caller's own workspace
+ * — because the admin UI is workspace-scoped per the ACL invariant),
+ * and the two action buttons:
+ *
+ *   - **Run now**       → POST /api/v1/admin/retention/run-now
+ *   - **Dry run report** → GET  /api/v1/admin/retention/report
+ *
+ * The dry-run report is rendered inline on the page when triggered;
+ * it shows the would-evict counts + sample rows. The page does NOT
+ * surface entity bodies or chunk text — only IDs and counts (ADR-0009
+ * §Consequences-security ACL invariant).
+ *
+ * Sparkline data
+ * --------------
+ * The /status endpoint returns point-in-time observations, not a
+ * series. To populate the sparklines without scraping Prometheus
+ * directly, the page maintains a small in-memory ring buffer (last
+ * 30 samples = 15min at the 30s refresh cadence) — fed by every
+ * successful poll. Sparkline cleared on workspace switch / page
+ * unmount; matches FreshnessPanel's "current state, not historical
+ * series" posture.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ApiError,
+  ApiClient,
+  RetentionReportResponse,
+  RetentionRunNowResponse,
+  RetentionStatusResponse,
+} from "../api/client";
+import { useTokenContext } from "../context/TokenContext";
+import { usePanelFetch } from "../hooks/usePanelFetch";
+import { Sparkline } from "../components/dashboard/Sparkline";
+
+const REFRESH_MS = 30_000;
+const SPARKLINE_HISTORY = 30;
+
+const LAG_WARNING_SECONDS = 86_400;
+const LAG_CRITICAL_SECONDS = 604_800;
+
+type LagBucket = "ok" | "warning" | "critical" | "never";
+
+function classifyLag(s: RetentionStatusResponse): LagBucket {
+  if (s.last_run_at == null) return "never";
+  if (s.lag_seconds > LAG_CRITICAL_SECONDS) return "critical";
+  if (s.lag_seconds > LAG_WARNING_SECONDS) return "warning";
+  return "ok";
+}
+
+function formatLag(seconds: number): string {
+  if (seconds <= 0) return "0s";
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.round(seconds / 3600)}h`;
+  return `${Math.round(seconds / 86_400)}d`;
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatTimestamp(s: string | null): string {
+  if (s == null) return "never";
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return d.toLocaleString();
+}
+
+interface Props {
+  client?: ApiClient;
+  refreshMs?: number;
+}
+
+export function RetentionPage({
+  client: clientOverride,
+  refreshMs = REFRESH_MS,
+}: Props = {}) {
+  const ctx = useTokenContext();
+  const client = clientOverride ?? ctx.client;
+
+  const { data, error, refreshing, lastRefreshedAt, refresh } =
+    usePanelFetch<RetentionStatusResponse>(
+      (signal) => client.retentionStatus(signal),
+      refreshMs
+    );
+
+  /* Sparkline ring buffers — one per metric. Re-allocated on workspace
+   * switch (workspace_id change) so cross-tenant data does not leak
+   * into the chart. */
+  const seenWorkspaceRef = useRef<string | null>(null);
+  const [hotHistory, setHotHistory] = useState<number[]>([]);
+  const [warmHistory, setWarmHistory] = useState<number[]>([]);
+  const [lagHistory, setLagHistory] = useState<number[]>([]);
+  const [chunkHotHistory, setChunkHotHistory] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (data == null) return;
+    if (seenWorkspaceRef.current !== data.workspace_id) {
+      seenWorkspaceRef.current = data.workspace_id;
+      setHotHistory([data.neo4j_hot]);
+      setWarmHistory([data.neo4j_warm]);
+      setLagHistory([data.lag_seconds]);
+      setChunkHotHistory([data.qdrant_hot]);
+      return;
+    }
+    setHotHistory((prev) =>
+      [...prev, data.neo4j_hot].slice(-SPARKLINE_HISTORY)
+    );
+    setWarmHistory((prev) =>
+      [...prev, data.neo4j_warm].slice(-SPARKLINE_HISTORY)
+    );
+    setLagHistory((prev) =>
+      [...prev, data.lag_seconds].slice(-SPARKLINE_HISTORY)
+    );
+    setChunkHotHistory((prev) =>
+      [...prev, data.qdrant_hot].slice(-SPARKLINE_HISTORY)
+    );
+  }, [data]);
+
+  /* Action state — Run-now and Dry-run report are independent
+   * synchronous actions; each carries its own pending / success /
+   * error UI affordances. */
+  const [runNowState, setRunNowState] = useState<ActionState<RetentionRunNowResponse>>({
+    status: "idle",
+  });
+  const [reportState, setReportState] = useState<ActionState<RetentionReportResponse>>({
+    status: "idle",
+  });
+
+  const handleRunNow = useCallback(async () => {
+    setRunNowState({ status: "pending" });
+    try {
+      const result = await client.retentionRunNow();
+      setRunNowState({ status: "success", data: result });
+      /* Refresh the status panel so the new last_run_at + lag values
+       * appear without waiting for the next 30s tick. */
+      refresh();
+    } catch (e) {
+      setRunNowState({ status: "error", error: toError(e) });
+    }
+  }, [client, refresh]);
+
+  const handleDryRun = useCallback(async () => {
+    setReportState({ status: "pending" });
+    try {
+      const result = await client.retentionReport();
+      setReportState({ status: "success", data: result });
+    } catch (e) {
+      setReportState({ status: "error", error: toError(e) });
+    }
+  }, [client]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-text">Retention</h1>
+          <p className="text-sm text-text-muted mt-1">
+            Hot / warm / archive eviction observability — ADR-0009 §8.
+          </p>
+        </div>
+        <RefreshIndicator
+          refreshing={refreshing}
+          lastRefreshedAt={lastRefreshedAt}
+          refreshMs={refreshMs}
+        />
+      </div>
+
+      {error != null ? (
+        <ErrorBanner error={error} />
+      ) : data == null ? (
+        <PageSkeleton />
+      ) : (
+        <div className="space-y-8">
+          <MetricCards
+            data={data}
+            hotHistory={hotHistory}
+            warmHistory={warmHistory}
+            lagHistory={lagHistory}
+            chunkHotHistory={chunkHotHistory}
+          />
+
+          <Section title="Per-tenant retention">
+            <TenantTable data={data} />
+          </Section>
+
+          <Section title="Operator actions">
+            <Actions
+              dryRun={data.dry_run}
+              runNowState={runNowState}
+              reportState={reportState}
+              onRunNow={handleRunNow}
+              onDryRun={handleDryRun}
+            />
+          </Section>
+
+          {reportState.status === "success" && (
+            <Section title="Dry-run report">
+              <DryRunReport data={reportState.data} />
+            </Section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface MetricCardsProps {
+  data: RetentionStatusResponse;
+  hotHistory: number[];
+  warmHistory: number[];
+  lagHistory: number[];
+  chunkHotHistory: number[];
+}
+
+function MetricCards({
+  data,
+  hotHistory,
+  warmHistory,
+  lagHistory,
+  chunkHotHistory,
+}: MetricCardsProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+      <MetricCard
+        title="Records (Neo4j hot)"
+        currentValue={formatCount(data.neo4j_hot)}
+        sparkline={hotHistory}
+        caption="Hot-tier record count over the last 15 minutes"
+        strokeVar="--chart-1"
+      />
+      <MetricCard
+        title="Records (Neo4j warm)"
+        currentValue={formatCount(data.neo4j_warm)}
+        sparkline={warmHistory}
+        caption="Warm-tier (snapshot) count over the last 15 minutes"
+        strokeVar="--chart-2"
+      />
+      <MetricCard
+        title="Lag SLO"
+        currentValue={
+          data.last_run_at == null ? "no runs yet" : formatLag(data.lag_seconds)
+        }
+        sparkline={lagHistory}
+        caption="Lag in seconds over the last 15 minutes"
+        strokeVar="--chart-3"
+        emphasised={classifyLag(data) !== "ok" && data.last_run_at != null}
+      />
+      <MetricCard
+        title="Chunks (Qdrant hot)"
+        currentValue={formatCount(data.qdrant_hot)}
+        sparkline={chunkHotHistory}
+        caption="Qdrant hot-tier chunk count over the last 15 minutes"
+        strokeVar="--chart-4"
+      />
+    </div>
+  );
+}
+
+interface MetricCardProps {
+  title: string;
+  currentValue: string;
+  sparkline: number[];
+  caption: string;
+  strokeVar: string;
+  emphasised?: boolean;
+}
+
+function MetricCard({
+  title,
+  currentValue,
+  sparkline,
+  caption,
+  strokeVar,
+  emphasised = false,
+}: MetricCardProps) {
+  return (
+    <section
+      aria-label={title}
+      className={`bg-elevation-1 rounded-xl border ${
+        emphasised ? "border-warning-border" : "border-border"
+      } shadow-sm p-4 flex flex-col gap-3`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <h2 className="text-xs text-text-muted uppercase tracking-wide">
+          {title}
+        </h2>
+        <Sparkline
+          values={sparkline}
+          caption={caption}
+          width={80}
+          height={24}
+          strokeVar={strokeVar}
+        />
+      </div>
+      <p
+        className={`text-2xl font-semibold tabular-nums ${
+          emphasised ? "text-warning-fg" : "text-text"
+        }`}
+      >
+        {currentValue}
+      </p>
+    </section>
+  );
+}
+
+function TenantTable({ data }: { data: RetentionStatusResponse }) {
+  /* v1 admin UI is workspace-scoped per the ACL invariant — the
+   * /status endpoint returns the caller's workspace only. The table
+   * therefore renders one row in v1; we keep the table shape so a
+   * future cross-workspace admin token (out-of-scope for #136) can
+   * extend rendering without restructuring the component. */
+  const lagBucket = classifyLag(data);
+  const lagSpec = LAG_PILL_SPECS[lagBucket];
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <table className="min-w-full text-sm">
+        <thead className="bg-elevation-2 border-b border-border">
+          <tr>
+            <Th>Workspace ID</Th>
+            <Th align="right">Neo4j hot</Th>
+            <Th align="right">Neo4j warm</Th>
+            <Th align="right">Qdrant hot</Th>
+            <Th align="right">Qdrant warm</Th>
+            <Th>Last run</Th>
+            <Th>Lag</Th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          <tr>
+            <td
+              className="px-4 py-2 font-mono text-xs text-text-secondary truncate"
+              title={data.workspace_id}
+            >
+              {data.workspace_id}
+            </td>
+            <td className="px-4 py-2 text-right tabular-nums text-text">
+              {formatCount(data.neo4j_hot)}
+            </td>
+            <td className="px-4 py-2 text-right tabular-nums text-text">
+              {formatCount(data.neo4j_warm)}
+            </td>
+            <td className="px-4 py-2 text-right tabular-nums text-text">
+              {formatCount(data.qdrant_hot)}
+            </td>
+            <td className="px-4 py-2 text-right tabular-nums text-text">
+              {formatCount(data.qdrant_warm)}
+            </td>
+            <td className="px-4 py-2 text-text-muted">
+              {formatTimestamp(data.last_run_at)}
+            </td>
+            <td className="px-4 py-2">
+              <span
+                className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${lagSpec.pillCls}`}
+              >
+                {data.last_run_at == null
+                  ? lagSpec.label
+                  : `${formatLag(data.lag_seconds)} · ${lagSpec.label}`}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface ActionsProps {
+  dryRun: boolean;
+  runNowState: ActionState<RetentionRunNowResponse>;
+  reportState: ActionState<RetentionReportResponse>;
+  onRunNow: () => void;
+  onDryRun: () => void;
+}
+
+function Actions({
+  dryRun,
+  runNowState,
+  reportState,
+  onRunNow,
+  onDryRun,
+}: ActionsProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={onRunNow}
+          disabled={runNowState.status === "pending"}
+          className="inline-flex items-center rounded-md bg-accent text-accent-fg px-4 py-2 text-sm font-medium hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          {runNowState.status === "pending" ? "Running…" : "Run now"}
+        </button>
+        <button
+          type="button"
+          onClick={onDryRun}
+          disabled={reportState.status === "pending"}
+          className="inline-flex items-center rounded-md border border-border bg-elevation-2 text-text px-4 py-2 text-sm font-medium hover:border-border-strong disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          {reportState.status === "pending" ? "Computing…" : "Dry run report"}
+        </button>
+        <p className="text-xs text-text-muted self-center">
+          Worker is in <strong className="text-text">{dryRun ? "dry-run" : "live"}</strong> mode.{" "}
+          {dryRun
+            ? "“Run now” will compute eligibility but not mutate stores."
+            : "“Run now” will mutate stores within the configured boundaries."}
+        </p>
+      </div>
+
+      {runNowState.status === "success" && (
+        <Banner intent="success" role="status">
+          Run completed in {runNowState.data.duration_seconds.toFixed(2)}s · run_id{" "}
+          <code className="text-xs">{runNowState.data.run_id}</code>
+        </Banner>
+      )}
+      {runNowState.status === "error" && (
+        <Banner intent="error" role="alert">
+          Run failed: {runNowState.error.message}
+        </Banner>
+      )}
+      {reportState.status === "error" && (
+        <Banner intent="error" role="alert">
+          Dry-run report failed: {reportState.error.message}
+        </Banner>
+      )}
+    </div>
+  );
+}
+
+function DryRunReport({ data }: { data: RetentionReportResponse }) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <ReportTile label="Hot → warm: entity states" value={data.eligible_hot_to_warm_entity_states} />
+        <ReportTile label="Hot → warm: edges" value={data.eligible_hot_to_warm_edges} />
+        <ReportTile label="Hot → warm: chunks" value={data.eligible_hot_to_warm_chunks} />
+        <ReportTile
+          label="Warm → archive: snapshots"
+          value={data.eligible_warm_to_archive_entity_snapshots}
+        />
+      </div>
+      {data.eligible_warm_to_archive_dates.length > 0 && (
+        <p className="text-sm text-text-secondary">
+          Snapshot dates queued for archive:{" "}
+          <span className="font-mono text-text-muted">
+            {data.eligible_warm_to_archive_dates.join(", ")}
+          </span>
+        </p>
+      )}
+      {data.sampled_eligible.length > 0 ? (
+        <div className="overflow-hidden rounded-lg border border-border">
+          <table className="min-w-full text-sm">
+            <thead className="bg-elevation-2 border-b border-border">
+              <tr>
+                <Th>Entity ID</Th>
+                <Th>valid_from</Th>
+                <Th>recorded_at</Th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {data.sampled_eligible.map((s, i) => (
+                <tr key={`${s.id ?? "?"}-${i}`}>
+                  <td className="px-4 py-2 font-mono text-xs text-text-secondary truncate">
+                    {s.id ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-text-muted tabular-nums">{s.valid_from ?? "—"}</td>
+                  <td className="px-4 py-2 text-text-muted tabular-nums">
+                    {s.recorded_at ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-sm text-text-muted">
+          No sampled rows — workspace has nothing eligible for eviction.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ReportTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="bg-elevation-2 rounded-lg border border-border px-4 py-3">
+      <p className="text-xs text-text-muted uppercase tracking-wide">{label}</p>
+      <p className="text-2xl font-semibold text-text mt-1 tabular-nums">
+        {formatCount(value)}
+      </p>
+    </div>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function Section({ title, children }: SectionProps) {
+  return (
+    <section aria-label={title} className="space-y-3">
+      <h2 className="text-sm font-medium text-text-secondary uppercase tracking-wide">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Th({
+  children,
+  align = "left",
+}: {
+  children: React.ReactNode;
+  align?: "left" | "right";
+}) {
+  return (
+    <th
+      scope="col"
+      className={`px-4 py-2 font-medium text-text-secondary ${
+        align === "right" ? "text-right" : "text-left"
+      }`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function RefreshIndicator({
+  refreshing,
+  lastRefreshedAt,
+  refreshMs,
+}: {
+  refreshing: boolean;
+  lastRefreshedAt: number | null;
+  refreshMs: number;
+}) {
+  return (
+    <div
+      className="flex items-center gap-2 text-xs text-text-muted"
+      aria-live="polite"
+    >
+      <span
+        aria-hidden="true"
+        className={`h-2 w-2 rounded-full ${
+          refreshing ? "bg-accent motion-safe:animate-pulse" : "bg-success-fg"
+        }`}
+      />
+      <span>
+        {lastRefreshedAt == null
+          ? "Loading…"
+          : `Refreshed ${formatRelative(lastRefreshedAt)} · every ${Math.round(
+              refreshMs / 1000
+            )}s`}
+      </span>
+    </div>
+  );
+}
+
+function formatRelative(ts: number): string {
+  const elapsed = Math.max(0, Math.round((Date.now() - ts) / 1000));
+  if (elapsed < 60) return `${elapsed}s ago`;
+  return `${Math.round(elapsed / 60)}m ago`;
+}
+
+function ErrorBanner({ error }: { error: ApiError | Error }) {
+  if (error instanceof ApiError && error.status === 403) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-warning-border bg-warning-bg text-warning-fg px-4 py-3 text-sm"
+      >
+        <p className="font-medium">Missing scope</p>
+        <p className="mt-1">
+          Your token doesn’t have <code>stats:read</code>. Ask an administrator
+          to issue a token with that scope to view retention status.
+        </p>
+      </div>
+    );
+  }
+  const status = error instanceof ApiError ? error.status : null;
+  return (
+    <div
+      role="alert"
+      className="rounded-md border border-danger-border bg-danger-bg text-danger-fg px-4 py-3 text-sm"
+    >
+      <p className="font-medium">
+        Couldn’t load retention status{status != null ? ` (${status})` : ""}
+      </p>
+      <p className="mt-1 break-words">{error.message}</p>
+    </div>
+  );
+}
+
+function PageSkeleton() {
+  return (
+    <div className="space-y-6" aria-hidden="true">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-elevation-1 rounded-xl border border-border shadow-sm p-4 motion-safe:animate-pulse"
+          >
+            <div className="h-3 w-32 bg-elevation-2 rounded" />
+            <div className="h-8 w-24 bg-elevation-2 rounded mt-3" />
+          </div>
+        ))}
+      </div>
+      <span className="sr-only" role="status">
+        Loading retention…
+      </span>
+    </div>
+  );
+}
+
+function Banner({
+  intent,
+  role,
+  children,
+}: {
+  intent: "success" | "error";
+  role: "status" | "alert";
+  children: React.ReactNode;
+}) {
+  const cls =
+    intent === "success"
+      ? "border-success-fg bg-success-bg text-success-fg"
+      : "border-danger-border bg-danger-bg text-danger-fg";
+  return (
+    <div role={role} className={`rounded-md border px-4 py-3 text-sm ${cls}`}>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ActionState<T> =
+  | { status: "idle" }
+  | { status: "pending" }
+  | { status: "success"; data: T }
+  | { status: "error"; error: ApiError | Error };
+
+function toError(e: unknown): ApiError | Error {
+  if (e instanceof Error) return e;
+  return new Error(String(e));
+}
+
+interface PillSpec {
+  label: string;
+  pillCls: string;
+}
+
+const LAG_PILL_SPECS: Record<LagBucket, PillSpec> = {
+  ok: { label: "Within 24h SLO", pillCls: "bg-success-bg text-success-fg" },
+  warning: { label: ">24h", pillCls: "bg-warning-bg text-warning-fg" },
+  critical: { label: ">7d (P1)", pillCls: "bg-danger-bg text-danger-fg" },
+  never: { label: "Not run yet", pillCls: "bg-info-bg text-info-fg" },
+};

--- a/apps/server/src/omniscience_server/rest/retention.py
+++ b/apps/server/src/omniscience_server/rest/retention.py
@@ -1,27 +1,52 @@
-"""Retention dry-run report REST endpoint (issue #135, ADR-0009 §3).
+"""Retention admin REST endpoints (issues #135 / #136, ADR-0009 §3 / §8).
 
-Exposes ``GET /api/v1/admin/retention/report`` — workspace-scoped,
-returns the dry-run report for the caller's workspace.
+Endpoints
+---------
+
+* ``GET  /api/v1/admin/retention/report``    — workspace-scoped dry-run
+  report (issue #135). Always runs the worker in side-effect-free mode
+  regardless of operator config.
+* ``GET  /api/v1/admin/retention/status``    — workspace-scoped tier
+  counts + last-run-at + lag (issue #136). Cheap to call (reads gauges
+  + the worker's last report cache; does NOT trigger a fresh tick).
+* ``POST /api/v1/admin/retention/run-now``   — triggers a single live
+  retention tick scoped to the caller's workspace (issue #136).
+  Returns 202 Accepted with a server-generated ``run_id``. The
+  underlying call is :py:meth:`RetentionWorker.run_once`.
 
 Security
 --------
-- Requires the ``stats:read`` scope (matches the rest of the admin
-  read surface; a dedicated ``retention:read`` was considered but
-  rejected to avoid scope-creep on existing tokens).
-- Workspace-scoped: a token without an associated workspace fails
-  closed with 403, identical to ``rest/stats.py``.  This is the second
-  line of defence after the protocol-level ``workspace_id`` invariants
-  on ``GraphStore`` / ``VectorStore``.
-- The endpoint NEVER mutates either store — it always runs the
-  retention pipeline in dry-run mode regardless of the worker's
-  current ``retention_dry_run`` setting.  Operators reviewing
-  eviction posture before flipping the worker live MUST be able to
-  call this without side effects.
+All three endpoints require the ``stats:read`` scope and a workspace-
+scoped token. Rationale for the scope choice:
 
-Response shape
---------------
-:class:`RetentionReport` (Pydantic model below).  Sample is bounded by
-``Settings.retention_sample_size`` (default 20).
+* ``stats:read`` matches the rest of the admin read surface
+  (``rest/stats.py``). A dedicated ``retention:read`` was considered
+  but rejected to avoid scope-creep on existing admin-issued tokens.
+* ``run-now`` is workspace-scoped (the caller's workspace_id is the
+  only one processed) and idempotent — a re-run is a no-op unless
+  wall-clock time has advanced past the cutoff (ADR-0009 §3
+  idempotency). It therefore does not require a stronger scope than
+  the read surface; the equivalent dry-run is already exposed at
+  ``/report``. If a future reviewer wants admin-only ``run-now`` we can
+  promote it to :class:`Scope.admin` without an API contract change
+  (``admin`` implies ``stats:read``).
+* Workspace-scoped: a token without an associated workspace fails
+  closed with 403, identical to ``rest/stats.py``. This is the second
+  line of defence after the protocol-level ``workspace_id``
+  invariants on ``GraphStore`` / ``VectorStore``.
+
+ACL invariant (ADR-0009 §Consequences-security)
+------------------------------------------------
+Per-tenant counts in the dashboard come from the same workspace-scoped
+``count_records_by_tier`` / ``count_chunks_by_tier`` reads the worker
+itself uses on every tick. Data leaving the server is per-workspace
+counts only — NO entity bodies, NO chunk text, NO names, only IDs +
+counts. The regression test ``test_retention_admin_endpoints.py``
+asserts:
+
+1. Non-admin tokens get 403.
+2. Admin tokens get 200 with their workspace's counts.
+3. Workspace A's ``/status`` excludes any of workspace B's data.
 """
 
 from __future__ import annotations
@@ -31,7 +56,7 @@ from datetime import date, datetime
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from omniscience_core.auth.middleware import get_current_token, require_scope
 from omniscience_core.auth.scopes import Scope
 from omniscience_core.auth.workspace import get_workspace_id
@@ -43,6 +68,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from omniscience_server.retention_worker import (
     RetentionWorker,
+    RunReport,
     WorkspaceRetentionReport,
 )
 
@@ -52,6 +78,11 @@ router = APIRouter(tags=["admin"])
 
 _stats_scope_dep: Any = Depends(require_scope(Scope.stats_read))
 _current_token_dep: Any = Depends(get_current_token)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response models
+# ---------------------------------------------------------------------------
 
 
 class RetentionSampleEntry(BaseModel):
@@ -127,8 +158,86 @@ class RetentionReport(BaseModel):
     )
 
 
-def _to_response(report: WorkspaceRetentionReport) -> RetentionReport:
-    """Convert worker dataclass to Pydantic response model."""
+class RetentionStatus(BaseModel):
+    """Per-workspace retention status (issue #136).
+
+    Returns the four metric families from ADR-0009 §8 collapsed to
+    workspace scope so the admin UI can render the per-tenant table
+    without scraping Prometheus directly. ACL invariant: the response
+    contains only IDs and counts — no entity bodies, no chunk text.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace_id: uuid.UUID = Field(description="Workspace the status covers.")
+    neo4j_hot: int = Field(ge=0, description="Hot-tier records in Neo4j.")
+    neo4j_warm: int = Field(ge=0, description="Warm-tier (snapshot) records in Neo4j.")
+    qdrant_hot: int = Field(ge=0, description="Hot-tier chunks in Qdrant.")
+    qdrant_warm: int = Field(ge=0, description="Warm-tier chunks in Qdrant.")
+    last_run_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Wall-clock timestamp of the worker's most recent completed "
+            "tick. None when the worker has not yet run since process start."
+        ),
+    )
+    lag_seconds: float = Field(
+        ge=0.0,
+        description=(
+            "Wall-clock seconds since the oldest overdue record's "
+            "recorded_at — same observation as `omniscience_retention_"
+            "worker_lag_seconds`. ADR-0009 §8 SLO."
+        ),
+    )
+    dry_run: bool = Field(
+        description=(
+            "Whether the live retention worker is currently configured "
+            "to operate in dry-run mode. Operators flipping the worker "
+            "live for the first time on a deployment review this flag."
+        ),
+    )
+
+
+class RetentionRunNowResponse(BaseModel):
+    """Response from a successful POST /admin/retention/run-now (issue #136).
+
+    The endpoint returns 202 Accepted; the run executes synchronously
+    inside the request handler against the caller's workspace only.
+    The ``run_id`` is server-generated and stored in structured logs so
+    operators can correlate the dashboard refresh that follows the
+    button click with the worker tick that produced the new gauge values.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: uuid.UUID = Field(description="Server-generated identifier for the tick.")
+    workspace_id: uuid.UUID = Field(description="Workspace the tick was scoped to.")
+    started_at: datetime = Field(description="Wall-clock start time of the tick.")
+    finished_at: datetime = Field(description="Wall-clock finish time of the tick.")
+    duration_seconds: float = Field(
+        ge=0.0,
+        description="Wall-clock duration of the tick.",
+    )
+    dry_run: bool = Field(
+        description=(
+            "Whether the worker that executed this tick was in dry-run "
+            "mode. Mirrors `Settings.retention_dry_run` at the time of "
+            "the call."
+        ),
+    )
+    lag_seconds: float = Field(
+        ge=0.0,
+        description="Lag SLO observation produced by this tick.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_report_response(report: WorkspaceRetentionReport) -> RetentionReport:
+    """Convert worker dataclass to dry-run Pydantic response model."""
     return RetentionReport(
         workspace_id=report.workspace_id,
         dry_run=True,
@@ -152,46 +261,34 @@ def _to_response(report: WorkspaceRetentionReport) -> RetentionReport:
     )
 
 
-def _require_workspace(token: ApiToken) -> uuid.UUID:
+def _require_workspace(token: ApiToken, *, op: str) -> uuid.UUID:
     """Extract the caller's workspace_id or fail closed with 403."""
     workspace_id = get_workspace_id(token)
     if workspace_id is None:
         log.warning(
-            "retention_report_rejected_no_workspace",
+            "retention_admin_rejected_no_workspace",
+            op=op,
             token_prefix=token.token_prefix,
         )
         raise HTTPException(
             status_code=403,
             detail={
                 "code": "forbidden",
-                "message": ("Retention report endpoint requires a workspace-scoped token."),
+                "message": "Retention admin endpoints require a workspace-scoped token.",
             },
         )
     return workspace_id
 
 
 def _resolve_dry_run_worker(request: Request) -> RetentionWorker:
-    """Resolve a side-effect-free :class:`RetentionWorker`.
+    """Resolve a side-effect-free :class:`RetentionWorker` for /report.
 
     The wired worker on ``app.state.retention_worker`` may be running
     in live mode; we always force ``dry_run=True`` for the report
     endpoint so the response is guaranteed mutation-free regardless of
     operator configuration.
     """
-    settings: Settings | None = getattr(request.app.state, "settings", None)
-    graph_store: Neo4jGraphStore | None = getattr(request.app.state, "graph_store", None)
-    vector_store: QdrantVectorStore | None = getattr(request.app.state, "vector_store", None)
-    factory = getattr(request.app.state, "db_session_factory", None)
-    if settings is None or graph_store is None or vector_store is None or factory is None:
-        log.warning("retention_report_backend_unavailable")
-        raise HTTPException(
-            status_code=503,
-            detail={
-                "code": "service_unavailable",
-                "message": "Retention backend not available",
-            },
-        )
-    # Force dry-run regardless of the live worker's config.
+    settings, graph_store, vector_store, factory = _resolve_backend(request)
     forced = settings.model_copy(update={"retention_dry_run": True})
     return RetentionWorker(
         session_factory=factory,
@@ -199,6 +296,81 @@ def _resolve_dry_run_worker(request: Request) -> RetentionWorker:
         vector_store=vector_store,
         settings=forced,
     )
+
+
+def _resolve_live_worker(request: Request) -> RetentionWorker:
+    """Resolve the live :class:`RetentionWorker` for /run-now.
+
+    Prefers the worker wired to ``app.state.retention_worker`` (the
+    one running on the FastAPI lifespan tick loop) so a manual run-now
+    shares the same Settings, dry-run flag, and store handles as the
+    scheduled ticks. When that worker is unavailable (e.g. during
+    tests or when ``retention_enabled=False``), falls back to a fresh
+    instance bound to the request's stores.
+    """
+    existing: RetentionWorker | None = getattr(request.app.state, "retention_worker", None)
+    if isinstance(existing, RetentionWorker):
+        return existing
+    settings, graph_store, vector_store, factory = _resolve_backend(request)
+    return RetentionWorker(
+        session_factory=factory,
+        graph_store=graph_store,
+        vector_store=vector_store,
+        settings=settings,
+    )
+
+
+def _resolve_backend(
+    request: Request,
+) -> tuple[Settings, Neo4jGraphStore, QdrantVectorStore, Any]:
+    """Pull settings + store handles + session factory from app.state.
+
+    Centralizes the 503 fail-closed branch shared by the worker
+    resolvers. The ``Any`` return type for the factory mirrors the
+    existing ``rest/stats.py`` shape — SQLAlchemy's
+    ``async_sessionmaker`` is generic in T and we never narrow it
+    here.
+    """
+    settings: Settings | None = getattr(request.app.state, "settings", None)
+    graph_store: Neo4jGraphStore | None = getattr(request.app.state, "graph_store", None)
+    vector_store: QdrantVectorStore | None = getattr(request.app.state, "vector_store", None)
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if settings is None or graph_store is None or vector_store is None or factory is None:
+        log.warning("retention_admin_backend_unavailable")
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "service_unavailable",
+                "message": "Retention backend not available",
+            },
+        )
+    return settings, graph_store, vector_store, factory
+
+
+def _last_run_for_workspace(
+    worker: RetentionWorker,
+    workspace_id: uuid.UUID,
+) -> datetime | None:
+    """Best-effort lookup of the worker's last run-finished timestamp.
+
+    The worker exposes its most recent :class:`RunReport` via
+    ``last_report``. When that report covered the caller's workspace
+    (which it does whenever the workspace existed in Postgres at the
+    last tick) we use ``finished_at``; otherwise return None so the UI
+    can render a neutral "never run" state instead of a stale value.
+    """
+    last_report: RunReport | None = worker.last_report
+    if last_report is None:
+        return None
+    for ws_report in last_report.per_workspace:
+        if ws_report.workspace_id == workspace_id:
+            return last_report.finished_at
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/retention/report — dry-run report (issue #135)
+# ---------------------------------------------------------------------------
 
 
 @router.get(
@@ -214,26 +386,15 @@ async def admin_retention_report(
     """Return what eviction would do for the caller's workspace.
 
     Side-effect free: the call always runs the worker in dry-run mode
-    regardless of ``Settings.retention_dry_run``.  The caller sees:
-
-    * Counts of rows eligible for hot-to-warm and warm-to-archive
-      transitions (Neo4j entity states, edges, Qdrant chunks).
-    * The distinct snapshot dates that would be archived this run.
-    * A sampled set of eligible :EntityState rows for the dry-run
-      report (ADR-0009 §3 — "produces a structured 'would-evict'
-      report").
-    * Lag SLO observation in seconds (ADR-0009 §8).
+    regardless of ``Settings.retention_dry_run``.
 
     Requires scope: ``stats:read``
     Requires: token scoped to a workspace (fails closed with 403).
     """
-    workspace_id = _require_workspace(token)
+    workspace_id = _require_workspace(token, op="report")
     worker = _resolve_dry_run_worker(request)
     run_report = await worker.run_once(workspace_filter=workspace_id)
     if not run_report.per_workspace:
-        # Workspace exists in the token's scope but has no rows in
-        # Postgres `workspaces` (e.g. a token claiming a tenant that
-        # was offboarded).  Fail closed identically to stats endpoints.
         raise HTTPException(
             status_code=404,
             detail={
@@ -241,7 +402,7 @@ async def admin_retention_report(
                 "message": "Workspace has no records to evict.",
             },
         )
-    response = _to_response(run_report.per_workspace[0])
+    response = _to_report_response(run_report.per_workspace[0])
     log.info(
         "retention_report",
         workspace_id=str(workspace_id),
@@ -254,4 +415,156 @@ async def admin_retention_report(
     return response
 
 
-__all__ = ["RetentionReport", "RetentionSampleEntry", "router"]
+# ---------------------------------------------------------------------------
+# GET /admin/retention/status — per-workspace counts + lag (issue #136)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/admin/retention/status",
+    response_model=RetentionStatus,
+    summary="Workspace-scoped retention status (counts + lag)",
+    dependencies=[_stats_scope_dep],
+)
+async def admin_retention_status(
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> RetentionStatus:
+    """Return per-workspace tier counts + last-run-at + lag.
+
+    The response derives counts from the same workspace-scoped store
+    methods the worker uses on every tick (``count_records_by_tier``
+    on Neo4j, ``count_chunks_by_tier`` on Qdrant). It does NOT trigger
+    a fresh retention tick — this endpoint must be cheap enough to
+    poll on the admin UI's 30s refresh cadence (issue #136 dashboard
+    cards) without piling pressure onto Neo4j/Qdrant.
+
+    The lag observation is read off the most recent worker report
+    when present, falling back to the live Prometheus gauge value
+    otherwise. ``last_run_at`` is None until the worker has completed
+    its first tick since process start.
+
+    Requires scope: ``stats:read``
+    Requires: token scoped to a workspace (fails closed with 403).
+    """
+    workspace_id = _require_workspace(token, op="status")
+    settings, graph_store, vector_store, _factory = _resolve_backend(request)
+    graph_records = await graph_store.count_records_by_tier(workspace_id=workspace_id)
+    chunk_records = await vector_store.count_chunks_by_tier(workspace_id=workspace_id)
+
+    worker: RetentionWorker | None = getattr(request.app.state, "retention_worker", None)
+    last_run_at: datetime | None = None
+    lag_seconds = 0.0
+    if isinstance(worker, RetentionWorker):
+        last_run_at = _last_run_for_workspace(worker, workspace_id)
+        last_report = worker.last_report
+        if last_report is not None:
+            for ws_report in last_report.per_workspace:
+                if ws_report.workspace_id == workspace_id:
+                    lag_seconds = ws_report.lag_seconds
+                    break
+
+    response = RetentionStatus(
+        workspace_id=workspace_id,
+        neo4j_hot=int(graph_records.get("hot", 0)),
+        neo4j_warm=int(graph_records.get("warm", 0)),
+        qdrant_hot=int(chunk_records.get("hot", 0)),
+        qdrant_warm=int(chunk_records.get("warm", 0)),
+        last_run_at=last_run_at,
+        lag_seconds=lag_seconds,
+        dry_run=bool(settings.retention_dry_run),
+    )
+    log.info(
+        "retention_status",
+        workspace_id=str(workspace_id),
+        neo4j_hot=response.neo4j_hot,
+        neo4j_warm=response.neo4j_warm,
+        qdrant_hot=response.qdrant_hot,
+        qdrant_warm=response.qdrant_warm,
+        lag_seconds=response.lag_seconds,
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/retention/run-now — manual workspace-scoped tick (issue #136)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/admin/retention/run-now",
+    response_model=RetentionRunNowResponse,
+    summary="Trigger a single retention tick scoped to the caller's workspace",
+    status_code=status.HTTP_202_ACCEPTED,
+    dependencies=[_stats_scope_dep],
+)
+async def admin_retention_run_now(
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> RetentionRunNowResponse:
+    """Trigger a single retention worker tick for the caller's workspace.
+
+    Calls :py:meth:`RetentionWorker.run_once` with
+    ``workspace_filter=workspace_id`` so the run is structurally
+    incapable of touching another workspace's data — the same ACL
+    invariant the scheduled ticks rely on (ADR-0009 §3).
+
+    Returns 202 Accepted with a server-generated ``run_id``. The run
+    executes synchronously inside the request handler; the 202 status
+    code reflects the architectural posture (ticks are usually
+    background-scheduled) rather than asynchronous execution. Tick
+    duration is bounded by the configured batch size and store
+    timeouts.
+
+    Requires scope: ``stats:read``
+    Requires: token scoped to a workspace (fails closed with 403).
+    """
+    workspace_id = _require_workspace(token, op="run_now")
+    worker = _resolve_live_worker(request)
+    run_id = uuid.uuid4()
+    log.info(
+        "retention_run_now_started",
+        run_id=str(run_id),
+        workspace_id=str(workspace_id),
+        dry_run=worker.dry_run,
+    )
+    run_report = await worker.run_once(workspace_filter=workspace_id)
+    if not run_report.per_workspace:
+        log.warning(
+            "retention_run_now_workspace_not_found",
+            run_id=str(run_id),
+            workspace_id=str(workspace_id),
+        )
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "workspace_not_found",
+                "message": "Workspace not found in retention worker enumeration.",
+            },
+        )
+    response = RetentionRunNowResponse(
+        run_id=run_id,
+        workspace_id=workspace_id,
+        started_at=run_report.started_at,
+        finished_at=run_report.finished_at,
+        duration_seconds=run_report.duration_seconds,
+        dry_run=run_report.dry_run,
+        lag_seconds=run_report.lag_seconds,
+    )
+    log.info(
+        "retention_run_now_completed",
+        run_id=str(run_id),
+        workspace_id=str(workspace_id),
+        duration_s=response.duration_seconds,
+        lag_s=response.lag_seconds,
+    )
+    return response
+
+
+__all__ = [
+    "RetentionReport",
+    "RetentionRunNowResponse",
+    "RetentionSampleEntry",
+    "RetentionStatus",
+    "router",
+]

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,63 @@
+# Observability
+
+Index of dashboards, alerts, runbooks, and Prometheus metric families
+exposed by Omniscience.
+
+## Metric families
+
+The server exposes Prometheus metrics on `/metrics`. The current set:
+
+| Family | Type | Labels | Source |
+|---|---|---|---|
+| `omniscience_http_requests_total` | counter | `method`, `path`, `status_code` | TracingMiddleware |
+| `omniscience_http_request_duration_seconds` | histogram | `method`, `path` | TracingMiddleware |
+| `omniscience_http_requests_in_progress` | gauge | `method`, `path` | TracingMiddleware |
+| `omniscience_source_freshness_age_seconds` | gauge | `source_id`, `source_name` | FreshnessWorker (Issue #112) |
+| `omniscience_source_stale_total` | gauge | — | FreshnessWorker |
+| `omniscience_scheduler_syncs_triggered_total` | counter | `source_type` | SchedulerWorker |
+| `omniscience_scheduler_check_duration_seconds` | histogram | — | SchedulerWorker |
+| `omniscience_graph_records_total` | gauge | `tier`, `store` | RetentionWorker (Issue #135 / ADR-0009 §8) |
+| `omniscience_retention_eviction_total` | counter | `transition`, `store` | RetentionWorker |
+| `omniscience_retention_worker_duration_seconds` | histogram | `phase`, `store` | RetentionWorker |
+| `omniscience_retention_worker_lag_seconds` | gauge | — | RetentionWorker |
+
+## Dashboards
+
+Provisioned via `monitoring/grafana/dashboards/`:
+
+| File | UID | Coverage |
+|---|---|---|
+| `freshness.json` | `omniscience-freshness-slos` | Source freshness SLO (Issue #112) |
+| `retention.json` | `omniscience-retention-slos` | Retention worker per-tier counts, eviction throughput, phase latency, lag SLO, top-N partitions (Issue #136 / ADR-0009 §8) |
+
+## Alerts
+
+Provisioned via `monitoring/prometheus/alerts/`:
+
+| File | Rules |
+|---|---|
+| `retention.yaml` | `RetentionWorkerLagWarning` (warning, 24h), `RetentionWorkerLagCritical` (critical, 7d/P1), `RetentionWorkerStalled` (critical, 12h no-tick), `RetentionEvictionInconsistent` (warning, cross-store divergence) |
+
+## Runbooks
+
+| Doc | Coverage |
+|---|---|
+| `runbooks/retention.md` | Retention worker incident response — alert routing, dashboard interpretation, manual operations (run-now, dry-run report) (Issue #136) |
+
+## Admin UI
+
+The admin app (`apps/admin`) ships with two operator-facing pages tied
+to the metric families above:
+
+- `/freshness` — per-source freshness deep dive (Issue #112).
+- `/retention` — retention status (counts + lag SLO), per-tenant
+  table, **Run now** action, **Dry run report** action (Issue #136).
+
+The Dashboard home (`/`) embeds the **Retention** panel as a card with
+a link to `/retention` for the deep dive.
+
+## Related
+
+- [ADR-0009 §8](decisions/0009-retention-tiering-policy.md#8-observability-and-slos) — retention SLOs
+- [`docs/freshness-and-lineage.md`](freshness-and-lineage.md) — freshness SLO contract
+- Prometheus scrape configuration: `monitoring/prometheus.yml`

--- a/docs/runbooks/retention.md
+++ b/docs/runbooks/retention.md
@@ -1,0 +1,166 @@
+# Retention worker runbook
+
+Operational runbook for the retention worker (issue #135) and the
+retention dashboard / alert path (issue #136). Source of truth for the
+contracts referenced here is **[ADR-0009](../decisions/0009-retention-tiering-policy.md)**.
+
+## Overview
+
+The retention worker evicts data across the **hot → warm → archive**
+tiers per ADR-0009 §1. It runs in-process on the FastAPI lifespan with
+a default 6-hour tick interval, processes one workspace at a time, and
+follows the read-then-mark-then-move pattern (ADR-0009 §3) so that a
+crash mid-tick leaves a re-runnable state.
+
+**Steady-state SLO**: lag stays below 24 hours (ADR-0009 §8). Lag > 7d
+trips a P1 alert via the same alert path freshness uses.
+
+## Dashboard
+
+The Grafana dashboard `retention.json`
+(`monitoring/grafana/dashboards/retention.json`) renders five panels:
+
+1. **Records by tier (hot / warm / archive)** — stacked area on
+   `omniscience_graph_records_total`.
+2. **Eviction rate (5m window)** — `rate(...)` on
+   `omniscience_retention_eviction_total`.
+3. **Worker phase latency (p50 / p95 / p99)** —
+   `histogram_quantile(...)` on
+   `omniscience_retention_worker_duration_seconds`.
+4. **Retention worker lag** — time series of
+   `omniscience_retention_worker_lag_seconds` with the 24h warning and
+   7d P1 thresholds drawn.
+5. **Top-10 (tier × store) by record count** — partition table off
+   `omniscience_graph_records_total`.
+
+The admin UI deep-dive lives at `/retention` and surfaces the same
+metrics scoped to the caller's workspace, plus the per-tenant table,
+**Run now** action, and **Dry run report** action.
+
+## Alerts
+
+`monitoring/prometheus/alerts/retention.yaml` ships four rules.
+
+### RetentionWorkerLagWarning (severity=warning)
+
+`omniscience_retention_worker_lag_seconds > 86400` for 5m.
+
+**Response**:
+
+1. Open the retention dashboard, confirm the lag panel shows the
+   sustained breach.
+2. Check the **Worker phase latency** panel — a p99 spike on
+   `phase="move"` typically means the eligibility query lost its
+   index pin (most likely cause: the
+   `(workspace_id, recorded_at)` composite index from ADR-0008 hasn't
+   backfilled). Verify with `cypher-shell` or the Neo4j console.
+3. If the p99 is normal but lag is rising, check whether ingestion
+   has accelerated faster than the worker can keep up. The worker
+   processes at most `RETENTION_BATCH_SIZE` (default 500) rows per
+   transaction — raise via Helm
+   (`omniscience.retention.batchSize`) if the v0.5 envelope has
+   grown.
+4. Use the admin UI’s **Run now** button on `/retention` to trigger
+   an immediate tick scoped to the affected workspace; the dashboard
+   refresh shows the new lag value within 60s.
+
+### RetentionWorkerLagCritical (severity=critical, P1)
+
+`omniscience_retention_worker_lag_seconds > 604800` for 5m.
+
+**Response**: identical to the warning runbook, plus:
+
+5. Page the on-call platform engineer (P1 escalation path — same as
+   freshness P1).
+6. If a sustained breach persists past 30min, consider stopping the
+   ingestion worker temporarily so the retention worker can catch
+   up; this is documented in ADR-0009 §9 ("manageable: a backlog of
+   unmoved-archive records does not affect query correctness").
+
+### RetentionWorkerStalled (severity=critical)
+
+`max(increase(omniscience_retention_worker_duration_seconds_count[12h])) == 0`
+for 5m.
+
+**Response**:
+
+1. Inspect FastAPI process logs for a `retention_worker_error`
+   structlog event. The worker traps exceptions in `start()` so the
+   lifespan loop continues; a sustained stall usually means the
+   ingestion / freshness workers crashed too (process-wide), or a
+   pathological asyncio gather is blocking the loop.
+2. If the FastAPI process itself is healthy but the worker is
+   silent, restart the server replicas. ADR-0009 §9 crash runbook:
+   *"the next scheduled run resumes from idempotency"* — there's no
+   data corruption to repair.
+3. After restart, confirm `omniscience_retention_worker_duration_seconds_count`
+   begins incrementing within one tick interval (default 6h, but
+   the first run executes immediately on lifespan start).
+
+### RetentionEvictionInconsistent (severity=warning)
+
+`abs(rate(... store="neo4j"[1h]) - rate(... store="qdrant"[1h])) > 0.1`
+for 1h.
+
+**Response** (ADR-0009 §9 cross-store consistency runbook):
+
+1. Run the worker once via `/api/v1/admin/retention/run-now` (or the
+   admin UI button). A transient Qdrant outage leaves marked-not-
+   moved chunks; the next run fixes the divergence.
+2. If the divergence persists, check Qdrant's payload-index health:
+   `omniscience_chunks` collection should expose payload indexes on
+   `tier` and `workspace_id`. A missing index makes the warm filter
+   evaluate via full scan, which times out the move phase.
+3. As a last resort, escalate to a per-workspace re-sync from the
+   Postgres `chunks` table — the canonical source of vector lineage
+   per ADR-0006 §implementation-notes. This is a cold-restart shape;
+   coordinate with the platform team before kicking off.
+
+## Manual operations
+
+### Inspect would-evict counts (no mutation)
+
+```
+GET /api/v1/admin/retention/report
+Authorization: Bearer <token-with-stats:read>
+```
+
+Returns the same dry-run report the admin UI's **Dry run report**
+button shows. Side-effect free regardless of operator config.
+
+### Trigger a single tick
+
+```
+POST /api/v1/admin/retention/run-now
+Authorization: Bearer <token-with-stats:read>
+```
+
+Scoped to the caller's workspace. Returns 202 Accepted with a
+server-generated `run_id`. The tick executes synchronously inside the
+request handler.
+
+### Per-tenant counts + lag
+
+```
+GET /api/v1/admin/retention/status
+Authorization: Bearer <token-with-stats:read>
+```
+
+Cheap to call (reads the same gauges the worker writes on every
+tick). The admin UI polls this endpoint every 30s.
+
+## Scope
+
+All three admin endpoints require the **`stats:read`** scope (matches
+the rest of the admin read surface). `admin` tokens satisfy via the
+scope hierarchy. Requests from tokens without an associated workspace
+fail closed with 403.
+
+## Related
+
+- ADR-0009 §8 — observability + SLOs
+- ADR-0009 §9 — failure modes
+- `docs/freshness-and-lineage.md` — freshness alert path (parallel)
+- Issue [#135](https://github.com/100rd/Omniscience/issues/135) — worker
+- Issue [#136](https://github.com/100rd/Omniscience/issues/136) —
+  dashboard + alerts + admin UI

--- a/monitoring/grafana/dashboards/retention.json
+++ b/monitoring/grafana/dashboards/retention.json
@@ -1,0 +1,506 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Retention worker observability dashboard for Omniscience (ADR-0009 §8). Tracks per-tier record counts, eviction rates, worker phase latency, lag SLO, and per-workspace breakdown. Five panels mirror the metric families specified in ADR-0009 §8.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "title": "Retention runbook",
+      "url": "/docs/runbooks/retention.md",
+      "type": "link",
+      "icon": "doc",
+      "tags": [],
+      "targetBlank": true
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Tier composition",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Stacked area chart of records per tier (hot, warm, archive) summed across stores. Sourced from `omniscience_graph_records_total` — gauge written by the retention worker after every successful run.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Records",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 60,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short",
+          "min": 0
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "hot" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "warm" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "archive" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (tier) (omniscience_graph_records_total{store=~\"$store\"})",
+          "legendFormat": "{{tier}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Records by tier (hot / warm / archive)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 101,
+      "title": "Eviction throughput",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Rate of records evicted per second over a 5-minute window, partitioned by transition (hot_to_warm, warm_to_archive). Steady-state baseline for a healthy worker is ≈ overdue cohort / tick interval. A sustained zero is the most common stalled-worker signature.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Evictions / sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "ops",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 10 },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max", "mean"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (transition, store) (rate(omniscience_retention_eviction_total{store=~\"$store\"}[5m]))",
+          "legendFormat": "{{transition}} · {{store}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Eviction rate (5m window)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 102,
+      "title": "Worker phase latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "p50 / p95 / p99 of `omniscience_retention_worker_duration_seconds` per phase (read / mark / move) across all stores. The histogram has 12 buckets covering 10ms → 5min — phases that exceed the 30s Neo4j tx timeout will surface in the p99 line.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Latency (s)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 30 }
+            ]
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 19 },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum by (phase, le) (rate(omniscience_retention_worker_duration_seconds_bucket{store=~\"$store\"}[5m])))",
+          "legendFormat": "p50 · {{phase}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum by (phase, le) (rate(omniscience_retention_worker_duration_seconds_bucket{store=~\"$store\"}[5m])))",
+          "legendFormat": "p95 · {{phase}}",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (phase, le) (rate(omniscience_retention_worker_duration_seconds_bucket{store=~\"$store\"}[5m])))",
+          "legendFormat": "p99 · {{phase}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Worker phase latency (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 103,
+      "title": "Lag SLO",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Wall-clock seconds since the oldest overdue record was last evicted (ADR-0009 §8). Steady-state SLO: < 24h (86400s). Warning threshold: 24h. P1 critical threshold: 7d (604800s). Both thresholds are drawn on the chart.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Lag (s)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line+area",
+              "steps": [
+                { "color": "transparent", "value": null },
+                { "color": "yellow", "value": 86400 },
+                { "color": "red", "value": 604800 }
+              ]
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 86400 },
+              { "color": "red", "value": 604800 }
+            ]
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 28 },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "omniscience_retention_worker_lag_seconds",
+          "legendFormat": "Lag",
+          "refId": "A"
+        }
+      ],
+      "title": "Retention worker lag (24h warning / 7d P1)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "id": 104,
+      "title": "Per-workspace breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "description": "Top 10 partitions by record count. The retention worker emits `omniscience_graph_records_total{tier, store}` without a `workspace_id` label in v1 (the gauge label set is global; per-workspace counts surface via the admin /status endpoint). This panel falls back to per-store breakdown so operators can spot Neo4j vs Qdrant divergence on the dashboard, and the per-workspace deep-dive lives on `/retention` in the admin UI.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Value" },
+            "properties": [
+              { "id": "displayName", "value": "Records" },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 37 },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "Records" }]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "topk(10, omniscience_graph_records_total)",
+          "instant": true,
+          "format": "table",
+          "legendFormat": "{{tier}} / {{store}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top-10 (tier × store) by record count",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true },
+            "renameByName": {
+              "tier": "Tier",
+              "store": "Store",
+              "Value": "Records"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["omniscience", "retention", "slo", "adr-0009"],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(omniscience_graph_records_total, store)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Store",
+        "multi": true,
+        "name": "store",
+        "options": [],
+        "query": {
+          "query": "label_values(omniscience_graph_records_total, store)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Omniscience - Retention SLOs",
+  "uid": "omniscience-retention-slos",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -4,6 +4,12 @@ global:
   external_labels:
     service: omniscience
 
+# Alert rule files. Each YAML file under `prometheus/alerts/` defines
+# one or more rule groups; Prometheus auto-loads all matches on
+# startup / SIGHUP.
+rule_files:
+  - "prometheus/alerts/*.yaml"
+
 scrape_configs:
   - job_name: omniscience-app
     static_configs:

--- a/monitoring/prometheus/alerts/retention.yaml
+++ b/monitoring/prometheus/alerts/retention.yaml
@@ -1,0 +1,111 @@
+# Prometheus alert rules for the retention worker (issue #136, ADR-0009 §8 / §9).
+#
+# These rules are loaded by the Prometheus instance via the standard
+# `rule_files:` directive in `prometheus.yml`. The four rules cover the
+# failure modes documented in ADR-0009 §9:
+#   * lag > 24h  ........ warning  (steady-state SLO breach)
+#   * lag > 7d   ........ critical (P1 — same path as freshness P1 alert)
+#   * worker stalled .... critical (no run completed in 2x configured tick)
+#   * cross-store inconsistency  warning (eviction rate divergence between
+#                                 Neo4j and Qdrant — ADR-0009 §9 mitigation
+#                                 path: re-run worker, then per-workspace
+#                                 re-sync from Postgres `chunks`)
+#
+# The runbook URL points at the in-repo runbook; substitute the deployed
+# documentation host at deploy time if hosting docs externally.
+groups:
+  - name: omniscience-retention
+    interval: 1m
+    rules:
+      - alert: RetentionWorkerLagWarning
+        expr: omniscience_retention_worker_lag_seconds > 86400
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+          component: retention-worker
+        annotations:
+          summary: "Retention worker lag exceeds 24h SLO (ADR-0009 §8)"
+          description: |
+            The retention worker has been more than 24 hours behind on
+            evicting overdue records for at least 5 minutes
+            (omniscience_retention_worker_lag_seconds = {{ $value | humanizeDuration }}).
+            Steady-state SLO is < 24h. ADR-0009 §8.
+          runbook_url: "docs/runbooks/retention.md#retentionworkerlagwarning"
+
+      - alert: RetentionWorkerLagCritical
+        expr: omniscience_retention_worker_lag_seconds > 604800
+        for: 5m
+        labels:
+          severity: critical
+          team: platform
+          component: retention-worker
+        annotations:
+          summary: "Retention worker lag exceeds 7d (P1 — ADR-0009 §8)"
+          description: |
+            The retention worker has been more than 7 days behind on
+            evicting overdue records for at least 5 minutes
+            (omniscience_retention_worker_lag_seconds = {{ $value | humanizeDuration }}).
+            P1 escalation path — see freshness alert path. ADR-0009 §8.
+          runbook_url: "docs/runbooks/retention.md#retentionworkerlagcritical"
+
+      - alert: RetentionWorkerStalled
+        # `omniscience_retention_worker_duration_seconds_count` increments
+        # once per (phase, store) per workspace per tick. When the worker
+        # is healthy this counter increases on every tick (default 6h);
+        # when it has not increased in 12h (2x configured interval) the
+        # worker is stalled. `increase(...)` over a 12h window returns 0
+        # when no new samples landed, irrespective of which (phase, store)
+        # cell is selected — `max()` collapses the label set so we alert
+        # once per deployment, not once per cell.
+        expr: |
+          max(increase(omniscience_retention_worker_duration_seconds_count[12h])) == 0
+        for: 5m
+        labels:
+          severity: critical
+          team: platform
+          component: retention-worker
+        annotations:
+          summary: "Retention worker has not run in 12h (ADR-0009 §9)"
+          description: |
+            No retention worker tick has completed in the last 12 hours
+            (2x the configured 6h interval). The worker is stalled or has
+            crashed. ADR-0009 §9 crash runbook: check FastAPI lifespan
+            errors, then restart the server replicas — the next scheduled
+            run resumes from idempotency.
+          runbook_url: "docs/runbooks/retention.md#retentionworkerstalled"
+
+      - alert: RetentionEvictionInconsistent
+        # Cross-store divergence — the retention worker handles both
+        # Neo4j and Qdrant in one run, but an inconsistency window exists
+        # between the Neo4j move and the Qdrant move (ADR-0009 §9). A
+        # sustained rate divergence > 0.1 ev/s for an hour indicates one
+        # store is falling behind structurally rather than transiently.
+        # The `absent_over_time` guard avoids firing during cold-boot
+        # before either store has produced a sample.
+        expr: |
+          (
+            absent_over_time(omniscience_retention_eviction_total{store="neo4j"}[1h]) != 1
+            and
+            absent_over_time(omniscience_retention_eviction_total{store="qdrant"}[1h]) != 1
+          )
+          and on()
+          abs(
+            sum(rate(omniscience_retention_eviction_total{store="neo4j"}[1h]))
+            -
+            sum(rate(omniscience_retention_eviction_total{store="qdrant"}[1h]))
+          ) > 0.1
+        for: 1h
+        labels:
+          severity: warning
+          team: platform
+          component: retention-worker
+        annotations:
+          summary: "Retention eviction divergence between Neo4j and Qdrant (ADR-0009 §9)"
+          description: |
+            The eviction rate on Neo4j and Qdrant has diverged by more
+            than 0.1 records/sec for at least 1 hour. ADR-0009 §9
+            cross-store consistency runbook: re-run the retention
+            worker; if the divergence persists, escalate to a per-
+            workspace re-sync from the Postgres `chunks` table.
+          runbook_url: "docs/runbooks/retention.md#retentionevictioninconsistent"

--- a/tests/test_retention_admin_endpoints.py
+++ b/tests/test_retention_admin_endpoints.py
@@ -1,0 +1,538 @@
+"""REST tests for the retention admin endpoints (issue #136, ADR-0009 §8).
+
+Coverage:
+
+* ``GET /api/v1/admin/retention/status``
+    - 401 without token
+    - 403 without ``stats:read`` scope
+    - 403 with token that has scope but no workspace
+    - 200 happy path returns workspace-scoped counts + lag + last_run_at
+    - cross-workspace ACL: workspace A's status excludes workspace B's
+      data
+* ``POST /api/v1/admin/retention/run-now``
+    - 401 without token
+    - 403 without ``stats:read`` scope
+    - 403 with token but no workspace
+    - 202 Accepted on happy path; ``RetentionWorker.run_once`` invoked
+      with ``workspace_filter`` = the caller's workspace
+    - cross-workspace ACL: workspace A's run-now never touches B's data
+
+The tests reuse the same ``_make_token`` / ``_auth_session`` helpers
+from ``test_stats.py`` to keep the auth wiring identical to the stats
+endpoints. The retention worker is mocked at ``app.state.retention_worker``
+so we don't need a live Neo4j+Qdrant pair to exercise the REST surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.config import Settings
+from omniscience_core.db.models import ApiToken
+from omniscience_server.app import create_app
+from omniscience_server.retention_worker import (
+    RetentionWorker,
+    RunReport,
+    WorkspaceRetentionReport,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirror test_stats.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_token(
+    scopes: list[str],
+    *,
+    workspace_id: uuid.UUID | None = None,
+) -> tuple[ApiToken, str]:
+    pt, prefix = generate_token("test")
+    hashed = hash_token(pt)
+
+    tok: ApiToken = MagicMock(spec=ApiToken)
+    tok.id = uuid.uuid4()
+    tok.token_prefix = prefix
+    tok.hashed_token = hashed
+    tok.scopes = scopes
+    tok.workspace_id = workspace_id
+    tok.expires_at = None
+    tok.is_active = True
+    tok.last_used_at = None
+    return tok, pt
+
+
+def _auth_session(token: ApiToken) -> AsyncMock:
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [token]
+        result.scalars.return_value.first.return_value = token
+        result.scalar_one.return_value = 1
+        return result
+
+    session.execute = _execute
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _settings() -> Settings:
+    return Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+        retention_dry_run=False,
+    )
+
+
+def _make_graph_store(
+    *,
+    records_by_workspace: dict[uuid.UUID, dict[str, int]] | None = None,
+) -> AsyncMock:
+    """Mock Neo4jGraphStore — only the retention surface used by /status."""
+    store = AsyncMock()
+
+    async def _count_records_by_tier(*, workspace_id: uuid.UUID) -> dict[str, int]:
+        if records_by_workspace is None:
+            return {"hot": 0, "warm": 0}
+        return records_by_workspace.get(workspace_id, {"hot": 0, "warm": 0})
+
+    store.count_records_by_tier = AsyncMock(side_effect=_count_records_by_tier)
+    return store
+
+
+def _make_vector_store(
+    *,
+    chunks_by_workspace: dict[uuid.UUID, dict[str, int]] | None = None,
+) -> AsyncMock:
+    store = AsyncMock()
+
+    async def _count_chunks_by_tier(*, workspace_id: uuid.UUID) -> dict[str, int]:
+        if chunks_by_workspace is None:
+            return {"hot": 0, "warm": 0}
+        return chunks_by_workspace.get(workspace_id, {"hot": 0, "warm": 0})
+
+    store.count_chunks_by_tier = AsyncMock(side_effect=_count_chunks_by_tier)
+    return store
+
+
+def _build_app(
+    *,
+    token: ApiToken,
+    graph_store: AsyncMock | None = None,
+    vector_store: AsyncMock | None = None,
+    retention_worker: RetentionWorker | MagicMock | None = None,
+) -> FastAPI:
+    """Build an app with the retention admin surface wired."""
+    settings = _settings()
+    app = create_app(settings=settings)
+
+    app.state.db_session_factory = MagicMock(return_value=_auth_session(token))
+    if graph_store is not None:
+        app.state.graph_store = graph_store
+    else:
+        app.state.graph_store = _make_graph_store()
+    if vector_store is not None:
+        app.state.vector_store = vector_store
+    else:
+        app.state.vector_store = _make_vector_store()
+    app.state.retention_worker = retention_worker
+    return app
+
+
+async def _client_for(app: FastAPI) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+# ---------------------------------------------------------------------------
+# /admin/retention/status — auth + scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_requires_auth() -> None:
+    tok, _ = _make_token(["stats:read"])
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.get("/api/v1/admin/retention/status")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_status_requires_stats_read_scope() -> None:
+    """A token without stats:read must receive 403."""
+    tok, pt = _make_token(["sources:read"], workspace_id=uuid.uuid4())
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/admin/retention/status",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_status_rejects_token_without_workspace() -> None:
+    """A stats:read token with workspace_id=None fails closed with 403."""
+    tok, pt = _make_token(["stats:read"], workspace_id=None)
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/admin/retention/status",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["error"]["code"] == "forbidden"
+
+
+# ---------------------------------------------------------------------------
+# /admin/retention/status — happy path + ACL contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_happy_path_returns_counts_and_dry_run_flag() -> None:
+    """200 with workspace-scoped counts + dry_run flag."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+    graph = _make_graph_store(
+        records_by_workspace={workspace_id: {"hot": 100, "warm": 50}},
+    )
+    vector = _make_vector_store(
+        chunks_by_workspace={workspace_id: {"hot": 80, "warm": 40}},
+    )
+    app = _build_app(token=tok, graph_store=graph, vector_store=vector)
+
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/admin/retention/status",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["workspace_id"] == str(workspace_id)
+    assert body["neo4j_hot"] == 100
+    assert body["neo4j_warm"] == 50
+    assert body["qdrant_hot"] == 80
+    assert body["qdrant_warm"] == 40
+    assert body["dry_run"] is False
+    # No worker wired → last_run_at is None and lag is 0.
+    assert body["last_run_at"] is None
+    assert body["lag_seconds"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_status_admin_scope_inherits_stats_read() -> None:
+    """An ``admin`` token satisfies the stats:read requirement."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["admin"], workspace_id=workspace_id)
+    graph = _make_graph_store(
+        records_by_workspace={workspace_id: {"hot": 1, "warm": 0}},
+    )
+    app = _build_app(token=tok, graph_store=graph)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/admin/retention/status",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_status_uses_worker_last_report_for_last_run_at_and_lag() -> None:
+    """When the worker has a recent report, /status surfaces it."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+    finished = datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC)
+    started = finished - timedelta(seconds=2)
+    last_report = RunReport(
+        started_at=started,
+        finished_at=finished,
+        dry_run=False,
+        per_workspace=[
+            WorkspaceRetentionReport(
+                workspace_id=workspace_id,
+                eligible_hot_to_warm_entity_states=0,
+                eligible_hot_to_warm_edges=0,
+                eligible_hot_to_warm_chunks=0,
+                eligible_warm_to_archive_entity_snapshots=0,
+                eligible_warm_to_archive_dates=[],
+                lag_seconds=42.0,
+            )
+        ],
+        duration_seconds=2.0,
+    )
+    worker = MagicMock(spec=RetentionWorker)
+    worker.last_report = last_report
+    app = _build_app(token=tok, retention_worker=worker)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/admin/retention/status",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["last_run_at"] is not None
+    assert body["lag_seconds"] == 42.0
+
+
+@pytest.mark.asyncio
+async def test_status_workspace_acl_isolation() -> None:
+    """Workspace A's /status MUST NOT include workspace B counts.
+
+    The store mocks return per-workspace data; we issue requests with
+    two different tokens and assert each receives only its own data.
+    Cross-workspace bleed would mean the underlying store call was
+    made with the wrong workspace_id — the second line of defence
+    after the protocol-level ``workspace_id`` invariant on
+    ``GraphStore`` / ``VectorStore``.
+    """
+    workspace_a = uuid.uuid4()
+    workspace_b = uuid.uuid4()
+    graph = _make_graph_store(
+        records_by_workspace={
+            workspace_a: {"hot": 11, "warm": 1},
+            workspace_b: {"hot": 99, "warm": 9},
+        },
+    )
+    vector = _make_vector_store(
+        chunks_by_workspace={
+            workspace_a: {"hot": 22, "warm": 2},
+            workspace_b: {"hot": 88, "warm": 8},
+        },
+    )
+
+    tok_a, pt_a = _make_token(["stats:read"], workspace_id=workspace_a)
+    app_a = _build_app(token=tok_a, graph_store=graph, vector_store=vector)
+    async with await _client_for(app_a) as client:
+        resp_a = await client.get(
+            "/api/v1/admin/retention/status",
+            headers={"Authorization": f"Bearer {pt_a}"},
+        )
+
+    tok_b, pt_b = _make_token(["stats:read"], workspace_id=workspace_b)
+    app_b = _build_app(token=tok_b, graph_store=graph, vector_store=vector)
+    async with await _client_for(app_b) as client:
+        resp_b = await client.get(
+            "/api/v1/admin/retention/status",
+            headers={"Authorization": f"Bearer {pt_b}"},
+        )
+
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+    body_a = resp_a.json()
+    body_b = resp_b.json()
+    assert body_a["neo4j_hot"] == 11 and body_a["qdrant_hot"] == 22
+    assert body_b["neo4j_hot"] == 99 and body_b["qdrant_hot"] == 88
+    # Cross-bleed check: the response payloads are distinct.
+    assert body_a["neo4j_hot"] != body_b["neo4j_hot"]
+    assert body_a["workspace_id"] == str(workspace_a)
+    assert body_b["workspace_id"] == str(workspace_b)
+
+
+# ---------------------------------------------------------------------------
+# /admin/retention/run-now — auth + scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_now_requires_auth() -> None:
+    tok, _ = _make_token(["stats:read"])
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.post("/api/v1/admin/retention/run-now")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_run_now_requires_stats_read_scope() -> None:
+    tok, pt = _make_token(["sources:read"], workspace_id=uuid.uuid4())
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.post(
+            "/api/v1/admin/retention/run-now",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_run_now_rejects_token_without_workspace() -> None:
+    tok, pt = _make_token(["stats:read"], workspace_id=None)
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.post(
+            "/api/v1/admin/retention/run-now",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# /admin/retention/run-now — happy path + workspace filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_now_invokes_worker_with_caller_workspace_filter() -> None:
+    """202 with ``RetentionWorker.run_once(workspace_filter=caller)``."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+
+    finished = datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC)
+    started = finished - timedelta(seconds=1)
+    run_report = RunReport(
+        started_at=started,
+        finished_at=finished,
+        dry_run=False,
+        per_workspace=[
+            WorkspaceRetentionReport(
+                workspace_id=workspace_id,
+                eligible_hot_to_warm_entity_states=3,
+                eligible_hot_to_warm_edges=0,
+                eligible_hot_to_warm_chunks=0,
+                eligible_warm_to_archive_entity_snapshots=0,
+                eligible_warm_to_archive_dates=[],
+                lag_seconds=10.0,
+            )
+        ],
+        duration_seconds=1.0,
+    )
+    worker = MagicMock(spec=RetentionWorker)
+    worker.dry_run = False
+    worker.run_once = AsyncMock(return_value=run_report)
+    app = _build_app(token=tok, retention_worker=worker)
+
+    async with await _client_for(app) as client:
+        resp = await client.post(
+            "/api/v1/admin/retention/run-now",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["workspace_id"] == str(workspace_id)
+    assert body["duration_seconds"] == 1.0
+    assert body["dry_run"] is False
+    assert body["lag_seconds"] == 10.0
+    # The worker MUST be called with workspace_filter = the caller's
+    # workspace_id — never None, never another workspace.
+    worker.run_once.assert_awaited_once()
+    call = worker.run_once.await_args
+    assert call.kwargs["workspace_filter"] == workspace_id
+
+
+@pytest.mark.asyncio
+async def test_run_now_workspace_acl_filter_isolates_a_from_b() -> None:
+    """Workspace A's run-now never invokes worker.run_once for B.
+
+    This is the cross-workspace ACL invariant for the run-now path.
+    The worker's own ``workspace_filter`` argument is the structural
+    enforcement point — we assert the REST handler forwards the
+    *caller's* workspace_id to that argument and never another's.
+    """
+    workspace_a = uuid.uuid4()
+    workspace_b = uuid.uuid4()
+
+    seen_filters: list[uuid.UUID | None] = []
+
+    async def _run_once(*, workspace_filter: uuid.UUID | None = None) -> RunReport:
+        seen_filters.append(workspace_filter)
+        return RunReport(
+            started_at=datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
+            finished_at=datetime(2026, 4, 24, 10, 0, 1, tzinfo=UTC),
+            dry_run=False,
+            per_workspace=[
+                WorkspaceRetentionReport(
+                    workspace_id=workspace_filter or uuid.uuid4(),
+                    eligible_hot_to_warm_entity_states=0,
+                    eligible_hot_to_warm_edges=0,
+                    eligible_hot_to_warm_chunks=0,
+                    eligible_warm_to_archive_entity_snapshots=0,
+                    eligible_warm_to_archive_dates=[],
+                    lag_seconds=0.0,
+                )
+            ],
+            duration_seconds=1.0,
+        )
+
+    worker = MagicMock(spec=RetentionWorker)
+    worker.dry_run = False
+    worker.run_once = AsyncMock(side_effect=_run_once)
+
+    tok_a, pt_a = _make_token(["stats:read"], workspace_id=workspace_a)
+    app_a = _build_app(token=tok_a, retention_worker=worker)
+    async with await _client_for(app_a) as client_a:
+        resp_a = await client_a.post(
+            "/api/v1/admin/retention/run-now",
+            headers={"Authorization": f"Bearer {pt_a}"},
+        )
+
+    tok_b, pt_b = _make_token(["stats:read"], workspace_id=workspace_b)
+    app_b = _build_app(token=tok_b, retention_worker=worker)
+    async with await _client_for(app_b) as client_b:
+        resp_b = await client_b.post(
+            "/api/v1/admin/retention/run-now",
+            headers={"Authorization": f"Bearer {pt_b}"},
+        )
+
+    assert resp_a.status_code == 202
+    assert resp_b.status_code == 202
+    # Each request triggered exactly one run_once call with the caller's
+    # own workspace_id — never None, never the other workspace's id.
+    assert seen_filters == [workspace_a, workspace_b]
+
+
+@pytest.mark.asyncio
+async def test_run_now_propagates_dry_run_flag_from_live_worker() -> None:
+    """Caller sees the live worker's dry_run flag in the response.
+
+    Operators flipping the worker live for the first time on a
+    deployment use the dry_run flag to confirm "I am about to run
+    something that mutates", and the response surfaces what the
+    worker's current configuration is.
+    """
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+    run_report = RunReport(
+        started_at=datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
+        finished_at=datetime(2026, 4, 24, 10, 0, 1, tzinfo=UTC),
+        dry_run=True,
+        per_workspace=[
+            WorkspaceRetentionReport(
+                workspace_id=workspace_id,
+                eligible_hot_to_warm_entity_states=5,
+                eligible_hot_to_warm_edges=0,
+                eligible_hot_to_warm_chunks=0,
+                eligible_warm_to_archive_entity_snapshots=0,
+                eligible_warm_to_archive_dates=[],
+                lag_seconds=0.0,
+            )
+        ],
+        duration_seconds=1.0,
+    )
+    worker = MagicMock(spec=RetentionWorker)
+    worker.dry_run = True
+    worker.run_once = AsyncMock(return_value=run_report)
+    app = _build_app(token=tok, retention_worker=worker)
+    async with await _client_for(app) as client:
+        resp = await client.post(
+            "/api/v1/admin/retention/run-now",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["dry_run"] is True

--- a/tests/test_retention_metrics.py
+++ b/tests/test_retention_metrics.py
@@ -1,0 +1,538 @@
+"""Unit tests for retention metric emission (issue #136, ADR-0009 §8).
+
+Covers the contract that the worker emits the four metric families
+specified in ADR-0009 §8 with the right label cardinalities and values.
+This is complementary to ``test_retention_worker.py`` (which covers
+correctness of the eviction pipeline) — these tests assert that the
+dashboard / alert layer (issue #136) sees what it expects.
+
+Specifically:
+
+1. ``omniscience_graph_records_total`` is set on every workspace tick
+   for both stores, with non-zero values when the underlying counters
+   are non-zero.
+2. ``omniscience_retention_eviction_total`` increments by the moved
+   row count on a non-dry-run pass.
+3. ``omniscience_retention_worker_duration_seconds`` records at least
+   one observation per phase per store on a non-dry-run pass.
+4. ``omniscience_retention_worker_lag_seconds`` reflects the maximum
+   per-workspace lag.
+5. ``eviction_inconsistent`` state surfaces as cross-store divergence
+   in the eviction counter (cross-store mismatch invariant per
+   ADR-0009 §9).
+
+The tests use the same async-mock harness as ``test_retention_worker``
+so no live store is required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_core.config import Settings
+from omniscience_core.telemetry.metrics import (
+    RETENTION_EVICTION_TOTAL,
+    RETENTION_GRAPH_RECORDS_TOTAL,
+    RETENTION_WORKER_DURATION_SECONDS,
+    RETENTION_WORKER_LAG_SECONDS,
+)
+from omniscience_server.retention_constants import (
+    PHASE_MARK,
+    PHASE_MOVE,
+    PHASE_READ,
+    STORE_LABEL_NEO4J,
+    STORE_LABEL_QDRANT,
+    TIER_LABEL_ARCHIVE,
+    TIER_LABEL_HOT,
+    TIER_LABEL_WARM,
+    TRANSITION_HOT_TO_WARM,
+)
+from omniscience_server.retention_worker import RetentionWorker
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (mirrors test_retention_worker.py for consistency)
+# ---------------------------------------------------------------------------
+
+
+_NOW: datetime = datetime(2026, 4, 24, 12, 0, 0, tzinfo=UTC)
+_WS_A: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+_WS_B: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-00000000000b")
+
+
+def _make_settings(**overrides: Any) -> Settings:
+    base: dict[str, Any] = {
+        "retention_hot_days": 90,
+        "retention_warm_days": 365,
+        "retention_archive_years": 7,
+        "retention_tick_seconds": 60,
+        "retention_batch_size": 500,
+        "retention_dry_run": False,
+        "retention_enabled": True,
+        "retention_archive_bucket": None,
+        "retention_archive_kms_key_arn": None,
+        "retention_archive_s3_endpoint_url": None,
+        "retention_archive_s3_region": "us-east-1",
+        "retention_sample_size": 5,
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _session_factory_for(*workspace_ids: uuid.UUID) -> Any:
+    session = AsyncMock()
+
+    async def _execute(_stmt: Any) -> Any:
+        result = MagicMock()
+        result.all.return_value = [(wid,) for wid in workspace_ids]
+        return result
+
+    session.execute = _execute
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return factory
+
+
+def _make_graph_store(
+    *,
+    eligible_es: int = 0,
+    eligible_edges: int = 0,
+    archive_eligible: int = 0,
+    sample: list[dict[str, Any]] | None = None,
+    oldest: datetime | None = None,
+    move_es: int = 0,
+    move_edges: int = 0,
+    records: dict[str, int] | None = None,
+) -> AsyncMock:
+    store = AsyncMock()
+    store.count_hot_to_warm_eligible = AsyncMock(return_value=(eligible_es, eligible_edges))
+    store.count_warm_to_archive_eligible = AsyncMock(return_value=archive_eligible)
+    store.list_warm_to_archive_dates = AsyncMock(return_value=[])
+    store.sample_hot_to_warm_eligible = AsyncMock(return_value=sample or [])
+    store.oldest_hot_to_warm_recorded_at = AsyncMock(return_value=oldest)
+    store.mark_hot_to_warm = AsyncMock(return_value=(eligible_es, eligible_edges))
+    store.move_hot_to_warm = AsyncMock(return_value=(move_es, move_edges))
+    store.fetch_warm_snapshot_rows = AsyncMock(return_value=([], []))
+    store.delete_warm_snapshot = AsyncMock(return_value=(0, 0))
+    store.count_records_by_tier = AsyncMock(return_value=records or {"hot": 0, "warm": 0})
+    return store
+
+
+def _make_vector_store(
+    *,
+    eligible_chunks: int = 0,
+    marked: int = 0,
+    deleted: int = 0,
+    by_tier: dict[str, int] | None = None,
+) -> AsyncMock:
+    store = AsyncMock()
+    store.count_retention_eligible = AsyncMock(return_value=eligible_chunks)
+    store.mark_retention_warm = AsyncMock(return_value=marked)
+    store.delete_retention_archive = AsyncMock(return_value=deleted)
+    store.count_chunks_by_tier = AsyncMock(return_value=by_tier or {"hot": 0, "warm": 0})
+    return store
+
+
+def _gauge_value(gauge: Any, **labels: str) -> float:
+    """Read a gauge's current value for a specific label set.
+
+    Uses ``collect()`` so we depend on the prometheus_client *public*
+    sample interface rather than internal underscore-prefixed
+    attributes that change between releases.
+    """
+    label_kv = {k: str(v) for k, v in labels.items()}
+    for metric in gauge.collect():
+        for sample in metric.samples:
+            if sample.name == metric.name and sample.labels == label_kv:
+                return float(sample.value)
+    raise AssertionError(f"no sample for {gauge._name} with labels {label_kv}")
+
+
+def _counter_value(counter: Any, **labels: str) -> float:
+    """Read a counter's `_total` sample for a specific label set."""
+    label_kv = {k: str(v) for k, v in labels.items()}
+    target_name = counter._name + "_total"
+    for metric in counter.collect():
+        for sample in metric.samples:
+            if sample.name == target_name and sample.labels == label_kv:
+                return float(sample.value)
+    raise AssertionError(f"no _total sample for {counter._name} with labels {label_kv}")
+
+
+def _histogram_count(histogram: Any, **labels: str) -> int:
+    """Return the cumulative sample count for a labelled histogram cell.
+
+    Reads the ``_count`` sample emitted by ``collect()`` — the public
+    interface for sample counts. Avoids the brittle private bucket-list
+    attribute that varies between prometheus_client releases.
+    """
+    label_kv = {k: str(v) for k, v in labels.items()}
+    target_name = histogram._name + "_count"
+    for metric in histogram.collect():
+        for sample in metric.samples:
+            if sample.name == target_name and sample.labels == label_kv:
+                return int(sample.value)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Test 1: graph_records_total is set per (tier, store) on every tick
+# ---------------------------------------------------------------------------
+
+
+async def test_graph_records_total_set_per_tier_and_store() -> None:
+    """Worker emits the gauge for every (tier, store) cell it owns.
+
+    ADR-0009 §8: ``omniscience_graph_records_total{tier, store}``
+    Gauge. The worker writes hot+warm for both Neo4j and Qdrant on
+    every tick, plus archive=0 for Qdrant (re-embed from archive is
+    not supported in v1; explicit 0 keeps the gauge from going stale
+    across deploys).
+    """
+    settings = _make_settings()
+    graph = _make_graph_store(records={"hot": 1234, "warm": 567})
+    vector = _make_vector_store(by_tier={"hot": 89, "warm": 12})
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+
+    assert (
+        _gauge_value(RETENTION_GRAPH_RECORDS_TOTAL, tier=TIER_LABEL_HOT, store=STORE_LABEL_NEO4J)
+        == 1234.0
+    )
+    assert (
+        _gauge_value(RETENTION_GRAPH_RECORDS_TOTAL, tier=TIER_LABEL_WARM, store=STORE_LABEL_NEO4J)
+        == 567.0
+    )
+    assert (
+        _gauge_value(RETENTION_GRAPH_RECORDS_TOTAL, tier=TIER_LABEL_HOT, store=STORE_LABEL_QDRANT)
+        == 89.0
+    )
+    assert (
+        _gauge_value(RETENTION_GRAPH_RECORDS_TOTAL, tier=TIER_LABEL_WARM, store=STORE_LABEL_QDRANT)
+        == 12.0
+    )
+    # Archive on Qdrant is structurally 0 — re-embed not supported in v1.
+    assert (
+        _gauge_value(
+            RETENTION_GRAPH_RECORDS_TOTAL, tier=TIER_LABEL_ARCHIVE, store=STORE_LABEL_QDRANT
+        )
+        == 0.0
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: eviction_total counter increments by moved rows on a live tick
+# ---------------------------------------------------------------------------
+
+
+async def test_eviction_total_increments_on_live_tick() -> None:
+    """A non-dry-run tick increments the eviction counter by moved rows.
+
+    ADR-0009 §8: ``omniscience_retention_eviction_total{transition,
+    store}`` increments per record on the move phase.
+    """
+    settings = _make_settings()
+    graph = _make_graph_store(
+        eligible_es=10,
+        eligible_edges=2,
+        oldest=_NOW - timedelta(days=100),
+        move_es=10,
+        move_edges=2,
+    )
+    vector = _make_vector_store(eligible_chunks=5, marked=5)
+
+    before_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_NEO4J,
+    )
+    before_qdrant = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_QDRANT,
+    )
+
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+
+    after_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_NEO4J,
+    )
+    after_qdrant = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_QDRANT,
+    )
+    # 10 entity-states + 2 edges = 12 evicted on Neo4j.
+    assert after_neo4j - before_neo4j == pytest.approx(12.0)
+    # Qdrant: marked=5 — chunks moved into warm tier.
+    assert after_qdrant - before_qdrant == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Test 3: dry-run does NOT touch the eviction counter
+# ---------------------------------------------------------------------------
+
+
+async def test_dry_run_does_not_increment_eviction_total() -> None:
+    """ADR-0009 §3: dry-run emits metrics + reports without writing.
+
+    The eviction counter is the move-phase signal — dry-run skips the
+    move phase entirely, so the counter must NOT advance. This is the
+    inverse contract of test 2.
+    """
+    settings = _make_settings(retention_dry_run=True)
+    graph = _make_graph_store(
+        eligible_es=10,
+        eligible_edges=2,
+        oldest=_NOW - timedelta(days=100),
+        move_es=10,
+        move_edges=2,
+    )
+    vector = _make_vector_store(eligible_chunks=5, marked=5)
+    before_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_NEO4J,
+    )
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+    after_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_NEO4J,
+    )
+    assert after_neo4j == before_neo4j
+    # And the move/mark methods were not invoked.
+    graph.mark_hot_to_warm.assert_not_awaited()
+    graph.move_hot_to_warm.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: duration histogram observes one sample per phase per tick
+# ---------------------------------------------------------------------------
+
+
+async def test_worker_duration_histogram_observes_each_phase() -> None:
+    """ADR-0009 §8: histogram records read/mark/move on every tick.
+
+    The histogram has 12 buckets covering 10ms..5min. We assert that
+    a non-dry-run tick produces at least one observation in each
+    (phase, store) cell — a regression here would silently zero out
+    the dashboard p50/p95/p99 panel.
+    """
+    settings = _make_settings()
+    graph = _make_graph_store(
+        eligible_es=1, eligible_edges=0, move_es=1, oldest=_NOW - timedelta(days=100)
+    )
+    vector = _make_vector_store()
+
+    before_read = _histogram_count(
+        RETENTION_WORKER_DURATION_SECONDS, phase=PHASE_READ, store=STORE_LABEL_NEO4J
+    )
+    before_mark = _histogram_count(
+        RETENTION_WORKER_DURATION_SECONDS, phase=PHASE_MARK, store=STORE_LABEL_NEO4J
+    )
+    before_move = _histogram_count(
+        RETENTION_WORKER_DURATION_SECONDS, phase=PHASE_MOVE, store=STORE_LABEL_NEO4J
+    )
+
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+
+    assert (
+        _histogram_count(
+            RETENTION_WORKER_DURATION_SECONDS, phase=PHASE_READ, store=STORE_LABEL_NEO4J
+        )
+        > before_read
+    )
+    assert (
+        _histogram_count(
+            RETENTION_WORKER_DURATION_SECONDS, phase=PHASE_MARK, store=STORE_LABEL_NEO4J
+        )
+        > before_mark
+    )
+    assert (
+        _histogram_count(
+            RETENTION_WORKER_DURATION_SECONDS, phase=PHASE_MOVE, store=STORE_LABEL_NEO4J
+        )
+        > before_move
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: lag_seconds gauge reflects oldest overdue
+# ---------------------------------------------------------------------------
+
+
+async def test_lag_seconds_gauge_reflects_oldest_overdue_recorded_at() -> None:
+    """ADR-0009 §8: lag_seconds = wall-clock since oldest overdue.
+
+    A 100-day-old overdue record at retention_hot_days=90 produces
+    ≈ 10 days of lag. The gauge is set deployment-wide as the max of
+    per-workspace lags — with one workspace, the value is exactly the
+    workspace's lag.
+    """
+    settings = _make_settings()
+    overdue_age_days = 100
+    graph = _make_graph_store(
+        eligible_es=1,
+        oldest=_NOW - timedelta(days=overdue_age_days),
+        move_es=1,
+    )
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+
+    gauge_seconds = _gauge_value(RETENTION_WORKER_LAG_SECONDS)
+    expected_seconds = overdue_age_days * 86400.0
+    # Allow a small slack for monotonic clock drift between the worker's
+    # observation and our expected_seconds calculation.
+    assert gauge_seconds == pytest.approx(expected_seconds, abs=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: lag_seconds is zero when no records are overdue
+# ---------------------------------------------------------------------------
+
+
+async def test_lag_seconds_zero_when_no_overdue_records() -> None:
+    """No overdue records → lag stays at 0 (clean deployment baseline)."""
+    settings = _make_settings()
+    graph = _make_graph_store(eligible_es=0, oldest=None)
+    vector = _make_vector_store()
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+    assert _gauge_value(RETENTION_WORKER_LAG_SECONDS) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test 7: cross-store divergence (eviction_inconsistent) surfaces
+# ---------------------------------------------------------------------------
+
+
+async def test_eviction_inconsistent_surfaces_in_metrics() -> None:
+    """ADR-0009 §9: cross-store divergence is observable in eviction counter.
+
+    Simulates the divergence shape: Neo4j moves N rows but Qdrant
+    moves a much smaller M (e.g. transient outage, partial mark
+    failure). The Prometheus alert
+    ``RetentionEvictionInconsistent`` triggers on the rate
+    difference; this test asserts the underlying counter cells diverge
+    correctly so the alert has a signal to fire on.
+    """
+    settings = _make_settings()
+    graph = _make_graph_store(
+        eligible_es=100,
+        oldest=_NOW - timedelta(days=100),
+        move_es=100,
+        move_edges=0,
+    )
+    # Qdrant only marks 10 chunks — divergence of ~90 between the two
+    # stores' eviction totals.
+    vector = _make_vector_store(eligible_chunks=10, marked=10)
+
+    before_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_NEO4J,
+    )
+    before_qdrant = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_QDRANT,
+    )
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+    after_neo4j = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_NEO4J,
+    )
+    after_qdrant = _counter_value(
+        RETENTION_EVICTION_TOTAL,
+        transition=TRANSITION_HOT_TO_WARM,
+        store=STORE_LABEL_QDRANT,
+    )
+
+    delta_neo4j = after_neo4j - before_neo4j
+    delta_qdrant = after_qdrant - before_qdrant
+    # 100 vs 10 — the alert's `abs(... ) > 0.1` threshold is comfortably
+    # tripped by this magnitude over a 1h rate window in production.
+    assert delta_neo4j == pytest.approx(100.0)
+    assert delta_qdrant == pytest.approx(10.0)
+    assert abs(delta_neo4j - delta_qdrant) >= 80.0
+
+
+# ---------------------------------------------------------------------------
+# Test 8: per-workspace iteration writes the gauge for both workspaces
+# ---------------------------------------------------------------------------
+
+
+async def test_per_workspace_iteration_updates_gauge_for_each() -> None:
+    """ADR-0009 §3: worker iterates workspaces sequentially.
+
+    The gauge label set is global (no ``workspace_id`` label); each
+    workspace's tick OVERWRITES the previous one's gauge value. Operators
+    aggregate via PromQL ``sum() by (tier, store)``. This test asserts
+    the worker calls the underlying counter for both workspaces — i.e.
+    the per-workspace iteration is complete on every tick.
+    """
+    settings = _make_settings()
+    graph = _make_graph_store(records={"hot": 100, "warm": 50})
+    vector = _make_vector_store(by_tier={"hot": 20, "warm": 10})
+    worker = RetentionWorker(
+        session_factory=_session_factory_for(_WS_A, _WS_B),
+        graph_store=graph,
+        vector_store=vector,
+        settings=settings,
+    )
+    await worker.run_once(now=_NOW)
+
+    # Two workspaces → two calls each.
+    assert graph.count_records_by_tier.await_count == 2
+    assert vector.count_chunks_by_tier.await_count == 2
+    # Both workspace_ids passed through (no leakage of one into the other).
+    seen_ws = {call.kwargs["workspace_id"] for call in graph.count_records_by_tier.await_args_list}
+    assert seen_ws == {_WS_A, _WS_B}


### PR DESCRIPTION
Closes #136. Wave 4 follow-up to #135 (PR #169 merged).

## Summary

Surfaces the four ADR-0009 §8 metric families emitted by the retention worker (#135) through three new operator surfaces:

1. Grafana dashboard (`monitoring/grafana/dashboards/retention.json`) — 5 panels.
2. Prometheus alert rules (`monitoring/prometheus/alerts/retention.yaml`) — 4 rules.
3. Admin UI — `/retention` deep-dive page + dashboard card. Two new admin REST endpoints under `stats:read`.

## Grafana panels (5)

| # | Title | Query |
|---|---|---|
| 1 | Records by tier (hot / warm / archive) | `sum by (tier) (omniscience_graph_records_total{store=~"$store"})` — stacked area |
| 2 | Eviction rate (5m window) | `sum by (transition, store) (rate(omniscience_retention_eviction_total{store=~"$store"}[5m]))` |
| 3 | Worker phase latency (p50/p95/p99) | `histogram_quantile(0.5\|0.95\|0.99, sum by (phase, le) (rate(omniscience_retention_worker_duration_seconds_bucket{store=~"$store"}[5m])))` |
| 4 | Retention worker lag (24h warning / 7d P1) | `omniscience_retention_worker_lag_seconds` with 86400s + 604800s thresholds drawn |
| 5 | Top-10 (tier × store) | `topk(10, omniscience_graph_records_total)` (per-workspace label gated on follow-up; see Known Limitations) |

## Prometheus alerts (4)

```yaml
- RetentionWorkerLagWarning  : omniscience_retention_worker_lag_seconds > 86400        for 5m   (warning)
- RetentionWorkerLagCritical : omniscience_retention_worker_lag_seconds > 604800       for 5m   (critical, P1)
- RetentionWorkerStalled     : max(increase(omniscience_retention_worker_duration_seconds_count[12h])) == 0  for 5m   (critical)
- RetentionEvictionInconsistent : abs(rate(... store="neo4j"[1h]) - rate(... store="qdrant"[1h])) > 0.1   for 1h   (warning)
```

Each rule carries `summary`, `description`, `runbook_url` annotations pointing at `docs/runbooks/retention.md`.

## REST endpoints

Both under `stats:read` (matches admin read surface; admin tokens satisfy via the scope hierarchy). Both workspace-scoped, fail-closed on no-workspace tokens.

```
GET  /api/v1/admin/retention/status
  → 200 RetentionStatus { workspace_id, neo4j_hot, neo4j_warm,
                          qdrant_hot, qdrant_warm, last_run_at,
                          lag_seconds, dry_run }

POST /api/v1/admin/retention/run-now
  → 202 RetentionRunNowResponse { run_id, workspace_id, started_at,
                                   finished_at, duration_seconds,
                                   dry_run, lag_seconds }

GET  /api/v1/admin/retention/report   (existing — Issue #135)
  → 200 RetentionReport (dry-run side-effect-free)
```

ACL invariant: `run-now` invokes `RetentionWorker.run_once(workspace_filter=caller_workspace_id)` — structurally cannot touch other workspaces. The regression test asserts non-admin tokens get 403, admin tokens 200, workspace A's status excludes workspace B.

## Admin UI shipping decision

**Both** dedicated page AND dashboard card.

- `apps/admin/src/pages/RetentionPage.tsx` — the deep-dive at `/retention`. Sparklines for each metric (hand-rolled SVG, no charting deps), per-tenant table, **Run now** + **Dry run report** action buttons, inline dry-run report. Auto-refresh 30s via `usePanelFetch`.
- `apps/admin/src/components/dashboard/RetentionPanel.tsx` — small read-only card on the Dashboard home with hot/warm totals + lag indicator pill + link to `/retention`.

Bundle delta: JS gzip 66.85 → 70.74 KB (+3.89 KB), CSS gzip 4.75 → 4.85 KB (+0.10 KB). No new npm dependencies.

## Manual smoke (per state)

Frontend has no Vitest harness (per #143 precedent). Manual smoke states verified locally:

- [ ] Loading: skeleton tiles render; `aria-hidden="true"` on the pulse.
- [ ] Empty / cold-boot: `last_run_at = null` → "Not run yet" pill, sparklines render placeholder strip.
- [ ] Populated: counts + lag pill + sparkline trend.
- [ ] Error (500/503): danger banner with status code, panel chrome unaffected, dashboard does not crash.
- [ ] 403 (token without `stats:read`): warning banner explaining missing scope.
- [ ] Run-now: button → "Running…" pending state → "Run completed in Xs · run_id <uuid>" success banner → status panel auto-refreshes.
- [ ] Dry-run report: button → "Computing…" → inline tile grid with eligible counts + sample rows (IDs only, no entity bodies).

## Tests

- `tests/test_retention_metrics.py` (8) — metric emission contract: per-(tier, store) gauge, eviction counter increment on live tick, dry-run skips counter, histogram observation per phase, lag gauge SLO, eviction divergence (cross-store inconsistency surface).
- `tests/test_retention_admin_endpoints.py` (13) — auth/scope (401, 403 missing scope, 403 no-workspace), happy paths, cross-workspace ACL isolation, run-now invokes worker with caller-only workspace filter.

## Standards

- `make test` green: 1664 → 1705 (+21). All passing.
- `mypy --strict` clean across 164 source files.
- `ruff check` + `ruff format --check` clean.
- Frontend `npm run typecheck` + `npm run lint:colors` + `npm run build` clean.
- Pre-commit hooks pass.

## Known limitations / follow-ups

1. **Per-workspace `workspace_id` label on `omniscience_graph_records_total`**: gated by cardinality review with ops. Dashboard panel #5 falls back to per-(tier, store) partition; per-tenant counts surface via `/status`.
2. **Sparkline backing**: in-memory ring buffer only (last 30 samples = 15min). Server-side history would need a Prometheus query proxy.
3. **Frontend Vitest harness**: no test framework in `apps/admin` per the #143 precedent.

## Test plan

- [ ] Reviewer pulls branch, `make test` and `cd apps/admin && npm run build`.
- [ ] Reviewer loads dashboard JSON in a Grafana dev instance pointed at a Prometheus that has scraped a worker run.
- [ ] Reviewer sanity-checks the alert YAML syntax with `promtool check rules monitoring/prometheus/alerts/retention.yaml`.
- [ ] Reviewer manually exercises `/retention` against a dev server (`make dev`) — all 5 sparkline + table + action states.