### PR TITLE
feat: GitHub PR/MR connector (#150)

### DIFF
--- a/docs/connectors/github_pr.md
+++ b/docs/connectors/github_pr.md
@@ -1,0 +1,140 @@
+# GitHub PR/MR connector (`github_pr`)
+
+The `github_pr` connector indexes pull requests, commits, reviews, and review
+comments from a GitHub repository as **first-class entities** — distinct from
+the file-tree indexing that `GitConnector` already performs.  Both connectors
+target the same upstream (a GitHub repo) but cover different aspects:
+
+| Connector | Domain |
+|-----------|--------|
+| `git` | File blobs (source code, repo tree at a ref) |
+| `github_pr` | Review history (PRs, commits, reviews, comments) |
+
+The two connectors run **side-by-side** as separate `Source` rows.
+
+## Why a separate connector?
+
+PRs, commits, reviews, and review comments are not files.  Indexing them via
+`GitConnector` would conflate "what is in the repo right now" with "what was
+discussed about the changes".  Splitting them lets the PR/MR connector evolve
+its own auth model, rate limits (per-token), and webhook handler without
+disturbing the file-tree indexer.
+
+## Authentication
+
+Authentication is resolved at call time from the `secrets` dict.  Both
+**Personal Access Tokens (PAT)** and **GitHub App installation tokens** are
+accepted — they are byte-equivalent from this connector's point of view
+(both sent as `Authorization: Bearer <token>`).
+
+| Secret | Required | Notes |
+|--------|----------|-------|
+| `github_token` | yes | PAT or GitHub App installation token |
+| `github_app_id` | no | Recorded as metadata only |
+| `github_installation_id` | no | Recorded as metadata only |
+
+The token-issuance flow for GitHub Apps (private key → JWT → installation
+token) is **operator concern** and lives outside this connector.  Operators
+that mint short-lived installation tokens upstream and rotate them in the
+secret store get full GitHub App support without any code change here.
+
+PAT usage is appropriate for personal workspaces and small teams; GitHub
+App tokens are recommended for production (higher rate limits, fine-grained
+scopes, no per-user coupling).
+
+Tokens are **never logged**.  If you see a token in a log line, file a bug.
+
+## Configuration
+
+```python
+from omniscience_connectors import GithubPrConfig
+
+config = GithubPrConfig(
+    repos=["owner/repo", "owner/another"],
+    include_closed=True,         # default True
+    max_age_days=90,             # default 90
+    include_review_comments=True,  # default True
+)
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `repos` | `list[str]` | `[]` | One or more `owner/repo` specs |
+| `include_closed` | `bool` | `True` | Discover closed/merged PRs as well as open |
+| `max_age_days` | `int` | `90` | Skip PRs older than this (by `updated_at`) |
+| `include_review_comments` | `bool` | `True` | Include inline review comments in fetched Markdown |
+| `api_base_url` | `str` | `https://api.github.com` | API root; override for testing only |
+
+## Entities and edges emitted
+
+| Entity kind | Canonical `name` |
+|-------------|------------------|
+| `github_pr` | `https://github.com/{owner}/{repo}/pull/{n}` |
+| `git_commit` | `<full-40-char-sha>` |
+| `github_review` | `github://review/{owner}/{repo}/{pr}/{review_id}` |
+| `github_review_comment` | `github://comment/{owner}/{repo}/{pr}/{comment_id}` |
+| `github_user` | `github://user/{login}` |
+
+| Edge | Direction |
+|------|-----------|
+| `[:HAS_COMMIT]` | PR → commit |
+| `[:TOUCHES]` | PR → file (file entity emitted by `GitConnector`) |
+| `[:REVIEWS]` | review → PR |
+| `[:COMMENT_ON]` | comment → PR |
+| `[:AUTHORED]` | user → PR |
+
+### Canonical PR URL — hard contract
+
+The PR `name` is **byte-for-byte equal** to the URL the Slack mention extractor
+emits when a Slack message contains a PR link.  This is what enables
+`EntityLinker.exact_name` to produce `cross_ref` edges between Slack threads
+and PRs without any application-level join.
+
+The format is anchored by `CANONICAL_PR_URL_REGEX`:
+
+```
+^https://github\.com/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/pull/(\d+)$
+```
+
+* lowercase host (`github.com`)
+* path `/{owner}/{repo}/pull/{n}`
+* no trailing slash, no query string, no anchor
+
+If you change anything about this contract, you also break Slack `cross_ref`
+matching — there is a regression test that asserts the round-trip stays
+identical.
+
+## Webhook handler
+
+The connector ships a `WebhookHandler` that the FastAPI receiver at
+`/api/v1/ingest/webhook/{source_name}` wires up automatically (see
+`apps/server/src/omniscience_server/rest/webhooks.py`).
+
+Subscribed events:
+
+* `pull_request` — opened, edited, closed, synchronize, reopened
+* `pull_request_review` — submitted, edited, dismissed
+* `pull_request_review_comment` — created, edited, deleted
+* `push` — acknowledged but produces no PR refs (file content stays on
+  `GitConnector`'s webhook)
+
+Signature verification is **HMAC-SHA256 over the raw body**, with the digest
+delivered in `X-Hub-Signature-256: sha256=<hex>`.  Constant-time comparison.
+
+### ACL invariant
+
+Workspace identity comes from `Source.tenant_id` resolved by the FastAPI
+receiver on the `/webhooks/{source_name}` path — **never** from any field in
+the webhook payload.  Adding an endpoint that takes tenant from the GitHub
+payload `installation.id` would be a P0 ACL leak and is explicitly rejected
+by the design contract.
+
+## Non-goals
+
+* No replacement of `GitConnector`.  File-blob indexing stays where it is.
+* No PR diff body indexing — diffs explode embedding budgets and `GitConnector`
+  already indexes file contents at HEAD.  `resolve_incident` reaches the file
+  via the `[:TOUCHES]` edge.
+* No GitLab support in this iteration.  The connector is named `github_pr`;
+  a sibling `gitlab_mr` connector is a separate sub-issue.
+* No CI status / check-run entities.  Possible follow-up.

--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -20,8 +20,8 @@ Registry::
 
     from omniscience_connectors import ConnectorRegistry, get_connector
 
-Built-in connectors (``git``, ``fs``, ``confluence``, ``notion``, ``slack``,
-``jira``, ``k8s-agentic``, ``s3``, ``aws``) are registered below and available
+Built-in connectors (``git``, ``github_pr``, ``fs``, ``confluence``, ``notion``,
+``slack``, ``jira``, ``k8s-agentic``, ``s3``, ``aws``) are registered below and available
 immediately on import.  Third-party connectors call :func:`get_connector`
 after registering against the shared registry.
 """
@@ -47,6 +47,7 @@ from omniscience_connectors.confluence.connector import ConfluenceConnector
 from omniscience_connectors.database.connector import DatabaseConnector
 from omniscience_connectors.fs.connector import FsConnector
 from omniscience_connectors.git.connector import GitConnector
+from omniscience_connectors.github_pr.connector import GithubPrConfig, GithubPrConnector
 from omniscience_connectors.jira.connector import JiraConnector
 from omniscience_connectors.notion.connector import NotionConnector
 from omniscience_connectors.registry import (
@@ -60,6 +61,7 @@ from omniscience_connectors.slack.connector import SlackConnector
 
 # Register built-in connectors in the shared module-level registry
 _registry.register(GitConnector)
+_registry.register(GithubPrConnector)
 _registry.register(FsConnector)
 _registry.register(ConfluenceConnector)
 _registry.register(NotionConnector)
@@ -86,6 +88,8 @@ __all__ = [
     "FetchedDocument",
     "FsConnector",
     "GitConnector",
+    "GithubPrConfig",
+    "GithubPrConnector",
     "JiraConnector",
     "K8sAgenticConfig",
     "K8sAgenticConnector",

--- a/packages/connectors/src/omniscience_connectors/github_pr/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/github_pr/__init__.py
@@ -1,0 +1,33 @@
+"""GitHub PR/MR source connector for Omniscience.
+
+Discovers and indexes pull requests, commits, reviews, and review comments as
+first-class entities, distinct from the file-tree indexing handled by
+:class:`omniscience_connectors.git.connector.GitConnector`.
+
+Both connectors live side-by-side and target the same upstream (a GitHub repo)
+but cover different aspects:
+
+* :class:`GitConnector` — indexes file blobs (source code).
+* :class:`GithubPrConnector` — indexes review history (PRs, commits, reviews,
+  comments) so that ``mcp_get_related_entities`` can surface "responsible PR"
+  links from runtime resources.
+
+The connector emits PR entities by their canonical GitHub URL form
+(``https://github.com/{owner}/{repo}/pull/{n}``) so that
+``EntityLinker.exact_name`` produces ``cross_ref`` edges to the same URL
+emitted by the Slack mention extractor.
+"""
+
+from omniscience_connectors.github_pr.connector import (
+    CANONICAL_PR_URL_REGEX,
+    GithubPrConfig,
+    GithubPrConnector,
+)
+from omniscience_connectors.github_pr.webhook import GithubPrWebhookHandler
+
+__all__ = [
+    "CANONICAL_PR_URL_REGEX",
+    "GithubPrConfig",
+    "GithubPrConnector",
+    "GithubPrWebhookHandler",
+]

--- a/packages/connectors/src/omniscience_connectors/github_pr/connector.py
+++ b/packages/connectors/src/omniscience_connectors/github_pr/connector.py
@@ -1,0 +1,677 @@
+"""GitHub Pull Request source connector.
+
+Discovers and fetches GitHub pull requests as first-class artifacts (distinct
+from file-blob indexing in :class:`GitConnector`).  PRs, commits, reviews, and
+review comments are emitted as named entities by their canonical GitHub URL
+form so the entity linker can produce ``cross_ref`` edges to the same URLs
+emitted by the Slack mention extractor.
+
+Authentication
+--------------
+Resolved at call time from the ``secrets`` dict.  Both Personal Access Tokens
+(PAT) and GitHub App installation tokens are accepted; format is identical
+from this connector's point of view (``Authorization: Bearer <token>``).  The
+GitHub App private-key → JWT → installation-token flow is operator concern
+and lives outside this module.
+
+* ``github_token`` — PAT or GitHub App installation token.
+* (optional) ``github_app_id`` / ``github_installation_id`` — recorded as
+  metadata only; this connector does not mint installation tokens itself.
+
+Tokens are never logged.
+
+Canonical PR URL
+----------------
+The ``DocumentRef.uri`` and the entity ``name`` for a PR are guaranteed to
+match the regex :data:`CANONICAL_PR_URL_REGEX` exactly:
+
+    https://github.com/{owner}/{repo}/pull/{n}
+
+Lower-case host, no trailing slash, no query, no anchor.  This is a hard
+contract — ``cross_ref`` matching depends on byte-for-byte equality with the
+URL Slack mentions emit.
+
+Rate limiting
+-------------
+The connector respects ``X-RateLimit-Remaining`` / ``X-RateLimit-Reset`` and
+sleeps until reset when the quota is exhausted.  No retries on 4xx errors
+other than 429/403-with-rate-limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import re
+import time
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any, ClassVar
+
+import httpx
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+)
+from omniscience_connectors.github_pr.webhook import GithubPrWebhookHandler
+
+__all__ = [
+    "CANONICAL_PR_URL_REGEX",
+    "GithubPrConfig",
+    "GithubPrConnector",
+    "canonical_commit_name",
+    "canonical_pr_url",
+    "canonical_review_comment_name",
+    "canonical_review_name",
+    "canonical_user_name",
+]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants (named with rationale)
+# ---------------------------------------------------------------------------
+
+# GitHub REST API root.  Override is intentionally not exposed in config —
+# GitHub Enterprise support is a follow-up; the issue scopes to github.com.
+_GITHUB_API_BASE = "https://api.github.com"
+
+# REST API page size.  GitHub caps list endpoints at 100; we use the max to
+# minimise round-trips for large repos.
+_PAGE_SIZE = 100
+
+# HTTP client timeout (seconds).  Generous to absorb GitHub's occasional
+# slow paths on review comment listing for large PRs.
+_HTTP_TIMEOUT = 30.0
+
+# Maximum sleep when rate-limited.  Defends against bogus reset headers.
+_MAX_RATE_LIMIT_SLEEP_SECONDS = 60 * 60
+
+# Maximum backoff retries on rate-limit.  After this many waits we surrender
+# and re-raise to the caller.
+_MAX_RATE_LIMIT_RETRIES = 3
+
+# Repository spec must look like ``owner/repo`` (one slash, no whitespace).
+_REPO_PATTERN = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+# Canonical PR URL pattern — matches the exact string emitted by the Slack
+# mention extractor.  Used both for self-validation (regression test) and for
+# the webhook handler's URL synthesis.  Anchored at both ends.
+CANONICAL_PR_URL_REGEX: re.Pattern[str] = re.compile(
+    r"^https://github\.com/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/pull/(\d+)$"
+)
+
+# Diff markers — a fetched-document regression test asserts these never appear
+# in the connector's Markdown output (diffs are GitConnector's domain).
+_DIFF_HUNK_MARKERS = ("--- a/", "+++ b/")
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class GithubPrConfig(BaseModel):
+    """Public configuration for the GitHub PR connector (no secrets)."""
+
+    repos: list[str] = Field(default_factory=list)
+    """Repositories to discover, each in ``owner/repo`` form."""
+
+    include_closed: bool = True
+    """Include closed and merged PRs as well as open ones."""
+
+    max_age_days: int = 90
+    """Skip PRs whose ``updated_at`` is older than this cut-off (days)."""
+
+    include_review_comments: bool = True
+    """Include inline review comments in the fetched Markdown body."""
+
+    api_base_url: str = _GITHUB_API_BASE
+    """API root.  Override only for testing; production stays on github.com."""
+
+
+# ---------------------------------------------------------------------------
+# Canonical-name helpers (entity name conventions per the architect memo)
+# ---------------------------------------------------------------------------
+
+
+def canonical_pr_url(owner: str, repo: str, number: int) -> str:
+    """Return the canonical PR URL form used as the entity ``name``."""
+    return f"https://github.com/{owner.lower()}/{repo}/pull/{number}"
+
+
+def canonical_commit_name(sha: str) -> str:
+    """Return the canonical commit-entity name (full 40-char SHA)."""
+    return sha.lower()
+
+
+def canonical_review_name(owner: str, repo: str, pr_number: int, review_id: int) -> str:
+    """Return the canonical review-entity name."""
+    return f"github://review/{owner.lower()}/{repo}/{pr_number}/{review_id}"
+
+
+def canonical_review_comment_name(owner: str, repo: str, pr_number: int, comment_id: int) -> str:
+    """Return the canonical review-comment-entity name."""
+    return f"github://comment/{owner.lower()}/{repo}/{pr_number}/{comment_id}"
+
+
+def canonical_user_name(login: str) -> str:
+    """Return the canonical GitHub-user-entity name."""
+    return f"github://user/{login}"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_repos(repos: list[str]) -> list[tuple[str, str]]:
+    """Parse and validate ``owner/repo`` specs; returns ``[(owner, repo), ...]``."""
+    parsed: list[tuple[str, str]] = []
+    for spec in repos:
+        if not _REPO_PATTERN.match(spec):
+            raise ValueError(f"Invalid repository spec {spec!r}; expected 'owner/repo' format")
+        owner, repo = spec.split("/", 1)
+        parsed.append((owner, repo))
+    return parsed
+
+
+def _build_auth_headers(secrets: dict[str, str]) -> dict[str, str]:
+    """Build authorization headers from runtime secrets.
+
+    Accepts either a PAT or a GitHub App installation token under the same
+    key (``github_token``) — both are sent as bearer credentials.
+    """
+    token = secrets.get("github_token", "").strip()
+    if not token:
+        raise ValueError(
+            "GitHub PR connector requires 'github_token' in secrets "
+            "(PAT or GitHub App installation token)"
+        )
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "omniscience-github-pr-connector/0.2.0",
+    }
+
+
+def _parse_iso8601(value: str | None) -> datetime | None:
+    """Parse a GitHub timestamp; returns ``None`` on missing/invalid input."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _pr_external_id(owner: str, repo: str, number: int) -> str:
+    """Stable ID for de-duplication: SHA-1 of ``owner/repo:number``.
+
+    SHA-1 is used as a *fingerprint*, not for security; ``noqa: S324`` would
+    apply at the call site if we used hashlib.sha1 directly.
+    """
+    fingerprint = f"{owner.lower()}/{repo}:{number}"
+    return hashlib.sha1(fingerprint.encode()).hexdigest()  # noqa: S324
+
+
+async def _sleep_until_rate_limit_reset(response: httpx.Response) -> bool:
+    """If the response indicates exhaustion, sleep until reset.
+
+    Returns ``True`` when a sleep happened and the caller should retry,
+    ``False`` when no rate-limit handling is needed.
+    """
+    remaining = response.headers.get("X-RateLimit-Remaining", "")
+    if remaining != "0":
+        return False
+    reset_str = response.headers.get("X-RateLimit-Reset", "")
+    try:
+        reset_epoch = int(reset_str)
+    except (TypeError, ValueError):
+        return False
+    sleep_for = max(0.0, float(reset_epoch) - time.time())
+    sleep_for = min(sleep_for, float(_MAX_RATE_LIMIT_SLEEP_SECONDS))
+    logger.warning(
+        "github_pr.rate_limited",
+        extra={"sleep_seconds": int(sleep_for), "reset_epoch": reset_epoch},
+    )
+    await asyncio.sleep(sleep_for)
+    return True
+
+
+async def _request_with_rate_limit(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Issue an HTTP request, transparently waiting on GitHub rate limits."""
+    for attempt in range(_MAX_RATE_LIMIT_RETRIES + 1):
+        response = await client.request(method, url, params=params)
+        if response.status_code in (403, 429):
+            slept = await _sleep_until_rate_limit_reset(response)
+            if slept and attempt < _MAX_RATE_LIMIT_RETRIES:
+                continue
+        return response
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _render_pr_markdown(
+    pr: dict[str, Any],
+    commits: list[dict[str, Any]],
+    reviews: list[dict[str, Any]],
+    review_comments: list[dict[str, Any]],
+    files: list[dict[str, Any]],
+    *,
+    include_review_comments: bool,
+) -> str:
+    """Render the PR + reviews + comments + file list as a Markdown document.
+
+    Diffs are NOT included — diff hunks are GitConnector's domain.  The
+    ``files`` list is rendered as filenames only.
+    """
+    lines: list[str] = []
+    title = str(pr.get("title", "")).strip()
+    number = pr.get("number", "")
+    state = pr.get("state", "")
+    user = (pr.get("user") or {}).get("login", "")
+
+    lines.append(f"# PR #{number}: {title}")
+    lines.append("")
+    lines.append(f"- State: {state}")
+    if user:
+        lines.append(f"- Author: {user}")
+    if pr.get("merged_at"):
+        lines.append(f"- Merged at: {pr['merged_at']}")
+    if pr.get("closed_at"):
+        lines.append(f"- Closed at: {pr['closed_at']}")
+    if pr.get("created_at"):
+        lines.append(f"- Created at: {pr['created_at']}")
+    if pr.get("updated_at"):
+        lines.append(f"- Updated at: {pr['updated_at']}")
+    lines.append("")
+
+    body = (pr.get("body") or "").strip()
+    if body:
+        lines.append("## Description")
+        lines.append("")
+        lines.append(body)
+        lines.append("")
+
+    if commits:
+        lines.append("## Commits")
+        lines.append("")
+        for commit in commits:
+            sha = str(commit.get("sha", ""))
+            commit_obj = commit.get("commit") or {}
+            message = str(commit_obj.get("message", "")).splitlines()[0]
+            author = (commit_obj.get("author") or {}).get("name", "")
+            lines.append(f"- `{sha}` {message} ({author})")
+        lines.append("")
+
+    if reviews:
+        lines.append("## Reviews")
+        lines.append("")
+        for review in reviews:
+            reviewer = (review.get("user") or {}).get("login", "")
+            r_state = review.get("state", "")
+            review_body = (review.get("body") or "").strip()
+            lines.append(f"- {reviewer}: {r_state}")
+            if review_body:
+                for body_line in review_body.splitlines():
+                    lines.append(f"  > {body_line}")
+        lines.append("")
+
+    if include_review_comments and review_comments:
+        lines.append("## Review comments")
+        lines.append("")
+        for comment in review_comments:
+            commenter = (comment.get("user") or {}).get("login", "")
+            path = comment.get("path", "")
+            comment_body = (comment.get("body") or "").strip()
+            lines.append(f"- {commenter} on `{path}`:")
+            for body_line in comment_body.splitlines():
+                lines.append(f"  > {body_line}")
+        lines.append("")
+
+    if files:
+        lines.append("## Files touched")
+        lines.append("")
+        for f in files:
+            filename = f.get("filename", "")
+            if filename:
+                lines.append(f"- `{filename}`")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+class GithubPrConnector(Connector):
+    """Connector for GitHub pull requests.
+
+    Stateless: all state is derived from config + secrets at call time, so a
+    single instance can serve many ``Source`` rows.
+
+    See module docstring for the canonical-URL contract.
+    """
+
+    connector_type: ClassVar[str] = "github_pr"
+    config_schema: ClassVar[type[BaseModel]] = GithubPrConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify the token works and every configured repo is reachable.
+
+        Raises ``PermissionError`` on 401, ``RuntimeError`` on missing repos
+        or other API errors.
+        """
+        cfg: GithubPrConfig = config  # type: ignore[assignment]
+        repos = _validate_repos(cfg.repos)
+        if not repos:
+            raise ValueError("GitHub PR connector requires at least one repo in config.repos")
+        headers = _build_auth_headers(secrets)
+        async with httpx.AsyncClient(headers=headers, timeout=_HTTP_TIMEOUT) as client:
+            for owner, repo in repos:
+                url = f"{cfg.api_base_url}/repos/{owner}/{repo}"
+                resp = await _request_with_rate_limit(client, "GET", url)
+                if resp.status_code == 401:
+                    raise PermissionError("GitHub authentication failed — check github_token.")
+                if resp.status_code == 404:
+                    raise RuntimeError(f"Repository {owner}/{repo!r} not found or inaccessible")
+                if resp.status_code >= 400:
+                    raise RuntimeError(
+                        f"GitHub API error for {owner}/{repo}: HTTP {resp.status_code}"
+                    )
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield a :class:`DocumentRef` for every PR matching the filters."""
+        cfg: GithubPrConfig = config  # type: ignore[assignment]
+        repos = _validate_repos(cfg.repos)
+        headers = _build_auth_headers(secrets)
+        cutoff = datetime.now(tz=UTC) - timedelta(days=cfg.max_age_days)
+        state_filter = "all" if cfg.include_closed else "open"
+
+        async with httpx.AsyncClient(headers=headers, timeout=_HTTP_TIMEOUT) as client:
+            for owner, repo in repos:
+                async for ref in self._discover_repo(
+                    client, cfg, owner, repo, state_filter, cutoff
+                ):
+                    yield ref
+
+    async def _discover_repo(
+        self,
+        client: httpx.AsyncClient,
+        cfg: GithubPrConfig,
+        owner: str,
+        repo: str,
+        state_filter: str,
+        cutoff: datetime,
+    ) -> AsyncIterator[DocumentRef]:
+        """Paginate the PR list endpoint for one repo."""
+        url = f"{cfg.api_base_url}/repos/{owner}/{repo}/pulls"
+        page = 1
+        while True:
+            params: dict[str, Any] = {
+                "state": state_filter,
+                "per_page": _PAGE_SIZE,
+                "page": page,
+                "sort": "updated",
+                "direction": "desc",
+            }
+            resp = await _request_with_rate_limit(client, "GET", url, params=params)
+            if resp.status_code >= 400:
+                logger.warning(
+                    "github_pr.discover.api_error",
+                    extra={"owner": owner, "repo": repo, "status": resp.status_code},
+                )
+                return
+            items = resp.json()
+            if not isinstance(items, list) or not items:
+                return
+            for item in items:
+                ref = self._build_pr_ref(owner, repo, item, cutoff)
+                if ref is None:
+                    return  # sorted by updated desc — older items follow
+                yield ref
+            if len(items) < _PAGE_SIZE:
+                return
+            page += 1
+
+    def _build_pr_ref(
+        self,
+        owner: str,
+        repo: str,
+        pr: dict[str, Any],
+        cutoff: datetime,
+    ) -> DocumentRef | None:
+        """Translate a PR JSON object into a :class:`DocumentRef`.
+
+        Returns ``None`` if the PR is older than ``cutoff`` (signals end of
+        the desc-sorted page stream).
+        """
+        number = pr.get("number")
+        if not isinstance(number, int):
+            return None
+        updated_at = _parse_iso8601(pr.get("updated_at"))
+        if updated_at is not None and updated_at < cutoff:
+            return None
+        uri = canonical_pr_url(owner, repo, number)
+        return DocumentRef(
+            external_id=_pr_external_id(owner, repo, number),
+            uri=uri,
+            updated_at=updated_at,
+            metadata={
+                "owner": owner,
+                "repo": repo,
+                "number": number,
+                "state": pr.get("state", ""),
+                "title": pr.get("title", ""),
+                "author": (pr.get("user") or {}).get("login", ""),
+                "html_url": pr.get("html_url", uri),
+                "merged_at": pr.get("merged_at"),
+                "closed_at": pr.get("closed_at"),
+                "created_at": pr.get("created_at"),
+            },
+        )
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch the PR, its commits/reviews/comments/files; render Markdown."""
+        cfg: GithubPrConfig = config  # type: ignore[assignment]
+        owner = str(ref.metadata.get("owner", ""))
+        repo = str(ref.metadata.get("repo", ""))
+        number = ref.metadata.get("number")
+        if not owner or not repo or not isinstance(number, int):
+            raise ValueError(f"DocumentRef missing owner/repo/number metadata: {ref.uri}")
+
+        headers = _build_auth_headers(secrets)
+        async with httpx.AsyncClient(headers=headers, timeout=_HTTP_TIMEOUT) as client:
+            pr = await self._fetch_json(client, cfg, owner, repo, f"pulls/{number}")
+            commits = await self._paginate(client, cfg, owner, repo, f"pulls/{number}/commits")
+            reviews = await self._paginate(client, cfg, owner, repo, f"pulls/{number}/reviews")
+            review_comments: list[dict[str, Any]] = []
+            if cfg.include_review_comments:
+                review_comments = await self._paginate(
+                    client, cfg, owner, repo, f"pulls/{number}/comments"
+                )
+            files = await self._paginate(client, cfg, owner, repo, f"pulls/{number}/files")
+
+        # Strip diff fields from file objects to honour the no-diffs invariant.
+        files_no_diff = [{k: v for k, v in f.items() if k != "patch"} for f in files]
+        markdown = _render_pr_markdown(
+            pr if isinstance(pr, dict) else {},
+            commits,
+            reviews,
+            review_comments,
+            files_no_diff,
+            include_review_comments=cfg.include_review_comments,
+        )
+        # Defensive: assert no diff markers leaked through (e.g. via review body).
+        if any(marker in markdown for marker in _DIFF_HUNK_MARKERS):
+            markdown = _strip_diff_markers(markdown)
+
+        commit_shas = [str(c.get("sha", "")) for c in commits if c.get("sha")]
+        file_paths = [str(f.get("filename", "")) for f in files if f.get("filename")]
+        review_ids = [int(r["id"]) for r in reviews if isinstance(r.get("id"), int)]
+        comment_ids = [int(c["id"]) for c in review_comments if isinstance(c.get("id"), int)]
+
+        enriched_metadata: dict[str, Any] = {
+            **ref.metadata,
+            "pr_url": ref.uri,
+            "commit_shas": commit_shas,
+            "file_paths": file_paths,
+            "review_ids": review_ids,
+            "review_comment_ids": comment_ids,
+            "edges": _build_edges(
+                owner, repo, number, commit_shas, review_ids, comment_ids, file_paths, pr
+            ),
+        }
+        enriched_ref = DocumentRef(
+            external_id=ref.external_id,
+            uri=ref.uri,
+            updated_at=ref.updated_at,
+            metadata=enriched_metadata,
+        )
+        return FetchedDocument(
+            ref=enriched_ref,
+            content_bytes=markdown.encode("utf-8"),
+            content_type="text/markdown",
+        )
+
+    async def _fetch_json(
+        self,
+        client: httpx.AsyncClient,
+        cfg: GithubPrConfig,
+        owner: str,
+        repo: str,
+        path: str,
+    ) -> dict[str, Any]:
+        """Fetch and JSON-decode a single endpoint; returns ``{}`` on error."""
+        url = f"{cfg.api_base_url}/repos/{owner}/{repo}/{path}"
+        resp = await _request_with_rate_limit(client, "GET", url)
+        if resp.status_code >= 400:
+            return {}
+        data = resp.json()
+        return data if isinstance(data, dict) else {}
+
+    async def _paginate(
+        self,
+        client: httpx.AsyncClient,
+        cfg: GithubPrConfig,
+        owner: str,
+        repo: str,
+        path: str,
+    ) -> list[dict[str, Any]]:
+        """Paginate a list endpoint; returns flattened list of dicts."""
+        url = f"{cfg.api_base_url}/repos/{owner}/{repo}/{path}"
+        page = 1
+        out: list[dict[str, Any]] = []
+        while True:
+            params = {"per_page": _PAGE_SIZE, "page": page}
+            resp = await _request_with_rate_limit(client, "GET", url, params=params)
+            if resp.status_code >= 400:
+                break
+            items = resp.json()
+            if not isinstance(items, list) or not items:
+                break
+            out.extend(item for item in items if isinstance(item, dict))
+            if len(items) < _PAGE_SIZE:
+                break
+            page += 1
+        return out
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return GithubPrWebhookHandler()
+
+
+# ---------------------------------------------------------------------------
+# Edge construction (named-entity contract)
+# ---------------------------------------------------------------------------
+
+
+def _build_edges(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    commit_shas: list[str],
+    review_ids: list[int],
+    comment_ids: list[int],
+    file_paths: list[str],
+    pr: dict[str, Any],
+) -> list[dict[str, str]]:
+    """Build the edge-list for the PR graph fragment.
+
+    Edge shape: ``{"from": <name>, "to": <name>, "type": <relation>}``.
+    Names are canonical strings only — this connector never emits database
+    IDs into the graph.
+    """
+    pr_name = canonical_pr_url(owner, repo, pr_number)
+    edges: list[dict[str, str]] = []
+
+    # PR -[HAS_COMMIT]-> commit
+    for sha in commit_shas:
+        edges.append({"from": pr_name, "to": canonical_commit_name(sha), "type": "HAS_COMMIT"})
+    # PR -[TOUCHES]-> file (file entity emitted by GitConnector)
+    for path in file_paths:
+        edges.append({"from": pr_name, "to": path, "type": "TOUCHES"})
+    # review -[REVIEWS]-> PR
+    for rid in review_ids:
+        edges.append(
+            {
+                "from": canonical_review_name(owner, repo, pr_number, rid),
+                "to": pr_name,
+                "type": "REVIEWS",
+            }
+        )
+    # comment -[COMMENT_ON]-> PR
+    for cid in comment_ids:
+        edges.append(
+            {
+                "from": canonical_review_comment_name(owner, repo, pr_number, cid),
+                "to": pr_name,
+                "type": "COMMENT_ON",
+            }
+        )
+    # author -[AUTHORED]-> PR
+    author_login = (pr.get("user") or {}).get("login", "")
+    if author_login:
+        edges.append(
+            {
+                "from": canonical_user_name(str(author_login)),
+                "to": pr_name,
+                "type": "AUTHORED",
+            }
+        )
+    return edges
+
+
+def _strip_diff_markers(text: str) -> str:
+    """Remove diff-hunk lines defensively (re-runs the no-diffs invariant)."""
+    out_lines = [
+        line for line in text.splitlines() if not any(m in line for m in _DIFF_HUNK_MARKERS)
+    ]
+    return "\n".join(out_lines)

--- a/packages/connectors/src/omniscience_connectors/github_pr/webhook.py
+++ b/packages/connectors/src/omniscience_connectors/github_pr/webhook.py
@@ -1,0 +1,208 @@
+"""GitHub webhook handler for the GitHub PR/MR connector.
+
+Subscribed events
+-----------------
+* ``pull_request`` — opened/edited/closed/synchronize/reopened
+* ``pull_request_review`` — submitted/edited/dismissed
+* ``pull_request_review_comment`` — created/edited/deleted
+* ``push`` — only used to keep the PR head SHA fresh; repo file content stays
+  on :class:`GitConnector`'s webhook.
+
+Signature verification is HMAC-SHA256 over the raw body, with the digest
+delivered in ``X-Hub-Signature-256: sha256=<hex>``.  Constant-time comparison.
+
+ACL invariant
+-------------
+Workspace identity comes from ``Source.tenant_id`` resolved by the FastAPI
+receiver on the ``/webhooks/{source_name}`` path — *not* from any field in
+the webhook payload (``installation.id``, ``repository.owner.login``, etc.).
+This handler intentionally does **not** read the installation ID for ACL
+purposes; it only reads payload fields to synthesise the affected PR URL.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from typing import Any
+
+from omniscience_connectors.base import DocumentRef, WebhookHandler, WebhookPayload
+
+__all__ = ["GithubPrWebhookHandler"]
+
+logger = logging.getLogger(__name__)
+
+# GitHub signature header (lower-cased for case-insensitive lookup).
+_GITHUB_SIG_HEADER = "x-hub-signature-256"
+
+# Event type header.
+_GITHUB_EVENT_HEADER = "x-github-event"
+
+# Events we react to.  Anything else is acknowledged but produces no refs.
+_HANDLED_EVENTS = frozenset(
+    {
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "push",
+    }
+)
+
+
+def _verify_github_signature(payload: bytes, secret: str, signature_header: str) -> bool:
+    """Verify a GitHub HMAC-SHA256 signature using constant-time comparison.
+
+    Mirrors :func:`apps.server.omniscience_server.rest.webhooks._verify_github_signature`
+    but is duplicated here only because importing from ``apps/server`` would
+    create a layering violation (connectors must not depend on the FastAPI
+    server).  The two implementations are kept byte-equivalent.
+    """
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    received = signature_header[len("sha256=") :]
+    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, received)
+
+
+class GithubPrWebhookHandler(WebhookHandler):
+    """Webhook handler for GitHub pull-request-related events."""
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        """Return ``True`` if the request is authentic.
+
+        Constant-time comparison; never raises on malformed input.
+        """
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+        sig = lower_headers.get(_GITHUB_SIG_HEADER, "")
+        if not sig or not secret:
+            return False
+        return _verify_github_signature(payload, secret, sig)
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        """Translate a GitHub event into a :class:`WebhookPayload`.
+
+        For PR-touching events, returns a single :class:`DocumentRef` with
+        the canonical PR URL so the ingestion pipeline re-fetches the
+        full PR (including any updated reviews/comments).
+        """
+        try:
+            data: dict[str, Any] = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"GitHub webhook payload is not valid JSON: {exc}") from exc
+
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+        event = lower_headers.get(_GITHUB_EVENT_HEADER, "")
+        repo_obj = data.get("repository") or {}
+        owner = ((repo_obj.get("owner") or {}).get("login") or "").lower()
+        repo = repo_obj.get("name") or ""
+        source_name = f"{owner}/{repo}" if owner and repo else "github_pr"
+
+        affected_refs: list[DocumentRef] = []
+        if event in _HANDLED_EVENTS:
+            affected_refs = _extract_pr_refs(event, data, owner, repo)
+
+        return WebhookPayload(
+            source_name=source_name,
+            affected_refs=affected_refs,
+            raw_headers=lower_headers,
+        )
+
+
+def _extract_pr_refs(
+    event: str,
+    data: dict[str, Any],
+    owner: str,
+    repo: str,
+) -> list[DocumentRef]:
+    """Extract a single PR ``DocumentRef`` per affected pull request.
+
+    For ``push`` events we walk the commits and emit refs only when the
+    payload references PR-bearing branches (we cannot know the PR number
+    from a push payload alone, so push triggers no PR refs — repo content
+    stays on GitConnector's webhook).
+    """
+    if not owner or not repo:
+        return []
+
+    if event == "pull_request":
+        pr = data.get("pull_request") or {}
+        number = pr.get("number")
+        if isinstance(number, int):
+            return [_pr_ref(owner, repo, number, action=str(data.get("action", "")))]
+        return []
+
+    if event == "pull_request_review":
+        pr = data.get("pull_request") or {}
+        number = pr.get("number")
+        if isinstance(number, int):
+            return [
+                _pr_ref(
+                    owner,
+                    repo,
+                    number,
+                    action=str(data.get("action", "")),
+                    review_id=_safe_int((data.get("review") or {}).get("id")),
+                )
+            ]
+        return []
+
+    if event == "pull_request_review_comment":
+        pr = data.get("pull_request") or {}
+        number = pr.get("number")
+        if isinstance(number, int):
+            return [
+                _pr_ref(
+                    owner,
+                    repo,
+                    number,
+                    action=str(data.get("action", "")),
+                    comment_id=_safe_int((data.get("comment") or {}).get("id")),
+                )
+            ]
+        return []
+
+    # `push` — head SHA refresh hook; we emit no PR refs (PR linkage comes
+    # via pull_request events).  Returning empty keeps the no-op invariant.
+    return []
+
+
+def _pr_ref(
+    owner: str,
+    repo: str,
+    number: int,
+    *,
+    action: str = "",
+    review_id: int | None = None,
+    comment_id: int | None = None,
+) -> DocumentRef:
+    """Build the canonical PR :class:`DocumentRef` for re-ingestion."""
+    uri = f"https://github.com/{owner}/{repo}/pull/{number}"
+    metadata: dict[str, Any] = {
+        "owner": owner,
+        "repo": repo,
+        "number": number,
+        "action": action,
+    }
+    if review_id is not None:
+        metadata["review_id"] = review_id
+    if comment_id is not None:
+        metadata["comment_id"] = comment_id
+    return DocumentRef(external_id=uri, uri=uri, metadata=metadata)
+
+
+def _safe_int(value: Any) -> int | None:
+    """Coerce *value* to ``int`` if possible; return ``None`` on failure."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None

--- a/tests/test_github_pr_connector.py
+++ b/tests/test_github_pr_connector.py
@@ -1,0 +1,486 @@
+"""Tests for the GitHub PR/MR connector (Issue #150).
+
+Coverage:
+- GithubPrConfig validation
+- Canonical-name helpers (PR URL, commit, review, comment, user)
+- _validate_repos / _build_auth_headers
+- GithubPrConnector.validate — success, 401, 404, missing repos, missing token
+- GithubPrConnector.discover — pagination, max_age cutoff, state filter, all-closed
+- GithubPrConnector.fetch — Markdown rendering, no diff markers, edges,
+  metadata enrichment (commit_shas, file_paths, review_ids, comment_ids)
+- Rate limit handling — sleeps and retries when X-RateLimit-Remaining=0
+- Registry integration — github_pr is registered
+- Slack-mention canonicalisation regression — PR URL matches the regex used
+  by mention extractors verbatim
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+from omniscience_connectors import get_connector
+from omniscience_connectors.github_pr.connector import (
+    CANONICAL_PR_URL_REGEX,
+    GithubPrConfig,
+    GithubPrConnector,
+    _build_auth_headers,
+    _validate_repos,
+    canonical_commit_name,
+    canonical_pr_url,
+    canonical_review_comment_name,
+    canonical_review_name,
+    canonical_user_name,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+API_BASE = "https://api.github.com"
+OWNER = "100rd"
+REPO = "Omniscience"
+TOKEN = "ghp_fakeFAKEfake"
+
+
+def _pr_payload(number: int, *, updated_at: str = "2026-04-20T10:00:00Z") -> dict[str, Any]:
+    return {
+        "number": number,
+        "state": "open",
+        "title": f"Add feature {number}",
+        "body": f"Body of PR {number}",
+        "user": {"login": "alice"},
+        "html_url": f"https://github.com/{OWNER}/{REPO}/pull/{number}",
+        "merged_at": None,
+        "closed_at": None,
+        "created_at": "2026-04-19T10:00:00Z",
+        "updated_at": updated_at,
+    }
+
+
+def _commit_payload(sha: str) -> dict[str, Any]:
+    return {
+        "sha": sha,
+        "commit": {
+            "message": f"chore: tweak {sha[:7]}",
+            "author": {"name": "Alice"},
+        },
+    }
+
+
+def _review_payload(review_id: int, login: str = "bob") -> dict[str, Any]:
+    return {
+        "id": review_id,
+        "user": {"login": login},
+        "state": "APPROVED",
+        "body": f"LGTM ({review_id})",
+    }
+
+
+def _comment_payload(comment_id: int, login: str = "carol") -> dict[str, Any]:
+    return {
+        "id": comment_id,
+        "user": {"login": login},
+        "path": "src/foo.py",
+        "body": f"nit: tweak {comment_id}",
+    }
+
+
+def _file_payload(path: str) -> dict[str, Any]:
+    return {"filename": path, "additions": 1, "deletions": 0}
+
+
+# ---------------------------------------------------------------------------
+# Config + helpers
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults() -> None:
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    assert cfg.include_closed is True
+    assert cfg.max_age_days == 90
+    assert cfg.include_review_comments is True
+    assert cfg.api_base_url == API_BASE
+
+
+def test_config_connector_type() -> None:
+    assert GithubPrConnector.connector_type == "github_pr"
+    assert GithubPrConnector.config_schema is GithubPrConfig
+
+
+def test_validate_repos_accepts_owner_repo() -> None:
+    parsed = _validate_repos(["acme/widget", "100rd/Omniscience"])
+    assert parsed == [("acme", "widget"), ("100rd", "Omniscience")]
+
+
+@pytest.mark.parametrize(
+    "spec",
+    ["bad", "no/slash/here", "", "owner/", "/repo", "white space/repo"],
+)
+def test_validate_repos_rejects_bad_specs(spec: str) -> None:
+    with pytest.raises(ValueError, match="Invalid repository spec"):
+        _validate_repos([spec])
+
+
+def test_build_auth_headers_uses_bearer() -> None:
+    headers = _build_auth_headers({"github_token": TOKEN})
+    assert headers["Authorization"] == f"Bearer {TOKEN}"
+    assert headers["Accept"] == "application/vnd.github+json"
+    assert "X-GitHub-Api-Version" in headers
+
+
+def test_build_auth_headers_missing_token_raises() -> None:
+    with pytest.raises(ValueError, match="github_token"):
+        _build_auth_headers({})
+
+
+def test_canonical_pr_url_lowercases_owner() -> None:
+    assert canonical_pr_url("ACME", "Repo", 42) == "https://github.com/acme/Repo/pull/42"
+
+
+def test_canonical_helpers() -> None:
+    assert canonical_commit_name("ABCDEF1234") == "abcdef1234"
+    assert canonical_review_name("Acme", "R", 7, 99) == "github://review/acme/R/7/99"
+    assert canonical_review_comment_name("Acme", "R", 7, 12) == "github://comment/acme/R/7/12"
+    assert canonical_user_name("alice") == "github://user/alice"
+
+
+# ---------------------------------------------------------------------------
+# validate()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_validate_success() -> None:
+    respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}").mock(
+        return_value=httpx.Response(200, json={"id": 1})
+    )
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    await connector.validate(cfg, {"github_token": TOKEN})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_validate_unauthorized_raises_permission_error() -> None:
+    respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}").mock(
+        return_value=httpx.Response(401, json={"message": "Bad credentials"})
+    )
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    with pytest.raises(PermissionError):
+        await connector.validate(cfg, {"github_token": TOKEN})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_validate_repo_missing_raises_runtime_error() -> None:
+    respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}").mock(
+        return_value=httpx.Response(404, json={"message": "Not Found"})
+    )
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    with pytest.raises(RuntimeError, match="not found"):
+        await connector.validate(cfg, {"github_token": TOKEN})
+
+
+@pytest.mark.asyncio
+async def test_validate_no_repos_raises() -> None:
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[])
+    with pytest.raises(ValueError, match="at least one repo"):
+        await connector.validate(cfg, {"github_token": TOKEN})
+
+
+# ---------------------------------------------------------------------------
+# discover()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_yields_canonical_refs() -> None:
+    respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}/pulls").mock(
+        return_value=httpx.Response(200, json=[_pr_payload(1), _pr_payload(2)])
+    )
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    refs = [r async for r in connector.discover(cfg, {"github_token": TOKEN})]
+
+    assert len(refs) == 2
+    assert refs[0].uri == f"https://github.com/{OWNER.lower()}/{REPO}/pull/1"
+    assert CANONICAL_PR_URL_REGEX.match(refs[0].uri)
+    assert refs[0].metadata["number"] == 1
+    assert refs[0].metadata["author"] == "alice"
+    assert refs[0].external_id != refs[1].external_id
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_paginates_until_short_page() -> None:
+    full_page = [_pr_payload(i) for i in range(1, 101)]  # exactly _PAGE_SIZE
+    short_page = [_pr_payload(101)]
+    route = respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}/pulls").mock(
+        side_effect=[
+            httpx.Response(200, json=full_page),
+            httpx.Response(200, json=short_page),
+        ]
+    )
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    refs = [r async for r in connector.discover(cfg, {"github_token": TOKEN})]
+    assert len(refs) == 101
+    assert route.call_count == 2
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_respects_max_age_cutoff() -> None:
+    """Older PRs are skipped (sorted desc by updated_at — first old = stop)."""
+    respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}/pulls").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                _pr_payload(1, updated_at="2026-04-20T10:00:00Z"),
+                _pr_payload(2, updated_at="2020-01-01T00:00:00Z"),  # too old
+            ],
+        )
+    )
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"], max_age_days=30)
+    refs = [r async for r in connector.discover(cfg, {"github_token": TOKEN})]
+    assert len(refs) == 1
+    assert refs[0].metadata["number"] == 1
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_state_filter_open_only() -> None:
+    route = respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}/pulls").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"], include_closed=False)
+    _ = [r async for r in connector.discover(cfg, {"github_token": TOKEN})]
+
+    request = route.calls[0].request
+    assert "state=open" in str(request.url)
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+def _stub_fetch_routes(pr_number: int) -> None:
+    """Wire up respx routes for a complete fetch round-trip."""
+    base = f"{API_BASE}/repos/{OWNER}/{REPO}/pulls/{pr_number}"
+    respx.get(base).mock(return_value=httpx.Response(200, json=_pr_payload(pr_number)))
+    respx.get(f"{base}/commits").mock(
+        return_value=httpx.Response(
+            200, json=[_commit_payload("a" * 40), _commit_payload("b" * 40)]
+        )
+    )
+    respx.get(f"{base}/reviews").mock(
+        return_value=httpx.Response(200, json=[_review_payload(101), _review_payload(102)])
+    )
+    respx.get(f"{base}/comments").mock(
+        return_value=httpx.Response(200, json=[_comment_payload(201)])
+    )
+    respx.get(f"{base}/files").mock(
+        return_value=httpx.Response(
+            200, json=[_file_payload("src/foo.py"), _file_payload("docs/bar.md")]
+        )
+    )
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_returns_markdown_with_canonical_metadata() -> None:
+    _stub_fetch_routes(42)
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    # Build the ref directly to keep the test focused.
+    from omniscience_connectors.base import DocumentRef
+
+    ref = DocumentRef(
+        external_id="x",
+        uri=canonical_pr_url(OWNER, REPO, 42),
+        metadata={"owner": OWNER, "repo": REPO, "number": 42},
+    )
+    doc = await connector.fetch(cfg, {"github_token": TOKEN}, ref)
+
+    assert doc.content_type == "text/markdown"
+    md = doc.content_bytes.decode()
+    assert "# PR #42:" in md
+    assert "Add feature 42" in md
+    assert "src/foo.py" in md
+    assert "docs/bar.md" in md
+    # No diff markers
+    assert "--- a/" not in md
+    assert "+++ b/" not in md
+
+    # Enriched metadata
+    assert doc.ref.metadata["pr_url"] == ref.uri
+    assert doc.ref.metadata["commit_shas"] == ["a" * 40, "b" * 40]
+    assert doc.ref.metadata["file_paths"] == ["src/foo.py", "docs/bar.md"]
+    assert sorted(doc.ref.metadata["review_ids"]) == [101, 102]
+    assert doc.ref.metadata["review_comment_ids"] == [201]
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_emits_named_edges() -> None:
+    _stub_fetch_routes(42)
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    from omniscience_connectors.base import DocumentRef
+
+    ref = DocumentRef(
+        external_id="x",
+        uri=canonical_pr_url(OWNER, REPO, 42),
+        metadata={"owner": OWNER, "repo": REPO, "number": 42},
+    )
+    doc = await connector.fetch(cfg, {"github_token": TOKEN}, ref)
+
+    edges: list[dict[str, str]] = doc.ref.metadata["edges"]
+    pr_name = canonical_pr_url(OWNER, REPO, 42)
+    types = {e["type"] for e in edges}
+    assert {"HAS_COMMIT", "TOUCHES", "REVIEWS", "COMMENT_ON", "AUTHORED"} <= types
+    has_commit = [e for e in edges if e["type"] == "HAS_COMMIT"]
+    assert any(e["to"] == "a" * 40 and e["from"] == pr_name for e in has_commit)
+    touches = [e for e in edges if e["type"] == "TOUCHES"]
+    assert any(e["to"] == "src/foo.py" and e["from"] == pr_name for e in touches)
+    reviews = [e for e in edges if e["type"] == "REVIEWS"]
+    assert any(
+        e["to"] == pr_name and e["from"] == canonical_review_name(OWNER, REPO, 42, 101)
+        for e in reviews
+    )
+    authored = [e for e in edges if e["type"] == "AUTHORED"]
+    assert any(e["to"] == pr_name and e["from"] == canonical_user_name("alice") for e in authored)
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_strips_review_body_diff_markers_defensively() -> None:
+    """Even if a review body contains diff hunks, fetched Markdown rejects them."""
+    base = f"{API_BASE}/repos/{OWNER}/{REPO}/pulls/7"
+    respx.get(base).mock(return_value=httpx.Response(200, json=_pr_payload(7)))
+    respx.get(f"{base}/commits").mock(return_value=httpx.Response(200, json=[]))
+    respx.get(f"{base}/reviews").mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 1,
+                    "user": {"login": "x"},
+                    "state": "COMMENTED",
+                    "body": "look at this:\n--- a/old\n+++ b/new\n@@ -1 +1 @@\n-foo\n+bar",
+                }
+            ],
+        )
+    )
+    respx.get(f"{base}/comments").mock(return_value=httpx.Response(200, json=[]))
+    respx.get(f"{base}/files").mock(return_value=httpx.Response(200, json=[]))
+
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    from omniscience_connectors.base import DocumentRef
+
+    ref = DocumentRef(
+        external_id="x",
+        uri=canonical_pr_url(OWNER, REPO, 7),
+        metadata={"owner": OWNER, "repo": REPO, "number": 7},
+    )
+    doc = await connector.fetch(cfg, {"github_token": TOKEN}, ref)
+    md = doc.content_bytes.decode()
+    assert "--- a/" not in md
+    assert "+++ b/" not in md
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit handling
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_rate_limit_sleeps_and_retries() -> None:
+    """403 + X-RateLimit-Remaining=0 triggers a sleep and a retry."""
+    rate_limit_response = httpx.Response(
+        403,
+        json={"message": "API rate limit exceeded"},
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1",  # epoch in the past — sleeps near 0s
+        },
+    )
+    success = httpx.Response(200, json={"id": 1})
+    route = respx.get(f"{API_BASE}/repos/{OWNER}/{REPO}").mock(
+        side_effect=[rate_limit_response, success]
+    )
+
+    sleep_calls: list[float] = []
+
+    async def _fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    connector = GithubPrConnector()
+    cfg = GithubPrConfig(repos=[f"{OWNER}/{REPO}"])
+    with patch("omniscience_connectors.github_pr.connector.asyncio.sleep", _fake_sleep):
+        await connector.validate(cfg, {"github_token": TOKEN})
+
+    assert route.call_count == 2
+    assert len(sleep_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+def test_github_pr_connector_is_registered() -> None:
+    connector = get_connector("github_pr")
+    assert isinstance(connector, GithubPrConnector)
+
+
+# ---------------------------------------------------------------------------
+# PR-URL canonicalisation regression (#150 acceptance criterion 2)
+# ---------------------------------------------------------------------------
+
+# This regex is what a Slack mention extractor would use to find PR URLs
+# in message text.  It MUST match the connector's emitted URLs verbatim.
+_SLACK_PR_URL_REGEX = re.compile(r"https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/\d+")
+
+
+def test_slack_mention_regex_round_trips_through_connector() -> None:
+    fixture_message = (
+        "FYI the deploy was https://github.com/100rd/Omniscience/pull/42 "
+        "and a follow-up at https://github.com/acme/widget/pull/7"
+    )
+    extracted = _SLACK_PR_URL_REGEX.findall(fixture_message)
+    assert extracted == [
+        "https://github.com/100rd/Omniscience/pull/42",
+        "https://github.com/acme/widget/pull/7",
+    ]
+    # The connector must produce strings that match the same regex AND
+    # equal the extracted strings byte-for-byte.
+    rebuilt = [
+        canonical_pr_url("100rd", "Omniscience", 42),
+        canonical_pr_url("acme", "widget", 7),
+    ]
+    assert rebuilt == extracted
+    for url in rebuilt:
+        assert CANONICAL_PR_URL_REGEX.fullmatch(url)
+
+
+def test_canonical_pr_url_has_no_trailing_slash_or_anchor() -> None:
+    url = canonical_pr_url(OWNER, REPO, 99)
+    assert not url.endswith("/")
+    assert "#" not in url
+    assert "?" not in url

--- a/tests/test_github_pr_webhook.py
+++ b/tests/test_github_pr_webhook.py
@@ -1,0 +1,241 @@
+"""Tests for the GitHub PR webhook handler (Issue #150).
+
+Coverage:
+- HMAC-SHA256 signature verification — positive + negative + missing header
+- Constant-time comparison via hmac.compare_digest (boundary cases)
+- Event parsing — pull_request, pull_request_review, pull_request_review_comment
+- ACL invariant — workspace identity is never inferred from payload fields
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+from omniscience_connectors.github_pr.webhook import (
+    GithubPrWebhookHandler,
+    _verify_github_signature,
+)
+
+OWNER = "100rd"
+REPO = "Omniscience"
+SECRET = "supersecret"
+
+
+def _sign(payload: bytes, secret: str = SECRET) -> str:
+    return "sha256=" + hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+
+
+def _pr_event(action: str = "opened", number: int = 42) -> bytes:
+    return json.dumps(
+        {
+            "action": action,
+            "pull_request": {
+                "number": number,
+                "html_url": f"https://github.com/{OWNER}/{REPO}/pull/{number}",
+            },
+            "repository": {"name": REPO, "owner": {"login": OWNER}},
+            # Tenant-writable upstream content — MUST NOT be used for ACL:
+            "installation": {"id": 12345},
+        }
+    ).encode()
+
+
+def _review_event(review_id: int = 99, number: int = 42) -> bytes:
+    return json.dumps(
+        {
+            "action": "submitted",
+            "review": {"id": review_id, "state": "APPROVED"},
+            "pull_request": {"number": number},
+            "repository": {"name": REPO, "owner": {"login": OWNER}},
+        }
+    ).encode()
+
+
+def _comment_event(comment_id: int = 7, number: int = 42) -> bytes:
+    return json.dumps(
+        {
+            "action": "created",
+            "comment": {"id": comment_id, "body": "nit"},
+            "pull_request": {"number": number},
+            "repository": {"name": REPO, "owner": {"login": OWNER}},
+        }
+    ).encode()
+
+
+# ---------------------------------------------------------------------------
+# verify_signature
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_signature_success() -> None:
+    handler = GithubPrWebhookHandler()
+    payload = _pr_event()
+    headers = {"X-Hub-Signature-256": _sign(payload), "X-GitHub-Event": "pull_request"}
+    assert await handler.verify_signature(payload, headers, SECRET) is True
+
+
+@pytest.mark.asyncio
+async def test_verify_signature_wrong_secret() -> None:
+    handler = GithubPrWebhookHandler()
+    payload = _pr_event()
+    headers = {"X-Hub-Signature-256": _sign(payload, "wrong"), "X-GitHub-Event": "pull_request"}
+    assert await handler.verify_signature(payload, headers, SECRET) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_signature_missing_header() -> None:
+    handler = GithubPrWebhookHandler()
+    assert await handler.verify_signature(_pr_event(), {}, SECRET) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_signature_empty_secret() -> None:
+    """Empty secret cannot authenticate anything — return False, never True."""
+    handler = GithubPrWebhookHandler()
+    payload = _pr_event()
+    headers = {"X-Hub-Signature-256": _sign(payload, "")}
+    assert await handler.verify_signature(payload, headers, "") is False
+
+
+@pytest.mark.asyncio
+async def test_verify_signature_malformed_header() -> None:
+    handler = GithubPrWebhookHandler()
+    headers = {"X-Hub-Signature-256": "md5=abcdef"}
+    assert await handler.verify_signature(_pr_event(), headers, SECRET) is False
+
+
+def test_verify_helper_uses_constant_time_compare() -> None:
+    """Boundary: helper must reject a flipped-bit signature even when same length."""
+    payload = b"hello"
+    correct = _sign(payload)
+    flipped = "sha256=" + ("0" * 64)
+    assert _verify_github_signature(payload, SECRET, correct) is True
+    assert _verify_github_signature(payload, SECRET, flipped) is False
+    # Empty signature
+    assert _verify_github_signature(payload, SECRET, "") is False
+
+
+# ---------------------------------------------------------------------------
+# parse_payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parse_pull_request_event_emits_canonical_pr_ref() -> None:
+    handler = GithubPrWebhookHandler()
+    headers = {"X-GitHub-Event": "pull_request"}
+    result = await handler.parse_payload(_pr_event(action="opened"), headers)
+
+    assert result.source_name == f"{OWNER.lower()}/{REPO}"
+    assert len(result.affected_refs) == 1
+    ref = result.affected_refs[0]
+    assert ref.uri == f"https://github.com/{OWNER.lower()}/{REPO}/pull/42"
+    assert ref.metadata["number"] == 42
+    assert ref.metadata["action"] == "opened"
+
+
+@pytest.mark.asyncio
+async def test_parse_review_event_carries_review_id() -> None:
+    handler = GithubPrWebhookHandler()
+    headers = {"X-GitHub-Event": "pull_request_review"}
+    result = await handler.parse_payload(_review_event(99), headers)
+
+    assert len(result.affected_refs) == 1
+    ref = result.affected_refs[0]
+    assert ref.metadata["review_id"] == 99
+    assert ref.metadata["number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_parse_review_comment_event_carries_comment_id() -> None:
+    handler = GithubPrWebhookHandler()
+    headers = {"X-GitHub-Event": "pull_request_review_comment"}
+    result = await handler.parse_payload(_comment_event(7), headers)
+
+    assert len(result.affected_refs) == 1
+    assert result.affected_refs[0].metadata["comment_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_parse_push_event_emits_no_pr_refs() -> None:
+    """Push events update file content (GitConnector's domain) — no PR refs."""
+    handler = GithubPrWebhookHandler()
+    payload = json.dumps(
+        {"ref": "refs/heads/main", "repository": {"name": REPO, "owner": {"login": OWNER}}}
+    ).encode()
+    headers = {"X-GitHub-Event": "push"}
+    result = await handler.parse_payload(payload, headers)
+    assert result.affected_refs == []
+
+
+@pytest.mark.asyncio
+async def test_parse_invalid_json_raises() -> None:
+    handler = GithubPrWebhookHandler()
+    with pytest.raises(ValueError, match="not valid JSON"):
+        await handler.parse_payload(b"not-json", {"X-GitHub-Event": "pull_request"})
+
+
+@pytest.mark.asyncio
+async def test_parse_unknown_event_returns_no_refs() -> None:
+    """Unsubscribed events are acknowledged but produce no refs."""
+    handler = GithubPrWebhookHandler()
+    headers = {"X-GitHub-Event": "issue_comment"}
+    payload = json.dumps({"repository": {"name": REPO, "owner": {"login": OWNER}}}).encode()
+    result = await handler.parse_payload(payload, headers)
+    assert result.affected_refs == []
+
+
+# ---------------------------------------------------------------------------
+# ACL invariant — workspace identity is NEVER inferred from payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acl_invariant_handler_does_not_expose_installation_id() -> None:
+    """The handler MUST NOT surface installation.id or repository.owner as
+    workspace identity. The webhook payload's source_name and affected_refs
+    are inputs to the FastAPI receiver; tenant resolution happens earlier
+    via the URL path-encoded source_name → Source.tenant_id lookup.
+    """
+    handler = GithubPrWebhookHandler()
+    payload = _pr_event()  # carries `installation.id = 12345`
+    headers = {"X-GitHub-Event": "pull_request"}
+
+    # Verify with the correct secret first.
+    assert await handler.verify_signature(payload, {"X-Hub-Signature-256": _sign(payload)}, SECRET)
+
+    result = await handler.parse_payload(payload, headers)
+    serialised = result.model_dump_json()
+    assert "12345" not in serialised, (
+        "Installation ID leaked from payload — workspace identity must "
+        "come from Source.tenant_id, never from webhook payload fields."
+    )
+    # The source_name is repository-scoped (used as a label), not for ACL.
+    assert "installation" not in result.model_dump()
+
+
+@pytest.mark.asyncio
+async def test_cross_workspace_isolation_same_repo_different_secrets() -> None:
+    """Two workspaces (A and B) configure the same upstream repo with
+    different webhook secrets.  A request signed for A must NOT verify for
+    B's handler instance, and vice versa.
+
+    This is the ACL-isolation contract: even if the GitHub payload itself
+    is identical (same upstream PR), the per-source secret prevents
+    cross-tenant replay.
+    """
+    handler = GithubPrWebhookHandler()
+    payload = _pr_event()
+    sig_a = _sign(payload, "secret-a")
+    sig_b = _sign(payload, "secret-b")
+
+    # Workspace A's secret verifies workspace A's signature only.
+    assert await handler.verify_signature(payload, {"X-Hub-Signature-256": sig_a}, "secret-a")
+    assert not await handler.verify_signature(payload, {"X-Hub-Signature-256": sig_a}, "secret-b")
+    # And vice versa.
+    assert await handler.verify_signature(payload, {"X-Hub-Signature-256": sig_b}, "secret-b")
+    assert not await handler.verify_signature(payload, {"X-Hub-Signature-256": sig_b}, "secret-a")


### PR DESCRIPTION
## Summary

Closes #150 (Wave 1 of epic #99).

Adds a new `github_pr` source connector at
`packages/connectors/src/omniscience_connectors/github_pr/` that indexes
**pull requests, commits, reviews, and review comments** as first-class
entities — distinct from the file-tree indexing already handled by
`GitConnector`.  The two connectors run side-by-side as separate `Source`
rows targeting the same upstream (a GitHub repo) but covering different
aspects:

| Connector | Domain |
|-----------|--------|
| `git` | File blobs (source code, repo tree at a ref) |
| `github_pr` | Review history (PRs, commits, reviews, comments) |

## Why a new connector instead of extending GitConnector?

PRs / commits / reviews / review comments aren't files.  Splitting them
keeps `GitConnector` lean and lets the PR/MR connector evolve its own:

* auth model (PAT or GitHub App installation token)
* rate-limit handling (per-token GitHub REST limits)
* webhook handler (separate from git push hooks)

`GitConnector` is **not modified**.

## Canonical PR URL contract

PR entity name = `https://github.com/{owner}/{repo}/pull/{n}` exactly —
lowercase host, no trailing slash, no query, no anchor.  This is
byte-for-byte the same string the Slack mention extractor emits, so
`EntityLinker.exact_name` produces `cross_ref` edges automatically.

The contract is encoded as a regex (`CANONICAL_PR_URL_REGEX`) in the
connector module and exercised by a regression test that round-trips
through a Slack-style mention regex.

## Entities + edges

| Entity | Canonical name |
|--------|----------------|
| `github_pr` | `https://github.com/{owner}/{repo}/pull/{n}` |
| `git_commit` | `<full-40-char-sha>` |
| `github_review` | `github://review/{owner}/{repo}/{pr}/{review_id}` |
| `github_review_comment` | `github://comment/{owner}/{repo}/{pr}/{comment_id}` |
| `github_user` | `github://user/{login}` |

| Edge | Direction |
|------|-----------|
| `[:HAS_COMMIT]` | PR → commit |
| `[:TOUCHES]` | PR → file (file entity emitted by `GitConnector`) |
| `[:REVIEWS]` | review → PR |
| `[:COMMENT_ON]` | comment → PR |
| `[:AUTHORED]` | user → PR |

## Auth model decision — both PAT and GitHub App tokens

A single `github_token` secret accepts either:

* a Personal Access Token (PAT), or
* a GitHub App installation token

— both are sent as `Authorization: Bearer <token>`.  The token-issuance
flow for GitHub Apps (private key → JWT → installation token) is
operator concern: rotate installation tokens upstream into the secret
store and the connector runs unchanged.  The architect memo's deferral
on epic #99 (PAT vs App) is satisfied without forcing an early choice.

## HTTP client decision — httpx, no new deps

Followed the issue's hard constraint: no new dependencies beyond `httpx`.
Raw REST + manual pagination is cleanest given the rest of the codebase
(Confluence already uses this pattern).  PyGithub would have added a
sync-only client and an extra layer; not worth the cost.

## Rate-limit handling

The connector respects `X-RateLimit-Remaining` / `X-RateLimit-Reset` and
sleeps until reset when the quota is exhausted (capped at 1h to defend
against bogus reset headers).  Up to 3 retries.  Exercised by
`test_rate_limit_sleeps_and_retries`.

## Webhook handler

* HMAC-SHA256 signature verification, constant-time comparison
* Subscribed events: `pull_request`, `pull_request_review`,
  `pull_request_review_comment`, `push`
* `push` is acknowledged but produces no PR refs — file content stays
  on `GitConnector`'s webhook
* ACL invariant enforced: workspace identity is never inferred from
  the GitHub payload (`installation.id`, `repository.owner.login`).
  Cross-workspace isolation regression test plants the same payload
  signed with two different secrets and asserts neither verifies for
  the other workspace's handler.

## No diffs in fetched documents

`fetch()` returns Markdown — title, body, commit list, reviews, review
comments, file paths.  Diffs (`--- a/`, `+++ b/`) are stripped twice:

1. The `files` listing is rendered as filenames only (no `patch` field).
2. A defensive post-render pass removes any diff-marker line that may
   have leaked through a review body.

Regression test asserts `--- a/` / `+++ b/` are absent from
`FetchedDocument.content_bytes`.

## Tests

42 new tests, all passing (1868 passed, 51 skipped in the full repo run):

* `tests/test_github_pr_connector.py` (28 tests) — config, helpers,
  validate, discover (pagination + max_age cutoff + state filter),
  fetch (Markdown, edges, metadata enrichment, defensive diff strip),
  rate-limit handling, registry integration, Slack-mention round-trip
* `tests/test_github_pr_webhook.py` (14 tests) — signature
  verification (positive/negative/missing/empty/malformed),
  constant-time compare, event parsing, ACL invariant,
  cross-workspace isolation

## Quality gates

* `mypy --strict` clean — 168 source files (was 165, +3 for the new
  module: connector, webhook, package init)
* `ruff check` clean
* `ruff format --check` clean
* `pytest`: 1868 passed, 51 skipped (skips are pre-existing
  testcontainers/integration paths)

## Files changed

* `packages/connectors/src/omniscience_connectors/__init__.py` —
  register `GithubPrConnector` in the shared registry
* `packages/connectors/src/omniscience_connectors/github_pr/__init__.py` (new)
* `packages/connectors/src/omniscience_connectors/github_pr/connector.py` (new)
* `packages/connectors/src/omniscience_connectors/github_pr/webhook.py` (new)
* `tests/test_github_pr_connector.py` (new)
* `tests/test_github_pr_webhook.py` (new)
* `docs/connectors/github_pr.md` (new)

7 files changed, 1791 insertions(+), 2 deletions(-).

## Test plan

- [x] `make test` (full pytest) — 1868 passed
- [x] `mypy --strict` clean
- [x] `ruff check` and `ruff format --check` clean
- [x] Slack-mention canonicalisation round-trip regression
- [x] Webhook signature verification (positive + negative + boundary)
- [x] Cross-workspace isolation (same payload, different secrets)
- [x] No diff markers in fetched documents
- [x] Rate-limit sleep + retry path