### PR TITLE
feat: Slack incident-grade entity surface (#149)

### DIFF
--- a/packages/connectors/src/omniscience_connectors/slack/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/slack/__init__.py
@@ -1,5 +1,24 @@
 """Slack source connector."""
 
 from omniscience_connectors.slack.connector import SlackConfig, SlackConnector
+from omniscience_connectors.slack.entities import (
+    EXTRACTOR_VERSION,
+    MENTION_KIND,
+    EdgeData,
+    EntityData,
+    extract_mentions,
+    extract_slack_graph,
+    slack_thread_name,
+)
 
-__all__ = ["SlackConfig", "SlackConnector"]
+__all__ = [
+    "EXTRACTOR_VERSION",
+    "MENTION_KIND",
+    "EdgeData",
+    "EntityData",
+    "SlackConfig",
+    "SlackConnector",
+    "extract_mentions",
+    "extract_slack_graph",
+    "slack_thread_name",
+]

--- a/packages/connectors/src/omniscience_connectors/slack/connector.py
+++ b/packages/connectors/src/omniscience_connectors/slack/connector.py
@@ -26,8 +26,15 @@ from omniscience_connectors.base import (
     WebhookHandler,
     WebhookPayload,
 )
+from omniscience_connectors.slack.entities import extract_slack_graph
 
 __all__ = ["SlackConfig", "SlackConnector"]
+
+# Metadata keys under which the connector stamps the extracted entity
+# surface for the downstream ingestion pipeline.  Documented as part of
+# the connector contract — pipeline code reads these by name.
+_META_ENTITIES_KEY: str = "entities"
+_META_EDGES_KEY: str = "edges"
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +215,14 @@ class SlackConnector(Connector):
         secrets: dict[str, str],
         ref: DocumentRef,
     ) -> FetchedDocument:
-        """Fetch a Slack thread (root + replies) and return as Markdown."""
+        """Fetch a Slack thread (root + replies) and return as Markdown.
+
+        Side effect (issue #149): stamps the extracted entity surface onto
+        ``ref.metadata['entities']`` / ``ref.metadata['edges']`` for the
+        downstream ingestion pipeline to emit into the graph.  Workspace
+        identity is NEVER read from the Slack payload — the pipeline
+        layer derives it from ``Source.tenant_id`` and stamps each entity.
+        """
         cfg: SlackConfig = config  # type: ignore[assignment]
         headers = _auth_headers(secrets)
 
@@ -220,34 +234,57 @@ class SlackConnector(Connector):
                 f"DocumentRef missing 'channel_id' or 'thread_ts' in metadata: {ref.uri!r}"
             )
 
-        # Fetch root message
-        root_messages = await self._history_page(channel_id, thread_ts, thread_ts, headers)
-        root_text = ""
-        if root_messages:
-            root_text = _message_to_markdown(root_messages[0])
+        ordered = await self._collect_thread_messages(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            include_replies=cfg.include_threads,
+            headers=headers,
+        )
 
-        # Fetch replies if configured
-        reply_text = ""
-        if cfg.include_threads:
-            replies = await self._fetch_replies(channel_id, thread_ts, headers)
-            reply_lines = [_message_to_markdown(m) for m in replies if m.get("ts") != thread_ts]
-            if reply_lines:
-                reply_text = "\n\n".join(reply_lines)
+        channel_name = str(ref.metadata.get("channel_name", channel_id))
+        content = _render_thread_markdown(channel_name, thread_ts, ordered)
 
-        # Assemble document
-        channel_name = ref.metadata.get("channel_name", channel_id)
-        parts = [f"## #{channel_name} — Thread {thread_ts}"]
-        if root_text:
-            parts.append(root_text)
-        if reply_text:
-            parts.append("### Replies\n\n" + reply_text)
+        # Stamp the extracted entity surface (issue #149).  The downstream
+        # ingestion pipeline reads these keys; absence is benign.
+        entities, edges = extract_slack_graph(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            channel_name=channel_name,
+            messages=ordered,
+        )
+        ref.metadata[_META_ENTITIES_KEY] = entities
+        ref.metadata[_META_EDGES_KEY] = edges
 
-        content = "\n\n".join(parts)
         return FetchedDocument(
             ref=ref,
             content_bytes=content.encode("utf-8"),
             content_type="text/markdown",
         )
