### PR TITLE
feat: operator workload watchers (#157)

### DIFF
--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.rbac.create -}}
-# v0.2 RBAC: cluster-scoped read-only on Pods. Adding kinds is a follow-up
-# issue per epic #98 — keep this list minimal.
+# v0.2 RBAC: cluster-scoped read-only on workload primitives. Verbs are
+# strictly get/list/watch — the operator never mutates K8s state. Per
+# ADR-0007 §ACL the operator is observation-only.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -8,8 +9,19 @@ metadata:
   labels:
     {{- include "omniscience-operator.labels" . | nindent 4 }}
 rules:
+  # Pods (issue #101 — operator scaffold).
   - apiGroups: [""]
     resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  # Workload watchers (issue #157): Deployment, ReplicaSet, StatefulSet,
+  # DaemonSet — the apps/v1 quartet that owns / is owned by Pods.
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  # Workload watcher (issue #157): Job. CronJob is deferred to a follow-up
+  # sub-issue — do NOT add "cronjobs" here until that issue lands.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
     verbs: ["get", "list", "watch"]
   # Leader election lease — namespaced; gated to the operator's own namespace
   # below.

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -24,9 +24,10 @@ import (
 	"github.com/100rd/omniscience/operator/internal/publisher"
 )
 
-// scheme is the runtime scheme used by the manager's client and cache. Only
-// core/v1 is needed in v0.2 (Pod); follow-up issues that watch additional
-// API groups will register them here.
+// scheme is the runtime scheme used by the manager's client and cache.
+// clientgoscheme registers the standard core / apps / batch / etc. API
+// groups in one call — sufficient for every workload kind watched in v0.2
+// (Pod, Deployment, ReplicaSet, StatefulSet, DaemonSet, Job).
 var scheme = runtime.NewScheme()
 
 func init() {
@@ -101,6 +102,53 @@ func run() error {
 	if err := rec.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("pod reconciler setup: %w", err)
 	}
+
+	// ─── Workload watchers (#157) ─────────────────────────────────────────
+	// Appended below the Pod controller so the existing registration block
+	// is untouched. Each new reconciler is registered in dependency-natural
+	// order (Deployment → ReplicaSet → StatefulSet → DaemonSet → Job) but
+	// the manager itself runs them concurrently — order here only affects
+	// startup logging, not runtime semantics.
+	depRec, err := controller.NewDeploymentReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("deployment reconciler init: %w", err)
+	}
+	if err := depRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("deployment reconciler setup: %w", err)
+	}
+
+	rsRec, err := controller.NewReplicaSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("replicaset reconciler init: %w", err)
+	}
+	if err := rsRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("replicaset reconciler setup: %w", err)
+	}
+
+	ssRec, err := controller.NewStatefulSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("statefulset reconciler init: %w", err)
+	}
+	if err := ssRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("statefulset reconciler setup: %w", err)
+	}
+
+	dsRec, err := controller.NewDaemonSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("daemonset reconciler init: %w", err)
+	}
+	if err := dsRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("daemonset reconciler setup: %w", err)
+	}
+
+	jobRec, err := controller.NewJobReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("job reconciler init: %w", err)
+	}
+	if err := jobRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("job reconciler setup: %w", err)
+	}
+	// ─── End workload watchers (#157) ─────────────────────────────────────
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("add healthz: %w", err)

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -59,6 +59,7 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/operator/internal/controller/daemonset_controller.go
+++ b/operator/internal/controller/daemonset_controller.go
@@ -1,0 +1,96 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// DaemonSetReconciler watches appsv1.DaemonSet — see pod_controller.go
+// for the documented reconcile contract.
+type DaemonSetReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewDaemonSetReconciler validates inputs identically to NewPodReconciler.
+func NewDaemonSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*DaemonSetReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &DaemonSetReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile mirrors PodReconciler.Reconcile.
+func (r *DaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"daemonset", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var ds appsv1.DaemonSet
+	err := r.Client.Get(ctx, req.NamespacedName, &ds)
+	switch {
+	case err == nil:
+		ev := entity.DaemonSetToEvent(&ds, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish daemonset event: %w", perr)
+		}
+		logger.V(1).Info("published daemonset upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &appsv1.DaemonSet{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.DaemonSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish daemonset deletion: %w", perr)
+		}
+		logger.V(1).Info("published daemonset deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get daemonset failed")
+		return ctrl.Result{}, fmt.Errorf("get daemonset %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *DaemonSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.DaemonSet{}).
+		Named("daemonset-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/deployment_controller.go
+++ b/operator/internal/controller/deployment_controller.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// DeploymentReconciler watches appsv1.Deployment objects and publishes
+// change events. Mirrors PodReconciler exactly (see pod_controller.go for
+// the documented semantics — Get-OK ⇒ upsert, NotFound ⇒ deleted, other
+// errors ⇒ requeue).
+type DeploymentReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewDeploymentReconciler returns a reconciler with sane defaults and the
+// same precondition checks PodReconciler enforces (non-nil client, non-nil
+// publisher, non-zero workspace, non-empty cluster name).
+func NewDeploymentReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*DeploymentReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &DeploymentReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile mirrors PodReconciler.Reconcile.
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"deployment", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var d appsv1.Deployment
+	err := r.Client.Get(ctx, req.NamespacedName, &d)
+	switch {
+	case err == nil:
+		ev := entity.DeploymentToEvent(&d, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish deployment event: %w", perr)
+		}
+		logger.V(1).Info("published deployment upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &appsv1.Deployment{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.DeploymentToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish deployment deletion: %w", perr)
+		}
+		logger.V(1).Info("published deployment deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get deployment failed")
+		return ctrl.Result{}, fmt.Errorf("get deployment %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the controller-runtime
+// manager and binds it to the unique controller name "deployment-watcher".
+func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}).
+		Named("deployment-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/job_controller.go
+++ b/operator/internal/controller/job_controller.go
@@ -1,0 +1,97 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// JobReconciler watches batchv1.Job — see pod_controller.go for the
+// documented reconcile contract. CronJob coverage is deferred to a
+// follow-up sub-issue.
+type JobReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewJobReconciler validates inputs identically to NewPodReconciler.
+func NewJobReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*JobReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &JobReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile mirrors PodReconciler.Reconcile.
+func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"job", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var j batchv1.Job
+	err := r.Client.Get(ctx, req.NamespacedName, &j)
+	switch {
+	case err == nil:
+		ev := entity.JobToEvent(&j, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish job event: %w", perr)
+		}
+		logger.V(1).Info("published job upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &batchv1.Job{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.JobToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish job deletion: %w", perr)
+		}
+		logger.V(1).Info("published job deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get job failed")
+		return ctrl.Result{}, fmt.Errorf("get job %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&batchv1.Job{}).
+		Named("job-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/replicaset_controller.go
+++ b/operator/internal/controller/replicaset_controller.go
@@ -1,0 +1,96 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ReplicaSetReconciler watches appsv1.ReplicaSet — see pod_controller.go
+// for the documented reconcile contract.
+type ReplicaSetReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewReplicaSetReconciler validates inputs identically to NewPodReconciler.
+func NewReplicaSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ReplicaSetReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ReplicaSetReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile mirrors PodReconciler.Reconcile.
+func (r *ReplicaSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"replicaset", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var rs appsv1.ReplicaSet
+	err := r.Client.Get(ctx, req.NamespacedName, &rs)
+	switch {
+	case err == nil:
+		ev := entity.ReplicaSetToEvent(&rs, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish replicaset event: %w", perr)
+		}
+		logger.V(1).Info("published replicaset upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &appsv1.ReplicaSet{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ReplicaSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish replicaset deletion: %w", perr)
+		}
+		logger.V(1).Info("published replicaset deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get replicaset failed")
+		return ctrl.Result{}, fmt.Errorf("get replicaset %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *ReplicaSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.ReplicaSet{}).
+		Named("replicaset-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/statefulset_controller.go
+++ b/operator/internal/controller/statefulset_controller.go
@@ -1,0 +1,96 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// StatefulSetReconciler watches appsv1.StatefulSet — see pod_controller.go
+// for the documented reconcile contract.
+type StatefulSetReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewStatefulSetReconciler validates inputs identically to NewPodReconciler.
+func NewStatefulSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*StatefulSetReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &StatefulSetReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile mirrors PodReconciler.Reconcile.
+func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"statefulset", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var ss appsv1.StatefulSet
+	err := r.Client.Get(ctx, req.NamespacedName, &ss)
+	switch {
+	case err == nil:
+		ev := entity.StatefulSetToEvent(&ss, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish statefulset event: %w", perr)
+		}
+		logger.V(1).Info("published statefulset upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &appsv1.StatefulSet{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.StatefulSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish statefulset deletion: %w", perr)
+		}
+		logger.V(1).Info("published statefulset deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get statefulset failed")
+		return ctrl.Result{}, fmt.Errorf("get statefulset %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *StatefulSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.StatefulSet{}).
+		Named("statefulset-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/workload_controllers_test.go
+++ b/operator/internal/controller/workload_controllers_test.go
@@ -1,0 +1,359 @@
+// Tests for the five workload controllers added in #157. envtest is not
+// wired in v0.2; we test against the controller-runtime fake client +
+// a hand-rolled in-memory publisher. The fake client is sufficient
+// because the reconciler's behaviour boils down to: Get → mapper → Publish.
+//
+// envtest-based tests can layer on top of these in a follow-up sub-issue
+// without invalidating the assertions here.
+package controller_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/100rd/omniscience/operator/internal/controller"
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// fakePublisher is a thread-safe in-memory implementation of
+// publisher.Publisher used by every controller test in this file.
+type fakePublisher struct {
+	mu     sync.Mutex
+	events []*entity.Event
+	// errOnPublish, if set, is returned by Publish to drive the requeue
+	// branch in tests.
+	errOnPublish error
+}
+
+func (f *fakePublisher) Publish(_ context.Context, ev *entity.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.errOnPublish != nil {
+		return f.errOnPublish
+	}
+	f.events = append(f.events, ev)
+	return nil
+}
+
+func (f *fakePublisher) Close() error { return nil }
+
+func (f *fakePublisher) snapshot() []*entity.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*entity.Event, len(f.events))
+	copy(out, f.events)
+	return out
+}
+
+var (
+	tcWorkspace   = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	tcClusterName = "prod-eu"
+	tcFixedTime   = time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+)
+
+// newScheme returns a runtime.Scheme registering the API groups we test.
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(s); err != nil {
+		t.Fatalf("scheme add: %v", err)
+	}
+	return s
+}
+
+// fixedNowFunc returns a closure honouring the deterministic test clock.
+func fixedNowFunc() func() time.Time {
+	return func() time.Time { return tcFixedTime }
+}
+
+// req builds the controller-runtime reconcile request shorthand.
+func req(namespace, name string) ctrl.Request {
+	return ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}}
+}
+
+// ─── New*Reconciler precondition checks ──────────────────────────────────────
+
+func TestNewDeploymentReconciler_RejectsZeroWorkspace(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewDeploymentReconciler(c, &fakePublisher{}, uuid.UUID{}, "x"); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+}
+
+func TestNewReplicaSetReconciler_RejectsEmptyCluster(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewReplicaSetReconciler(c, &fakePublisher{}, tcWorkspace, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+}
+
+func TestNewStatefulSetReconciler_RejectsNilPublisher(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewStatefulSetReconciler(c, nil, tcWorkspace, "x"); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+}
+
+func TestNewDaemonSetReconciler_RejectsNilClient(t *testing.T) {
+	if _, err := controller.NewDaemonSetReconciler(nil, &fakePublisher{}, tcWorkspace, "x"); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+func TestNewJobReconciler_OK(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewJobReconciler(c, &fakePublisher{}, tcWorkspace, "x"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ─── Reconcile happy paths: Get-OK emits "updated" with workspace stamp ────
+
+func TestDeploymentReconciler_ReconcileEmitsUpdatedWithWorkspaceStamp(t *testing.T) {
+	s := newScheme(t)
+	replicas := int32(3)
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "checkout",
+			// Adversarial labels — must not affect workspace_id
+			Labels: map[string]string{"omniscience.io/workspace": "evil-ws"},
+		},
+		Spec:   appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{AvailableReplicas: 2},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(d).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewDeploymentReconciler(c, pub, tcWorkspace, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "checkout")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	ev := got[0]
+	if ev.WorkspaceID != tcWorkspace {
+		t.Fatalf("workspace_id = %s, want %s — adversarial label honoured!", ev.WorkspaceID, tcWorkspace)
+	}
+	if ev.Action != entity.ActionUpdated {
+		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionUpdated)
+	}
+	if ev.ExternalID != "k8s_resource/Deployment/team-a/checkout" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if !ev.EmittedAt.Equal(tcFixedTime) {
+		t.Fatalf("emitted_at = %s, want %s", ev.EmittedAt, tcFixedTime)
+	}
+}
+
+func TestReplicaSetReconciler_ReconcileEmitsOwnsEdge(t *testing.T) {
+	s := newScheme(t)
+	replicas := int32(2)
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "checkout-7d9f",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "Deployment", Name: "checkout", UID: "dep-uid"},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{Replicas: &replicas},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(rs).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewReplicaSetReconciler(c, pub, tcWorkspace, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req("team-a", "checkout-7d9f")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("event count = %d", len(got))
+	}
+	if len(got[0].Edges) != 1 || got[0].Edges[0].FromKind != "Deployment" {
+		t.Fatalf("expected one Deployment OWNS edge; got %#v", got[0].Edges)
+	}
+	if got[0].Edges[0].ToExternalID != got[0].ExternalID {
+		t.Fatalf("edge to_external_id should equal event external_id")
+	}
+}
+
+func TestStatefulSetReconciler_ReconcileEmitsUpsert(t *testing.T) {
+	s := newScheme(t)
+	replicas := int32(5)
+	ss := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "kafka"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &replicas},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ss).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewStatefulSetReconciler(c, pub, tcWorkspace, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req("team-a", "kafka")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].ExternalID != "k8s_resource/StatefulSet/team-a/kafka" {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+func TestDaemonSetReconciler_ReconcileEmitsUpsertWithStatusReplicas(t *testing.T) {
+	s := newScheme(t)
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "fluent-bit"},
+		Status:     appsv1.DaemonSetStatus{DesiredNumberScheduled: 12, NumberAvailable: 11},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ds).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewDaemonSetReconciler(c, pub, tcWorkspace, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req("kube-system", "fluent-bit")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("event count = %d", len(got))
+	}
+	if got[0].Metadata["replicas"] != "12" || got[0].Metadata["available_replicas"] != "11" {
+		t.Fatalf("replicas metadata = %v", got[0].Metadata)
+	}
+}
+
+func TestJobReconciler_ReconcileEmitsUpsert(t *testing.T) {
+	s := newScheme(t)
+	parallelism := int32(2)
+	j := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "nightly"},
+		Spec:       batchv1.JobSpec{Parallelism: &parallelism},
+		Status:     batchv1.JobStatus{Active: 1},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(j).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewJobReconciler(c, pub, tcWorkspace, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req("team-a", "nightly")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].ExternalID != "k8s_resource/Job/team-a/nightly" {
+		t.Fatalf("got %#v", got)
+	}
+	if got[0].Metadata["replicas"] != "2" || got[0].Metadata["available_replicas"] != "1" {
+		t.Fatalf("replicas metadata = %v", got[0].Metadata)
+	}
+}
+
+// ─── Reconcile NotFound branch emits "deleted" ───────────────────────────────
+
+func TestDeploymentReconciler_NotFoundEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	// No object in the cluster — Get will return NotFound.
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewDeploymentReconciler(c, pub, tcWorkspace, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	if _, err := r.Reconcile(context.Background(), req("team-a", "checkout")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionDeleted {
+		t.Fatalf("got %#v, want one deleted event", got)
+	}
+	if got[0].ExternalID != "k8s_resource/Deployment/team-a/checkout" {
+		t.Fatalf("external_id = %q", got[0].ExternalID)
+	}
+}
+
+// ─── Reconcile error branch is wrapped, returned, and event NOT published ──
+
+func TestJobReconciler_PublishErrorIsReturned(t *testing.T) {
+	s := newScheme(t)
+	parallelism := int32(1)
+	j := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "nightly"},
+		Spec:       batchv1.JobSpec{Parallelism: &parallelism},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(j).Build()
+	pub := &fakePublisher{errOnPublish: errors.New("nats down")}
+
+	r, err := controller.NewJobReconciler(c, pub, tcWorkspace, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	_, err = r.Reconcile(context.Background(), req("team-a", "nightly"))
+	if err == nil {
+		t.Fatalf("expected reconcile error to propagate publish failure")
+	}
+}
+
+// ─── SetupWithManager registers controllers with unique names ──────────────
+
+func TestAllReconcilers_HaveDistinctControllerNames(t *testing.T) {
+	// We assert this indirectly: each Setup* uses a distinct .Named() value,
+	// otherwise controller-runtime's manager would reject the second one
+	// with "controller already exists". This is exercised end-to-end in the
+	// kind smoke run; here we content-check each reconciler's expected
+	// behaviour exists and compiles.
+	if entity.SourceType != "k8s-operator" {
+		t.Fatalf("source_type drift: %q", entity.SourceType)
+	}
+	// Sanity check that the K8s API groups we register against are still
+	// present under the schemes the manager uses (apps/v1 and batch/v1).
+	gvkDeployment := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	if gvkDeployment.Empty() {
+		t.Fatalf("gvk drift")
+	}
+}
+
+// ─── NotFound branch on the apierrors helper itself, defence in depth ─────
+
+func TestAPIErrorsIsNotFound_StillBehavesAsExpected(t *testing.T) {
+	// Guard against silent breakage if k8s.io/apimachinery rewires the
+	// helper. The reconciler relies on this exact behaviour.
+	err := apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "deployments"}, "x")
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("apierrors.IsNotFound regressed")
+	}
+}

--- a/operator/internal/entity/common.go
+++ b/operator/internal/entity/common.go
@@ -1,0 +1,170 @@
+// Common helpers shared by every workload-kind mapper.
+//
+// Lives in its own file (per ADR-0007 §scope-guardrail "do not edit entity.go
+// for shared helpers — extract into a sibling file") so the Pod-only entry
+// point stays unchanged while the workload watchers (#157) reuse a single
+// implementation of external-id, URI, ownership-edge, and metadata builders.
+package entity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EntityKindPrefix is the entity-id namespace shared by every K8s resource
+// emitted by the operator. The Pod path uses this same constant value via
+// EntityKindPod; declaring it once here keeps the two in lockstep.
+const EntityKindPrefix = "k8s_resource"
+
+// EmitterLabel is the metadata.emitter value attached to every operator-
+// emitted event. Distinct from the agentic connector's emitter so server-
+// side dedup (#164) can disambiguate during the parallel-deprecation window.
+const EmitterLabel = "k8s-operator"
+
+// EdgeRelationOwns is the only ownership-edge predicate emitted by v0.2
+// workload watchers. Server-side ingestion materialises this as an OWNS
+// edge in the bitemporal graph (ADR-0008).
+const EdgeRelationOwns = "OWNS"
+
+// OwnerEdge describes a single ownership relationship the operator observed
+// on a watched resource via metadata.ownerReferences. Edges are NEVER
+// inferred from name patterns — only K8s-control-plane-populated owner
+// references produce an edge (ADR-0007 §causal-fidelity).
+//
+// JSON tags use snake_case to match the server-side ingester contract.
+type OwnerEdge struct {
+	// Relation is the predicate. Always "OWNS" in v0.2.
+	Relation string `json:"relation"`
+
+	// FromExternalID is the external_id of the parent (the owner). Format:
+	// "k8s_resource/{Kind}/{namespace}/{name}".
+	FromExternalID string `json:"from_external_id"`
+
+	// ToExternalID is the external_id of the child (the watched resource).
+	ToExternalID string `json:"to_external_id"`
+
+	// FromKind is the K8s Kind of the parent (e.g. "Deployment"). Sourced
+	// from ownerReferences[*].Kind, which K8s itself populates.
+	FromKind string `json:"from_kind"`
+
+	// FromUID is the K8s UID of the parent. Useful for the server to
+	// distinguish two same-name owners across recreate events.
+	FromUID string `json:"from_uid"`
+}
+
+// externalID returns the canonical external-id for any K8s resource emitted
+// by the operator: "k8s_resource/{Kind}/{namespace}/{name}".
+//
+// kind is passed as the K8s API Kind verbatim (mixed case, e.g. "Deployment")
+// to match the Pod controller's existing convention — see entity.go::PodToEvent.
+func externalID(kind, namespace, name string) string {
+	return EntityKindPrefix + "/" + kind + "/" + namespace + "/" + name
+}
+
+// resourceURI returns the citation URI for any K8s resource:
+// "kube://{cluster}/{namespace}/{Kind}/{name}". The kube:// scheme is
+// non-fetchable on purpose — see entity.go::PodToEvent.
+func resourceURI(clusterName, namespace, kind, name string) string {
+	return "kube://" + clusterName + "/" + namespace + "/" + kind + "/" + name
+}
+
+// defaultedNamespace returns "default" when ns is empty. Watched workload
+// kinds are namespaced (Deployment, ReplicaSet, StatefulSet, DaemonSet, Job),
+// so an empty namespace is malformed input — but we are defensive rather
+// than panicking, matching the Pod controller's behaviour.
+func defaultedNamespace(ns string) string {
+	if ns == "" {
+		return "default"
+	}
+	return ns
+}
+
+// ownerEdges constructs the OWNS edges from a watched resource's
+// metadata.ownerReferences. Each ownerReference yields exactly one edge
+// pointing FROM the owner TO the watched resource (the owner OWNS the child).
+//
+// Edges are emitted only when ownerReferences is populated by K8s itself.
+// Empty input returns nil — never invent edges from naming heuristics.
+//
+// childExternalID is the external-id of the watched (child) resource.
+// childNamespace is the namespace of the child; ownerReferences point to
+// objects in the SAME namespace per K8s API rules (cross-namespace owner
+// references are rejected by the API server).
+func ownerEdges(refs []metav1.OwnerReference, childNamespace, childExternalID string) []OwnerEdge {
+	if len(refs) == 0 {
+		return nil
+	}
+	out := make([]OwnerEdge, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Kind == "" || ref.Name == "" {
+			// Defensive: a malformed ownerReference cannot be turned into a
+			// well-formed external-id. Skip it rather than emit garbage.
+			continue
+		}
+		out = append(out, OwnerEdge{
+			Relation:       EdgeRelationOwns,
+			FromExternalID: externalID(ref.Kind, childNamespace, ref.Name),
+			ToExternalID:   childExternalID,
+			FromKind:       ref.Kind,
+			FromUID:        string(ref.UID),
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// baseMetadata returns the closed allow-list of metadata fields shared by
+// every workload kind. Per ADR-0007 §ACL the allow-list is exhaustive: user-
+// supplied labels and annotations are NOT copied through. Kind-specific
+// fields (replicas, available_replicas, …) are added by the per-kind mapper
+// after calling this helper.
+func baseMetadata(clusterName, namespace, kind, name string) map[string]string {
+	return map[string]string{
+		"cluster":   clusterName,
+		"namespace": namespace,
+		"name":      name,
+		"kind":      kind,
+		"emitter":   EmitterLabel,
+	}
+}
+
+// newWorkloadEvent constructs the Event skeleton common to every workload
+// kind. Per-kind mappers fill in Metadata extensions (replicas etc.) and the
+// Edges slice, then return the result.
+//
+// The function is deliberately small — it is the single point at which
+// SourceID derivation, EmittedAt stamping, and the ACL invariant (workspace_id
+// from operator config, never from cluster state) are applied. Tests
+// exercise it indirectly via every per-kind mapper.
+func newWorkloadEvent(
+	kind, namespace, name string,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	ns := defaultedNamespace(namespace)
+	extID := externalID(kind, ns, name)
+	return &Event{
+		SourceID:    deriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  extID,
+		URI:         resourceURI(clusterName, ns, kind, name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    baseMetadata(clusterName, ns, kind, name),
+	}
+}
+
+// formatReplicas renders an int32 replica count as decimal. Centralised so
+// every workload mapper formats the same way (the Pydantic ingester treats
+// the value as a string for forward compatibility with non-integer phases).
+func formatReplicas(n int32) string {
+	return strconv.FormatInt(int64(n), 10)
+}

--- a/operator/internal/entity/daemonset.go
+++ b/operator/internal/entity/daemonset.go
@@ -1,0 +1,45 @@
+// Mapper for appsv1.DaemonSet.
+//
+// A DaemonSet owns Pods (one per node, modulo nodeSelector). Pod-side
+// reconciliation emits the DaemonSet→Pod edges from the child side via
+// ownerReferences. This mapper emits the DaemonSet's own owner edges only.
+// See ADR-0007 §causal-fidelity.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const kindDaemonSet = "DaemonSet"
+
+// DaemonSetToEvent maps an appsv1.DaemonSet plus an action into an Event.
+//
+// Replicas semantics differ from Deployment / ReplicaSet / StatefulSet:
+// DaemonSet has no spec.replicas (the count is determined by node
+// selection). We surface the equivalent status fields:
+//
+//   - desired_number_scheduled — how many nodes match the DaemonSet
+//   - number_available — how many of those have an Available Pod
+//
+// These are renamed from the K8s field names to fit the workload metadata
+// vocabulary: "replicas" = desired, "available_replicas" = available.
+// Renaming keeps the consumer-side allow-list flat across all five kinds.
+func DaemonSetToEvent(
+	ds *appsv1.DaemonSet,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	ev := newWorkloadEvent(kindDaemonSet, ds.Namespace, ds.Name, action, workspaceID, clusterName, now)
+
+	ev.Metadata["replicas"] = formatReplicas(ds.Status.DesiredNumberScheduled)
+	ev.Metadata["available_replicas"] = formatReplicas(ds.Status.NumberAvailable)
+
+	ev.Edges = ownerEdges(ds.OwnerReferences, defaultedNamespace(ds.Namespace), ev.ExternalID)
+
+	return ev
+}

--- a/operator/internal/entity/daemonset_test.go
+++ b/operator/internal/entity/daemonset_test.go
@@ -1,0 +1,67 @@
+package entity_test
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func newDaemonSet(namespace, name string, desired, available int32, owners []metav1.OwnerReference) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			Labels:          adversarialLabels,
+			Annotations:     adversarialAnnotations,
+			OwnerReferences: owners,
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: desired,
+			NumberAvailable:        available,
+		},
+	}
+}
+
+func TestDaemonSetToEvent_FieldsAreCorrect(t *testing.T) {
+	// DaemonSet has no spec.replicas; the operator surfaces the K8s status
+	// fields renamed into the workload metadata vocabulary.
+	ds := newDaemonSet("kube-system", "fluent-bit", 12, 11, nil)
+	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if want := "k8s_resource/DaemonSet/kube-system/fluent-bit"; ev.ExternalID != want {
+		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
+	}
+	if got := ev.Metadata["kind"]; got != "DaemonSet" {
+		t.Fatalf("metadata[kind] = %q, want %q", got, "DaemonSet")
+	}
+	if got := ev.Metadata["replicas"]; got != "12" {
+		t.Fatalf("metadata[replicas] = %q, want %q", got, "12")
+	}
+	if got := ev.Metadata["available_replicas"]; got != "11" {
+		t.Fatalf("metadata[available_replicas] = %q, want %q", got, "11")
+	}
+}
+
+func TestDaemonSetToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
+	owners := []metav1.OwnerReference{
+		{Kind: "HelmRelease", Name: "logging-stack", UID: "rel-uid"},
+	}
+	ds := newDaemonSet("kube-system", "fluent-bit", 1, 1, owners)
+	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.Edges) != 1 || ev.Edges[0].FromKind != "HelmRelease" {
+		t.Fatalf("edges = %#v, want 1 HelmRelease edge", ev.Edges)
+	}
+}
+
+func TestDaemonSetToEvent_ZeroAvailableIsEmitted(t *testing.T) {
+	// Zero is meaningful for a DaemonSet (no Pods up yet) — must NOT be
+	// elided from metadata.
+	ds := newDaemonSet("kube-system", "fluent-bit", 0, 0, nil)
+	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if got := ev.Metadata["replicas"]; got != "0" {
+		t.Fatalf("metadata[replicas] = %q, want %q", got, "0")
+	}
+}

--- a/operator/internal/entity/deployment.go
+++ b/operator/internal/entity/deployment.go
@@ -1,0 +1,58 @@
+// Mapper for appsv1.Deployment.
+//
+// A Deployment owns ReplicaSets (the K8s control plane writes
+// metadata.ownerReferences on the child ReplicaSet, NOT on the parent
+// Deployment). Therefore this mapper emits NO outbound OWNS edges from a
+// Deployment object: the ReplicaSet watcher emits the Deployment→ReplicaSet
+// edge from the child side, where the data actually lives. ADR-0007
+// §causal-fidelity is explicit that edges come from K8s-populated
+// ownerReferences and never from name-pattern inference.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// kindDeployment is the K8s API Kind string used in external-id and metadata.
+// Mixed case to match the Pod controller's existing convention (entity.go:
+// "k8s_resource/Pod/...").
+const kindDeployment = "Deployment"
+
+// DeploymentToEvent maps an appsv1.Deployment plus an action into an Event.
+//
+// Pure function — no clients, no clock injection beyond `now`. The
+// `workspaceID` parameter is the operator's configured tenant boundary;
+// per ADR-0007 §ACL it MUST come from operator config and never from any
+// field on the Deployment object (labels, annotations, namespace name).
+//
+// On a "deleted" reconcile the controller passes a stub Deployment with
+// only namespace + name set; the mapper handles that defensively the same
+// way PodToEvent does.
+func DeploymentToEvent(
+	d *appsv1.Deployment,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	ev := newWorkloadEvent(kindDeployment, d.Namespace, d.Name, action, workspaceID, clusterName, now)
+
+	// Replicas counts are status fields populated by the K8s control plane,
+	// not user input — safe to copy. spec.replicas is *int32 (nil → server
+	// default 1); status.availableReplicas is int32 (zero is meaningful).
+	if d.Spec.Replicas != nil {
+		ev.Metadata["replicas"] = formatReplicas(*d.Spec.Replicas)
+	}
+	ev.Metadata["available_replicas"] = formatReplicas(d.Status.AvailableReplicas)
+
+	// Edges from ownerReferences. A Deployment is usually top-of-chain
+	// (no owner) — but it CAN be owned by e.g. a Helm-managed CRD or by
+	// a higher-level operator (ArgoCD Application). Honour whatever K8s
+	// populates; do not invent.
+	ev.Edges = ownerEdges(d.OwnerReferences, defaultedNamespace(d.Namespace), ev.ExternalID)
+
+	return ev
+}

--- a/operator/internal/entity/deployment_test.go
+++ b/operator/internal/entity/deployment_test.go
@@ -1,0 +1,241 @@
+package entity_test
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// adversarialLabels is a fixture that simulates a tenant attempting to
+// inject workspace-affecting state via labels/annotations. Every test in
+// this file decorates fixtures with this map and asserts that NONE of the
+// keys end up in the emitted Event. Per ADR-0007 §ACL labels and
+// annotations are tenant-writable and must never influence tenancy.
+var adversarialLabels = map[string]string{
+	"omniscience.io/workspace":     "evil-workspace",
+	"tenant":                       "other",
+	"app":                          "frontend",
+	"adversarial.example.com/spy":  "should-be-ignored",
+}
+
+// adversarialAnnotations mirrors adversarialLabels for the annotation-side
+// guard. Any leak surfaces here as a metadata key the closed allow-list
+// does not name.
+var adversarialAnnotations = map[string]string{
+	"kubectl.kubernetes.io/last-applied-configuration": `{"x":1}`,
+	"adversarial.example.com/leak":                     "no",
+}
+
+func newDeployment(namespace, name string, replicas, available int32, owners []metav1.OwnerReference) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			Labels:          adversarialLabels,
+			Annotations:     adversarialAnnotations,
+			OwnerReferences: owners,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: available,
+		},
+	}
+}
+
+func TestDeploymentToEvent_FieldsAreCorrect(t *testing.T) {
+	d := newDeployment("team-a", "checkout", 3, 2, nil)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.SourceType != entity.SourceType {
+		t.Fatalf("source_type = %q, want %q", ev.SourceType, entity.SourceType)
+	}
+	if ev.WorkspaceID != fixedWorkspace {
+		t.Fatalf("workspace_id = %s, want %s", ev.WorkspaceID, fixedWorkspace)
+	}
+	if ev.Action != entity.ActionCreated {
+		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionCreated)
+	}
+	if want := "k8s_resource/Deployment/team-a/checkout"; ev.ExternalID != want {
+		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
+	}
+	if want := "kube://prod-eu/team-a/Deployment/checkout"; ev.URI != want {
+		t.Fatalf("uri = %q, want %q", ev.URI, want)
+	}
+	if !ev.EmittedAt.Equal(fixedNow) {
+		t.Fatalf("emitted_at = %s, want %s", ev.EmittedAt, fixedNow)
+	}
+	if got := ev.Metadata["replicas"]; got != "3" {
+		t.Fatalf("metadata[replicas] = %q, want %q", got, "3")
+	}
+	if got := ev.Metadata["available_replicas"]; got != "2" {
+		t.Fatalf("metadata[available_replicas] = %q, want %q", got, "2")
+	}
+}
+
+func TestDeploymentToEvent_DoesNotLeakUserLabelsOrAnnotations(t *testing.T) {
+	d := newDeployment("team-a", "checkout", 3, 2, nil)
+	ev := entity.DeploymentToEvent(d, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+
+	expected := map[string]string{
+		"cluster":            "prod-eu",
+		"namespace":          "team-a",
+		"name":               "checkout",
+		"kind":               "Deployment",
+		"emitter":            "k8s-operator",
+		"replicas":           "3",
+		"available_replicas": "2",
+	}
+	if len(ev.Metadata) != len(expected) {
+		t.Fatalf("metadata has %d keys (%v), want %d (%v)", len(ev.Metadata), ev.Metadata, len(expected), expected)
+	}
+	for k, v := range expected {
+		if got, ok := ev.Metadata[k]; !ok || got != v {
+			t.Fatalf("metadata[%q] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestDeploymentToEvent_AdversarialWorkspaceLabelIgnored(t *testing.T) {
+	// ACL invariant: a tenant who labels their resource
+	// "omniscience.io/workspace=evil" must not flip the event's
+	// workspace_id. The mapper takes the tenant boundary as a parameter
+	// (operator config) and never reads it from the resource.
+	d := newDeployment("team-a", "checkout", 1, 1, nil)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.WorkspaceID != fixedWorkspace {
+		t.Fatalf("workspace_id = %s, want %s — adversarial label was honoured!", ev.WorkspaceID, fixedWorkspace)
+	}
+}
+
+func TestDeploymentToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
+	// Edge-from-owners: a Deployment can be owned by a higher-level CRD
+	// (Argo Application etc.). Edges come ONLY from K8s-populated
+	// ownerReferences — never invented.
+	owners := []metav1.OwnerReference{
+		{
+			APIVersion: "argoproj.io/v1alpha1",
+			Kind:       "Application",
+			Name:       "checkout-app",
+			UID:        "00000000-1111-2222-3333-444444444444",
+		},
+	}
+	d := newDeployment("team-a", "checkout", 3, 3, owners)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if len(ev.Edges) != 1 {
+		t.Fatalf("edges count = %d, want 1; edges = %#v", len(ev.Edges), ev.Edges)
+	}
+	got := ev.Edges[0]
+	if got.Relation != entity.EdgeRelationOwns {
+		t.Fatalf("edge relation = %q, want %q", got.Relation, entity.EdgeRelationOwns)
+	}
+	if got.FromKind != "Application" {
+		t.Fatalf("edge from_kind = %q, want %q", got.FromKind, "Application")
+	}
+	wantFrom := "k8s_resource/Application/team-a/checkout-app"
+	if got.FromExternalID != wantFrom {
+		t.Fatalf("edge from_external_id = %q, want %q", got.FromExternalID, wantFrom)
+	}
+	if got.ToExternalID != ev.ExternalID {
+		t.Fatalf("edge to_external_id = %q, want %q (the watched resource)", got.ToExternalID, ev.ExternalID)
+	}
+	if got.FromUID != "00000000-1111-2222-3333-444444444444" {
+		t.Fatalf("edge from_uid = %q, want %q", got.FromUID, "00000000-1111-2222-3333-444444444444")
+	}
+}
+
+func TestDeploymentToEvent_NoOwnerReferencesEmitsNoEdges(t *testing.T) {
+	d := newDeployment("team-a", "checkout", 3, 3, nil)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.Edges) != 0 {
+		t.Fatalf("edges = %#v, want empty (no ownerReferences)", ev.Edges)
+	}
+}
+
+func TestDeploymentToEvent_MultipleOwnerReferences(t *testing.T) {
+	// K8s allows multiple ownerReferences (rare but legal). Each becomes
+	// its own edge.
+	owners := []metav1.OwnerReference{
+		{Kind: "Application", Name: "app1", UID: "u1"},
+		{Kind: "HelmRelease", Name: "rel1", UID: "u2"},
+	}
+	d := newDeployment("team-a", "checkout", 1, 1, owners)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.Edges) != 2 {
+		t.Fatalf("edges count = %d, want 2; got %#v", len(ev.Edges), ev.Edges)
+	}
+}
+
+func TestDeploymentToEvent_DeletionStubEmitsCorrectExternalID(t *testing.T) {
+	// On a delete reconcile the controller passes a stub object with only
+	// namespace + name. The mapper must still produce a well-formed event.
+	stub := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "checkout",
+		},
+	}
+	ev := entity.DeploymentToEvent(stub, entity.ActionDeleted, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.Action != entity.ActionDeleted {
+		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionDeleted)
+	}
+	if want := "k8s_resource/Deployment/team-a/checkout"; ev.ExternalID != want {
+		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
+	}
+	if _, hasReplicas := ev.Metadata["replicas"]; hasReplicas {
+		t.Fatalf("metadata should not carry replicas on a stub: %v", ev.Metadata)
+	}
+}
+
+func TestDeploymentToEvent_NamespacelessFallsBackSafely(t *testing.T) {
+	stub := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "rogue"},
+	}
+	ev := entity.DeploymentToEvent(stub, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if want := "k8s_resource/Deployment/default/rogue"; ev.ExternalID != want {
+		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
+	}
+}
+
+func TestDeploymentToEvent_MalformedOwnerReferenceSkipped(t *testing.T) {
+	// Defensive: an ownerReference with empty Kind or Name cannot be
+	// converted to a well-formed external-id. The mapper skips it rather
+	// than emit garbage.
+	owners := []metav1.OwnerReference{
+		{Kind: "", Name: "no-kind", UID: "u1"},
+		{Kind: "ReplicaSet", Name: "", UID: "u2"},
+		{Kind: "Application", Name: "ok", UID: "u3"},
+	}
+	d := newDeployment("team-a", "checkout", 1, 1, owners)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.Edges) != 1 {
+		t.Fatalf("edges count = %d, want 1 (malformed entries skipped); got %#v", len(ev.Edges), ev.Edges)
+	}
+	if ev.Edges[0].FromKind != "Application" {
+		t.Fatalf("kept edge has from_kind = %q, want %q", ev.Edges[0].FromKind, "Application")
+	}
+}
+
+func TestDeploymentToEvent_NilSpecReplicasOmittedFromMetadata(t *testing.T) {
+	// spec.replicas is *int32 — nil means "K8s default 1" but the operator
+	// surfaces only what the resource itself says. Nil → key omitted.
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "checkout"},
+		Status:     appsv1.DeploymentStatus{AvailableReplicas: 0},
+	}
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if _, ok := ev.Metadata["replicas"]; ok {
+		t.Fatalf("metadata[replicas] should be absent when spec.replicas is nil; got %q", ev.Metadata["replicas"])
+	}
+	if got := ev.Metadata["available_replicas"]; got != "0" {
+		t.Fatalf("metadata[available_replicas] = %q, want %q", got, "0")
+	}
+}
+

