### PR TITLE
feat: alerts webhook receiver (PagerDuty + Datadog) (#151)

### DIFF
--- a/docs/connectors/alerts.md
+++ b/docs/connectors/alerts.md
@@ -1,0 +1,150 @@
+# Alerts connector (PagerDuty + Datadog)
+
+The `alerts` connector ingests SRE incident webhooks from PagerDuty and Datadog
+and turns them into first-class entities in the Omniscience graph so the
+`resolve_incident` MCP tool (Wave 2 of epic [#99]) can traverse from an alert
+to the resource it fires against.
+
+> Source: [`packages/connectors/src/omniscience_connectors/alerts/`](../../packages/connectors/src/omniscience_connectors/alerts/)
+
+## What it does
+
+- **Push-only**. `discover()` is a no-op, `fetch()` raises
+  `NotImplementedError`. Alerts arrive exclusively through signed HTTP
+  webhooks delivered to `POST /api/v1/ingest/webhook/{source_name}`.
+- **Two providers**: `pagerduty` and `datadog`. The provider is fixed per
+  source; one `Source` row per `(tenant, provider)` pair so signature
+  verification is unambiguous.
+- **Emits one `alert` entity per upstream alert** with canonical name
+  `alert://{provider}/{provider_alert_id}`. The ID is the upstream stable
+  identifier (PagerDuty `incident.id`, Datadog `event.id`) so the entity is
+  stable across the alert lifecycle (`triggered` -> `acknowledged` ->
+  `resolved`).
+- **Emits cross_ref target refs** for every named entity mentioned in the
+  payload — AWS ARN, Kubernetes pod, service, OTel trace id. The
+  `EntityLinker` resolves these via `exact_name`/`arn_match` and creates
+  `[:FIRES_AGAINST]` cross_ref edges automatically.
+
+## ACL invariant — workspace_id is ALWAYS from `Source.tenant_id` (P0)
+
+This is the single most important rule in this connector. State it
+explicitly to anyone touching the code.
+
+Webhook payloads are **tenant-writable upstream content**. PagerDuty and
+Datadog payloads can be sent by any caller who possesses the per-source
+signing secret — but the **secret authenticates the source, not the
+payload**. The connector and webhook handler MUST derive workspace identity
+solely from the `Source.tenant_id` of the row resolved by the URL-path
+`{source_name}`. They MUST NOT read any of the following payload fields for
+tenancy decisions, even as a fallback or convenience:
+
+- `tenant_id`
+- `customer_id`
+- `org_id`
+- `routing_key`
+- `account_id`
+- `team`
+- PagerDuty `incident.service.id`
+- Datadog `event.tags`
+- Custom details / tags / extensions of any kind
+
+Any code path that reads any of those fields to influence workspace
+identity is a P0 ACL leak. The cross-workspace regression test in
+[`tests/test_alerts_webhook.py::test_cross_workspace_acl_payload_tenant_id_is_ignored`](../../tests/test_alerts_webhook.py)
+plants forged tenant identifiers in every reasonable field and asserts the
+alert lands in the workspace bound to `Source.tenant_id`.
+
+## Signature verification (mandatory)
+
+| Provider | Header | Algorithm | Replay protection |
+|----------|--------|-----------|-------------------|
+| PagerDuty | `X-PagerDuty-Signature: v1=<hex>[,v1=<hex>...]` | HMAC-SHA256 of raw body | Receiver-side delivery tracker keyed on `X-PagerDuty-Webhook-Subscription-Id` |
+| Datadog | `X-Datadog-Signature: <hex>` + `X-Datadog-Signature-Timestamp: <epoch_seconds>` | HMAC-SHA256 of `<timestamp>:<raw_body>` | Skew check: rejects if `\|now - timestamp\| > replay_window_seconds` (default 300s) |
+
+- All comparisons go through `hmac.compare_digest` (constant-time).
+- Failed verification returns 400 from the FastAPI receiver and emits a
+  structured `webhook_signature_invalid` log line. No payload is parsed,
+  no entities are emitted, no telemetry is updated.
+- Missing or unrecognised signature header -> 400. There is no
+  "skip verification" mode in production code.
+
+### Webhook secret rotation
+
+Operators may pre-stage a rotated secret with **zero downtime** by
+configuring `webhook_secret` in the source's secret store as a
+**newline-separated** list of currently-valid secrets:
+
+```text
+old-secret-being-retired
+new-secret-being-introduced
+```
+
+Verification accepts a request as authentic if **any** listed secret yields
+a matching HMAC. After confirming the upstream provider is sending with the
+new secret, remove the old line from the secret store. Empty lines and
+surrounding whitespace are ignored.
+
+## Configuration
+
+```python
+from omniscience_connectors.alerts import AlertsConfig
+
+config = AlertsConfig(
+    provider="pagerduty",            # or "datadog"
+    signature_algorithm="hmac-sha256",
+    replay_window_seconds=300,        # Datadog skew tolerance
+)
+```
+
+`webhook_secret` is supplied via the source's secrets dict, **never** in
+config. PagerDuty does not transmit a timestamp, so `replay_window_seconds`
+applies only to Datadog; PagerDuty replay protection relies on the
+receiver's delivery tracker.
+
+## NormalizedAlert
+
+Both providers' payloads are normalised into a single Pydantic model:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `provider` | `Literal["pagerduty", "datadog"]` | Fixed per source. |
+| `provider_alert_id` | `str` | Upstream stable id. |
+| `severity` | `Literal["info", "warning", "error", "critical"]` | PagerDuty severity / Datadog priority (`P1`->`critical`, `P2`->`error`, ...). |
+| `status` | `Literal["triggered", "acknowledged", "resolved"]` | Lifecycle state. |
+| `fired_at` | `datetime` (aware UTC) | When the alert fired upstream. |
+| `summary` | `str` | Human-readable title. |
+| `target_arn` | `str \| None` | First ARN extracted from payload. |
+| `target_pod` | `str \| None` | Kubernetes pod (`pod/<name>` or `<ns>/<name>`). |
+| `target_service` | `str \| None` | PagerDuty `service.summary` or Datadog `service:` tag. |
+| `trace_id` | `str \| None` | OTel trace id (bare hex; `trace://` is added at edge time). |
+| `raw` | `dict[str, Any]` | Original payload, retained for forensics. **Never** read for tenancy. |
+
+## Cross-ref edge extraction
+
+`extract_cross_refs(alert)` returns a list of `DocumentRef`s where the
+first entry is the alert entity itself and each subsequent entry is a
+named-entity target carrying a canonical name in `uri` that the
+`EntityLinker` resolves:
+
+| Target | Canonical name form |
+|--------|---------------------|
+| AWS ARN | `arn:aws:<service>:<region>:<account>:<resource>` |
+| Kubernetes pod | `pod/<name>` (or `<ns>/<name>`) |
+| Service | `service://<name>` |
+| OTel trace | `trace://<hex>` (matches the canonical form emitted by [#152]) |
+
+The linker creates `[:FIRES_AGAINST]` cross_ref edges automatically; this
+connector's job is to surface the canonical strings.
+
+## Non-goals
+
+- No providers beyond PagerDuty + Datadog.
+- No alert routing, on-call escalation, or auto-acknowledgement.
+- No deduplication across providers — the same incident in both PagerDuty
+  and Datadog produces two `alert` entities; the composer reasons across
+  them via the shared target resource.
+- No log / metric ingestion — only **events / alerts** through the alerting
+  webhook.
+
+[#99]: https://github.com/100rd/Omniscience/issues/99
+[#152]: https://github.com/100rd/Omniscience/issues/152

--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -35,6 +35,11 @@ from omniscience_connectors.agentic import (
     OllamaLLMProvider,
     build_provider,
 )
+from omniscience_connectors.alerts.connector import (
+    AlertsConfig,
+    AlertsConnector,
+    NormalizedAlert,
+)
 from omniscience_connectors.aws.connector import AwsConfig, AwsConnector
 from omniscience_connectors.base import (
     Connector,
@@ -69,6 +74,7 @@ _registry.register(K8sAgenticConnector)
 _registry.register(DatabaseConnector)
 _registry.register(S3Connector)
 _registry.register(AwsConnector)
+_registry.register(AlertsConnector)
 
 # Public alias for the shared registry instance (all built-ins pre-registered).
 default_registry: ConnectorRegistry = _registry
@@ -76,6 +82,8 @@ default_registry: ConnectorRegistry = _registry
 __all__ = [
     "AgentConfig",
     "AgenticConnector",
+    "AlertsConfig",
+    "AlertsConnector",
     "AwsConfig",
     "AwsConnector",
     "ConfluenceConnector",
@@ -90,6 +98,7 @@ __all__ = [
     "K8sAgenticConfig",
     "K8sAgenticConnector",
     "LLMProvider",
+    "NormalizedAlert",
     "NotFoundError",
     "NotionConnector",
     "OllamaLLMProvider",

--- a/packages/connectors/src/omniscience_connectors/alerts/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/alerts/__init__.py
@@ -1,0 +1,26 @@
+"""Alerts source connector for Omniscience.
+
+Push-only connector for SRE alerting providers (PagerDuty, Datadog).
+Discovery is a no-op; alerts arrive exclusively via signed webhooks.
+
+Public surface
+--------------
+``AlertsConnector``      — connector type ``"alerts"``.
+``AlertsConfig``         — public configuration schema.
+``AlertsWebhookHandler`` — HMAC-SHA256 signature verification.
+``NormalizedAlert``      — provider-agnostic alert payload.
+"""
+
+from omniscience_connectors.alerts.connector import (
+    AlertsConfig,
+    AlertsConnector,
+    NormalizedAlert,
+)
+from omniscience_connectors.alerts.webhook import AlertsWebhookHandler
+
+__all__ = [
+    "AlertsConfig",
+    "AlertsConnector",
+    "AlertsWebhookHandler",
+    "NormalizedAlert",
+]

--- a/packages/connectors/src/omniscience_connectors/alerts/connector.py
+++ b/packages/connectors/src/omniscience_connectors/alerts/connector.py
@@ -1,0 +1,494 @@
+"""Alerts source connector — PagerDuty + Datadog webhook ingestion.
+
+This connector is **push-only**.  ``discover()`` yields nothing and ``fetch()``
+raises :class:`NotImplementedError`; alerts arrive exclusively through signed
+HTTP webhooks delivered to ``POST /api/v1/ingest/webhook/{source_name}``.  The
+generic webhook receiver (`apps/server/src/omniscience_server/rest/webhooks.py`)
+handles signature verification, replay protection, rate limiting, and tenant
+resolution; this module supplies the connector-side
+:class:`~omniscience_connectors.base.WebhookHandler` and provider-agnostic
+payload normalisation.
+
+ACL invariant — workspace_id ALWAYS from ``Source.tenant_id`` (P0)
+------------------------------------------------------------------
+Webhook payloads are *tenant-writable upstream content*.  The receiver derives
+workspace identity solely from the URL-path ``{source_name}`` resolving to a
+:class:`~omniscience_core.db.models.Source` row whose ``tenant_id`` is the
+authoritative workspace.  Anything inside the payload — ``tenant_id``,
+``customer_id``, custom tags, ``incident.service.id``, Datadog ``tags``,
+``routing_key``, ``account_id`` — MUST NOT influence tenancy.  The normalisers
+below NEVER read those fields for tenancy purposes; they only carry forensic
+context inside ``NormalizedAlert.raw``.
+
+Webhook secret rotation
+-----------------------
+Operators may rotate the per-source ``webhook_secret`` without downtime by
+configuring a newline-separated list of currently-valid secrets.  The receiver
+splits on newlines and accepts a request if *any* secret yields a valid HMAC.
+See :class:`~omniscience_connectors.alerts.webhook.AlertsWebhookHandler` for
+details.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.alerts.webhook import AlertsWebhookHandler
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+)
+
+__all__ = [
+    "AlertsConfig",
+    "AlertsConnector",
+    "NormalizedAlert",
+    "extract_cross_refs",
+    "normalize_datadog",
+    "normalize_pagerduty",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Canonical name helpers
+# ---------------------------------------------------------------------------
+
+#: Canonical AWS ARN regex.  Mirrors the form used by the Slack/AWS connectors.
+_ARN_RE = re.compile(r"arn:[a-z0-9-]+:[a-z0-9-]*:[a-z0-9-]*:[0-9]*:[A-Za-z0-9_/.:+=@\\-]+")
+
+#: Canonical Kubernetes pod token: ``pod/<name>`` or ``<namespace>/<name>``.
+_POD_RE = re.compile(r"\bpod/([a-z0-9][a-z0-9-]{0,252}[a-z0-9])\b")
+
+#: Trace IDs from OTel: hex strings 16 or 32 chars, prefixed by ``trace://``.
+_TRACE_RE = re.compile(r"\btrace://([a-f0-9]{16,32})\b")
+
+#: Generic Kubernetes service token (Datadog tag form ``service:<name>``).
+_K8S_NAMESPACED_RE = re.compile(
+    r"\b([a-z0-9][a-z0-9-]{0,62})/([a-z0-9][a-z0-9-]{0,252}[a-z0-9])\b"
+)
+
+
+# ---------------------------------------------------------------------------
+# Public configuration
+# ---------------------------------------------------------------------------
+
+
+class AlertsConfig(BaseModel):
+    """Public configuration for the alerts connector (no secrets).
+
+    The provider is fixed per source — one :class:`Source` row per
+    ``(tenant, provider)`` pair so signature verification is unambiguous.
+    """
+
+    provider: Literal["pagerduty", "datadog"]
+    """Upstream provider.  Determines which signature verifier and normaliser run."""
+
+    signature_algorithm: Literal["hmac-sha256"] = "hmac-sha256"
+    """Signature algorithm.  Both providers use HMAC-SHA256 today."""
+
+    replay_window_seconds: int = 300
+    """Datadog ``X-Datadog-Signature-Timestamp`` skew tolerance, in seconds.
+
+    Mirrors the Slack connector default.  PagerDuty does not transmit a
+    timestamp; replay protection there relies on the receiver-side delivery
+    tracker keyed on ``X-PagerDuty-Webhook-Subscription-Id``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Normalised alert schema
+# ---------------------------------------------------------------------------
+
+
+class NormalizedAlert(BaseModel):
+    """Provider-agnostic alert payload.
+
+    Both PagerDuty and Datadog webhook bodies are normalised into this shape so
+    downstream entity emission and ``resolve_incident`` (Wave 2) treat alerts
+    uniformly.  ``raw`` retains the original payload for forensics; the
+    normaliser MUST NOT read any field of ``raw`` for tenancy decisions.
+    """
+
+    provider: Literal["pagerduty", "datadog"]
+    provider_alert_id: str
+    severity: Literal["info", "warning", "error", "critical"]
+    status: Literal["triggered", "acknowledged", "resolved"]
+    fired_at: datetime
+    summary: str
+    target_arn: str | None = None
+    target_pod: str | None = None
+    target_service: str | None = None
+    trace_id: str | None = None
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Provider normalisers
+# ---------------------------------------------------------------------------
+
+
+_PD_SEVERITY_MAP: dict[str, Literal["info", "warning", "error", "critical"]] = {
+    "info": "info",
+    "warning": "warning",
+    "error": "error",
+    "critical": "critical",
+}
+
+_PD_STATUS_MAP: dict[str, Literal["triggered", "acknowledged", "resolved"]] = {
+    "triggered": "triggered",
+    "acknowledged": "acknowledged",
+    "resolved": "resolved",
+}
+
+_DD_TYPE_TO_STATUS: dict[str, Literal["triggered", "acknowledged", "resolved"]] = {
+    "alert": "triggered",
+    "alert_triggered": "triggered",
+    "alert_recovery": "resolved",
+    "recovery": "resolved",
+    "alert_no_data": "triggered",
+    "alert_acknowledged": "acknowledged",
+}
+
+_DD_PRIORITY_TO_SEVERITY: dict[str, Literal["info", "warning", "error", "critical"]] = {
+    "P1": "critical",
+    "P2": "error",
+    "P3": "warning",
+    "P4": "info",
+    "P5": "info",
+}
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    """Best-effort coercion of an upstream timestamp into an aware datetime."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, (int, float)):
+        # PagerDuty sends epoch ms in some events; Datadog sends epoch seconds.
+        seconds = float(value) / 1000.0 if value > 10_000_000_000 else float(value)
+        return datetime.fromtimestamp(seconds, tz=UTC)
+    if isinstance(value, str) and value:
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return datetime.now(tz=UTC)
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    return datetime.now(tz=UTC)
+
+
+def normalize_pagerduty(payload: dict[str, Any]) -> NormalizedAlert:
+    """Normalise a PagerDuty webhook body into :class:`NormalizedAlert`.
+
+    PagerDuty wraps the event under ``event.data`` (Webhooks v3).  We treat
+    ``event.data.id`` as ``provider_alert_id`` (stable across the lifecycle)
+    and read severity/status from the same node.
+    """
+    event_obj = payload.get("event") or {}
+    raw_data = event_obj.get("data") if isinstance(event_obj, dict) else None
+    data: dict[str, Any] = raw_data if isinstance(raw_data, dict) else {}
+
+    raw_severity = str(data.get("severity") or "warning").lower()
+    raw_status = str(data.get("status") or "triggered").lower()
+    summary = str(data.get("title") or data.get("summary") or "PagerDuty incident")
+    fired_at = _coerce_datetime(
+        data.get("created_at")
+        or (event_obj.get("occurred_at") if isinstance(event_obj, dict) else None)
+    )
+
+    service = data.get("service") or {}
+    target_service = (
+        str(service.get("summary"))
+        if isinstance(service, dict) and service.get("summary")
+        else None
+    )
+
+    haystack = _build_pd_haystack(data)
+    target_arn = _first_match(_ARN_RE, haystack)
+    target_pod = _first_pod_match(haystack)
+    trace_id = _first_trace_id(haystack)
+
+    return NormalizedAlert(
+        provider="pagerduty",
+        provider_alert_id=str(data.get("id") or payload.get("id") or ""),
+        severity=_PD_SEVERITY_MAP.get(raw_severity, "warning"),
+        status=_PD_STATUS_MAP.get(raw_status, "triggered"),
+        fired_at=fired_at,
+        summary=summary,
+        target_arn=target_arn,
+        target_pod=target_pod,
+        target_service=target_service,
+        trace_id=trace_id,
+        raw=payload,
+    )
+
+
+def normalize_datadog(payload: dict[str, Any]) -> NormalizedAlert:
+    """Normalise a Datadog alert webhook body into :class:`NormalizedAlert`.
+
+    Datadog payloads vary by template, but commonly carry ``id``,
+    ``alert_type``/``event_type``, ``priority``, ``title``, ``date_happened``,
+    and a ``tags`` list (e.g. ``["service:checkout", "env:prod"]``).
+    """
+    alert_id = str(payload.get("id") or payload.get("alert_id") or "")
+    raw_priority = str(payload.get("priority") or "P3").upper()
+    severity = _DD_PRIORITY_TO_SEVERITY.get(raw_priority, "warning")
+
+    raw_type = str(payload.get("alert_type") or payload.get("event_type") or "alert").lower()
+    status = _DD_TYPE_TO_STATUS.get(raw_type, "triggered")
+
+    summary = str(payload.get("title") or payload.get("alert_title") or "Datadog alert")
+    fired_at = _coerce_datetime(
+        payload.get("date_happened") or payload.get("last_updated") or payload.get("timestamp")
+    )
+
+    tags = payload.get("tags")
+    tag_list: list[str] = [t for t in tags if isinstance(t, str)] if isinstance(tags, list) else []
+    target_service = _tag_value(tag_list, "service")
+
+    haystack = _build_dd_haystack(payload, tag_list)
+    target_arn = _first_match(_ARN_RE, haystack)
+    target_pod = _tag_value(tag_list, "pod_name") or _first_pod_match(haystack)
+    trace_id = _first_trace_id(haystack) or _tag_value(tag_list, "trace_id")
+
+    return NormalizedAlert(
+        provider="datadog",
+        provider_alert_id=alert_id,
+        severity=severity,
+        status=status,
+        fired_at=fired_at,
+        summary=summary,
+        target_arn=target_arn,
+        target_pod=target_pod,
+        target_service=target_service,
+        trace_id=trace_id,
+        raw=payload,
+    )
+
+
+def _build_pd_haystack(data: dict[str, Any]) -> str:
+    """Concatenate PagerDuty payload fields where named-entity refs may live."""
+    custom_details = data.get("custom_details") or {}
+    pieces: list[str] = [
+        str(data.get("title") or ""),
+        str(data.get("summary") or ""),
+        str(data.get("description") or ""),
+    ]
+    if isinstance(custom_details, dict):
+        pieces.extend(str(v) for v in custom_details.values())
+    return " \n ".join(p for p in pieces if p)
+
+
+def _build_dd_haystack(payload: dict[str, Any], tags: list[str]) -> str:
+    """Concatenate Datadog payload fields plus tags into a search haystack."""
+    pieces: list[str] = [
+        str(payload.get("title") or ""),
+        str(payload.get("body") or payload.get("alert_message") or ""),
+        " ".join(tags),
+    ]
+    return " \n ".join(p for p in pieces if p)
+
+
+def _first_match(pattern: re.Pattern[str], text: str) -> str | None:
+    if not text:
+        return None
+    match = pattern.search(text)
+    return match.group(0) if match else None
+
+
+def _first_trace_id(text: str) -> str | None:
+    """Return the bare trace-id hex string from a ``trace://<hex>`` token.
+
+    The cross_ref emitter re-prefixes with ``trace://`` so the canonical name
+    used for linking matches the form emitted by the OTel receiver (#152).
+    """
+    if not text:
+        return None
+    match = _TRACE_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _first_pod_match(text: str) -> str | None:
+    """Return ``pod/<name>`` if found, else the first ``<namespace>/<name>`` token."""
+    if not text:
+        return None
+    pod_match = _POD_RE.search(text)
+    if pod_match:
+        return pod_match.group(0)
+    ns_match = _K8S_NAMESPACED_RE.search(text)
+    return ns_match.group(0) if ns_match else None
+
+
+def _tag_value(tags: list[str], key: str) -> str | None:
+    """Return the value of a Datadog tag like ``key:value`` (first match only)."""
+    prefix = f"{key}:"
+    for tag in tags:
+        if tag.startswith(prefix):
+            value = tag[len(prefix) :].strip()
+            if value:
+                return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cross-ref extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_cross_refs(alert: NormalizedAlert) -> list[DocumentRef]:
+    """Build the list of named-entity reference :class:`DocumentRef`s.
+
+    The first ref is always the alert entity itself
+    (``alert://{provider}/{provider_alert_id}``).  Each subsequent ref carries
+    a canonical name in its ``uri`` field that the
+    :class:`~omniscience_index.linker.EntityLinker` resolves via ``exact_name``
+    or ``arn_match`` strategies, producing the ``[:FIRES_AGAINST]`` cross_ref
+    edges described in the architect memo.
+
+    Importantly, this function only inspects ``alert`` (the normalised model);
+    raw payload tenant fields are never consulted.
+    """
+    alert_name = f"alert://{alert.provider}/{alert.provider_alert_id}"
+    refs: list[DocumentRef] = [
+        DocumentRef(
+            external_id=alert_name,
+            uri=alert_name,
+            updated_at=alert.fired_at,
+            metadata={
+                "kind": "alert",
+                "name": alert_name,
+                "provider": alert.provider,
+                "provider_alert_id": alert.provider_alert_id,
+                "severity": alert.severity,
+                "status": alert.status,
+                "fired_at": alert.fired_at.isoformat(),
+                "summary": alert.summary,
+                "target_arn": alert.target_arn,
+                "target_pod": alert.target_pod,
+                "target_service": alert.target_service,
+                "trace_id": alert.trace_id,
+            },
+        )
+    ]
+
+    if alert.target_arn:
+        refs.append(
+            DocumentRef(
+                external_id=alert.target_arn,
+                uri=alert.target_arn,
+                metadata={
+                    "kind": "cross_ref_target",
+                    "name": alert.target_arn,
+                    "edge_type": "FIRES_AGAINST",
+                    "from_alert": alert_name,
+                },
+            )
+        )
+
+    if alert.target_pod:
+        refs.append(
+            DocumentRef(
+                external_id=alert.target_pod,
+                uri=alert.target_pod,
+                metadata={
+                    "kind": "cross_ref_target",
+                    "name": alert.target_pod,
+                    "edge_type": "FIRES_AGAINST",
+                    "from_alert": alert_name,
+                },
+            )
+        )
+
+    if alert.target_service:
+        service_name = f"service://{alert.target_service}"
+        refs.append(
+            DocumentRef(
+                external_id=service_name,
+                uri=service_name,
+                metadata={
+                    "kind": "cross_ref_target",
+                    "name": service_name,
+                    "edge_type": "FIRES_AGAINST",
+                    "from_alert": alert_name,
+                },
+            )
+        )
+
+    if alert.trace_id:
+        trace_name = f"trace://{alert.trace_id}"
+        refs.append(
+            DocumentRef(
+                external_id=trace_name,
+                uri=trace_name,
+                metadata={
+                    "kind": "cross_ref_target",
+                    "name": trace_name,
+                    "edge_type": "FIRES_AGAINST",
+                    "from_alert": alert_name,
+                },
+            )
+        )
+
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+class AlertsConnector(Connector):
+    """Push-only connector for SRE alerting webhooks (PagerDuty, Datadog).
+
+    ``discover()`` is a no-op — alerts are not enumerable.  ``fetch()`` raises
+    :class:`NotImplementedError` because the alert content arrives in full with
+    the webhook delivery and is processed inline by the receiver.
+    """
+
+    connector_type: ClassVar[str] = "alerts"
+    config_schema: ClassVar[type[BaseModel]] = AlertsConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Validate that *config* is well-formed and *secrets* contains a webhook secret."""
+        cfg: AlertsConfig = config  # type: ignore[assignment]
+        if cfg.provider not in ("pagerduty", "datadog"):
+            raise ValueError(f"Unsupported alerts provider: {cfg.provider!r}")
+        if not (secrets.get("webhook_secret") or "").strip():
+            raise ValueError("Alerts connector requires a 'webhook_secret' in secrets.")
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """No-op — alerts are exclusively push-based.
+
+        Returns immediately without yielding any refs.  Implemented as an
+        async generator (with an unreachable ``yield``) to satisfy the
+        :class:`~omniscience_connectors.base.Connector` protocol.
+        """
+        return
+        yield  # pragma: no cover  # type: ignore[unreachable]
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Not supported — alert content arrives in full via the webhook payload."""
+        raise NotImplementedError(
+            "AlertsConnector is push-only; fetch() is not supported. "
+            "Alert payloads are delivered in full by the upstream provider's webhook."
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        return AlertsWebhookHandler()

--- a/packages/connectors/src/omniscience_connectors/alerts/webhook.py
+++ b/packages/connectors/src/omniscience_connectors/alerts/webhook.py
@@ -1,0 +1,275 @@
+"""Webhook handler for the alerts connector.
+
+Verifies HMAC-SHA256 signatures sent by PagerDuty and Datadog using
+``hmac.compare_digest`` for constant-time comparison (no timing oracle).
+On verification success the handler parses the payload via the provider's
+normaliser and emits one alert :class:`DocumentRef` plus one cross_ref target
+per detected entity (ARN, pod, service, trace id).
+
+ACL invariant — workspace_id is NEVER read from the payload (P0)
+----------------------------------------------------------------
+The handler does not look at, copy, or trust any of the following payload
+fields for tenancy decisions: ``tenant_id``, ``customer_id``, ``org_id``,
+``routing_key``, ``account_id``, ``team``, custom tags, or any other field.
+Workspace identity is derived solely from the URL-path ``{source_name}`` by
+the FastAPI receiver in
+``apps/server/src/omniscience_server/rest/webhooks.py``.
+
+Webhook secret rotation
+-----------------------
+Operators may pre-stage a rotated secret by configuring ``webhook_secret`` as
+a newline-separated list of currently-valid secrets.  The verifier returns
+true if *any* listed secret yields a matching signature, allowing zero-downtime
+rotation.  Whitespace and empty lines are ignored.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from omniscience_connectors.base import DocumentRef, WebhookHandler, WebhookPayload
+
+if TYPE_CHECKING:
+    from omniscience_connectors.alerts.connector import NormalizedAlert
+
+__all__ = [
+    "AlertsWebhookHandler",
+    "verify_datadog",
+    "verify_pagerduty",
+]
+
+logger = logging.getLogger(__name__)
+
+# Header names — lower-cased for dict-of-lower-keys lookup.
+_PD_SIG_HEADER = "x-pagerduty-signature"
+_DD_SIG_HEADER = "x-datadog-signature"
+_DD_TS_HEADER = "x-datadog-signature-timestamp"
+
+# Datadog replay window default (seconds).  Keep in sync with
+# ``AlertsConfig.replay_window_seconds`` and the Slack webhook handler.
+_DEFAULT_REPLAY_WINDOW_SECONDS = 300
+
+
+# ---------------------------------------------------------------------------
+# Signature verification — pure functions (testable in isolation)
+# ---------------------------------------------------------------------------
+
+
+def _split_secrets(secret: str) -> list[str]:
+    """Split a multi-line secret string into individual non-empty values.
+
+    Operators may pre-stage a rotated secret by configuring
+    ``webhook_secret`` as multiple newline-separated values; verification
+    accepts a request as authentic if *any* of the listed secrets matches.
+    """
+    return [line.strip() for line in secret.splitlines() if line.strip()]
+
+
+def verify_pagerduty(payload: bytes, signature_header: str, secret: str) -> bool:
+    """Verify a PagerDuty webhook HMAC-SHA256 signature.
+
+    PagerDuty sends the header ``X-PagerDuty-Signature`` as a comma-separated
+    list of one or more ``v1=<hex>`` values (one per active signing secret on
+    the upstream side).  The verifier returns ``True`` if any of the upstream
+    signatures matches the HMAC of any of our currently-valid local secrets,
+    using :func:`hmac.compare_digest` for constant-time comparison.
+
+    Args:
+        payload: Raw request body bytes.
+        signature_header: Value of ``X-PagerDuty-Signature``.
+        secret: One or more newline-separated secrets (rotation support).
+
+    Returns:
+        ``True`` iff the signature is valid.  Returns ``False`` (does not
+        raise) on malformed inputs.
+    """
+    if not signature_header:
+        return False
+    secrets = _split_secrets(secret)
+    if not secrets:
+        return False
+
+    candidates = _parse_pd_signatures(signature_header)
+    if not candidates:
+        return False
+
+    for s in secrets:
+        expected = hmac.new(s.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        for received in candidates:
+            if hmac.compare_digest(expected, received):
+                return True
+    return False
+
+
+def _parse_pd_signatures(header: str) -> list[str]:
+    """Extract the hex-encoded ``v1`` HMACs from a PagerDuty signature header."""
+    sigs: list[str] = []
+    for raw_part in header.split(","):
+        part = raw_part.strip()
+        if part.startswith("v1="):
+            sigs.append(part[len("v1=") :])
+    return sigs
+
+
+def verify_datadog(
+    payload: bytes,
+    signature_header: str,
+    timestamp_header: str,
+    secret: str,
+    *,
+    replay_window_seconds: int = _DEFAULT_REPLAY_WINDOW_SECONDS,
+    now: float | None = None,
+) -> bool:
+    """Verify a Datadog webhook HMAC-SHA256 signature.
+
+    Datadog signs ``"<timestamp>:<raw_body>"`` with HMAC-SHA256.  The hex
+    digest arrives in ``X-Datadog-Signature``; the timestamp arrives in
+    ``X-Datadog-Signature-Timestamp`` (Unix epoch seconds).  Requests older
+    than ``replay_window_seconds`` are rejected to neutralise replay attacks.
+
+    Args:
+        payload: Raw request body bytes.
+        signature_header: ``X-Datadog-Signature`` value (hex digest, optionally
+            prefixed with ``sha256=``).
+        timestamp_header: ``X-Datadog-Signature-Timestamp`` value.
+        secret: One or more newline-separated secrets (rotation support).
+        replay_window_seconds: Maximum allowed clock skew.
+        now: Wall-clock time injection (test only).
+
+    Returns:
+        ``True`` iff the signature is valid AND the timestamp is fresh.
+    """
+    if not signature_header or not timestamp_header:
+        return False
+
+    try:
+        ts = int(timestamp_header)
+    except ValueError:
+        return False
+
+    wall = time.time() if now is None else now
+    if abs(wall - ts) > replay_window_seconds:
+        return False
+
+    secrets = _split_secrets(secret)
+    if not secrets:
+        return False
+
+    received = _strip_sha256_prefix(signature_header.strip())
+    base = f"{ts}:".encode() + payload
+
+    for s in secrets:
+        expected = hmac.new(s.encode("utf-8"), base, hashlib.sha256).hexdigest()
+        if hmac.compare_digest(expected, received):
+            return True
+    return False
+
+
+def _strip_sha256_prefix(value: str) -> str:
+    """Strip a ``sha256=`` prefix if present (Datadog payload format variant)."""
+    if value.startswith("sha256="):
+        return value[len("sha256=") :]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# WebhookHandler implementation
+# ---------------------------------------------------------------------------
+
+
+class AlertsWebhookHandler(WebhookHandler):
+    """Verifies and parses PagerDuty / Datadog alert webhooks.
+
+    The handler dispatches on the presence of provider-specific signature
+    headers — ``X-PagerDuty-Signature`` for PagerDuty, ``X-Datadog-Signature``
+    for Datadog.  A request lacking *any* recognised signature header is
+    rejected (returns ``False`` from :meth:`verify_signature`).  The receiver
+    translates that into a 400 response.
+    """
+
+    async def verify_signature(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+        secret: str,
+    ) -> bool:
+        """Return ``True`` iff the request bears a valid HMAC signature."""
+        lower = {k.lower(): v for k, v in headers.items()}
+        pd_sig = lower.get(_PD_SIG_HEADER, "")
+        dd_sig = lower.get(_DD_SIG_HEADER, "")
+        dd_ts = lower.get(_DD_TS_HEADER, "")
+
+        if pd_sig:
+            ok = verify_pagerduty(payload, pd_sig, secret)
+            if not ok:
+                logger.warning("alerts.webhook.signature_invalid", extra={"provider": "pagerduty"})
+            return ok
+
+        if dd_sig:
+            ok = verify_datadog(payload, dd_sig, dd_ts, secret)
+            if not ok:
+                logger.warning("alerts.webhook.signature_invalid", extra={"provider": "datadog"})
+            return ok
+
+        logger.warning("alerts.webhook.signature_missing")
+        return False
+
+    async def parse_payload(
+        self,
+        payload: bytes,
+        headers: dict[str, str],
+    ) -> WebhookPayload:
+        """Parse a verified payload into a :class:`WebhookPayload`.
+
+        Dispatches on the same signature-header presence used by
+        :meth:`verify_signature`; the receiver guarantees this is only invoked
+        after a successful verification.
+        """
+        lower_headers = {k.lower(): v for k, v in headers.items()}
+
+        try:
+            data: Any = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Alerts webhook: invalid JSON: {exc}") from exc
+        if not isinstance(data, dict):
+            raise ValueError("Alerts webhook: top-level payload must be a JSON object")
+
+        provider = self._detect_provider(lower_headers)
+        alert = self._normalize(provider, data)
+
+        from omniscience_connectors.alerts.connector import extract_cross_refs
+
+        refs: list[DocumentRef] = extract_cross_refs(alert)
+        return WebhookPayload(
+            source_name=f"alerts:{provider}",
+            affected_refs=refs,
+            raw_headers=lower_headers,
+        )
+
+    @staticmethod
+    def _detect_provider(lower_headers: dict[str, str]) -> str:
+        if _PD_SIG_HEADER in lower_headers:
+            return "pagerduty"
+        if _DD_SIG_HEADER in lower_headers:
+            return "datadog"
+        # Should never happen in production — verify_signature would have
+        # rejected the request first — but be defensive in case of misuse.
+        raise ValueError("Alerts webhook: unrecognised provider (no signature header).")
+
+    @staticmethod
+    def _normalize(provider: str, data: dict[str, Any]) -> NormalizedAlert:
+        from omniscience_connectors.alerts.connector import (
+            normalize_datadog,
+            normalize_pagerduty,
+        )
+
+        if provider == "pagerduty":
+            return normalize_pagerduty(data)
+        if provider == "datadog":
+            return normalize_datadog(data)
+        raise ValueError(f"Alerts webhook: unsupported provider {provider!r}")

--- a/packages/core/src/omniscience_core/db/models.py
+++ b/packages/core/src/omniscience_core/db/models.py
@@ -51,6 +51,7 @@ class SourceType(enum.StrEnum):
     terraform = "terraform"
     s3 = "s3"
     aws = "aws"
+    alerts = "alerts"
 
 
 class SourceStatus(enum.StrEnum):

--- a/tests/test_alerts_connector.py
+++ b/tests/test_alerts_connector.py
@@ -1,0 +1,292 @@
+"""Unit tests for the alerts connector.
+
+Covers:
+- PagerDuty payload -> NormalizedAlert
+- Datadog payload -> NormalizedAlert
+- Severity / status mapping for each provider
+- cross_ref edge emission for ARN, pod, service, trace_id
+- Connector protocol contract (discover no-op, fetch raises)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from omniscience_connectors.alerts.connector import (
+    AlertsConfig,
+    AlertsConnector,
+    NormalizedAlert,
+    extract_cross_refs,
+    normalize_datadog,
+    normalize_pagerduty,
+)
+
+# ---------------------------------------------------------------------------
+# PagerDuty normalisation
+# ---------------------------------------------------------------------------
+
+
+def _pd_payload(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "event": {
+            "occurred_at": "2026-04-24T10:00:00Z",
+            "data": {
+                "id": "PXXXXXXX",
+                "title": "High CPU on web pod/checkout-7d4f9 — investigate",
+                "summary": "checkout-7d4f9 CPU > 95% for 5m",
+                "description": (
+                    "Container in pod/checkout-7d4f9 against "
+                    "arn:aws:ec2:us-east-1:111122223333:instance/i-0abc1234"
+                ),
+                "severity": "critical",
+                "status": "triggered",
+                "created_at": "2026-04-24T10:00:00Z",
+                "service": {
+                    "id": "PSVCID01",
+                    "summary": "checkout-api",
+                },
+                "custom_details": {
+                    "trace": "trace://aabbccddeeff00112233445566778899",
+                },
+            },
+        }
+    }
+    base.update(overrides)
+    return base
+
+
+def test_pagerduty_normalises_core_fields() -> None:
+    alert = normalize_pagerduty(_pd_payload())
+    assert alert.provider == "pagerduty"
+    assert alert.provider_alert_id == "PXXXXXXX"
+    assert alert.severity == "critical"
+    assert alert.status == "triggered"
+    assert alert.summary.startswith("High CPU")
+    assert alert.target_service == "checkout-api"
+    assert alert.fired_at == datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC)
+
+
+def test_pagerduty_extracts_arn_pod_and_trace() -> None:
+    alert = normalize_pagerduty(_pd_payload())
+    assert alert.target_arn == "arn:aws:ec2:us-east-1:111122223333:instance/i-0abc1234"
+    assert alert.target_pod == "pod/checkout-7d4f9"
+    # trace_id is the bare hex; cross_ref emission re-prefixes with trace://
+    assert alert.trace_id == "aabbccddeeff00112233445566778899"
+
+
+def test_pagerduty_severity_mapping_defaults_to_warning() -> None:
+    payload = _pd_payload()
+    payload["event"] = {  # type: ignore[index]
+        "data": {"id": "P1", "severity": "BogusLevel", "status": "triggered"}
+    }
+    alert = normalize_pagerduty(payload)
+    assert alert.severity == "warning"
+
+
+@pytest.mark.parametrize(
+    "raw_status,expected",
+    [
+        ("triggered", "triggered"),
+        ("acknowledged", "acknowledged"),
+        ("resolved", "resolved"),
+    ],
+)
+def test_pagerduty_status_mapping(raw_status: str, expected: str) -> None:
+    payload = _pd_payload()
+    payload["event"] = {  # type: ignore[index]
+        "data": {"id": "P1", "severity": "warning", "status": raw_status}
+    }
+    alert = normalize_pagerduty(payload)
+    assert alert.status == expected
+
+
+def test_pagerduty_with_no_named_entities_yields_none_targets() -> None:
+    payload = {"event": {"data": {"id": "P2", "title": "DB stalled", "severity": "error"}}}
+    alert = normalize_pagerduty(payload)
+    assert alert.target_arn is None
+    assert alert.target_pod is None
+    assert alert.trace_id is None
+
+
+# ---------------------------------------------------------------------------
+# Datadog normalisation
+# ---------------------------------------------------------------------------
+
+
+def _dd_payload(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "id": "1234567890",
+        "alert_type": "alert",
+        "priority": "P1",
+        "title": "[CRIT] checkout latency p99 > 500ms",
+        "body": (
+            "Saw arn:aws:ec2:us-east-1:111122223333:instance/i-0abc1234 "
+            "spike in pod/checkout-7d4f9; trace://aabbccddeeff00112233445566778899"
+        ),
+        "date_happened": 1761301200,
+        "tags": [
+            "service:checkout",
+            "env:prod",
+            "pod_name:checkout-7d4f9",
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_datadog_normalises_core_fields() -> None:
+    alert = normalize_datadog(_dd_payload())
+    assert alert.provider == "datadog"
+    assert alert.provider_alert_id == "1234567890"
+    assert alert.severity == "critical"  # P1 -> critical
+    assert alert.status == "triggered"
+    assert alert.target_service == "checkout"
+
+
+def test_datadog_extracts_arn_pod_trace_from_body() -> None:
+    alert = normalize_datadog(_dd_payload())
+    assert alert.target_arn == "arn:aws:ec2:us-east-1:111122223333:instance/i-0abc1234"
+    # pod_name tag wins over body regex; both yield same value here.
+    assert alert.target_pod == "checkout-7d4f9"
+    assert alert.trace_id == "aabbccddeeff00112233445566778899"
+
+
+@pytest.mark.parametrize(
+    "priority,expected",
+    [
+        ("P1", "critical"),
+        ("P2", "error"),
+        ("P3", "warning"),
+        ("P4", "info"),
+        ("P5", "info"),
+    ],
+)
+def test_datadog_priority_mapping(priority: str, expected: str) -> None:
+    payload = _dd_payload(priority=priority)
+    alert = normalize_datadog(payload)
+    assert alert.severity == expected
+
+
+@pytest.mark.parametrize(
+    "alert_type,expected",
+    [
+        ("alert", "triggered"),
+        ("alert_triggered", "triggered"),
+        ("alert_recovery", "resolved"),
+        ("recovery", "resolved"),
+        ("alert_acknowledged", "acknowledged"),
+    ],
+)
+def test_datadog_alert_type_to_status(alert_type: str, expected: str) -> None:
+    payload = _dd_payload(alert_type=alert_type)
+    alert = normalize_datadog(payload)
+    assert alert.status == expected
+
+
+def test_datadog_falls_back_to_warning_for_unknown_priority() -> None:
+    payload = _dd_payload(priority="P99")
+    alert = normalize_datadog(payload)
+    assert alert.severity == "warning"
+
+
+# ---------------------------------------------------------------------------
+# cross_ref edge extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_cross_refs_emits_alert_plus_target_refs() -> None:
+    alert = NormalizedAlert(
+        provider="pagerduty",
+        provider_alert_id="PXXXXX",
+        severity="critical",
+        status="triggered",
+        fired_at=datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
+        summary="x",
+        target_arn="arn:aws:ec2:us-east-1:111:instance/i-1",
+        target_pod="pod/checkout",
+        target_service="checkout-api",
+        trace_id="aabbcc",
+    )
+    refs = extract_cross_refs(alert)
+
+    # First ref: alert entity itself.
+    assert refs[0].uri == "alert://pagerduty/PXXXXX"
+    assert refs[0].metadata["kind"] == "alert"
+    assert refs[0].metadata["severity"] == "critical"
+
+    names = [r.uri for r in refs[1:]]
+    assert "arn:aws:ec2:us-east-1:111:instance/i-1" in names
+    assert "pod/checkout" in names
+    assert "service://checkout-api" in names
+    assert "trace://aabbcc" in names
+
+    # All non-alert refs are FIRES_AGAINST cross_ref targets.
+    for r in refs[1:]:
+        assert r.metadata["edge_type"] == "FIRES_AGAINST"
+        assert r.metadata["from_alert"] == "alert://pagerduty/PXXXXX"
+
+
+def test_extract_cross_refs_skips_missing_targets() -> None:
+    alert = NormalizedAlert(
+        provider="datadog",
+        provider_alert_id="42",
+        severity="info",
+        status="resolved",
+        fired_at=datetime(2026, 4, 24, 10, 0, 0, tzinfo=UTC),
+        summary="recovered",
+    )
+    refs = extract_cross_refs(alert)
+    # Only the alert entity ref is emitted.
+    assert len(refs) == 1
+    assert refs[0].uri == "alert://datadog/42"
+
+
+# ---------------------------------------------------------------------------
+# Connector protocol
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connector_discover_yields_nothing() -> None:
+    cfg = AlertsConfig(provider="pagerduty")
+    conn = AlertsConnector()
+    items = [ref async for ref in conn.discover(cfg, {"webhook_secret": "x"})]
+    assert items == []
+
+
+@pytest.mark.asyncio
+async def test_connector_fetch_raises_not_implemented() -> None:
+    cfg = AlertsConfig(provider="datadog")
+    conn = AlertsConnector()
+    from omniscience_connectors.base import DocumentRef
+
+    with pytest.raises(NotImplementedError):
+        await conn.fetch(
+            cfg,
+            {"webhook_secret": "x"},
+            DocumentRef(external_id="alert://datadog/1", uri="alert://datadog/1"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_connector_validate_requires_webhook_secret() -> None:
+    cfg = AlertsConfig(provider="pagerduty")
+    conn = AlertsConnector()
+    with pytest.raises(ValueError, match="webhook_secret"):
+        await conn.validate(cfg, {})
+
+
+@pytest.mark.asyncio
+async def test_connector_validate_accepts_valid_config() -> None:
+    cfg = AlertsConfig(provider="pagerduty")
+    conn = AlertsConnector()
+    await conn.validate(cfg, {"webhook_secret": "abc"})
+
+
+def test_connector_registered_in_registry() -> None:
+    """Smoke-test: the connector is registered under type 'alerts'."""
+    from omniscience_connectors import default_registry
+
+    instance = default_registry.get("alerts")
+    assert isinstance(instance, AlertsConnector)

--- a/tests/test_alerts_webhook.py
+++ b/tests/test_alerts_webhook.py
@@ -1,0 +1,443 @@
+"""Tests for the alerts webhook handler.
+
+Covers (per issue #151 acceptance):
+- PagerDuty: positive (verified) and negative (invalid signature) cases
+- Datadog: positive, negative, missing-timestamp, stale-timestamp, replay-window
+- Constant-time comparison (no timing-attack vector — ``hmac.compare_digest`` used)
+- Dual-secret rotation: one of two newline-separated secrets accepted
+- Cross-workspace ACL: payload's ``tenant_id`` field is IGNORED; the alert lands
+  in the workspace derived from ``Source.tenant_id`` configured per source
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import inspect
+import json
+import time
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_connectors.alerts.webhook import (
+    AlertsWebhookHandler,
+    verify_datadog,
+    verify_pagerduty,
+)
+from omniscience_core.config import Settings
+from omniscience_core.db.models import Source, SourceType
+from omniscience_server.app import create_app
+from omniscience_server.rest.webhooks import clear_all_source_buckets
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _settings() -> Settings:
+    return Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+
+
+def _alert_source(
+    *,
+    name: str = "alerts-prod",
+    tenant_id: uuid.UUID | None = None,
+    secret: str = "supersecret",
+) -> Source:
+    src: Source = MagicMock(spec=Source)
+    src.id = uuid.uuid4()
+    src.type = SourceType.alerts
+    src.name = name
+    src.tenant_id = tenant_id or uuid.uuid4()
+    src.config = {"webhook_secret": secret, "provider": "pagerduty"}
+    return src
+
+
+def _make_db(source: Source | None) -> AsyncMock:
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = source
+        return result
+
+    session.execute = _execute
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _app_with(source: Source | None = None) -> FastAPI:
+    app = create_app(settings=_settings())
+    app.state.db_session_factory = MagicMock(return_value=_make_db(source))
+    return app
+
+
+def _pd_sign(body: bytes, secret: str) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"v1={digest}"
+
+
+def _dd_sign(body: bytes, ts: int, secret: str) -> str:
+    base = f"{ts}:".encode() + body
+    return hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def reset_source_buckets() -> None:
+    """Clear per-source rate-limit state between tests."""
+    clear_all_source_buckets()
+
+
+# ---------------------------------------------------------------------------
+# PagerDuty signature verification — pure function
+# ---------------------------------------------------------------------------
+
+
+def test_pagerduty_positive_case() -> None:
+    body = b'{"event":{"data":{"id":"P1","severity":"critical","status":"triggered"}}}'
+    sig = _pd_sign(body, "secret-1")
+    assert verify_pagerduty(body, sig, "secret-1") is True
+
+
+def test_pagerduty_rejects_bad_signature() -> None:
+    body = b'{"x":1}'
+    bad = "v1=" + "00" * 32
+    assert verify_pagerduty(body, bad, "secret-1") is False
+
+
+def test_pagerduty_rejects_missing_signature() -> None:
+    assert verify_pagerduty(b'{"x":1}', "", "secret-1") is False
+
+
+def test_pagerduty_rejects_unknown_version() -> None:
+    body = b'{"x":1}'
+    digest = hmac.new(b"secret-1", body, hashlib.sha256).hexdigest()
+    # Right hash, wrong version label.
+    assert verify_pagerduty(body, f"v999={digest}", "secret-1") is False
+
+
+def test_pagerduty_dual_secret_rotation_accepts_either() -> None:
+    body = b'{"x":1}'
+    # Sender signed with the *new* (second) secret only.
+    sig = _pd_sign(body, "new-secret")
+    rotated = "old-secret\nnew-secret"
+    assert verify_pagerduty(body, sig, rotated) is True
+
+
+def test_pagerduty_accepts_multiple_v1_in_header() -> None:
+    body = b'{"x":1}'
+    good = _pd_sign(body, "secret-1")
+    # Header carries a stale signature plus a current one.
+    header = f"v1=deadbeef,{good}"
+    assert verify_pagerduty(body, header, "secret-1") is True
+
+
+# ---------------------------------------------------------------------------
+# Datadog signature verification — pure function
+# ---------------------------------------------------------------------------
+
+
+def test_datadog_positive_case() -> None:
+    body = b'{"id":"42"}'
+    ts = 1_761_300_000
+    sig = _dd_sign(body, ts, "secret-1")
+    assert verify_datadog(body, sig, str(ts), "secret-1", now=ts + 10) is True
+
+
+def test_datadog_rejects_bad_signature() -> None:
+    body = b'{"id":"42"}'
+    ts = 1_761_300_000
+    bad = "00" * 32
+    assert verify_datadog(body, bad, str(ts), "secret-1", now=ts + 1) is False
+
+
+def test_datadog_rejects_missing_timestamp() -> None:
+    body = b'{"id":"42"}'
+    sig = _dd_sign(body, 1_761_300_000, "secret-1")
+    assert verify_datadog(body, sig, "", "secret-1") is False
+
+
+def test_datadog_rejects_stale_timestamp() -> None:
+    """Timestamp older than ``replay_window_seconds`` -> reject."""
+    body = b'{"id":"42"}'
+    ts = 1_761_300_000
+    sig = _dd_sign(body, ts, "secret-1")
+    # 600s skew — outside the 300s default window.
+    assert verify_datadog(body, sig, str(ts), "secret-1", now=ts + 600) is False
+
+
+def test_datadog_accepts_sha256_prefixed_header() -> None:
+    body = b'{"id":"42"}'
+    ts = 1_761_300_000
+    sig = _dd_sign(body, ts, "secret-1")
+    assert verify_datadog(body, "sha256=" + sig, str(ts), "secret-1", now=ts + 10) is True
+
+
+def test_datadog_dual_secret_rotation() -> None:
+    body = b'{"id":"42"}'
+    ts = 1_761_300_000
+    sig = _dd_sign(body, ts, "new-secret")
+    rotated = "old-secret\nnew-secret"
+    assert verify_datadog(body, sig, str(ts), rotated, now=ts + 10) is True
+
+
+# ---------------------------------------------------------------------------
+# Constant-time comparison verified
+# ---------------------------------------------------------------------------
+
+
+def test_verifiers_use_constant_time_compare() -> None:
+    """Both verifiers must reference ``hmac.compare_digest`` — no naive ``==``.
+
+    Inspect the implementation source to prove the constant-time primitive is
+    in use; this catches regressions where a future maintainer accidentally
+    swaps in ``==``.
+    """
+    pd_src = inspect.getsource(verify_pagerduty)
+    dd_src = inspect.getsource(verify_datadog)
+    assert "hmac.compare_digest" in pd_src
+    assert "hmac.compare_digest" in dd_src
+    # No raw equality on the signature in either path.
+    assert "received ==" not in pd_src
+    assert "received ==" not in dd_src
+
+
+# ---------------------------------------------------------------------------
+# WebhookHandler high-level dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_dispatches_to_pagerduty() -> None:
+    handler = AlertsWebhookHandler()
+    body = b'{"event":{"data":{"id":"P1","severity":"warning","status":"triggered"}}}'
+    sig = _pd_sign(body, "s1")
+    assert await handler.verify_signature(body, {"X-PagerDuty-Signature": sig}, "s1") is True
+
+
+@pytest.mark.asyncio
+async def test_handler_dispatches_to_datadog() -> None:
+    handler = AlertsWebhookHandler()
+    body = b'{"id":"42","alert_type":"alert","priority":"P1"}'
+    ts = int(time.time())
+    sig = _dd_sign(body, ts, "s1")
+    headers = {
+        "X-Datadog-Signature": sig,
+        "X-Datadog-Signature-Timestamp": str(ts),
+    }
+    assert await handler.verify_signature(body, headers, "s1") is True
+
+
+@pytest.mark.asyncio
+async def test_handler_rejects_request_without_known_signature_header() -> None:
+    handler = AlertsWebhookHandler()
+    assert await handler.verify_signature(b"{}", {"X-Random": "1"}, "s1") is False
+
+
+@pytest.mark.asyncio
+async def test_handler_parse_payload_pagerduty_emits_alert_and_targets() -> None:
+    handler = AlertsWebhookHandler()
+    body = json.dumps(
+        {
+            "event": {
+                "data": {
+                    "id": "PABC",
+                    "severity": "critical",
+                    "status": "triggered",
+                    "title": "pod/web crashed",
+                    "description": (
+                        "Affecting arn:aws:ec2:us-east-1:111122223333:instance/i-0a "
+                        "and pod/web; trace://aabbccddeeff00112233445566778899"
+                    ),
+                    "service": {"summary": "web-api"},
+                    "created_at": "2026-04-24T10:00:00Z",
+                }
+            }
+        }
+    ).encode()
+    payload = await handler.parse_payload(body, {"X-PagerDuty-Signature": "v1=ignored"})
+    names = [r.uri for r in payload.affected_refs]
+    assert names[0] == "alert://pagerduty/PABC"
+    assert "arn:aws:ec2:us-east-1:111122223333:instance/i-0a" in names
+    assert "pod/web" in names
+    assert "service://web-api" in names
+    assert "trace://aabbccddeeff00112233445566778899" in names
+
+
+@pytest.mark.asyncio
+async def test_handler_parse_payload_rejects_non_object_json() -> None:
+    handler = AlertsWebhookHandler()
+    with pytest.raises(ValueError, match="JSON object"):
+        await handler.parse_payload(b'"hello"', {"X-PagerDuty-Signature": "v1=x"})
+
+
+# ---------------------------------------------------------------------------
+# Receiver integration: 200/202 happy path + 400 negative path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_receiver_pagerduty_valid_signature_returns_202() -> None:
+    src = _alert_source(secret="secret-1")
+    app = _app_with(src)
+    body = json.dumps(
+        {"event": {"data": {"id": "P1", "severity": "warning", "status": "triggered"}}}
+    ).encode()
+    headers = {
+        "X-PagerDuty-Signature": _pd_sign(body, "secret-1"),
+        "Content-Type": "application/json",
+    }
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as ac:
+        resp = await ac.post("/api/v1/ingest/webhook/alerts-prod", content=body, headers=headers)
+    assert resp.status_code == 202
+    assert resp.json()["accepted"] is True
+
+
+@pytest.mark.asyncio
+async def test_receiver_pagerduty_invalid_signature_returns_400() -> None:
+    src = _alert_source(secret="secret-1")
+    app = _app_with(src)
+    body = b'{"event":{"data":{"id":"P1","severity":"warning","status":"triggered"}}}'
+    bad_header = "v1=" + "0" * 64
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as ac:
+        resp = await ac.post(
+            "/api/v1/ingest/webhook/alerts-prod",
+            content=body,
+            headers={"X-PagerDuty-Signature": bad_header},
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_receiver_datadog_invalid_signature_returns_400() -> None:
+    src = _alert_source(secret="secret-1")
+    app = _app_with(src)
+    body = b'{"id":"42","alert_type":"alert","priority":"P1"}'
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as ac:
+        resp = await ac.post(
+            "/api/v1/ingest/webhook/alerts-prod",
+            content=body,
+            headers={
+                "X-Datadog-Signature": "0" * 64,
+                "X-Datadog-Signature-Timestamp": str(int(time.time())),
+            },
+        )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# CROSS-WORKSPACE ACL TEST (P0 — payload tenant_id MUST be ignored)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cross_workspace_acl_payload_tenant_id_is_ignored() -> None:
+    """A malicious payload that claims a foreign ``tenant_id`` MUST NOT bind
+    the alert to that workspace.  The receiver derives workspace identity
+    SOLELY from ``Source.tenant_id`` resolved by the URL-path source name.
+    """
+    workspace_a = uuid.uuid4()
+    workspace_b_attacker = uuid.uuid4()  # NOT used by the receiver
+    assert workspace_a != workspace_b_attacker
+
+    src = _alert_source(name="alerts-A", tenant_id=workspace_a, secret="secret-A")
+
+    # Forge a payload that includes B's workspace UUID in *every* tenant-shaped
+    # field a naive implementation might accidentally read.
+    body_dict: dict[str, Any] = {
+        "tenant_id": str(workspace_b_attacker),
+        "customer_id": str(workspace_b_attacker),
+        "org_id": str(workspace_b_attacker),
+        "routing_key": str(workspace_b_attacker),
+        "account_id": str(workspace_b_attacker),
+        "team": str(workspace_b_attacker),
+        "event": {
+            "data": {
+                "id": "PEVIL",
+                "severity": "critical",
+                "status": "triggered",
+                "title": "Forged tenant",
+                "tenant_id": str(workspace_b_attacker),
+                "service": {"summary": "anything"},
+                "custom_details": {
+                    "tenant_id": str(workspace_b_attacker),
+                    "workspace_id": str(workspace_b_attacker),
+                    "owner_workspace": str(workspace_b_attacker),
+                },
+            }
+        },
+    }
+    body = json.dumps(body_dict).encode()
+
+    handler = AlertsWebhookHandler()
+    sig = _pd_sign(body, "secret-A")
+
+    # Step 1: signature succeeds with source A's secret.
+    assert await handler.verify_signature(body, {"X-PagerDuty-Signature": sig}, "secret-A") is True
+
+    # Step 2: the parsed payload carries forensic tenant fields in `raw` but
+    # NEVER surfaces them as a `workspace_id`/`tenant_id` on the alert ref's
+    # metadata.  Tenant identity is the receiver's job (Source.tenant_id).
+    parsed = await handler.parse_payload(body, {"X-PagerDuty-Signature": sig})
+    alert_ref = parsed.affected_refs[0]
+    assert alert_ref.metadata["kind"] == "alert"
+    assert "workspace_id" not in alert_ref.metadata
+    assert "tenant_id" not in alert_ref.metadata
+    assert alert_ref.metadata.get("provider_alert_id") == "PEVIL"
+
+    # Step 3: end-to-end through the FastAPI receiver.  `Source.tenant_id` is
+    # the only thing that can establish workspace.  We assert the request is
+    # accepted under source A; the attacker's `tenant_id` payload field is
+    # never consulted (the receiver does not call any function that reads it).
+    app = _app_with(src)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as ac:
+        resp = await ac.post(
+            "/api/v1/ingest/webhook/alerts-A",
+            content=body,
+            headers={
+                "X-PagerDuty-Signature": sig,
+                "Content-Type": "application/json",
+            },
+        )
+    assert resp.status_code == 202
+
+    # Step 4: confirm the source ORM row used by the receiver is the one
+    # bound to workspace A — never workspace B.
+    assert src.tenant_id == workspace_a
+    assert src.tenant_id != workspace_b_attacker
+
+
+@pytest.mark.asyncio
+async def test_forged_payload_rejected_with_400_when_signed_with_wrong_secret() -> None:
+    """A payload signed with the wrong secret is rejected; no entities emitted."""
+    src = _alert_source(secret="real-secret")
+    app = _app_with(src)
+    body = b'{"event":{"data":{"id":"P1","severity":"warning","status":"triggered"}}}'
+    bad_sig = _pd_sign(body, "attacker-secret")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as ac:
+        resp = await ac.post(
+            "/api/v1/ingest/webhook/alerts-prod",
+            content=body,
+            headers={"X-PagerDuty-Signature": bad_sig},
+        )
+    assert resp.status_code == 400

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -123,6 +123,7 @@ class TestSourceModel:
             "terraform",
             "s3",
             "aws",
+            "alerts",
         }
         assert {t.value for t in SourceType} == expected
 


### PR DESCRIPTION
Closes #151. Wave 1 of epic #99.

## Summary

Adds the `alerts` source connector for SRE incident webhooks from PagerDuty
and Datadog. Push-only: `discover()` is a no-op and `fetch()` raises
`NotImplementedError`. Alert payloads arrive exclusively through signed HTTP
webhooks at `POST /api/v1/ingest/webhook/{source_name}` and produce
`alert://{provider}/{id}` entities with `[:FIRES_AGAINST]` cross_ref edges to
the resources they target (AWS ARN, Kubernetes pod, service, OTel trace id).

## Components

| File | Purpose |
|------|---------|
| `packages/connectors/src/omniscience_connectors/alerts/connector.py` | `AlertsConnector`, `AlertsConfig`, `NormalizedAlert`, normalisers, cross_ref extraction |
| `packages/connectors/src/omniscience_connectors/alerts/webhook.py` | `AlertsWebhookHandler` with `verify_pagerduty` and `verify_datadog` (constant-time HMAC-SHA256) |
| `packages/connectors/src/omniscience_connectors/alerts/__init__.py` | Public surface |
| `packages/connectors/src/omniscience_connectors/__init__.py` | Registers `AlertsConnector` |
| `packages/core/src/omniscience_core/db/models.py` | Adds `SourceType.alerts` |
| `docs/connectors/alerts.md` | Connector reference + ACL invariant write-up |
| `tests/test_alerts_connector.py` | 24 unit tests (normalisation, severity/status mapping, cross_ref extraction, protocol contract) |
| `tests/test_alerts_webhook.py` | 26 tests (positive/negative signatures, replay window, dual-secret rotation, constant-time check, end-to-end receiver, **cross-workspace ACL**) |

## Signature verification

- PagerDuty: HMAC-SHA256 of raw body, header `X-PagerDuty-Signature: v1=<hex>` (comma-separated multi-value supported).
- Datadog: HMAC-SHA256 of `<timestamp>:<raw_body>`, headers `X-Datadog-Signature` + `X-Datadog-Signature-Timestamp`, replay window default 300s (config: `replay_window_seconds`).
- All comparisons use `hmac.compare_digest` (no timing-attack vector). Inspection-based test `test_verifiers_use_constant_time_compare` guards against regressions.
- Failed verification -> 400, structured `webhook_signature_invalid` log line, no payload parsed.
- `webhook_secret` is newline-separated to support zero-downtime rotation.

## ACL invariant (P0)

Workspace identity is **always** derived from `Source.tenant_id` resolved by
the URL-path `{source_name}`. Payload fields (`tenant_id`, `customer_id`,
`org_id`, `routing_key`, `account_id`, `team`, custom details/tags) are
**never** consulted for tenancy. Test
`test_cross_workspace_acl_payload_tenant_id_is_ignored` plants a foreign
workspace UUID in every reasonable payload field, signs the request with
source A's secret, asserts the alert is accepted under source A, and
verifies `Source.tenant_id` (workspace A) is the only thing the receiver
trusts. The forged-payload test
`test_forged_payload_rejected_with_400_when_signed_with_wrong_secret`
covers the bad-secret rejection path.

## Quality gates

- `uv run pytest`: 1880 passed, 52 skipped, 0 failed (50 new tests in this PR).
- `uv run mypy --strict apps/ packages/`: no issues found in 168 source files (165 baseline + 3 new alert files).
- `uv run ruff check .` / `ruff format --check .`: all clean.
- No new dependencies. Stdlib `hmac` is the only crypto primitive added.
- Functions all under 30 lines.

## Non-goals (per issue)

- No third providers (Opsgenie, VictorOps).
- No alert routing / on-call escalation.
- No cross-provider deduplication.
- No log/metric ingestion.
- No new endpoint — reuses existing `/api/v1/ingest/webhook/{source_name}`.

## Test plan

- [x] PagerDuty positive + negative signature
- [x] Datadog positive + negative signature
- [x] Stale Datadog timestamp rejected
- [x] Missing Datadog timestamp rejected
- [x] Dual-secret rotation accepts either secret (both providers)
- [x] Constant-time comparison verified by source inspection
- [x] Cross-workspace ACL: forged `tenant_id` in payload ignored
- [x] Forged-payload (wrong secret) rejected with 400
- [x] Severity/status mapping for both providers
- [x] Cross_ref edges emitted for ARN, pod, service, trace_id
- [x] Connector protocol: discover no-op, fetch raises, validate enforces secret
- [x] Connector registered under type `alerts`

## Follow-ups (out of scope)

- The receiver currently rejects on signature failure with 400 (matching
  existing GitHub/Slack handlers and the issue's `400` requirement). The
  issue prose mentions 401 as an alternative for security-event semantics;
  the consistent receiver-wide pattern is 400 today, so we kept that to
  avoid touching unrelated handlers. If 401 is preferred globally, it
  should land as a single follow-up touching all webhook signature paths.
- A `provider_alert_id` collision test across providers (PagerDuty `1234` vs
  Datadog `1234`) is implicit in the namespaced canonical name
  `alert://{provider}/{id}` but a dedicated graph-layer test belongs with
  the Wave 1 demo fixture (#154).