+
+    async def _collect_thread_messages(
+        self,
+        *,
+        channel_id: str,
+        thread_ts: str,
+        include_replies: bool,
+        headers: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        """Fetch the root + (optional) replies and return them in ts order.
+
+        Centralised so :meth:`fetch` can both render Markdown AND feed the
+        message dicts to the entity extractor without re-fetching.
+        """
+        root_messages = await self._history_page(channel_id, thread_ts, thread_ts, headers)
+        ordered: list[dict[str, Any]] = []
+        if root_messages:
+            ordered.append(root_messages[0])
+
+        if include_replies:
+            replies = await self._fetch_replies(channel_id, thread_ts, headers)
+            for m in replies:
+                if m.get("ts") != thread_ts:
+                    ordered.append(m)
+        return ordered
 
     def webhook_handler(self) -> WebhookHandler | None:
         return SlackWebhookHandler()
@@ -440,6 +477,28 @@ def _auth_headers(secrets: dict[str, str]) -> dict[str, str]:
     if not token.startswith("xoxb-"):
         raise ValueError("Slack 'bot_token' must start with 'xoxb-'.")
     return {"Authorization": f"Bearer {token}"}
+
+
+def _render_thread_markdown(
+    channel_name: str,
+    thread_ts: str,
+    messages: list[dict[str, Any]],
+) -> str:
+    """Render an ordered list of Slack message dicts as a Markdown thread.
+
+    First message is treated as the thread root.  Remaining messages are
+    rendered under a ``### Replies`` heading to match the prior contract
+    (existing tests in ``tests/test_connectors_v2.py`` assert against
+    "Reply here" appearing in the body).
+    """
+    parts = [f"## #{channel_name} — Thread {thread_ts}"]
+    if messages:
+        parts.append(_message_to_markdown(messages[0]))
+        replies = messages[1:]
+        if replies:
+            reply_lines = [_message_to_markdown(m) for m in replies]
+            parts.append("### Replies\n\n" + "\n\n".join(reply_lines))
+    return "\n\n".join(parts)
 
 
 def _message_to_markdown(msg: dict[str, Any]) -> str:

--- a/packages/connectors/src/omniscience_connectors/slack/entities.py
+++ b/packages/connectors/src/omniscience_connectors/slack/entities.py
@@ -1,0 +1,614 @@
+"""Slack entity surface extractor for incident-grade GraphRAG (issue #149).
+
+Given a Markdown document produced by :class:`SlackConnector.fetch` and the
+``DocumentRef.metadata`` it carries, this module extracts:
+
+1. **Structural entities** for the thread itself
+   (``slack_thread``, ``slack_message``, ``slack_user``, ``slack_channel``).
+2. **Mention-target entities** named after canonical strings inside the
+   message bodies — GitHub PR URLs, AWS ARNs, Kubernetes pod names, and
+   error tokens.  These are emitted as ``slack_mention`` entities whose
+   ``name`` is the canonical mention string.  The cross-source
+   :class:`~omniscience_index.linker.EntityLinker` creates ``cross_ref``
+   edges between them and the matching entities from the GitHub PR/MR,
+   AWS, and K8s connectors via the existing ``exact_name`` and
+   ``arn_match`` strategies (no new linker strategies introduced —
+   per issue #149's explicit non-goal).
+
+ACL invariant
+-------------
+The extractor emits entities by **name only** — workspace stamping
+happens later in :mod:`omniscience_server.ingestion.pipeline` (see
+``_tag_entity_workspace``).  Mentions are tenant-writable Slack content;
+they enter the graph as edge targets named by the user-supplied string,
+**not** as authoritative source-of-truth entities.  The authoritative
+entity for a PR / ARN / pod is always the one emitted by the trusted
+connector (GitHub / AWS / K8s).
+
+The connector's ``Source.tenant_id`` is the only legitimate source of
+workspace identity — payload fields such as ``team_id``, ``user`` ids,
+or any mention string MUST NEVER be used to infer workspace.
+
+Mention extraction
+------------------
+All four mention extractors run on a *normalised* version of the message
+text where Markdown code fences (triple-backtick blocks) and inline code
+spans (single-backtick spans) are stripped.  This avoids false positives
+from example payloads that the user pasted into the discussion
+(issue #149 adversarial-string requirement).
+
+The four extractors are intentionally **conservative** — they prefer
+false negatives over false positives — because every match feeds the
+linker, and a false positive mention pollutes the graph with a
+tenant-controlled name that could shadow a real entity at retrieval
+time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "EXTRACTOR_VERSION",
+    "MENTION_KIND",
+    "EdgeData",
+    "EntityData",
+    "build_thread_entities",
+    "extract_mentions",
+    "extract_slack_graph",
+    "slack_thread_name",
+]
+
+
+# ---------------------------------------------------------------------------
+# Local DTOs — kept structurally identical to
+# :class:`omniscience_parsers.infra.graph.EntityData` / ``EdgeData`` so the
+# downstream ingestion pipeline (which accepts a generic
+# ``(entities, edges)`` tuple from any extractor — see
+# ``apps/server/src/omniscience_server/ingestion/pipeline.py``) can consume
+# them without adapter code.
+#
+# Defined locally rather than imported from ``omniscience_parsers`` to keep
+# the connector package's dependency graph minimal (connectors -> core only;
+# the parsers package may later depend on connector types and we must avoid
+# the cycle).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EntityData:
+    """A node emitted by the Slack entity extractor.
+
+    Attributes:
+        symbol: Canonical identifier — for Slack entities this matches
+            :func:`slack_thread_name` / equivalents; for mention-target
+            entities this is the canonical mention string itself.
+        kind: Entity kind (``slack_thread``, ``slack_message``,
+            ``slack_user``, ``slack_channel``, or :data:`MENTION_KIND`).
+        name: Human-readable name; same as ``symbol`` for all kinds the
+            Slack extractor produces (canonical strings ARE the names).
+        namespace: Reserved (unused for Slack); kept for shape compatibility.
+        labels: Reserved (unused for Slack); kept for shape compatibility.
+        extra: Per-kind additional metadata.  See the kind-specific builders.
+    """
+
+    symbol: str
+    kind: str
+    name: str
+    namespace: str = ""
+    labels: dict[str, str] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EdgeData:
+    """A directed edge emitted by the Slack entity extractor.
+
+    Edge types used:
+
+    - ``in_thread``: SlackMessage -> SlackThread.
+    - ``in_channel``: SlackThread -> SlackChannel.
+    - ``authored``: SlackUser -> SlackMessage.
+    - ``mentions``: SlackThread -> mention-target entity.
+    """
+
+    from_symbol: str
+    to_symbol: str
+    edge_type: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Stamp written to ``EntityData.extra['extractor_version']`` so downstream
+#: queries can segment by extraction strategy version (mirrors
+#: ``_PARSER_VERSION`` in ``ingestion.pipeline``).
+EXTRACTOR_VERSION: str = "slack-entities-v1"
+
+#: Entity kind for mention-target entities.  Distinct from the canonical
+#: kinds emitted by trusted connectors (``aws_live``, ``k8s_resource``,
+#: GitHub PR kind, …) so that retrieval can distinguish a Slack-mention
+#: anchor from the authoritative entity.  The linker still creates
+#: ``cross_ref`` edges via the source-agnostic ``exact_name`` strategy.
+MENTION_KIND: str = "slack_mention"
+
+
+# ---------------------------------------------------------------------------
+# Mention regex patterns — module-level constants with rationale comments.
+# ---------------------------------------------------------------------------
+
+# GitHub PR URL: capture the canonical https://github.com/{owner}/{repo}/pull/{n}
+# form.  We capture only the BASE URL — query strings (``?diff=split``) and
+# fragments (``#discussion_r123``) are matched after the captured group but
+# discarded so the emitted canonical name matches what the GitHub PR/MR
+# connector (issue #150) emits as PR ``name`` regardless of how the user
+# pasted the URL into Slack.
+#
+# Anchor: the URL must be preceded by start-of-string, whitespace, ``(``, ``[``,
+# ``<``, ``"`` or ``'``.  Trailing query/fragment is consumed by a non-capturing
+# group so the captured base URL is always punctuation-free.
+_RE_PR_URL = re.compile(
+    r"(?:^|(?<=[\s(\[<\"']))"
+    r"(https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/pull/\d+)"
+    r"(?:[?#][^\s)\]>\"']*)?",
+)
+
+# AWS ARN: arn:{partition}:{service}:{region}:{account}:{resource}.
+# Partition allows aws, aws-cn, aws-us-gov.  Resource segment is anything
+# that is not whitespace or a closing quote/bracket character (matches the
+# RFC-permissive form actually seen in the wild — IAM, S3, EC2, …).
+#
+# We deliberately reject ARNs whose service segment is empty (``arn:aws::``)
+# to avoid matching the literal string ``arn:`` followed by whitespace.
+_RE_ARN = re.compile(
+    r"(?:^|(?<=[\s(\[<\"']))"
+    r"(arn:aws[a-z0-9-]*:[a-z0-9-]+:[a-z0-9-]*:[0-9]*:[^\s\"'`)\]>]+)",
+)
+
+# Kubernetes pod name (deployment-replicaset-pod hash form):
+#   {prefix}-{8-10 hex chars}-{5 alphanum chars}
+#
+# The hash segments come from the ReplicaSet template-hash and the pod's
+# 5-char random suffix.  This is the most common form for Deployment-managed
+# pods.  Standalone pods or StatefulSet pods have different shapes; those
+# are out of scope for incident-grade mention extraction (the alerts/OTel
+# sibling sub-issues will surface them by trace ID).
+#
+# Word boundaries on each side prevent matching inside longer identifiers.
+_RE_POD_NAME = re.compile(
+    r"(?<![A-Za-z0-9-])"
+    r"([a-z0-9]+(?:-[a-z0-9]+)*-[a-f0-9]{8,10}-[a-z0-9]{5})"
+    r"(?![A-Za-z0-9-])",
+)
+
+# Error tokens: SCREAMING_SNAKE_CASE identifiers of length >= 5
+# (e.g. ECONNRESET, OOMKILLED, E_DB_TIMEOUT, ERROR_RATE_LIMIT).
+#
+# We deliberately require at least one underscore OR a length >= 6 to avoid
+# matching short all-caps acronyms (AWS, JSON, HTTP) that frequently appear
+# in normal prose.  The 5-char minimum from the issue scope is preserved
+# for tokens that contain an underscore (e.g. ``E_DB``).
+_RE_ERROR_TOKEN = re.compile(
+    r"(?<![A-Za-z0-9_])"
+    r"([A-Z][A-Z0-9_]{4,})"
+    r"(?![A-Za-z0-9_])",
+)
+
+# Code-fence stripper: removes everything between triple backticks (multi-line)
+# and inside single backtick spans (single-line).  Applied before mention
+# extraction to skip user-quoted payloads.  Order matters — fences first,
+# inline second, otherwise the fence's body would be re-scanned as inline.
+_RE_CODE_FENCE = re.compile(r"```.*?```", re.DOTALL)
+_RE_INLINE_CODE = re.compile(r"`[^`]*`")
+
+# Common false-positive tokens that match the error-token regex but are not
+# actual error codes.  Filtered explicitly so they do not poison the graph.
+_ERROR_TOKEN_DENYLIST: frozenset[str] = frozenset(
+    {
+        "TODO",
+        "FIXME",
+        "XXX",
+        "NOTE",
+        "WARNING",
+        "INFO",
+        "DEBUG",
+        "TRACE",
+        "HTTPS",
+        "JSON",
+        "YAML",
+        "HTML",
+        "XHTML",
+        "REST",
+        "GRPC",
+        "MAYBE",
+        "ALWAYS",
+        "NEVER",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Canonical name builders
+# ---------------------------------------------------------------------------
+
+
+def slack_thread_name(channel_id: str, thread_ts: str) -> str:
+    """Return the canonical name for a Slack thread entity.
+
+    Matches the ``DocumentRef.uri`` form already produced by
+    :meth:`SlackConnector.discover` so the same string appears in both
+    the document-side index and the graph-side entity row.
+    """
+    return f"slack://channel/{channel_id}/thread/{thread_ts}"
+
+
+def _slack_message_name(channel_id: str, ts: str) -> str:
+    """Canonical name for a single Slack message (root or reply)."""
+    return f"slack://channel/{channel_id}/message/{ts}"
+
+
+def _slack_user_name(user_id: str) -> str:
+    """Canonical name for a Slack user entity."""
+    return f"slack://user/{user_id}"
+
+
+def _slack_channel_name(channel_id: str) -> str:
+    """Canonical name for a Slack channel entity."""
+    return f"slack://channel/{channel_id}"
+
+
+# ---------------------------------------------------------------------------
+# Mention extraction
+# ---------------------------------------------------------------------------
+
+
+def _strip_code(text: str) -> str:
+    """Return *text* with Markdown code fences and inline code spans removed.
+
+    Order matters — fenced blocks first (``re.DOTALL``), inline spans second.
+    Whitespace inside the stripped regions is replaced with a space so the
+    surrounding regex anchors still see word boundaries cleanly.
+    """
+    no_fences = _RE_CODE_FENCE.sub(" ", text)
+    return _RE_INLINE_CODE.sub(" ", no_fences)
+
+
+def _trim_trailing_punct(s: str) -> str:
+    """Strip URL-trailing punctuation that is almost always sentence punctuation."""
+    return s.rstrip(".,;:!?)]>'\"")
+
+
+def extract_mentions(text: str) -> dict[str, list[str]]:
+    """Extract mention strings from a Slack message body.
+
+    Args:
+        text: Raw Slack message text (Markdown).
+
+    Returns:
+        A dict with keys ``"pr_urls"``, ``"arns"``, ``"pods"``, ``"errors"``
+        and lists of unique canonical strings (insertion-order preserved)
+        for each category.  An empty list is returned when no matches fire.
+
+    Notes:
+        - Markdown code fences (triple-backtick blocks) and inline code
+          spans (single-backtick spans) are stripped before extraction so
+          user-quoted payloads cannot inject false mentions.
+        - All four extractors are independent — a token can in principle
+          match more than one (e.g. an all-caps ARN segment vs an error
+          token), but the regex anchors are disjoint enough in practice
+          that this does not happen with realistic Slack content.
+    """
+    cleaned = _strip_code(text)
+
+    pr_urls: list[str] = list(
+        dict.fromkeys(_trim_trailing_punct(m) for m in _RE_PR_URL.findall(cleaned))
+    )
+    arns: list[str] = list(
+        dict.fromkeys(_trim_trailing_punct(m) for m in _RE_ARN.findall(cleaned))
+    )
+    pods: list[str] = list(dict.fromkeys(_RE_POD_NAME.findall(cleaned)))
+    errors: list[str] = [
+        tok
+        for tok in dict.fromkeys(_RE_ERROR_TOKEN.findall(cleaned))
+        if tok not in _ERROR_TOKEN_DENYLIST
+    ]
+
+    return {
+        "pr_urls": pr_urls,
+        "arns": arns,
+        "pods": pods,
+        "errors": errors,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Structural entity builders
+# ---------------------------------------------------------------------------
+
+
+def _thread_entity(
+    channel_id: str,
+    thread_ts: str,
+    *,
+    channel_name: str,
+    message_count: int,
+    root_author: str,
+    earliest_ts: str,
+    latest_ts: str,
+) -> EntityData:
+    """Build the ``slack_thread`` entity for a fetched thread."""
+    return EntityData(
+        symbol=slack_thread_name(channel_id, thread_ts),
+        kind="slack_thread",
+        name=slack_thread_name(channel_id, thread_ts),
+        extra={
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "thread_ts": thread_ts,
+            "message_count": message_count,
+            "root_author": root_author,
+            "earliest_ts": earliest_ts,
+            "latest_ts": latest_ts,
+            "extractor_version": EXTRACTOR_VERSION,
+        },
+    )
+
+
+def _message_entity(channel_id: str, message_ts: str, author: str) -> EntityData:
+    """Build a ``slack_message`` entity for a single root or reply message."""
+    return EntityData(
+        symbol=_slack_message_name(channel_id, message_ts),
+        kind="slack_message",
+        name=_slack_message_name(channel_id, message_ts),
+        extra={
+            "channel_id": channel_id,
+            "message_ts": message_ts,
+            "author": author,
+            "extractor_version": EXTRACTOR_VERSION,
+        },
+    )
+
+
+def _user_entity(user_id: str) -> EntityData:
+    """Build a ``slack_user`` entity for a message author."""
+    return EntityData(
+        symbol=_slack_user_name(user_id),
+        kind="slack_user",
+        name=_slack_user_name(user_id),
+        extra={"user_id": user_id, "extractor_version": EXTRACTOR_VERSION},
+    )
+
+
+def _channel_entity(channel_id: str, channel_name: str) -> EntityData:
+    """Build a ``slack_channel`` entity for a referenced channel."""
+    return EntityData(
+        symbol=_slack_channel_name(channel_id),
+        kind="slack_channel",
+        name=_slack_channel_name(channel_id),
+        extra={
+            "channel_id": channel_id,
+            "channel_name": channel_name,
+            "extractor_version": EXTRACTOR_VERSION,
+        },
+    )
+
+
+def _mention_entity(canonical_name: str, mention_kind: str) -> EntityData:
+    """Build a ``slack_mention`` entity for a single canonical mention string.
+
+    ``mention_kind`` is the *category* of the mention (``pr_url``, ``arn``,
+    ``pod``, ``error``) and is stored under ``extra['mention_kind']`` so
+    retrieval can filter by category.  The entity ``kind`` field stays the
+    coarse :data:`MENTION_KIND` so the downstream graph store can apply
+    a uniform label.
+    """
+    return EntityData(
+        symbol=canonical_name,
+        kind=MENTION_KIND,
+        name=canonical_name,
+        extra={
+            "mention_kind": mention_kind,
+            "extractor_version": EXTRACTOR_VERSION,
+        },
+    )
+
+
+def _structural_edges(
+    *,
+    channel_id: str,
+    thread_ts: str,
+    channel_name: str,
+    messages: list[dict[str, str]],
+) -> list[EdgeData]:
+    """Build IN_THREAD, AUTHORED, and IN_CHANNEL edges for a thread."""
+    thread_sym = slack_thread_name(channel_id, thread_ts)
+    edges: list[EdgeData] = [
+        EdgeData(
+            from_symbol=thread_sym,
+            to_symbol=_slack_channel_name(channel_id),
+            edge_type="in_channel",
+            extra={"channel_name": channel_name},
+        ),
+    ]
+    for msg in messages:
+        msg_sym = _slack_message_name(channel_id, msg["ts"])
+        edges.append(
+            EdgeData(
+                from_symbol=msg_sym,
+                to_symbol=thread_sym,
+                edge_type="in_thread",
+            )
+        )
+        author = msg.get("user", "")
+        if author:
+            edges.append(
+                EdgeData(
+                    from_symbol=_slack_user_name(author),
+                    to_symbol=msg_sym,
+                    edge_type="authored",
+                )
+            )
+    return edges
+
+
+def _mention_edges(
+    *,
+    channel_id: str,
+    thread_ts: str,
+    mentions_by_message: list[tuple[str, dict[str, list[str]]]],
+) -> tuple[list[EntityData], list[EdgeData]]:
+    """Build mention-target entities + ``mentions`` edges for one thread.
+
+    Edges go from the SlackThread (NOT individual messages) so retrieval
+    needs only one hop from a matched mention to reach the discussion.
+    The decision is documented in the issue (#149: "the implementer
+    picks").  Per-message granularity remains available via the
+    ``IN_THREAD`` edge if a follow-up wants tighter localisation.
+
+    Args:
+        channel_id: The Slack channel id (used to build the thread symbol).
+        thread_ts: The Slack thread root timestamp.
+        mentions_by_message: Sequence of ``(message_ts, mentions_dict)``
+            pairs from :func:`extract_mentions`.  ``message_ts`` is unused
+            for edge construction (we go thread-level) but kept in the
+            signature so a follow-up can switch granularity without
+            re-extracting.
+
+    Returns:
+        ``(mention_entities, mention_edges)`` — entities are deduped by
+        canonical name across all messages in the thread.
+    """
+    seen: dict[str, str] = {}  # canonical_name -> mention_kind
+    for _msg_ts, mentions in mentions_by_message:
+        for kind, names in mentions.items():
+            for name in names:
+                # First occurrence wins; later messages don't change kind.
+                if name not in seen:
+                    seen[name] = kind
+
+    entities = [_mention_entity(name, kind) for name, kind in seen.items()]
+    thread_sym = slack_thread_name(channel_id, thread_ts)
+    edges = [
+        EdgeData(
+            from_symbol=thread_sym,
+            to_symbol=name,
+            edge_type="mentions",
+            extra={"mention_kind": kind},
+        )
+        for name, kind in seen.items()
+    ]
+    return entities, edges
+
+
+# ---------------------------------------------------------------------------
+# Top-level entrypoint
+# ---------------------------------------------------------------------------
+
+
+def build_thread_entities(
+    *,
+    channel_id: str,
+    thread_ts: str,
+    channel_name: str,
+    messages: list[dict[str, str]],
+) -> tuple[list[EntityData], list[EdgeData]]:
+    """Build the structural entity graph for one Slack thread (no mentions).
+
+    Public for tests; production code should call
+    :func:`extract_slack_graph` instead — it includes mention extraction.
+    """
+    if not messages:
+        return [], []
+
+    timestamps = [m["ts"] for m in messages if m.get("ts")]
+    earliest = min(timestamps) if timestamps else thread_ts
+    latest = max(timestamps) if timestamps else thread_ts
+    root_author = messages[0].get("user", "")
+
+    entities: list[EntityData] = [
+        _thread_entity(
+            channel_id,
+            thread_ts,
+            channel_name=channel_name,
+            message_count=len(messages),
+            root_author=root_author,
+            earliest_ts=earliest,
+            latest_ts=latest,
+        ),
+        _channel_entity(channel_id, channel_name),
+    ]
+    seen_users: set[str] = set()
+    for msg in messages:
+        entities.append(_message_entity(channel_id, msg["ts"], msg.get("user", "")))
+        author = msg.get("user", "")
+        if author and author not in seen_users:
+            entities.append(_user_entity(author))
+            seen_users.add(author)
+
+    edges = _structural_edges(
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        channel_name=channel_name,
+        messages=messages,
+    )
+    return entities, edges
+
+
+def extract_slack_graph(
+    *,
+    channel_id: str,
+    thread_ts: str,
+    channel_name: str,
+    messages: list[dict[str, Any]],
+) -> tuple[list[EntityData], list[EdgeData]]:
+    """Extract the full Slack entity surface for one fetched thread.
+
+    Combines structural entities with mention-target entities + edges.
+    The connector calls this from :meth:`SlackConnector.fetch` and stamps
+    the result onto ``DocumentRef.metadata`` (keys ``entities`` /
+    ``edges``) for the downstream pipeline.
+
+    Args:
+        channel_id: Slack channel id (the trusted ACL handle is set by
+            the pipeline; this is passed through only for canonical-name
+            construction).
+        thread_ts: Root message timestamp of the thread.
+        channel_name: Human-readable channel name (best-effort; falls
+            back to ``channel_id`` when unknown).
+        messages: List of Slack message dicts (root + replies, in
+            chronological order).  Each dict must carry ``ts`` and
+            ``text``; ``user`` and ``thread_ts`` are optional.
+
+    Returns:
+        ``(entities, edges)`` — flat lists.  Order is stable across calls
+        with identical input so test assertions can rely on it.
+    """
+    str_messages: list[dict[str, str]] = [
+        {
+            "ts": str(m.get("ts", "")),
+            "user": str(m.get("user", "")),
+            "text": str(m.get("text", "")),
+        }
+        for m in messages
+    ]
+    structural_entities, structural_edges = build_thread_entities(
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        channel_name=channel_name,
+        messages=str_messages,
+    )
+
+    mentions_by_message: list[tuple[str, dict[str, list[str]]]] = [
+        (m["ts"], extract_mentions(m["text"])) for m in str_messages
+    ]
+    mention_entities, mention_edges = _mention_edges(
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        mentions_by_message=mentions_by_message,
+    )
+
+    return structural_entities + mention_entities, structural_edges + mention_edges

--- a/tests/test_slack_connector_entities.py
+++ b/tests/test_slack_connector_entities.py
@@ -1,0 +1,325 @@
+"""Slack connector entity-emission integration tests (issue #149).
+
+Asserts that :meth:`SlackConnector.fetch` stamps the extracted entity
+surface onto ``DocumentRef.metadata`` for the downstream ingestion
+pipeline AND that the ACL invariant holds — workspace identity is
+NEVER inferred from the Slack payload.
+
+Existing fetch / discover behaviour is covered in
+``tests/test_connectors_v2.py``; this file is additive.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from omniscience_connectors import DocumentRef, SlackConnector
+from omniscience_connectors.slack.connector import SlackConfig
+from omniscience_connectors.slack.entities import (
+    MENTION_KIND,
+    EdgeData,
+    EntityData,
+    slack_thread_name,
+)
+
+_SLACK_TOKEN = "xoxb-fake-token"
+
+
+def _ents(metadata: dict[str, Any]) -> list[EntityData]:
+    raw = metadata.get("entities", [])
+    assert isinstance(raw, list)
+    return raw  # type: ignore[no-any-return]
+
+
+def _edges(metadata: dict[str, Any]) -> list[EdgeData]:
+    raw = metadata.get("edges", [])
+    assert isinstance(raw, list)
+    return raw  # type: ignore[no-any-return]
+
+
+def _names_of_kind(entities: list[EntityData], kind: str) -> list[str]:
+    return [e.name for e in entities if e.kind == kind]
+
+
+def _mock_thread(
+    *,
+    channel_id: str,
+    thread_ts: str,
+    root_text: str,
+    reply_text: str,
+    reply_ts: str = "1700000060.000200",
+) -> None:
+    """Install respx mocks for a single Slack thread fetch."""
+    respx.get("https://slack.com/api/conversations.history").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "messages": [
+                    {"user": "U_SRE", "ts": thread_ts, "text": root_text},
+                ],
+            },
+        )
+    )
+    respx.get("https://slack.com/api/conversations.replies").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "messages": [
+                    {"user": "U_SRE", "ts": thread_ts, "text": root_text},
+                    {"user": "U_DEV", "ts": reply_ts, "text": reply_text},
+                ],
+                "has_more": False,
+                "response_metadata": {"next_cursor": ""},
+            },
+        )
+    )
+
+
+# ===========================================================================
+# Connector emits entities + edges via ref.metadata
+# ===========================================================================
+
+
+class TestConnectorEntityEmission:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_stamps_thread_and_mention_entities(self) -> None:
+        channel_id = "C_INC"
+        thread_ts = "1700000000.000100"
+        root_text = "Investigating https://github.com/acme/api/pull/42"
+        reply_text = "Pod web-frontend-7d9f8b4c8-xk5pq OOMKILLED. Bucket arn:aws:s3:::acme-logs."
+        _mock_thread(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            root_text=root_text,
+            reply_text=reply_text,
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(include_threads=True)
+        ref = DocumentRef(
+            external_id="abc",
+            uri=f"slack://channel/{channel_id}/thread/{thread_ts}",
+            metadata={
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "channel_name": "incidents",
+            },
+        )
+        result = await connector.fetch(config, {"bot_token": _SLACK_TOKEN}, ref)
+
+        # Backwards compat: existing Markdown content shape preserved.
+        body = result.content_bytes.decode()
+        assert "OOMKILLED" in body
+        assert "https://github.com/acme/api/pull/42" in body
+
+        ents = _ents(ref.metadata)
+        edges = _edges(ref.metadata)
+
+        # SlackThread carries the canonical name shape.
+        threads = [e for e in ents if e.kind == "slack_thread"]
+        assert len(threads) == 1
+        assert threads[0].name == slack_thread_name(channel_id, thread_ts)
+
+        # Four mention-target entities: PR + ARN + pod + OOMKILLED.
+        mentions = sorted(_names_of_kind(ents, MENTION_KIND))
+        assert mentions == sorted(
+            [
+                "arn:aws:s3:::acme-logs",
+                "https://github.com/acme/api/pull/42",
+                "OOMKILLED",
+                "web-frontend-7d9f8b4c8-xk5pq",
+            ]
+        )
+
+        # Each mention has a thread -> mention edge (linker picks them up).
+        thread_sym = slack_thread_name(channel_id, thread_ts)
+        mention_edges = [(e.from_symbol, e.to_symbol) for e in edges if e.edge_type == "mentions"]
+        assert {to for _from, to in mention_edges} == set(mentions)
+        assert all(frm == thread_sym for frm, _to in mention_edges)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fetch_with_no_mentions_emits_only_structural(self) -> None:
+        # Backwards compat sanity: a no-mention thread still produces the
+        # structural entity surface but no mention-target entities.
+        channel_id = "C_OPS"
+        thread_ts = "1700000000.000100"
+        _mock_thread(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            root_text="Looking into it.",
+            reply_text="Got it, working now.",
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(include_threads=True)
+        ref = DocumentRef(
+            external_id="abc",
+            uri=f"slack://channel/{channel_id}/thread/{thread_ts}",
+            metadata={
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "channel_name": "ops",
+            },
+        )
+        await connector.fetch(config, {"bot_token": _SLACK_TOKEN}, ref)
+
+        ents = _ents(ref.metadata)
+        assert _names_of_kind(ents, MENTION_KIND) == []
+        # 1 thread + 1 channel + 2 messages + 2 users = 6 structural.
+        assert len(ents) == 6
+
+
+# ===========================================================================
+# ACL invariant — workspace_id NEVER inferred from Slack payload
+# ===========================================================================
+
+
+class TestWorkspaceAclInvariant:
+    """Cross-workspace isolation contract for the Slack entity surface.
+
+    The Slack connector emits entities by NAME only — workspace
+    stamping happens later in
+    :func:`omniscience_server.ingestion.pipeline._tag_entity_workspace`
+    using the ``Source.tenant_id`` resolved by the worker.  This test
+    asserts that the connector's emission is workspace-agnostic: two
+    different ``Source`` rows pointing at the same Slack thread (same
+    payload, same mention strings) emit IDENTICAL entity/edge data
+    irrespective of any payload field.
+
+    The actual cross-workspace edge isolation is enforced in the graph
+    layer (``test_graphrag_workspace_isolation``); the connector-level
+    invariant we assert here is that the connector NEVER reads
+    ``team_id``, ``user.team`` or any other payload field as a
+    workspace hint.
+    """
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_payload_team_id_does_not_leak_into_entities(self) -> None:
+        # The Slack message payload includes a ``team`` field; a buggy
+        # implementation might use it as a workspace hint.  This test
+        # asserts that even when a hostile payload sets ``team`` to a
+        # different value than the connector's source-config workspace,
+        # the emitted entity names contain ZERO references to team or
+        # any payload-derived workspace identity.
+        channel_id = "C_HOSTILE"
+        thread_ts = "1700000000.000100"
+
+        # Hostile payload: pretends to be from "evil-team" and tries to
+        # use a workspace-shaped string in the message body.  None of
+        # this should appear in emitted entity names.
+        respx.get("https://slack.com/api/conversations.history").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "messages": [
+                        {
+                            "user": "U_HOSTILE",
+                            "ts": thread_ts,
+                            "team": "T_EVIL",
+                            "text": "workspace://evil-team — payload PR ref: "
+                            "https://github.com/acme/api/pull/42",
+                        }
+                    ],
+                },
+            )
+        )
+        respx.get("https://slack.com/api/conversations.replies").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "messages": [],
+                    "has_more": False,
+                    "response_metadata": {"next_cursor": ""},
+                },
+            )
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(include_threads=True)
+        ref = DocumentRef(
+            external_id="x",
+            uri=f"slack://channel/{channel_id}/thread/{thread_ts}",
+            # The trusted handle here is ``channel_id``; ``team`` from
+            # the payload MUST NOT be used.  We deliberately omit any
+            # team_id from the metadata to make the contract explicit.
+            metadata={
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "channel_name": "hostile",
+            },
+        )
+        await connector.fetch(config, {"bot_token": _SLACK_TOKEN}, ref)
+
+        ents = _ents(ref.metadata)
+        # The emitted thread name uses ``channel_id`` (trusted source-
+        # config handle), NEVER the payload's ``team`` field.
+        thread_names = _names_of_kind(ents, "slack_thread")
+        assert thread_names == [slack_thread_name(channel_id, thread_ts)]
+        # No entity carries the payload's ``T_EVIL`` team id.
+        all_names = " ".join(e.name for e in ents)
+        assert "T_EVIL" not in all_names
+        # No entity carries any ``workspace_id`` either — that stamp is
+        # the ingestion pipeline's responsibility, not the connector's.
+        for e in ents:
+            assert "workspace_id" not in e.extra
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_two_workspaces_same_thread_emit_identical_entities(self) -> None:
+        # Same Slack thread (channel + ts + content) produces byte-identical
+        # entity NAMES regardless of which Source.tenant_id eventually
+        # owns them.  The pipeline tags the workspace; the connector does
+        # not.  This is the connector-level half of the cross-workspace
+        # isolation property; the graph-level half lives in
+        # ``test_graphrag_workspace_isolation``.
+        channel_id = "C_SHARED"
+        thread_ts = "1700000000.000100"
+        _mock_thread(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            root_text="Same content https://github.com/acme/api/pull/42",
+            reply_text="ack",
+        )
+
+        connector = SlackConnector()
+        config = SlackConfig(include_threads=True)
+        # Two refs differing only in external_id (representing two Source
+        # rows that both happen to subscribe to the same channel).
+        ref_a = DocumentRef(
+            external_id="src-A",
+            uri=f"slack://channel/{channel_id}/thread/{thread_ts}",
+            metadata={
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "channel_name": "shared",
+            },
+        )
+        ref_b = DocumentRef(
+            external_id="src-B",
+            uri=f"slack://channel/{channel_id}/thread/{thread_ts}",
+            metadata={
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "channel_name": "shared",
+            },
+        )
+        await connector.fetch(config, {"bot_token": _SLACK_TOKEN}, ref_a)
+        await connector.fetch(config, {"bot_token": _SLACK_TOKEN}, ref_b)
+
+        # Names must be identical between A and B because the connector
+        # never reads workspace from the payload.  The ingestion pipeline
+        # is the place where the same name in two workspaces becomes two
+        # distinct rows scoped by workspace_id.
+        names_a = sorted(e.name for e in _ents(ref_a.metadata))
+        names_b = sorted(e.name for e in _ents(ref_b.metadata))
+        assert names_a == names_b