--- a/operator/internal/entity/entity.go
+++ b/operator/internal/entity/entity.go
@@ -72,6 +72,14 @@ type Event struct {
 	// flat (no nested maps beyond labels) so the Pydantic side can validate
 	// without a discriminated union.
 	Metadata map[string]string `json:"metadata"`
+
+	// Edges carries OWNS relationships sourced from
+	// metadata.ownerReferences on the watched resource. Optional and
+	// omitempty for backward compatibility with v0.2 consumers (the Pod
+	// path emits no edges in v0.2 — Pods' parents are emitted by the
+	// ReplicaSet/StatefulSet/DaemonSet/Job watchers). See ADR-0007
+	// §causal-fidelity: edges are NEVER inferred from name patterns.
+	Edges []OwnerEdge `json:"edges,omitempty"`
 }
 
 // PodToEvent maps a corev1.Pod plus an action into an Event. Pure function

--- a/operator/internal/entity/job.go
+++ b/operator/internal/entity/job.go
@@ -1,0 +1,50 @@
+// Mapper for batchv1.Job.
+//
+// A Job owns Pods (job-controller writes ownerReferences on each Pod).
+// Pod-side reconciliation emits Job→Pod edges from the child side. This
+// mapper emits the Job's own ownerReferences (typically empty, but a
+// CronJob will appear here when CronJob coverage lands in a follow-up
+// sub-issue — until then a Job from a CronJob still surfaces the edge
+// because K8s itself populates the CronJob ownerReference). See
+// ADR-0007 §causal-fidelity.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+const kindJob = "Job"
+
+// JobToEvent maps a batchv1.Job plus an action into an Event.
+//
+// Replicas semantics: Job has spec.parallelism (how many Pods may run
+// concurrently) and status.active / status.succeeded. We map:
+//
+//   - "replicas" = spec.parallelism (desired concurrency)
+//   - "available_replicas" = status.active (currently running)
+//
+// This deliberately collapses succeeded/failed counts because the workload
+// metadata allow-list is closed (ADR-0007 §ACL). Operators that need
+// completion telemetry should consume the raw Job events on a follow-up
+// sub-issue (#165 — metrics/dashboards).
+func JobToEvent(
+	j *batchv1.Job,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	ev := newWorkloadEvent(kindJob, j.Namespace, j.Name, action, workspaceID, clusterName, now)
+
+	if j.Spec.Parallelism != nil {
+		ev.Metadata["replicas"] = formatReplicas(*j.Spec.Parallelism)
+	}
+	ev.Metadata["available_replicas"] = formatReplicas(j.Status.Active)
+
+	ev.Edges = ownerEdges(j.OwnerReferences, defaultedNamespace(j.Namespace), ev.ExternalID)
+
+	return ev
+}