--- a/tests/test_slack_entity_extraction.py
+++ b/tests/test_slack_entity_extraction.py
@@ -1,0 +1,393 @@
+"""Slack entity / mention extraction tests (issue #149).
+
+Covers the four mention extractors (PR URL, ARN, pod name, error token),
+the structural entity surface (slack_thread / slack_message / slack_user
+/ slack_channel), the canonical-name shape, and the false-positive
+handling for code fences and inline code spans.
+
+The cross-workspace isolation property is asserted in
+:mod:`tests.test_slack_connector_entities` (integration scope) — this
+file keeps to pure-function unit coverage.
+"""
+
+from __future__ import annotations
+
+from omniscience_connectors.slack.entities import (
+    EXTRACTOR_VERSION,
+    MENTION_KIND,
+    EdgeData,
+    EntityData,
+    build_thread_entities,
+    extract_mentions,
+    extract_slack_graph,
+    slack_thread_name,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ents_by_kind(entities: list[EntityData], kind: str) -> list[EntityData]:
+    return [e for e in entities if e.kind == kind]
+
+
+def _names(entities: list[EntityData]) -> list[str]:
+    return [e.name for e in entities]
+
+
+def _edge_pairs(edges: list[EdgeData], edge_type: str) -> list[tuple[str, str]]:
+    return [(e.from_symbol, e.to_symbol) for e in edges if e.edge_type == edge_type]
+
+
+# ===========================================================================
+# Mention extraction — PR URLs
+# ===========================================================================
+
+
+class TestPrUrlExtraction:
+    def test_clean_url_in_prose(self) -> None:
+        text = "See https://github.com/foo/bar/pull/42 for the fix."
+        out = extract_mentions(text)
+        assert out["pr_urls"] == ["https://github.com/foo/bar/pull/42"]
+
+    def test_url_with_query_string_keeps_base(self) -> None:
+        # The canonical name emitted MUST be the bare URL form so it
+        # matches what the GitHub PR/MR connector emits as PR.name.
+        text = "Diff at https://github.com/foo/bar/pull/42?diff=split now."
+        out = extract_mentions(text)
+        assert out["pr_urls"] == ["https://github.com/foo/bar/pull/42"]
+
+    def test_url_inside_markdown_link(self) -> None:
+        text = "[the fix](https://github.com/foo/bar/pull/42)"
+        out = extract_mentions(text)
+        assert out["pr_urls"] == ["https://github.com/foo/bar/pull/42"]
+
+    def test_repeated_url_is_deduped(self) -> None:
+        text = "See https://github.com/foo/bar/pull/42 . Again: https://github.com/foo/bar/pull/42"
+        out = extract_mentions(text)
+        assert out["pr_urls"] == ["https://github.com/foo/bar/pull/42"]
+
+    def test_url_inside_code_fence_is_skipped(self) -> None:
+        # Code fences carry user-pasted content that must not pollute the
+        # graph (issue #149 false-positive requirement).
+        text = "```\nhttps://github.com/foo/bar/pull/9999\n```"
+        out = extract_mentions(text)
+        assert out["pr_urls"] == []
+
+    def test_inline_code_span_is_skipped(self) -> None:
+        text = "Don't reference `https://github.com/foo/bar/pull/9999` directly."
+        out = extract_mentions(text)
+        assert out["pr_urls"] == []
+
+    def test_non_pull_path_is_ignored(self) -> None:
+        # Issues, commits, blob URLs are explicitly NOT in scope for #149.
+        text = "https://github.com/foo/bar/issues/42"
+        out = extract_mentions(text)
+        assert out["pr_urls"] == []
+
+
+# ===========================================================================
+# Mention extraction — ARNs
+# ===========================================================================
+
+
+class TestArnExtraction:
+    def test_s3_bucket_arn(self) -> None:
+        text = "Bucket arn:aws:s3:::pilot-logs is empty."
+        out = extract_mentions(text)
+        assert out["arns"] == ["arn:aws:s3:::pilot-logs"]
+
+    def test_iam_role_arn(self) -> None:
+        text = "Assume arn:aws:iam::123456789012:role/EKSClusterRole then."
+        out = extract_mentions(text)
+        assert out["arns"] == ["arn:aws:iam::123456789012:role/EKSClusterRole"]
+
+    def test_ec2_instance_arn(self) -> None:
+        text = "Instance arn:aws:ec2:us-east-1:123456789012:instance/i-0abc123."
+        out = extract_mentions(text)
+        assert out["arns"] == ["arn:aws:ec2:us-east-1:123456789012:instance/i-0abc123"]
+
+    def test_china_partition_arn(self) -> None:
+        text = "China region: arn:aws-cn:s3:::cn-bucket"
+        out = extract_mentions(text)
+        assert out["arns"] == ["arn:aws-cn:s3:::cn-bucket"]
+
+    def test_arn_inside_code_fence_skipped(self) -> None:
+        # The classic adversarial case: a user pastes an example ARN block.
+        text = "Example payload:\n```\narn:aws:iam::000000000000:user/example\n```"
+        out = extract_mentions(text)
+        assert out["arns"] == []
+
+    def test_arn_inside_inline_code_skipped(self) -> None:
+        text = "The format is `arn:aws:s3:::example-bucket` — never paste real ones."
+        out = extract_mentions(text)
+        assert out["arns"] == []
+
+    def test_bare_arn_colon_does_not_match(self) -> None:
+        # ``arn:`` followed by whitespace is sentence prose, not an ARN.
+        text = "The arn: format is documented at AWS."
+        out = extract_mentions(text)
+        assert out["arns"] == []
+
+
+# ===========================================================================
+# Mention extraction — pod names
+# ===========================================================================
+
+
+class TestPodNameExtraction:
+    def test_classic_replicaset_pod_name(self) -> None:
+        text = "Pod web-frontend-7d9f8b4c8-xk5pq is in CrashLoopBackOff."
+        out = extract_mentions(text)
+        assert out["pods"] == ["web-frontend-7d9f8b4c8-xk5pq"]
+
+    def test_multi_segment_deployment_name(self) -> None:
+        text = "checking api-backend-v2-66dccfb9b8-z2w8m logs"
+        out = extract_mentions(text)
+        assert out["pods"] == ["api-backend-v2-66dccfb9b8-z2w8m"]
+
+    def test_pod_inside_code_fence_skipped(self) -> None:
+        text = "```\nweb-frontend-7d9f8b4c8-xk5pq\n```"
+        out = extract_mentions(text)
+        assert out["pods"] == []
+
+    def test_no_match_for_short_hash(self) -> None:
+        # Hash segment must be >= 8 hex chars; deployment-only names are
+        # not reliable pod names so we reject them.
+        text = "web-frontend-abc-xk5pq"
+        out = extract_mentions(text)
+        assert out["pods"] == []
+
+    def test_no_match_for_uppercase(self) -> None:
+        # K8s pod names are always lowercase per RFC 1123.
+        text = "Web-Frontend-7d9f8b4c8-XK5PQ"
+        out = extract_mentions(text)
+        assert out["pods"] == []
+
+
+# ===========================================================================
+# Mention extraction — error tokens
+# ===========================================================================
+
+
+class TestErrorTokenExtraction:
+    def test_classic_econnreset(self) -> None:
+        text = "Got ECONNRESET from upstream at 14:23 UTC."
+        out = extract_mentions(text)
+        assert "ECONNRESET" in out["errors"]
+
+    def test_oomkilled(self) -> None:
+        text = "Pod was OOMKILLED last night."
+        out = extract_mentions(text)
+        assert "OOMKILLED" in out["errors"]
+
+    def test_underscore_token(self) -> None:
+        text = "Saw E_DB_TIMEOUT three times in a row."
+        out = extract_mentions(text)
+        assert "E_DB_TIMEOUT" in out["errors"]
+
+    def test_denylist_filters_common_words(self) -> None:
+        # TODO/FIXME/HTTPS/JSON match the regex shape but are not error
+        # codes — they would otherwise pollute every Slack thread.
+        text = "TODO check this. Use HTTPS. Parse JSON output."
+        out = extract_mentions(text)
+        assert out["errors"] == []
+
+    def test_short_acronym_rejected(self) -> None:
+        # Length < 5 — single-token acronyms like AWS, FOO are noise.
+        text = "AWS is fine. FOO is a placeholder."
+        out = extract_mentions(text)
+        assert out["errors"] == []
+
+    def test_error_inside_code_fence_skipped(self) -> None:
+        # Counter-example: an error inside a fence is treated as quoted
+        # diagnostic output and skipped (issue #149: code-fence false-
+        # positive rejection requirement).  Decision documented in the
+        # extractor module.
+        text = "```\npanic: ECONNRESET\n```"
+        out = extract_mentions(text)
+        assert out["errors"] == []
+
+
+# ===========================================================================
+# Structural entities + canonical names
+# ===========================================================================
+
+
+class TestStructuralEntities:
+    _CHANNEL = "C123"
+    _THREAD_TS = "1700000000.000100"
+    _CHANNEL_NAME = "incidents"
+
+    def _messages(self) -> list[dict[str, str]]:
+        return [
+            {"ts": self._THREAD_TS, "user": "U_ALICE", "text": "Issue spotted."},
+            {"ts": "1700000060.000200", "user": "U_BOB", "text": "Looking now."},
+            {"ts": "1700000120.000300", "user": "U_ALICE", "text": "Fixed in PR."},
+        ]
+
+    def test_slack_thread_canonical_name(self) -> None:
+        # The canonical name MUST equal the URI form already used by
+        # SlackConnector.discover so the document-side index and graph
+        # entity row carry the same string (linker exact_name relies on it).
+        name = slack_thread_name(self._CHANNEL, self._THREAD_TS)
+        assert name == "slack://channel/C123/thread/1700000000.000100"
+
+    def test_thread_entity_emitted_with_canonical_name(self) -> None:
+        entities, _edges = build_thread_entities(
+            channel_id=self._CHANNEL,
+            thread_ts=self._THREAD_TS,
+            channel_name=self._CHANNEL_NAME,
+            messages=self._messages(),
+        )
+        threads = _ents_by_kind(entities, "slack_thread")
+        assert len(threads) == 1
+        assert threads[0].name == slack_thread_name(self._CHANNEL, self._THREAD_TS)
+        assert threads[0].extra["message_count"] == 3
+        assert threads[0].extra["root_author"] == "U_ALICE"
+        assert threads[0].extra["earliest_ts"] == self._THREAD_TS
+        assert threads[0].extra["latest_ts"] == "1700000120.000300"
+        assert threads[0].extra["extractor_version"] == EXTRACTOR_VERSION
+
+    def test_messages_users_channel_emitted(self) -> None:
+        entities, _ = build_thread_entities(
+            channel_id=self._CHANNEL,
+            thread_ts=self._THREAD_TS,
+            channel_name=self._CHANNEL_NAME,
+            messages=self._messages(),
+        )
+        assert len(_ents_by_kind(entities, "slack_message")) == 3
+        # Two distinct users: U_ALICE (twice) and U_BOB — dedup by user_id.
+        users = _ents_by_kind(entities, "slack_user")
+        assert sorted(_names(users)) == ["slack://user/U_ALICE", "slack://user/U_BOB"]
+        channels = _ents_by_kind(entities, "slack_channel")
+        assert _names(channels) == ["slack://channel/C123"]
+
+    def test_structural_edges(self) -> None:
+        _ents, edges = build_thread_entities(
+            channel_id=self._CHANNEL,
+            thread_ts=self._THREAD_TS,
+            channel_name=self._CHANNEL_NAME,
+            messages=self._messages(),
+        )
+        thread_sym = slack_thread_name(self._CHANNEL, self._THREAD_TS)
+        # Three IN_THREAD edges (one per message).
+        in_thread = _edge_pairs(edges, "in_thread")
+        assert len(in_thread) == 3
+        assert all(to == thread_sym for _from, to in in_thread)
+
+        # One IN_CHANNEL edge thread -> channel.
+        in_channel = _edge_pairs(edges, "in_channel")
+        assert in_channel == [(thread_sym, "slack://channel/C123")]
+
+        # AUTHORED edges: 3 messages, each one authored by its user.
+        authored = _edge_pairs(edges, "authored")
+        assert len(authored) == 3
+
+
+# ===========================================================================
+# extract_slack_graph (top-level): mentions become entities + cross-ref edges
+# ===========================================================================
+
+
+class TestSlackGraphMentions:
+    _CHANNEL = "C_INC"
+    _THREAD_TS = "1700001000.000100"
+    _CHANNEL_NAME = "incidents"
+
+    def test_pr_mention_creates_named_entity_and_edge(self) -> None:
+        messages = [
+            {
+                "ts": self._THREAD_TS,
+                "user": "U_SRE",
+                "text": "Probably https://github.com/acme/api/pull/42",
+            }
+        ]
+        entities, edges = extract_slack_graph(
+            channel_id=self._CHANNEL,
+            thread_ts=self._THREAD_TS,
+            channel_name=self._CHANNEL_NAME,
+            messages=messages,
+        )
+        mentions = _ents_by_kind(entities, MENTION_KIND)
+        # The mention entity carries the canonical PR URL as its name.
+        # The linker's exact_name strategy will match this against the
+        # GitHub PR/MR connector's PR entity (issue #150) which uses the
+        # same string as ``name``.
+        assert _names(mentions) == ["https://github.com/acme/api/pull/42"]
+        assert mentions[0].extra["mention_kind"] == "pr_urls"
+
+        thread_sym = slack_thread_name(self._CHANNEL, self._THREAD_TS)
+        mention_edges = _edge_pairs(edges, "mentions")
+        assert mention_edges == [(thread_sym, "https://github.com/acme/api/pull/42")]
+
+    def test_arn_pod_error_in_one_thread(self) -> None:
+        # Mixed-mention thread.  Three categories must produce three
+        # mention-target entities + three thread->mention edges.
+        messages = [
+            {
+                "ts": self._THREAD_TS,
+                "user": "U_SRE",
+                "text": (
+                    "Pod web-frontend-7d9f8b4c8-xk5pq is OOMKILLED. "
+                    "Resource: arn:aws:ec2:us-east-1:111122223333:instance/i-0abc."
+                ),
+            }
+        ]
+        entities, edges = extract_slack_graph(
+            channel_id=self._CHANNEL,
+            thread_ts=self._THREAD_TS,
+            channel_name=self._CHANNEL_NAME,
+            messages=messages,
+        )
+        mention_names = sorted(_names(_ents_by_kind(entities, MENTION_KIND)))
+        assert mention_names == sorted(
+            [
+                "arn:aws:ec2:us-east-1:111122223333:instance/i-0abc",
+                "OOMKILLED",
+                "web-frontend-7d9f8b4c8-xk5pq",
+            ]
+        )
+        assert len(_edge_pairs(edges, "mentions")) == 3
+
+    def test_no_mentions_yields_only_structural(self) -> None:
+        # Sanity: a thread with no canonical strings still emits structural
+        # entities (thread/message/user/channel) but no mention entities.
+        messages = [{"ts": self._THREAD_TS, "user": "U_SRE", "text": "Looking into it."}]
+        entities, edges = extract_slack_graph(
+            channel_id=self._CHANNEL,
+            thread_ts=self._THREAD_TS,
+            channel_name=self._CHANNEL_NAME,
+            messages=messages,
+        )
+        assert _ents_by_kind(entities, MENTION_KIND) == []
+        assert _edge_pairs(edges, "mentions") == []
+        # Structural sanity: thread + channel + 1 message + 1 user = 4.
+        assert len(entities) == 4
+
+    def test_mention_dedup_across_messages(self) -> None:
+        # The same PR URL mentioned in two messages produces ONE mention
+        # entity and ONE edge (the linker would create one cross_ref edge
+        # anyway, but we keep the Slack-side graph clean too).
+        messages = [
+            {
+                "ts": self._THREAD_TS,
+                "user": "U1",
+                "text": "Fix at https://github.com/acme/api/pull/42",
+            },
+            {
+                "ts": "1700001060.000200",
+                "user": "U2",
+                "text": "Confirmed: https://github.com/acme/api/pull/42 worked",
+            },
+        ]
+        entities, edges = extract_slack_graph(
+            channel_id=self._CHANNEL,
+            thread_ts=self._THREAD_TS,
+            channel_name=self._CHANNEL_NAME,
+            messages=messages,
+        )
+        mentions = _ents_by_kind(entities, MENTION_KIND)
+        assert len(mentions) == 1
+        assert len(_edge_pairs(edges, "mentions")) == 1


### PR DESCRIPTION
Closes #149 (Wave 1 of epic #99).

## Summary

Slack connector now emits an incident-grade entity surface so the linker can build `cross_ref` edges from Slack threads to mentioned PRs, ARNs, pods, and error tokens — unblocking the `resolve_incident` MCP tool (#153).

## Scope decisions

- **Smallest seam**: `SlackConnector.fetch` stamps `(entities, edges)` onto `DocumentRef.metadata` — no change to discover/fetch shape, no change to webhook signature verification, no new linker strategies.
- **No new dependency**: regex extraction is stdlib `re`; `EntityData`/`EdgeData` defined locally in the slack package to keep the connector layer's dependency graph minimal.
- **Workspace ACL**: connector emits names only. `Source.tenant_id` -> `workspace_id` stamping stays in `ingestion.pipeline._tag_entity_workspace` (unchanged).
- **Mention edges**: thread -> mention target (one edge per unique canonical string per thread). Per-message localisation remains available via `IN_THREAD` edges.

## Mention extractors (from `slack/entities.py`)

| Category | Pattern (rationale comments inline) |
|---|---|
| GitHub PR URL | `https://github.com/{owner}/{repo}/pull/{n}` — captures base only, strips `?query` / `#fragment` so the canonical name matches what #150 emits |
| AWS ARN | `arn:aws[a-z0-9-]*:{service}:{region}:{account}:{resource}` — supports `aws`, `aws-cn`, `aws-us-gov` partitions |
| K8s pod | `{prefix}-{8-10 hex}-{5 alphanum}` — Deployment/ReplicaSet hash form, lowercase per RFC 1123 |
| Error token | `[A-Z][A-Z0-9_]{4,}` minus a denylist (TODO, HTTPS, JSON, …) — keeps SCREAMING_SNAKE error codes, drops common acronyms |

All four extractors run on text with code fences (` ``` ... ``` `) and inline code spans (` `...` `) stripped — adversarial-paste safe.

## Entities & edges

| Kind | Canonical name | Notes |
|---|---|---|
| `slack_thread` | `slack://channel/{channel_id}/thread/{thread_ts}` | matches `DocumentRef.uri` |
| `slack_message` | `slack://channel/{channel_id}/message/{ts}` | one per root + reply |
| `slack_user` | `slack://user/{user_id}` | dedup per author |
| `slack_channel` | `slack://channel/{channel_id}` | one per channel |
| `slack_mention` | `<canonical_string>` | linker matches via `exact_name` against authoritative connectors |

Edge types: `in_thread`, `authored`, `in_channel`, `mentions`.

## Tests

- `tests/test_slack_entity_extraction.py` (28 unit tests) — happy paths, dedup, code-fence rejection, sentence-prose rejection, dedup across messages.
- `tests/test_slack_connector_entities.py` (4 integration tests) — entity emission via `ref.metadata`, no-mention sanity, **payload `team_id` does NOT leak into entities**, **same thread + two `Source` rows -> identical entity names**.
- All 97 existing Slack tests in `test_connectors_v2.py` pass unchanged — backwards compatible.

## Quality gates

- `mypy --strict apps/ packages/`: clean (166 source files; +1 vs post-#176 baseline 165).
- `ruff check .` / `ruff format --check .`: clean.
- `pytest`: 1867 passed, 52 skipped, 0 failed.

## Known limitations / follow-ups

- `message_ts` carried as entity property; bitemporal `valid_from`/`valid_to` enforcement lands when epic #97 wiring picks it up (per issue scope).
- Pod regex covers Deployment/ReplicaSet form only; standalone pods and StatefulSet pods are out of scope (alerts/OTel sub-issues will surface them via trace IDs).
- Wiring point in the ingestion pipeline that actually persists the metadata-stamped entities is left to a follow-up (the architect memo says implementer picks the seam — this PR ships the connector half so #153 has what it needs once the pipeline wiring lands).
- Error-token denylist is intentionally short — extend per real-world false positives rather than speculatively.