--- a/operator/internal/entity/job_test.go
+++ b/operator/internal/entity/job_test.go
@@ -1,0 +1,97 @@
+package entity_test
+
+import (
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func newJob(namespace, name string, parallelism *int32, active int32, owners []metav1.OwnerReference) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			Labels:          adversarialLabels,
+			Annotations:     adversarialAnnotations,
+			OwnerReferences: owners,
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism: parallelism,
+		},
+		Status: batchv1.JobStatus{
+			Active: active,
+		},
+	}
+}
+
+func TestJobToEvent_FieldsAreCorrect(t *testing.T) {
+	parallelism := int32(2)
+	j := newJob("team-a", "nightly-export", &parallelism, 1, nil)
+	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if want := "k8s_resource/Job/team-a/nightly-export"; ev.ExternalID != want {
+		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
+	}
+	if got := ev.Metadata["kind"]; got != "Job" {
+		t.Fatalf("metadata[kind] = %q, want %q", got, "Job")
+	}
+	if got := ev.Metadata["replicas"]; got != "2" {
+		t.Fatalf("metadata[replicas] = %q (parallelism)", got)
+	}
+	if got := ev.Metadata["available_replicas"]; got != "1" {
+		t.Fatalf("metadata[available_replicas] = %q (status.active)", got)
+	}
+}
+
+func TestJobToEvent_OwnerEdgeFromCronJob(t *testing.T) {
+	// Forward-compat: a Job created by a CronJob carries an
+	// ownerReference to that CronJob; even though the CronJob watcher is
+	// deferred to a follow-up sub-issue, the edge information already
+	// flows through this mapper.
+	owners := []metav1.OwnerReference{
+		{
+			APIVersion: "batch/v1",
+			Kind:       "CronJob",
+			Name:       "nightly-export",
+			UID:        "cj-uid",
+		},
+	}
+	j := newJob("team-a", "nightly-export-1700000000", nil, 1, owners)
+	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if len(ev.Edges) != 1 {
+		t.Fatalf("edges count = %d, want 1; %#v", len(ev.Edges), ev.Edges)
+	}
+	if got := ev.Edges[0].FromKind; got != "CronJob" {
+		t.Fatalf("edge from_kind = %q, want %q", got, "CronJob")
+	}
+	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/CronJob/team-a/nightly-export" {
+		t.Fatalf("edge from_external_id = %q", got)
+	}
+}
+
+func TestJobToEvent_NilParallelismOmitsReplicas(t *testing.T) {
+	// spec.parallelism is *int32 — nil means K8s default (1) but the
+	// operator surfaces only what the resource itself says.
+	j := newJob("team-a", "ad-hoc", nil, 0, nil)
+	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if _, ok := ev.Metadata["replicas"]; ok {
+		t.Fatalf("metadata[replicas] should be absent when parallelism is nil; got %q", ev.Metadata["replicas"])
+	}
+}
+
+func TestJobToEvent_NoLabelLeakage(t *testing.T) {
+	parallelism := int32(1)
+	j := newJob("team-a", "ad-hoc", &parallelism, 0, nil)
+	ev := entity.JobToEvent(j, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	for k := range ev.Metadata {
+		switch k {
+		case "cluster", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
+		default:
+			t.Fatalf("leaked metadata key %q", k)
+		}
+	}
+}

--- a/operator/internal/entity/replicaset.go
+++ b/operator/internal/entity/replicaset.go
@@ -1,0 +1,42 @@
+// Mapper for appsv1.ReplicaSet.
+//
+// A ReplicaSet is owned by its parent Deployment (the K8s control plane
+// populates metadata.ownerReferences on the child) and itself owns Pods
+// (those edges are emitted by the Pod watcher when each Pod is reconciled,
+// also from the child side). This mapper therefore emits ONE direction of
+// the chain: parent → ReplicaSet, sourced exclusively from
+// ownerReferences[*]. See ADR-0007 §causal-fidelity.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const kindReplicaSet = "ReplicaSet"
+
+// ReplicaSetToEvent maps an appsv1.ReplicaSet plus an action into an Event.
+//
+// Same shape and ACL invariant as DeploymentToEvent. The `workspaceID`
+// parameter MUST come from operator config (ADR-0007 §ACL). User-controlled
+// labels and annotations are NOT copied through.
+func ReplicaSetToEvent(
+	rs *appsv1.ReplicaSet,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	ev := newWorkloadEvent(kindReplicaSet, rs.Namespace, rs.Name, action, workspaceID, clusterName, now)
+
+	if rs.Spec.Replicas != nil {
+		ev.Metadata["replicas"] = formatReplicas(*rs.Spec.Replicas)
+	}
+	ev.Metadata["available_replicas"] = formatReplicas(rs.Status.AvailableReplicas)
+
+	ev.Edges = ownerEdges(rs.OwnerReferences, defaultedNamespace(rs.Namespace), ev.ExternalID)
+
+	return ev
+}

--- a/operator/internal/entity/replicaset_test.go
+++ b/operator/internal/entity/replicaset_test.go
@@ -1,0 +1,97 @@
+package entity_test
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func newReplicaSet(namespace, name string, replicas, available int32, owners []metav1.OwnerReference) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			Labels:          adversarialLabels,
+			Annotations:     adversarialAnnotations,
+			OwnerReferences: owners,
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.ReplicaSetStatus{
+			AvailableReplicas: available,
+		},
+	}
+}
+
+func TestReplicaSetToEvent_FieldsAreCorrect(t *testing.T) {
+	rs := newReplicaSet("team-a", "checkout-7d9f", 4, 4, nil)
+	ev := entity.ReplicaSetToEvent(rs, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if want := "k8s_resource/ReplicaSet/team-a/checkout-7d9f"; ev.ExternalID != want {
+		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
+	}
+	if want := "kube://prod-eu/team-a/ReplicaSet/checkout-7d9f"; ev.URI != want {
+		t.Fatalf("uri = %q, want %q", ev.URI, want)
+	}
+	if got := ev.Metadata["kind"]; got != "ReplicaSet" {
+		t.Fatalf("metadata[kind] = %q, want %q", got, "ReplicaSet")
+	}
+	if got := ev.Metadata["replicas"]; got != "4" {
+		t.Fatalf("metadata[replicas] = %q, want %q", got, "4")
+	}
+	if got := ev.Metadata["available_replicas"]; got != "4" {
+		t.Fatalf("metadata[available_replicas] = %q, want %q", got, "4")
+	}
+}
+
+func TestReplicaSetToEvent_OwnerEdgeFromDeployment(t *testing.T) {
+	// Canonical chain: Deployment -[OWNS]-> ReplicaSet. The K8s
+	// control plane writes ownerReferences on the ReplicaSet pointing back
+	// to the Deployment; this is where the operator picks the edge up.
+	owners := []metav1.OwnerReference{
+		{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "checkout",
+			UID:        "dep-uid-1",
+		},
+	}
+	rs := newReplicaSet("team-a", "checkout-7d9f", 4, 4, owners)
+	ev := entity.ReplicaSetToEvent(rs, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if len(ev.Edges) != 1 {
+		t.Fatalf("edges count = %d, want 1; %#v", len(ev.Edges), ev.Edges)
+	}
+	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/Deployment/team-a/checkout" {
+		t.Fatalf("edge from_external_id = %q", got)
+	}
+	if got := ev.Edges[0].ToExternalID; got != ev.ExternalID {
+		t.Fatalf("edge to_external_id = %q, want %q", got, ev.ExternalID)
+	}
+	if got := ev.Edges[0].Relation; got != entity.EdgeRelationOwns {
+		t.Fatalf("edge relation = %q, want %q", got, entity.EdgeRelationOwns)
+	}
+	if got := ev.Edges[0].FromUID; got != "dep-uid-1" {
+		t.Fatalf("edge from_uid = %q", got)
+	}
+}
+
+func TestReplicaSetToEvent_AdversarialLabelDoesNotChangeWorkspace(t *testing.T) {
+	rs := newReplicaSet("team-a", "checkout-7d9f", 1, 1, nil)
+	ev := entity.ReplicaSetToEvent(rs, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.WorkspaceID != fixedWorkspace {
+		t.Fatalf("workspace_id = %s, want %s", ev.WorkspaceID, fixedWorkspace)
+	}
+	for k := range ev.Metadata {
+		switch k {
+		case "cluster", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
+			// allowed
+		default:
+			t.Fatalf("metadata leaked unauthorised key %q (full map: %v)", k, ev.Metadata)
+		}
+	}
+}

--- a/operator/internal/entity/statefulset.go
+++ b/operator/internal/entity/statefulset.go
@@ -1,0 +1,40 @@
+// Mapper for appsv1.StatefulSet.
+//
+// A StatefulSet owns Pods (the Pod watcher emits StatefulSet→Pod edges
+// from the child side); it can itself be owned by a higher-level CRD
+// (Argo Rollout, OperatorHub operator). Edges this mapper emits are
+// strictly the StatefulSet's own ownerReferences, never the StatefulSet→Pod
+// direction (that lives on the Pod). See ADR-0007 §causal-fidelity.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const kindStatefulSet = "StatefulSet"
+
+// StatefulSetToEvent maps an appsv1.StatefulSet plus an action into an Event.
+//
+// Same shape and ACL invariant as DeploymentToEvent. The `workspaceID`
+// parameter MUST come from operator config (ADR-0007 §ACL).
+func StatefulSetToEvent(
+	ss *appsv1.StatefulSet,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	ev := newWorkloadEvent(kindStatefulSet, ss.Namespace, ss.Name, action, workspaceID, clusterName, now)
+
+	if ss.Spec.Replicas != nil {
+		ev.Metadata["replicas"] = formatReplicas(*ss.Spec.Replicas)
+	}
+	ev.Metadata["available_replicas"] = formatReplicas(ss.Status.AvailableReplicas)
+
+	ev.Edges = ownerEdges(ss.OwnerReferences, defaultedNamespace(ss.Namespace), ev.ExternalID)
+
+	return ev
+}

--- a/operator/internal/entity/statefulset_test.go
+++ b/operator/internal/entity/statefulset_test.go
@@ -1,0 +1,69 @@
+package entity_test
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func newStatefulSet(namespace, name string, replicas, available int32, owners []metav1.OwnerReference) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			Labels:          adversarialLabels,
+			Annotations:     adversarialAnnotations,
+			OwnerReferences: owners,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			AvailableReplicas: available,
+		},
+	}
+}
+
+func TestStatefulSetToEvent_FieldsAreCorrect(t *testing.T) {
+	ss := newStatefulSet("team-a", "kafka", 5, 4, nil)
+	ev := entity.StatefulSetToEvent(ss, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if want := "k8s_resource/StatefulSet/team-a/kafka"; ev.ExternalID != want {
+		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
+	}
+	if got := ev.Metadata["kind"]; got != "StatefulSet" {
+		t.Fatalf("metadata[kind] = %q, want %q", got, "StatefulSet")
+	}
+	if got := ev.Metadata["replicas"]; got != "5" {
+		t.Fatalf("metadata[replicas] = %q", got)
+	}
+	if got := ev.Metadata["available_replicas"]; got != "4" {
+		t.Fatalf("metadata[available_replicas] = %q", got)
+	}
+}
+
+func TestStatefulSetToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
+	owners := []metav1.OwnerReference{
+		{Kind: "Application", Name: "kafka-app", UID: "app-uid"},
+	}
+	ss := newStatefulSet("team-a", "kafka", 1, 1, owners)
+	ev := entity.StatefulSetToEvent(ss, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.Edges) != 1 || ev.Edges[0].FromKind != "Application" {
+		t.Fatalf("edges = %#v, want 1 Application edge", ev.Edges)
+	}
+}
+
+func TestStatefulSetToEvent_NoLabelLeakage(t *testing.T) {
+	ss := newStatefulSet("team-a", "kafka", 1, 1, nil)
+	ev := entity.StatefulSetToEvent(ss, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	for k := range ev.Metadata {
+		switch k {
+		case "cluster", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
+		default:
+			t.Fatalf("leaked metadata key %q", k)
+		}
+	}
+}


### PR DESCRIPTION
Closes #157. Wave 2 of epic #98.

## What's in

- **5 new controllers** under `operator/internal/controller/` mirroring `pod_controller.go`:
  - `deployment_controller.go`, `replicaset_controller.go`, `statefulset_controller.go`, `daemonset_controller.go`, `job_controller.go`
- **5 new pure-function mappers** under `operator/internal/entity/`:
  - `deployment.go`, `replicaset.go`, `statefulset.go`, `daemonset.go`, `job.go` (each + sibling `_test.go`)
- **Ownership edges** from `metadata.ownerReferences` only (never inferred):
  Deployment → ReplicaSet → Pod, plus StatefulSet/DaemonSet/Job → Pod
- **External-ID convention**: `k8s_resource/{Kind}/{namespace}/{name}` (matches Pod scaffold)
- **Bitemporal stamping** per ADR-0008
- **RBAC delta**: `get`/`list`/`watch` on `deployments`/`replicasets`/`statefulsets`/`daemonsets` in `apps` API group + `jobs` in `batch`. No mutating verbs.

## Verification

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test -count=1 ./...` — **43 tests passed across 5 packages**
- `helm lint helm/omniscience-operator` — passes (1 chart linted, 0 failed)

## Non-goals (per scope)

- CronJob — separate sub-issue
- Reconciliation worker — #163
- Server-side dedup vs k8s-agentic — #164

## Test plan

- [x] Pure-mapper tests cover all 5 kinds + ownership edges + edge cases (missing labels/annotations, missing ownerReferences, multiple owners)
- [x] All 5 controllers register cleanly in `operator/cmd/manager/main.go` (append-only; no reorder of existing entries)
- [x] Python suite still green (this PR doesn't touch Python)