### PR TITLE
feat: operator networking + config watchers (#158)

### DIFF
--- a/docs/connectors/k8s-operator-secrets.md
+++ b/docs/connectors/k8s-operator-secrets.md
@@ -1,0 +1,181 @@
+# K8s operator — Secret & ConfigMap handling
+
+This document explains why the omniscience-operator's networking + config
+watchers (issue #158) drop Secret values unconditionally and ConfigMap
+values by default, and how to opt a specific ConfigMap into value indexing.
+
+## Hard rule — Secret values
+
+**The operator NEVER emits Secret `data`, `stringData`, `binaryData`, or any
+value bytes — ever, under any condition.**
+
+This is enforced at three layers:
+
+1. **Mapper** — `operator/internal/entity/secret.go::SecretToEvent` reads
+   only metadata fields (namespace, name, type, data key *names*). The raw
+   values are never read off the `corev1.Secret`, so they cannot reach the
+   `Event` payload by accident.
+2. **Structural test** — `operator/internal/entity/secret_test.go::
+   TestSecretToEvent_NeverLeaksValues` constructs a Secret carrying canary
+   strings (`CANARY-PWD-XYZZY-1`, etc.) in `data` and `stringData`,
+   marshals the emitted `Event` to JSON, and substring-searches for the
+   canaries (raw and base64-encoded forms). The test fails if a single byte
+   of a value appears anywhere in the payload.
+3. **RBAC** — the operator's `ClusterRole` requests only `get/list/watch`
+   on `secrets`. There are no write verbs anywhere in the chart. The
+   `get/list` permission is unavoidable for the watcher to function; the
+   value-drop in the mapper is the security cap.
+
+The hard rule extends to the per-resource `omniscience.io/index-data`
+annotation: **the Secret mapper does not honour the opt-in.** That
+annotation only opts ConfigMaps into value indexing.
+
+### Why values are forbidden
+
+- Secrets routinely carry credentials (database passwords, API tokens, TLS
+  private keys). Indexing them puts every downstream component (graph
+  store, vector store, retrieval API, audit logs, replication) in the
+  credential blast radius.
+- Kubernetes itself protects Secret values via etcd encryption-at-rest;
+  pulling them through Omniscience would route them into stores that may
+  have different at-rest guarantees.
+- The retrieval signal from a Secret name (e.g. `stripe-prod-key`) is
+  already strong enough for the incident-resolution use case. Knowing
+  which Pods consume which Secret-name (Wave 3 follow-up: Pod-side
+  CONSUMES edges) closes the loop without ever reading the value.
+
+### What IS emitted for a Secret
+
+The closed allow-list (`operator/internal/entity/secret.go`):
+
+| Key            | Source                                      |
+|----------------|---------------------------------------------|
+| `cluster`      | operator config                             |
+| `namespace`    | `metadata.namespace`                        |
+| `name`         | `metadata.name`                             |
+| `kind`         | constant `"Secret"`                         |
+| `secret_type`  | `type` (e.g. `Opaque`, `kubernetes.io/tls`) |
+| `data_keys`    | sorted comma-joined list of *names* in `data` ∪ `stringData` |
+| `data_count`   | total key count as string                   |
+| `emitter`      | constant `"k8s-operator"`                   |
+
+Notably absent:
+
+- `data.*` values (the secret content)
+- `stringData.*` values (the cleartext form)
+- `binaryData.*` values (the binary form)
+- User-supplied labels (tenant-writable, not safe to copy verbatim)
+- User-supplied annotations (same)
+
+Tenant-writable labels and annotations are dropped because they are an
+ACL-leak surface: a malicious workload could plant a label like
+`omniscience.io/workspace-id=<other-workspace>` and, if we copied it into
+Event metadata, expose itself to the wrong tenant. See ADR-0007 §ACL.
+
+## ConfigMap — metadata only by default, opt-in for values
+
+ConfigMaps follow the same posture as Secrets *by default*: only the
+allow-list of metadata fields and the sorted list of key *names* is
+emitted. The values are dropped.
+
+To allow a *specific* ConfigMap to emit its `data` values, set this
+annotation on the ConfigMap:
+
+```yaml
+metadata:
+  annotations:
+    omniscience.io/index-data: "true"
+```
+
+The annotation must be exactly the literal string `"true"`. Any other
+value (`"True"`, `"1"`, `"yes"`) is treated as a no-opt — the gate is
+deliberately conservative, mirroring the strict matching in
+`isIndexDataOptIn`.
+
+When the opt-in is present:
+
+- `data` values are emitted as a JSON-encoded map under
+  `metadata.data_values_json`.
+- `binaryData` values are STILL dropped (binary blobs are almost never
+  useful for retrieval and bypass the human-reviewable surface).
+- `metadata.indexed = "true"` so consumers can distinguish opt-in payloads
+  from default ones.
+
+When the opt-in is absent (default):
+
+- No values appear anywhere in the payload.
+- `metadata.indexed = "false"`.
+
+The opt-in is per-ConfigMap and namespace-scoped; the operator does not
+expose a chart-level switch that would flip the default for all
+ConfigMaps. Forcing per-resource opt-in keeps the explicit-consent
+boundary visible to the ConfigMap author.
+
+### Why opt-in for ConfigMap (and not for Secret)
+
+ConfigMaps frequently carry application configuration that *is* useful to
+index — feature flags, internal hostnames, knob values. The cost of
+indexing them is real but bounded: the values are not credentials.
+
+Secrets, by definition, are credentials. The cost of indexing them is
+unbounded (a leak compromises the whole credential). The asymmetry in
+posture matches the asymmetry in risk.
+
+## Topology edges
+
+The networking + config watchers also emit topology edges where K8s
+itself has authoritative pointers:
+
+- `Service` -[`SELECTS`]-> `Pod` — owned by the **Endpoints** controller,
+  resolved via `Endpoints.subsets[].addresses[].targetRef`. The Service
+  controller does NOT re-evaluate selectors locally.
+- `Ingress` -[`ROUTES_TO`]-> `Service` — from `spec.rules[].http.paths[]
+  .backend.service.name` and `spec.defaultBackend.service.name`.
+- `NetworkPolicy` -[`APPLIES_TO`]-> `Pod` — NOT emitted by the operator
+  (deferred to the reconciliation worker, #163, which has the cross-stream
+  label index). The NetworkPolicy entity carries the rendered selector
+  string in `metadata.pod_selector` so the resolution can happen
+  server-side without the operator re-emitting.
+- `Pod` -[`CONSUMES`]-> `ConfigMap` and `Pod` -[`CONSUMES`]-> `Secret`
+  — owned by the **Pod controller**. Tracked as a Wave-3 follow-up; this
+  PR does not touch the Pod controller.
+
+## ACL invariant — workspace_id
+
+The operator's `workspace_id` is fixed at startup, sourced from a
+secret-mounted token. **No watched resource — Service annotation,
+ConfigMap label, Secret type, NetworkPolicy podSelector — can change the
+workspace_id at runtime.** This invariant is asserted by the existing Pod
+controller test suite and is preserved by every new mapper added in
+issue #158.
+
+A label like `omniscience.io/workspace-id=<other>` planted on a Service
+is silently ignored.
+
+## Roll-out
+
+The chart enables all networking + config watchers by default. There is no
+per-kind opt-out toggle in `values.yaml` — the chart's posture is "all
+watchers on, security cap in the mapper". Removing kinds is a chart-fork
+exercise rather than a config knob.
+
+## Verification recipe
+
+In a `kind` cluster:
+
+```bash
+# Create a Secret with a canary value.
+kubectl create secret generic stripe-prod-key \
+  --from-literal=token=devtoken-CANARY-XYZZY
+
+# Capture the operator's NATS publish stream (assuming nats CLI configured).
+nats sub "k8s.operator.events.${WORKSPACE_ID}" > /tmp/events.log &
+
+# Wait a few seconds, then assert no canary leak.
+grep -F 'CANARY-XYZZY' /tmp/events.log && echo LEAK || echo OK
+```
+
+Expected output: `OK`. The structural test
+`TestSecretToEvent_NeverLeaksValues` makes the same assertion at the
+mapper boundary in CI; the kind-cluster recipe is the end-to-end
+confirmation.

--- a/helm/omniscience-operator/templates/NOTES.txt
+++ b/helm/omniscience-operator/templates/NOTES.txt
@@ -20,3 +20,14 @@ Smoke test — create a Pod and watch for the entity:
 
 See https://github.com/100rd/Omniscience/blob/main/docs/decisions/0007-k8s-operator-architecture.md
 for the architecture decisions.
+
+Security note (Secret + ConfigMap watchers — issue #158):
+
+  The operator runs with cluster-scoped read on Pods, Services, Endpoints,
+  Ingresses, NetworkPolicies, ConfigMaps, and Secrets. The Secret get/list
+  permission is unavoidable for the watcher to function — but values are
+  ALWAYS dropped at the mapper boundary, and the test suite enforces this
+  structurally. ConfigMap values are dropped by default; opt-in is per-
+  ConfigMap via the annotation `omniscience.io/index-data: "true"`.
+
+  See docs/connectors/k8s-operator-secrets.md for the complete posture.

--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -23,6 +23,19 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["get", "list", "watch"]
+  # ── #158 networking + config watchers ──────────────────────────────────
+  # Read-only verbs only. The Secret get/list permission is unavoidable for
+  # the watcher to function; the controller's secret_controller.go +
+  # internal/entity/secret.go drop all values at the mapper boundary, and
+  # the structural test in entity/secret_test.go asserts no value bytes
+  # ever reach the published Event. See docs/connectors/k8s-operator-secrets.md.
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  # ── end #158 ──────────────────────────────────────────────────────────
   # Leader election lease — namespaced; gated to the operator's own namespace
   # below.
   {{- if .Values.leaderElection.enabled }}

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -32,6 +34,9 @@ var scheme = runtime.NewScheme()
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	// ── #158 networking + config watchers — register networking.k8s.io/v1 ──
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
+	// ── end #158 ──
 }
 
 func main() {
@@ -150,6 +155,16 @@ func run() error {
 	}
 	// ─── End workload watchers (#157) ─────────────────────────────────────
 
+	// ── #158 networking + config watchers ─────────────────────────────────
+	// One reconciler per kind. Setup order doesn't matter — controller-
+	// runtime resolves dependencies at start time. Each Setup* call returns
+	// a wrapped error so a single line in kubectl logs identifies which
+	// kind failed to register.
+	if err := setupNetworkingAndConfigWatchers(mgr, pub, cfg.WorkspaceID, cfg.ClusterName); err != nil {
+		return err
+	}
+	// ── end #158 ──────────────────────────────────────────────────────────
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("add healthz: %w", err)
 	}
@@ -163,3 +178,59 @@ func run() error {
 	}
 	return nil
 }
+
+// ── #158 networking + config watchers — registration helper ────────────────
+//
+// setupNetworkingAndConfigWatchers wires the Service / Endpoints / Ingress /
+// NetworkPolicy / ConfigMap / Secret reconcilers into the manager. Kept in
+// its own function so the run() body stays readable and so adding/removing a
+// kind is a localised change. APPEND-only relative to the original main.go
+// per the parallel-team protocol.
+//
+// Each constructor validates its inputs (non-nil client, non-zero workspace,
+// non-empty cluster name) — those errors are wrapped with the kind so kubectl
+// logs identify the offender immediately on init failure.
+//
+// Goroutine-safety: each reconciler is independent and shares no mutable
+// state with the others. The publisher is concurrency-safe (NATS connection
+// is goroutine-safe by design).
+func setupNetworkingAndConfigWatchers(
+	mgr ctrl.Manager,
+	pub publisher.Publisher,
+	workspaceID uuid.UUID,
+	clusterName string,
+) error {
+	if svc, err := controller.NewServiceReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+		return fmt.Errorf("service reconciler init: %w", err)
+	} else if err := svc.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("service reconciler setup: %w", err)
+	}
+	if ep, err := controller.NewEndpointsReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+		return fmt.Errorf("endpoints reconciler init: %w", err)
+	} else if err := ep.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("endpoints reconciler setup: %w", err)
+	}
+	if ing, err := controller.NewIngressReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+		return fmt.Errorf("ingress reconciler init: %w", err)
+	} else if err := ing.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("ingress reconciler setup: %w", err)
+	}
+	if np, err := controller.NewNetworkPolicyReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+		return fmt.Errorf("networkpolicy reconciler init: %w", err)
+	} else if err := np.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("networkpolicy reconciler setup: %w", err)
+	}
+	if cm, err := controller.NewConfigMapReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+		return fmt.Errorf("configmap reconciler init: %w", err)
+	} else if err := cm.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("configmap reconciler setup: %w", err)
+	}
+	if sec, err := controller.NewSecretReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+		return fmt.Errorf("secret reconciler init: %w", err)
+	} else if err := sec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("secret reconciler setup: %w", err)
+	}
+	return nil
+}
+
+// ── end #158 ────────────────────────────────────────────────────────────────

--- a/operator/internal/controller/configmap_controller.go
+++ b/operator/internal/controller/configmap_controller.go
@@ -1,0 +1,100 @@
+// configmap_controller.go: controller for corev1.ConfigMap.
+//
+// Metadata-only by default; per-resource opt-in via the
+// "omniscience.io/index-data" annotation. The mapper enforces this — the
+// controller is the same shape as every other.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ConfigMapReconciler watches ConfigMaps and publishes change events.
+type ConfigMapReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewConfigMapReconciler returns a reconciler with sane defaults.
+func NewConfigMapReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ConfigMapReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ConfigMapReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every ConfigMap add/update/delete.
+func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"configmap", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var cm corev1.ConfigMap
+	err := r.Client.Get(ctx, req.NamespacedName, &cm)
+	switch {
+	case err == nil:
+		ev := entity.ConfigMapToEvent(&cm, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish configmap event: %w", perr)
+		}
+		logger.V(1).Info("published configmap upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.ConfigMap{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ConfigMapToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish configmap deletion: %w", perr)
+		}
+		logger.V(1).Info("published configmap deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get configmap failed")
+		return ctrl.Result{}, fmt.Errorf("get configmap %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		Named("configmap-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/endpoints_controller.go
+++ b/operator/internal/controller/endpoints_controller.go
@@ -1,0 +1,99 @@
+// endpoints_controller.go: controller for corev1.Endpoints.
+//
+// Endpoints is the topology resolver for Service-[SELECTS]->Pod (see
+// internal/entity/endpoints.go). Same lifecycle pattern as PodReconciler.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// EndpointsReconciler watches Endpoints and publishes change events.
+type EndpointsReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewEndpointsReconciler returns a reconciler with sane defaults.
+func NewEndpointsReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*EndpointsReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &EndpointsReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every Endpoints add/update/delete.
+func (r *EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"endpoints", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var ep corev1.Endpoints
+	err := r.Client.Get(ctx, req.NamespacedName, &ep)
+	switch {
+	case err == nil:
+		ev := entity.EndpointsToEvent(&ep, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish endpoints event: %w", perr)
+		}
+		logger.V(1).Info("published endpoints upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.Endpoints{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.EndpointsToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish endpoints deletion: %w", perr)
+		}
+		logger.V(1).Info("published endpoints deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get endpoints failed")
+		return ctrl.Result{}, fmt.Errorf("get endpoints %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *EndpointsReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Endpoints{}).
+		Named("endpoints-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/ingress_controller.go
+++ b/operator/internal/controller/ingress_controller.go
@@ -1,0 +1,96 @@
+// ingress_controller.go: controller for networkingv1.Ingress.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// IngressReconciler watches Ingresses and publishes change events.
+type IngressReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewIngressReconciler returns a reconciler with sane defaults.
+func NewIngressReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*IngressReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &IngressReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every Ingress add/update/delete.
+func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"ingress", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var ing networkingv1.Ingress
+	err := r.Client.Get(ctx, req.NamespacedName, &ing)
+	switch {
+	case err == nil:
+		ev := entity.IngressToEvent(&ing, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish ingress event: %w", perr)
+		}
+		logger.V(1).Info("published ingress upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &networkingv1.Ingress{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.IngressToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish ingress deletion: %w", perr)
+		}
+		logger.V(1).Info("published ingress deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get ingress failed")
+		return ctrl.Result{}, fmt.Errorf("get ingress %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *IngressReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&networkingv1.Ingress{}).
+		Named("ingress-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/networkpolicy_controller.go
+++ b/operator/internal/controller/networkpolicy_controller.go
@@ -1,0 +1,96 @@
+// networkpolicy_controller.go: controller for networkingv1.NetworkPolicy.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// NetworkPolicyReconciler watches NetworkPolicies and publishes change events.
+type NetworkPolicyReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewNetworkPolicyReconciler returns a reconciler with sane defaults.
+func NewNetworkPolicyReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*NetworkPolicyReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &NetworkPolicyReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every NetworkPolicy add/update/delete.
+func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"networkpolicy", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var np networkingv1.NetworkPolicy
+	err := r.Client.Get(ctx, req.NamespacedName, &np)
+	switch {
+	case err == nil:
+		ev := entity.NetworkPolicyToEvent(&np, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish networkpolicy event: %w", perr)
+		}
+		logger.V(1).Info("published networkpolicy upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &networkingv1.NetworkPolicy{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.NetworkPolicyToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish networkpolicy deletion: %w", perr)
+		}
+		logger.V(1).Info("published networkpolicy deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get networkpolicy failed")
+		return ctrl.Result{}, fmt.Errorf("get networkpolicy %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&networkingv1.NetworkPolicy{}).
+		Named("networkpolicy-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/secret_controller.go
+++ b/operator/internal/controller/secret_controller.go
@@ -1,0 +1,107 @@
+// secret_controller.go: controller for corev1.Secret.
+//
+// SECURITY POSTURE — see internal/entity/secret.go for the hard rule. The
+// controller is structurally identical to every other watcher; the value-
+// dropping happens in SecretToEvent. Doing the drop in the mapper means it
+// is unit-testable without a live cluster, and any future leak shows up in
+// secret_test.go's structural assertion.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// SecretReconciler watches Secrets and publishes change events. Values are
+// dropped at the mapper boundary — see internal/entity/secret.go.
+type SecretReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewSecretReconciler returns a reconciler with sane defaults.
+func NewSecretReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*SecretReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &SecretReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every Secret add/update/delete.
+func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"secret", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var s corev1.Secret
+	err := r.Client.Get(ctx, req.NamespacedName, &s)
+	switch {
+	case err == nil:
+		ev := entity.SecretToEvent(&s, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish secret event: %w", perr)
+		}
+		// Intentionally do NOT log the external_id at debug level for Secrets
+		// — the resource name itself can be sensitive (e.g. "stripe-prod-key").
+		// Pod and other watchers log the name; Secret does not. This is a
+		// defence-in-depth measure beyond the mapper-level value drop.
+		logger.V(1).Info("published secret upsert")
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.Secret{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.SecretToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish secret deletion: %w", perr)
+		}
+		logger.V(1).Info("published secret deletion")
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get secret failed")
+		return ctrl.Result{}, fmt.Errorf("get secret %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		Named("secret-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/service_controller.go
+++ b/operator/internal/controller/service_controller.go
@@ -1,0 +1,101 @@
+// service_controller.go: controller for corev1.Service.
+//
+// Mirrors PodReconciler exactly — see pod_controller.go for the design
+// contract. A new controller per kind keeps the controller-manager metrics
+// per-resource (named "service-watcher", "endpoints-watcher", …) and avoids
+// type-erased generic gymnastics.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ServiceReconciler watches Services and publishes change events.
+type ServiceReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewServiceReconciler returns a reconciler with sane defaults.
+func NewServiceReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ServiceReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ServiceReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every Service add/update/delete.
+func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"service", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var svc corev1.Service
+	err := r.Client.Get(ctx, req.NamespacedName, &svc)
+	switch {
+	case err == nil:
+		ev := entity.ServiceToEvent(&svc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish service event: %w", perr)
+		}
+		logger.V(1).Info("published service upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.Service{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ServiceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish service deletion: %w", perr)
+		}
+		logger.V(1).Info("published service deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get service failed")
+		return ctrl.Result{}, fmt.Errorf("get service %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}).
+		Named("service-watcher").
+		Complete(r)
+}

--- a/operator/internal/entity/common.go
+++ b/operator/internal/entity/common.go
@@ -7,6 +7,7 @@
 package entity
 
 import (
+	"sort"
 	"strconv"
 	"time"
 
@@ -168,3 +169,130 @@ func newWorkloadEvent(
 func formatReplicas(n int32) string {
 	return strconv.FormatInt(int64(n), 10)
 }
+
+// ---------------------------------------------------------------------------
+// #158 — networking + config watcher helpers (added on top of #157's base)
+// ---------------------------------------------------------------------------
+
+// Edge kinds emitted by operator mappers. Centralised to keep the controller
+// graph contract reviewable in one place.
+const (
+	// EdgeKindSelects: Service -> Pod, resolved via Endpoints (NEVER by
+	// re-evaluating selectors). The Endpoints controller owns this edge.
+	EdgeKindSelects = "SELECTS"
+
+	// EdgeKindRoutesTo: Ingress -> Service, from spec.rules[].http.paths[]
+	// .backend.service.name.
+	EdgeKindRoutesTo = "ROUTES_TO"
+
+	// EdgeKindAppliesTo: NetworkPolicy -> Pod, derived from spec.podSelector.
+	// The operator emits the *selector* on the NetworkPolicy entity; resolving
+	// which pods match is left to the server side (label index lives there).
+	EdgeKindAppliesTo = "APPLIES_TO"
+
+	// EdgeKindConsumes: Pod -> ConfigMap | Secret, from spec.volumes[] and
+	// spec.containers[].envFrom[]. The Pod controller owns these edges.
+	EdgeKindConsumes = "CONSUMES"
+)
+
+// EdgeRef is a lightweight, JSON-safe edge descriptor emitted alongside an
+// entity. Topology edges are derived from K8s-native pointers (spec.rules,
+// spec.volumes, etc.) — we NEVER infer edges from labels or annotations.
+type EdgeRef struct {
+	Kind             string `json:"kind"`
+	TargetExternalID string `json:"target_external_id"`
+}
+
+// DeriveSourceID returns the deterministic UUIDv5 source id for a
+// (workspaceID, clusterName) pair. Exported so #158's mappers (Service,
+// Ingress, etc.) share the same derivation as PodToEvent.
+func DeriveSourceID(workspaceID uuid.UUID, clusterName string) uuid.UUID {
+	return deriveSourceID(workspaceID, clusterName)
+}
+
+// resolveNamespace returns metaNamespace, falling back to "default" for
+// resources that arrive with an empty namespace. Public alias of
+// defaultedNamespace for the #158 mapper call sites.
+func resolveNamespace(metaNamespace string) string {
+	return defaultedNamespace(metaNamespace)
+}
+
+// externalIDFor returns "k8s_resource/{kind}/{namespace}/{name}". Public
+// alias of externalID for the #158 mapper call sites.
+func externalIDFor(kind, namespace, name string) string {
+	return externalID(kind, namespace, name)
+}
+
+// uriFor returns "kube://{cluster}/{namespace}/{kind}/{name}". Public alias
+// of resourceURI for the #158 mapper call sites.
+func uriFor(clusterName, namespace, kind, name string) string {
+	return resourceURI(clusterName, namespace, kind, name)
+}
+
+// sortedKeys returns the keys of m in lexicographic order. Used by
+// ConfigMapToEvent / SecretToEvent to emit a stable `data_keys` list (the
+// *names* of the keys, never their values — the security invariant).
+func sortedKeys[V any](m map[string]V) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+// formatLabelSelector renders a metav1.LabelSelector to a deterministic
+// string form so it can be carried in metadata as a single value. The
+// rendering is the standard Kubernetes label-selector syntax (matchLabels are
+// emitted as `k=v` joined by `,`, in lexicographic key order, followed by
+// matchExpressions in insertion order). Empty selector renders as the empty
+// string.
+//
+// We carry the selector as opaque text because the operator does NOT resolve
+// pods locally — see EdgeKindAppliesTo doc.
+func formatLabelSelector(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	out := ""
+	keys := make([]string, 0, len(sel.MatchLabels))
+	for k := range sel.MatchLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		if i > 0 {
+			out += ","
+		}
+		out += k + "=" + sel.MatchLabels[k]
+	}
+	for _, expr := range sel.MatchExpressions {
+		if out != "" {
+			out += ","
+		}
+		out += expr.Key + " " + string(expr.Operator)
+		if len(expr.Values) > 0 {
+			out += " (" + joinSorted(expr.Values) + ")"
+		}
+	}
+	return out
+}
+
+// joinSorted returns vs sorted lexicographically and joined with ",".
+// Defined here (not inline) so the formatLabelSelector body stays small.
+func joinSorted(vs []string) string {
+	cp := make([]string, len(vs))
+	copy(cp, vs)
+	sort.Strings(cp)
+	out := ""
+	for i, v := range cp {
+		if i > 0 {
+			out += ","
+		}
+		out += v
+	}
+	return out
+}
+

--- a/operator/internal/entity/configmap.go
+++ b/operator/internal/entity/configmap.go
@@ -1,0 +1,122 @@
+// configmap.go: corev1.ConfigMap -> Event mapper.
+//
+// SECURITY POSTURE — metadata only by default.
+//
+// ConfigMaps frequently carry application configuration that is *not*
+// sensitive in name only — connection strings, internal hostnames, feature
+// flags, etc. Treating them as opaque means the safe default is to emit only
+// the closed allow-list of metadata fields, NEVER the values.
+//
+// Opt-in for value emission is per-ConfigMap and namespace-scoped: the
+// ConfigMap author sets metadata.annotations["omniscience.io/index-data"] =
+// "true". This is documented in docs/connectors/k8s-operator-secrets.md.
+//
+// The emitted fields when the opt-in is absent (default):
+//   - cluster, namespace, name, kind, emitter (base)
+//   - data_keys: sorted comma-joined list of *names* in spec.data and
+//     spec.binaryData (NEVER values — same posture as Secret).
+//   - data_count: total count as a string.
+//   - indexed: "false"
+//
+// When the opt-in is present:
+//   - everything above, but `indexed` becomes "true" and an additional
+//     metadata key `data_values_json` carries the values (as JSON-encoded
+//     map). binaryData values are NOT emitted even with opt-in — they are
+//     opaque blobs and almost always not useful for retrieval.
+//
+// Issue #158 explicitly forbids data values from leaking via Secret. The same
+// hard rule applies to ConfigMap unless explicitly opted in per-resource.
+package entity
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EntityKindConfigMap is the K8s kind segment in ConfigMap external_ids.
+const EntityKindConfigMap = "ConfigMap"
+
+// IndexDataAnnotation is the per-resource opt-in annotation that allows the
+// ConfigMap mapper to emit `data` values. Default is metadata-only.
+const IndexDataAnnotation = "omniscience.io/index-data"
+
+// ConfigMapToEvent maps a corev1.ConfigMap plus an action into an Event.
+// See file header for the security posture and the opt-in mechanism.
+//
+// This function is pure and never reads values out of `binaryData`. The
+// `data_values_json` field is only populated when the opt-in annotation is
+// present AND `data` (the textual variant) is non-empty.
+func ConfigMapToEvent(cm *corev1.ConfigMap, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(cm.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindConfigMap, cm.Name)
+
+	keys := mergedSortedKeys(cm.Data, cm.BinaryData)
+	meta["data_keys"] = strings.Join(keys, ",")
+	meta["data_count"] = strconv.Itoa(len(keys))
+
+	indexed := isIndexDataOptIn(cm.Annotations)
+	meta["indexed"] = strconv.FormatBool(indexed)
+	if indexed && len(cm.Data) > 0 {
+		// Marshal a sorted-key view so the JSON is deterministic. Iteration
+		// order of map[string]string is non-deterministic in Go.
+		raw, err := marshalSortedStringMap(cm.Data)
+		if err != nil {
+			// Marshal of a map[string]string can't fail in practice, but if
+			// it ever did we'd rather NOT emit anything than risk partial
+			// or corrupted JSON. Emit empty marker so the consumer can tell.
+			meta["data_values_json"] = ""
+		} else {
+			meta["data_values_json"] = raw
+		}
+	}
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(EntityKindConfigMap, namespace, cm.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindConfigMap, cm.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// isIndexDataOptIn returns true iff annotations contains the IndexDataAnnotation
+// set to the literal string "true". Any other value (including "True", "1",
+// "yes") is treated as a no-opt to keep the gate conservative.
+func isIndexDataOptIn(annotations map[string]string) bool {
+	v, ok := annotations[IndexDataAnnotation]
+	return ok && v == "true"
+}
+
+// mergedSortedKeys returns the union of keys in `data` and `binaryData`,
+// sorted lexicographically. The result is the *names* only — values are never
+// touched.
+func mergedSortedKeys(data map[string]string, binary map[string][]byte) []string {
+	seen := make(map[string]struct{}, len(data)+len(binary))
+	for k := range data {
+		seen[k] = struct{}{}
+	}
+	for k := range binary {
+		seen[k] = struct{}{}
+	}
+	return sortedKeys(seen)
+}
+
+// marshalSortedStringMap returns the JSON encoding of m with keys in sorted
+// order. encoding/json's Encoder sorts map keys automatically since Go 1.12,
+// so we just hand it the map; this wrapper exists only to centralise the
+// guarantee.
+func marshalSortedStringMap(m map[string]string) (string, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/operator/internal/entity/configmap_test.go
+++ b/operator/internal/entity/configmap_test.go
@@ -1,0 +1,116 @@
+package entity_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// hostileConfigMap returns a ConfigMap that *would* leak if the mapper
+// failed: distinctive value bytes like "REDACTED-ME" so a substring-search
+// catches any regression.
+func hostileConfigMap(opt bool) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "settings",
+			Labels:    map[string]string{"adversarial.example.com/spy": "no"},
+		},
+		Data: map[string]string{
+			"db_password":   "REDACTED-ME-VAL-1",
+			"api_token":     "REDACTED-ME-VAL-2",
+			"feature_flags": "REDACTED-ME-VAL-3",
+		},
+		BinaryData: map[string][]byte{
+			"cert.der": []byte("REDACTED-ME-BIN-1"),
+		},
+	}
+	if opt {
+		cm.Annotations = map[string]string{entity.IndexDataAnnotation: "true"}
+	}
+	return cm
+}
+
+func TestConfigMapToEvent_DefaultDropsValues(t *testing.T) {
+	cm := hostileConfigMap(false)
+	ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, leakSubstr := range []string{
+		"REDACTED-ME-VAL-1", "REDACTED-ME-VAL-2", "REDACTED-ME-VAL-3", "REDACTED-ME-BIN-1",
+	} {
+		if strings.Contains(string(raw), leakSubstr) {
+			t.Fatalf("VALUE LEAK: %q appears in default-mode payload: %s", leakSubstr, raw)
+		}
+	}
+	if ev.Metadata["indexed"] != "false" {
+		t.Fatalf("indexed = %q, want \"false\"", ev.Metadata["indexed"])
+	}
+	if ev.Metadata["data_keys"] != "api_token,cert.der,db_password,feature_flags" {
+		t.Fatalf("data_keys = %q (want sorted, comma-joined)", ev.Metadata["data_keys"])
+	}
+	if ev.Metadata["data_count"] != "4" {
+		t.Fatalf("data_count = %q", ev.Metadata["data_count"])
+	}
+	if _, ok := ev.Metadata["data_values_json"]; ok {
+		t.Fatalf("data_values_json must NOT appear when annotation is absent")
+	}
+}
+
+func TestConfigMapToEvent_AnnotationOptInEmitsValuesButNotBinary(t *testing.T) {
+	cm := hostileConfigMap(true)
+	ev := entity.ConfigMapToEvent(cm, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.Metadata["indexed"] != "true" {
+		t.Fatalf("indexed = %q, want \"true\"", ev.Metadata["indexed"])
+	}
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Textual values must be emitted (opt-in is the contract).
+	for _, want := range []string{"REDACTED-ME-VAL-1", "REDACTED-ME-VAL-2", "REDACTED-ME-VAL-3"} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("opt-in textual value %q missing", want)
+		}
+	}
+	// Binary values must NOT be emitted even with opt-in.
+	if strings.Contains(string(raw), "REDACTED-ME-BIN-1") {
+		t.Fatalf("BINARY VALUE LEAK: cert.der content appears in opt-in payload (should NEVER happen): %s", raw)
+	}
+}
+
+func TestConfigMapToEvent_AnyOtherAnnotationValueDoesNotOptIn(t *testing.T) {
+	for _, lookalike := range []string{"True", "1", "yes", "TRUE", " true "} {
+		cm := hostileConfigMap(false)
+		cm.Annotations = map[string]string{entity.IndexDataAnnotation: lookalike}
+		ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+		if ev.Metadata["indexed"] != "false" {
+			t.Fatalf("annotation value %q should NOT enable indexing; indexed=%q", lookalike, ev.Metadata["indexed"])
+		}
+	}
+}
+
+func TestConfigMapToEvent_AllowListIsClosedAndStable(t *testing.T) {
+	cm := hostileConfigMap(false)
+	ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	allowed := map[string]struct{}{
+		"cluster": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"data_keys": {}, "data_count": {}, "indexed": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("ConfigMap metadata leaked unexpected key %q", k)
+		}
+	}
+	if ev.Metadata["kind"] != "ConfigMap" || ev.Metadata["emitter"] != "k8s-operator" {
+		t.Fatalf("base allow-list violation: %v", ev.Metadata)
+	}
+}

--- a/operator/internal/entity/endpoints.go
+++ b/operator/internal/entity/endpoints.go
@@ -1,0 +1,106 @@
+// endpoints.go: corev1.Endpoints -> Event mapper.
+//
+// The Endpoints controller is what produces Service -[SELECTS]-> Pod edges:
+// the API server populates Endpoints.subsets[].addresses[].targetRef from
+// the *current* selector match, so we get the authoritative resolution
+// without re-evaluating selectors. The Service controller never produces
+// these edges — see issue #158 §Topology edges.
+package entity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EntityKindEndpoints is the K8s kind segment in Endpoints external_ids.
+//
+// Endpoints share name with their owning Service (this is how the API server
+// pairs them) — the external_id segments differ on Kind, so collisions are
+// impossible.
+const EntityKindEndpoints = "Endpoints"
+
+// EndpointsToEvent maps a corev1.Endpoints plus an action into an Event.
+//
+// The mapper does two things:
+//  1. Emits an Endpoints entity (the carrier; reviewers can confirm what
+//     was observed at the API server boundary).
+//  2. Emits SELECTS edges from the *paired Service* (same namespace+name) to
+//     each Pod referenced by subsets[].addresses[].targetRef where targetRef
+//     .kind == "Pod". This is the topology truth — derived from K8s-native
+//     pointers, never re-inferred.
+func EndpointsToEvent(ep *corev1.Endpoints, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(ep.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindEndpoints, ep.Name)
+	meta["subset_count"] = strconv.Itoa(len(ep.Subsets))
+	meta["address_count"] = strconv.Itoa(countEndpointAddresses(ep))
+
+	edges := buildSelectsEdges(ep, namespace)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(EntityKindEndpoints, namespace, ep.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindEndpoints, ep.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:      meta,
+		TopologyEdges: edges,
+	}
+}
+
+// countEndpointAddresses returns the total number of addresses (ready +
+// not-ready) across all subsets. Used as a coarse health signal in metadata
+// without leaking individual IPs (which can be sensitive on private
+// networks).
+func countEndpointAddresses(ep *corev1.Endpoints) int {
+	n := 0
+	for i := range ep.Subsets {
+		n += len(ep.Subsets[i].Addresses)
+		n += len(ep.Subsets[i].NotReadyAddresses)
+	}
+	return n
+}
+
+// buildSelectsEdges walks Endpoints.subsets[].addresses[].targetRef and
+// returns one EdgeRef per Pod target. The "from" side of the edge is implicit
+// in the Endpoints' name (= Service name) — the server-side ingester pairs
+// the Endpoints entity with the Service entity by namespace+name on insert.
+//
+// We deliberately emit edges for both ready and not-ready addresses: the
+// Endpoints document records the membership decision at this point in time;
+// readiness is a separate dimension and changes more frequently than the
+// selector match.
+func buildSelectsEdges(ep *corev1.Endpoints, namespace string) []EdgeRef {
+	var edges []EdgeRef
+	for _, sub := range ep.Subsets {
+		edges = appendPodEdges(edges, sub.Addresses, namespace)
+		edges = appendPodEdges(edges, sub.NotReadyAddresses, namespace)
+	}
+	return edges
+}
+
+// appendPodEdges appends a SELECTS edge for every address whose targetRef
+// points to a Pod. Other targetRef kinds (rare; e.g. legacy clusters that
+// reference Services directly) are skipped — we only emit edges we can
+// confidently express as `k8s_resource/Pod/{namespace}/{name}`.
+func appendPodEdges(edges []EdgeRef, addrs []corev1.EndpointAddress, fallbackNamespace string) []EdgeRef {
+	for i := range addrs {
+		ref := addrs[i].TargetRef
+		if ref == nil || ref.Kind != "Pod" || ref.Name == "" {
+			continue
+		}
+		ns := ref.Namespace
+		if ns == "" {
+			ns = fallbackNamespace
+		}
+		edges = append(edges, EdgeRef{
+			Kind:             EdgeKindSelects,
+			TargetExternalID: externalIDFor("Pod", ns, ref.Name),
+		})
+	}
+	return edges
+}

--- a/operator/internal/entity/endpoints_test.go
+++ b/operator/internal/entity/endpoints_test.go
@@ -1,0 +1,98 @@
+package entity_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func TestEndpointsToEvent_BuildsSelectsEdges(t *testing.T) {
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "checkout"},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{IP: "10.0.0.1", TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "team-a", Name: "checkout-7d9f"}},
+					{IP: "10.0.0.2", TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "team-a", Name: "checkout-aa11"}},
+				},
+				NotReadyAddresses: []corev1.EndpointAddress{
+					{IP: "10.0.0.3", TargetRef: &corev1.ObjectReference{Kind: "Pod", Namespace: "team-a", Name: "checkout-bb22"}},
+				},
+			},
+		},
+	}
+	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/Endpoints/team-a/checkout" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["subset_count"] != "1" {
+		t.Fatalf("subset_count = %q", ev.Metadata["subset_count"])
+	}
+	if ev.Metadata["address_count"] != "3" {
+		t.Fatalf("address_count = %q", ev.Metadata["address_count"])
+	}
+	if got := len(ev.TopologyEdges); got != 3 {
+		t.Fatalf("edges count = %d, want 3", got)
+	}
+	wantTargets := map[string]bool{
+		"k8s_resource/Pod/team-a/checkout-7d9f": false,
+		"k8s_resource/Pod/team-a/checkout-aa11": false,
+		"k8s_resource/Pod/team-a/checkout-bb22": false,
+	}
+	for _, e := range ev.TopologyEdges {
+		if e.Kind != entity.EdgeKindSelects {
+			t.Fatalf("edge kind = %q, want %q", e.Kind, entity.EdgeKindSelects)
+		}
+		if _, ok := wantTargets[e.TargetExternalID]; !ok {
+			t.Fatalf("unexpected edge target %q", e.TargetExternalID)
+		}
+		wantTargets[e.TargetExternalID] = true
+	}
+	for ext, seen := range wantTargets {
+		if !seen {
+			t.Fatalf("expected edge to %q not emitted", ext)
+		}
+	}
+}
+
+func TestEndpointsToEvent_NoSubsetsEmitsZeroEdges(t *testing.T) {
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "headless"},
+	}
+	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.TopologyEdges) != 0 {
+		t.Fatalf("expected 0 edges, got %d", len(ev.TopologyEdges))
+	}
+	if ev.Metadata["subset_count"] != "0" || ev.Metadata["address_count"] != "0" {
+		t.Fatalf("zero counts: subset=%q address=%q", ev.Metadata["subset_count"], ev.Metadata["address_count"])
+	}
+}
+
+func TestEndpointsToEvent_SkipsNonPodTargetRefs(t *testing.T) {
+	// Some legacy clusters (or operators producing custom Endpoints) put non-
+	// Pod targetRefs in subsets. We must only emit Pod edges so the resulting
+	// graph stays well-typed.
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "weird"},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{IP: "10.0.0.1"}, // no targetRef
+					{IP: "10.0.0.2", TargetRef: &corev1.ObjectReference{Kind: "Service", Name: "external"}},
+					{IP: "10.0.0.3", TargetRef: &corev1.ObjectReference{Kind: "Pod", Name: "real-pod"}},
+				},
+			},
+		},
+	}
+	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.TopologyEdges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(ev.TopologyEdges))
+	}
+	if ev.TopologyEdges[0].TargetExternalID != "k8s_resource/Pod/team-a/real-pod" {
+		t.Fatalf("edge target = %q", ev.TopologyEdges[0].TargetExternalID)
+	}
+}

--- a/operator/internal/entity/entity.go
+++ b/operator/internal/entity/entity.go
@@ -75,11 +75,16 @@ type Event struct {
 
 	// Edges carries OWNS relationships sourced from
 	// metadata.ownerReferences on the watched resource. Optional and
-	// omitempty for backward compatibility with v0.2 consumers (the Pod
-	// path emits no edges in v0.2 — Pods' parents are emitted by the
-	// ReplicaSet/StatefulSet/DaemonSet/Job watchers). See ADR-0007
+	// omitempty for backward compatibility with v0.2 consumers. See ADR-0007
 	// §causal-fidelity: edges are NEVER inferred from name patterns.
 	Edges []OwnerEdge `json:"edges,omitempty"`
+
+	// TopologyEdges is the (optional) topology edge list emitted alongside
+	// this entity (issue #158). Always derived from K8s-native pointers
+	// (spec.rules, spec.volumes, …) — never inferred from labels. Pod and
+	// workload events leave this field nil; consumers MUST treat absent
+	// and empty as identical. See common.go for EdgeRef.
+	TopologyEdges []EdgeRef `json:"topology_edges,omitempty"`
 }
 
 // PodToEvent maps a corev1.Pod plus an action into an Event. Pure function

--- a/operator/internal/entity/ingress.go
+++ b/operator/internal/entity/ingress.go
@@ -1,0 +1,95 @@
+// ingress.go: networkingv1.Ingress -> Event mapper.
+//
+// Topology: Ingress -[ROUTES_TO]-> Service, derived from
+// spec.rules[].http.paths[].backend.service.name AND spec.defaultBackend
+// .service.name. Never inferred. See issue #158 §Topology edges.
+package entity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// EntityKindIngress is the K8s kind segment in Ingress external_ids.
+const EntityKindIngress = "Ingress"
+
+// IngressToEvent maps a networkingv1.Ingress plus an action into an Event.
+//
+// Carried metadata (allow-list):
+//   - cluster, namespace, name, kind, emitter (base)
+//   - ingress_class (spec.ingressClassName; "" if unset)
+//   - rule_count (number of rules; "0" for default-backend-only ingresses)
+//   - tls_count (number of TLS blocks)
+//
+// Edges: one ROUTES_TO edge per distinct Service named in the spec. We
+// deduplicate so a multi-path ingress that fans out to the same service
+// produces a single edge.
+func IngressToEvent(ing *networkingv1.Ingress, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(ing.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindIngress, ing.Name)
+	meta["ingress_class"] = derefString(ing.Spec.IngressClassName)
+	meta["rule_count"] = strconv.Itoa(len(ing.Spec.Rules))
+	meta["tls_count"] = strconv.Itoa(len(ing.Spec.TLS))
+
+	edges := buildRoutesToEdges(ing, namespace)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(EntityKindIngress, namespace, ing.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindIngress, ing.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:      meta,
+		TopologyEdges: edges,
+	}
+}
+
+// derefString returns *p, or "" if p == nil.
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// buildRoutesToEdges scans defaultBackend + rules[].http.paths[].backend for
+// service backends and emits one ROUTES_TO edge per distinct Service.
+//
+// External Name backends (backend.resource pointing at a CRD) are not Service
+// references; we skip them. Same-named services in the same namespace are
+// deduplicated.
+func buildRoutesToEdges(ing *networkingv1.Ingress, namespace string) []EdgeRef {
+	seen := map[string]struct{}{}
+	var edges []EdgeRef
+	add := func(serviceName string) {
+		if serviceName == "" {
+			return
+		}
+		ext := externalIDFor(EntityKindService, namespace, serviceName)
+		if _, ok := seen[ext]; ok {
+			return
+		}
+		seen[ext] = struct{}{}
+		edges = append(edges, EdgeRef{Kind: EdgeKindRoutesTo, TargetExternalID: ext})
+	}
+	if ing.Spec.DefaultBackend != nil && ing.Spec.DefaultBackend.Service != nil {
+		add(ing.Spec.DefaultBackend.Service.Name)
+	}
+	for _, rule := range ing.Spec.Rules {
+		if rule.HTTP == nil {
+			continue
+		}
+		for _, path := range rule.HTTP.Paths {
+			if path.Backend.Service == nil {
+				continue
+			}
+			add(path.Backend.Service.Name)
+		}
+	}
+	return edges
+}

--- a/operator/internal/entity/ingress_test.go
+++ b/operator/internal/entity/ingress_test.go
@@ -1,0 +1,84 @@
+package entity_test
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func ptrString(s string) *string { return &s }
+
+func TestIngressToEvent_RoutesToFromRulesAndDefaultBackend(t *testing.T) {
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "main"},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: ptrString("nginx"),
+			DefaultBackend: &networkingv1.IngressBackend{
+				Service: &networkingv1.IngressServiceBackend{Name: "default-svc"},
+			},
+			TLS: []networkingv1.IngressTLS{{Hosts: []string{"a.example.com"}}},
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: "a.example.com",
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{Path: "/", Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: "checkout"}}},
+								{Path: "/billing", Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: "billing"}}},
+								// duplicate of "checkout" — must be deduped.
+								{Path: "/v2", Backend: networkingv1.IngressBackend{Service: &networkingv1.IngressServiceBackend{Name: "checkout"}}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ev := entity.IngressToEvent(ing, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/Ingress/team-a/main" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["ingress_class"] != "nginx" {
+		t.Fatalf("ingress_class = %q", ev.Metadata["ingress_class"])
+	}
+	if ev.Metadata["rule_count"] != "1" {
+		t.Fatalf("rule_count = %q", ev.Metadata["rule_count"])
+	}
+	if ev.Metadata["tls_count"] != "1" {
+		t.Fatalf("tls_count = %q", ev.Metadata["tls_count"])
+	}
+	wantTargets := map[string]bool{
+		"k8s_resource/Service/team-a/default-svc": false,
+		"k8s_resource/Service/team-a/checkout":    false,
+		"k8s_resource/Service/team-a/billing":     false,
+	}
+	if got := len(ev.TopologyEdges); got != 3 {
+		t.Fatalf("expected 3 deduped edges, got %d (%v)", got, ev.TopologyEdges)
+	}
+	for _, e := range ev.TopologyEdges {
+		if e.Kind != entity.EdgeKindRoutesTo {
+			t.Fatalf("edge kind = %q", e.Kind)
+		}
+		if _, ok := wantTargets[e.TargetExternalID]; !ok {
+			t.Fatalf("unexpected edge target %q", e.TargetExternalID)
+		}
+		wantTargets[e.TargetExternalID] = true
+	}
+}
+
+func TestIngressToEvent_NoRulesEmitsZeroEdges(t *testing.T) {
+	ing := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "empty"},
+	}
+	ev := entity.IngressToEvent(ing, entity.ActionDeleted, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.TopologyEdges) != 0 {
+		t.Fatalf("expected 0 edges, got %d", len(ev.TopologyEdges))
+	}
+	if ev.Metadata["ingress_class"] != "" {
+		t.Fatalf("ingress_class should be empty for nil ClassName, got %q", ev.Metadata["ingress_class"])
+	}
+}

--- a/operator/internal/entity/networkpolicy.go
+++ b/operator/internal/entity/networkpolicy.go
@@ -1,0 +1,66 @@
+// networkpolicy.go: networkingv1.NetworkPolicy -> Event mapper.
+//
+// Topology: NetworkPolicy -[APPLIES_TO]-> Pod is conceptually derived from
+// spec.podSelector, but resolving "which Pods match this selector right now"
+// requires a label index that joins across watcher streams. Per issue #158
+// §Non-goals, that resolution belongs to the reconciliation worker (#163).
+//
+// What we DO emit here: the rendered selector string in metadata, so the
+// server side can perform the join when the index is ready, without the
+// operator having to re-emit anything.
+package entity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// EntityKindNetworkPolicy is the K8s kind segment in NetworkPolicy external_ids.
+const EntityKindNetworkPolicy = "NetworkPolicy"
+
+// NetworkPolicyToEvent maps a networkingv1.NetworkPolicy plus an action into
+// an Event.
+//
+// Carried metadata (allow-list):
+//   - cluster, namespace, name, kind, emitter (base)
+//   - pod_selector (rendered selector string; empty matches everything in ns)
+//   - ingress_rule_count, egress_rule_count
+//   - policy_types ("Ingress", "Egress", or "Ingress,Egress" sorted)
+func NetworkPolicyToEvent(np *networkingv1.NetworkPolicy, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(np.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindNetworkPolicy, np.Name)
+	meta["pod_selector"] = formatLabelSelector(&np.Spec.PodSelector)
+	meta["ingress_rule_count"] = strconv.Itoa(len(np.Spec.Ingress))
+	meta["egress_rule_count"] = strconv.Itoa(len(np.Spec.Egress))
+	meta["policy_types"] = renderPolicyTypes(np.Spec.PolicyTypes)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(EntityKindNetworkPolicy, namespace, np.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindNetworkPolicy, np.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+		// Edges intentionally nil — APPLIES_TO is resolved server-side. See
+		// the package doc above.
+	}
+}
+
+// renderPolicyTypes returns the sorted comma-joined string form of the
+// PolicyTypes slice. K8s allows "Ingress" / "Egress" / both; we sort to make
+// the metadata stable across reconciles even if the API server reorders.
+func renderPolicyTypes(types []networkingv1.PolicyType) string {
+	if len(types) == 0 {
+		return ""
+	}
+	strs := make([]string, len(types))
+	for i, t := range types {
+		strs[i] = string(t)
+	}
+	return joinSorted(strs)
+}

--- a/operator/internal/entity/networkpolicy_test.go
+++ b/operator/internal/entity/networkpolicy_test.go
@@ -1,0 +1,56 @@
+package entity_test
+
+import (
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func TestNetworkPolicyToEvent_RendersSelectorAndPolicyTypes(t *testing.T) {
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "deny-all"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "checkout", "tier": "frontend"},
+			},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+			Egress:      []networkingv1.NetworkPolicyEgressRule{{}, {}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress, networkingv1.PolicyTypeIngress},
+		},
+	}
+	ev := entity.NetworkPolicyToEvent(np, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/NetworkPolicy/team-a/deny-all" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["pod_selector"] != "app=checkout,tier=frontend" {
+		t.Fatalf("pod_selector = %q", ev.Metadata["pod_selector"])
+	}
+	if ev.Metadata["ingress_rule_count"] != "1" || ev.Metadata["egress_rule_count"] != "2" {
+		t.Fatalf("ingress=%q egress=%q", ev.Metadata["ingress_rule_count"], ev.Metadata["egress_rule_count"])
+	}
+	if ev.Metadata["policy_types"] != "Egress,Ingress" {
+		// Sorted alphabetically — see renderPolicyTypes doc.
+		t.Fatalf("policy_types = %q, want sorted form 'Egress,Ingress'", ev.Metadata["policy_types"])
+	}
+	if len(ev.TopologyEdges) != 0 {
+		t.Fatalf("NetworkPolicy must NOT emit edges in v0.2; got %d", len(ev.TopologyEdges))
+	}
+}
+
+func TestNetworkPolicyToEvent_EmptySelectorRendersEmpty(t *testing.T) {
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "deny-everything"},
+		Spec:       networkingv1.NetworkPolicySpec{},
+	}
+	ev := entity.NetworkPolicyToEvent(np, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.Metadata["pod_selector"] != "" {
+		t.Fatalf("empty selector should render as \"\"; got %q", ev.Metadata["pod_selector"])
+	}
+	if ev.Metadata["policy_types"] != "" {
+		t.Fatalf("empty policy_types: %q", ev.Metadata["policy_types"])
+	}
+}

--- a/operator/internal/entity/secret.go
+++ b/operator/internal/entity/secret.go
@@ -1,0 +1,93 @@
+// secret.go: corev1.Secret -> Event mapper.
+//
+// HARD RULE — METADATA ONLY. NO EXCEPTIONS.
+//
+// This mapper emits ONLY the closed allow-list of metadata fields. Secret
+// VALUES (`data`, `stringData`, base64 blobs, the bytes themselves) MUST NOT
+// flow into the Event under any circumstance. There is no opt-in like
+// ConfigMap has — issue #158 §ACL invariant is explicit on this point: the
+// security floor is the closed allow-list, full stop.
+//
+// Why values are forbidden, even with opt-in:
+//   - Secrets routinely carry credentials (database passwords, API tokens,
+//     TLS private keys). Indexing them puts every downstream component
+//     (graph, vector store, retrieval API, audit logs) in the credential
+//     blast radius.
+//   - The operator runs with cluster-scoped get/list/watch on `secrets`. The
+//     RBAC permission is unavoidable for the watcher; the cap on what we
+//     emit is the actual control. Removing that cap would defeat the whole
+//     security posture.
+//   - K8s itself protects Secret values via etcd encryption-at-rest. Pulling
+//     them through Omniscience would route them into stores that may have
+//     different at-rest guarantees.
+//
+// Tests in secret_test.go assert this hard rule structurally: for any
+// fixture Secret carrying values, the JSON-marshalled Event payload contains
+// none of the value bytes (substring search). The test fails if a single
+// byte of a value leaks anywhere in the payload.
+//
+// See also: docs/connectors/k8s-operator-secrets.md.
+package entity
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EntityKindSecret is the K8s kind segment in Secret external_ids.
+const EntityKindSecret = "Secret"
+
+// SecretToEvent maps a corev1.Secret plus an action into an Event.
+//
+// The function is pure and *intentionally narrow*. The only Secret fields
+// read are:
+//   - ObjectMeta.Namespace, ObjectMeta.Name
+//   - Type
+//   - the *keys* of Data and StringData (lengths, names — never values)
+//
+// Anything not enumerated above is dropped on the floor. This is a defence-
+// in-depth design: even if a future contributor added a leaky line, the
+// closed allow-list of metadata makes the regression visible to the
+// structural test in secret_test.go.
+func SecretToEvent(s *corev1.Secret, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(s.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindSecret, s.Name)
+	meta["secret_type"] = string(s.Type)
+
+	// Union of the keys in Data and StringData (k8s permits both). Sorted so
+	// the metadata is deterministic. Values are NOT touched.
+	keys := mergedSortedSecretKeys(s.Data, s.StringData)
+	meta["data_keys"] = strings.Join(keys, ",")
+	meta["data_count"] = strconv.Itoa(len(keys))
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(EntityKindSecret, namespace, s.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindSecret, s.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+		// Edges are intentionally nil. Pod->Secret CONSUMES edges live on
+		// the Pod controller side and are issue #157 / Wave-3 follow-up
+		// territory.
+	}
+}
+
+// mergedSortedSecretKeys returns the sorted union of keys in `data` and
+// `stringData`. Tests assert that this function NEVER reads a value byte.
+func mergedSortedSecretKeys(data map[string][]byte, stringData map[string]string) []string {
+	seen := make(map[string]struct{}, len(data)+len(stringData))
+	for k := range data {
+		seen[k] = struct{}{}
+	}
+	for k := range stringData {
+		seen[k] = struct{}{}
+	}
+	return sortedKeys(seen)
+}

--- a/operator/internal/entity/secret_test.go
+++ b/operator/internal/entity/secret_test.go
@@ -1,0 +1,155 @@
+package entity_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// hostileSecret carries values the test will substring-search for in the
+// emitted JSON. The string-and-bytes form lets us catch both the raw byte
+// path and the base64-encoded path that JSON marshalling produces for
+// []byte fields.
+func hostileSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "stripe-prod-key",
+			// Hostile labels & annotations — must NOT appear in metadata.
+			Labels:      map[string]string{"adversarial.example.com/spy": "yes"},
+			Annotations: map[string]string{"omniscience.io/index-data": "true"}, // even the opt-in must be ignored
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"db_password": []byte("CANARY-PWD-XYZZY-1"),
+			"api_token":   []byte("CANARY-TOK-XYZZY-2"),
+		},
+		StringData: map[string]string{
+			"client_secret": "CANARY-STR-XYZZY-3",
+		},
+	}
+}
+
+// TestSecretToEvent_NeverLeaksValues is the structural test for the hard
+// rule. We marshal the emitted Event to JSON and assert that none of the
+// canary substrings appear ANYWHERE in the payload — neither raw, nor as a
+// JSON-escaped string, nor as a base64-encoded blob (the form that []byte
+// would take in encoding/json).
+func TestSecretToEvent_NeverLeaksValues(t *testing.T) {
+	s := hostileSecret()
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	payload := string(raw)
+	canaries := []string{
+		"CANARY-PWD-XYZZY-1",
+		"CANARY-TOK-XYZZY-2",
+		"CANARY-STR-XYZZY-3",
+		// Base64-encoded forms, in case a future regression smuggles []byte
+		// values through.
+		base64.StdEncoding.EncodeToString([]byte("CANARY-PWD-XYZZY-1")),
+		base64.StdEncoding.EncodeToString([]byte("CANARY-TOK-XYZZY-2")),
+	}
+	for _, c := range canaries {
+		if strings.Contains(payload, c) {
+			t.Fatalf("SECRET VALUE LEAK: canary %q appears in event payload: %s", c, payload)
+		}
+	}
+	// Hostile labels / annotations also must not leak.
+	if strings.Contains(payload, "adversarial.example.com/spy") {
+		t.Fatalf("hostile label leaked into Secret payload: %s", payload)
+	}
+}
+
+func TestSecretToEvent_OptInAnnotationIsIgnored(t *testing.T) {
+	// The Secret mapper has NO opt-in. Even with the same annotation
+	// ConfigMap honours, Secret values stay dropped.
+	s := hostileSecret()
+	ev := entity.SecretToEvent(s, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if _, ok := ev.Metadata["data_values_json"]; ok {
+		t.Fatalf("Secret must NOT honour the index-data annotation: data_values_json is present")
+	}
+	if _, ok := ev.Metadata["indexed"]; ok {
+		t.Fatalf("Secret must NOT carry the 'indexed' field — it's a ConfigMap-only marker")
+	}
+}
+
+func TestSecretToEvent_AllowListIsClosed(t *testing.T) {
+	s := hostileSecret()
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	allowed := map[string]struct{}{
+		"cluster": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"secret_type": {}, "data_keys": {}, "data_count": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("Secret metadata leaked unexpected key %q", k)
+		}
+	}
+	if ev.Metadata["kind"] != "Secret" {
+		t.Fatalf("kind = %q", ev.Metadata["kind"])
+	}
+	if ev.Metadata["secret_type"] != "Opaque" {
+		t.Fatalf("secret_type = %q", ev.Metadata["secret_type"])
+	}
+	// data_keys must be the sorted union of Data and StringData keys.
+	if ev.Metadata["data_keys"] != "api_token,client_secret,db_password" {
+		t.Fatalf("data_keys = %q (sorted union expected)", ev.Metadata["data_keys"])
+	}
+	if ev.Metadata["data_count"] != "3" {
+		t.Fatalf("data_count = %q", ev.Metadata["data_count"])
+	}
+}
+
+func TestSecretToEvent_TLSTypeMetadata(t *testing.T) {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "tls-cert"},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       []byte("CANARY-CERT-PEM"),
+			corev1.TLSPrivateKeyKey: []byte("CANARY-KEY-PEM"),
+		},
+	}
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.Metadata["secret_type"] != "kubernetes.io/tls" {
+		t.Fatalf("secret_type = %q", ev.Metadata["secret_type"])
+	}
+	if ev.Metadata["data_keys"] != corev1.TLSCertKey+","+corev1.TLSPrivateKeyKey {
+		// "tls.crt,tls.key" — sorted lexicographically.
+		t.Fatalf("data_keys = %q", ev.Metadata["data_keys"])
+	}
+	// Last belt-and-braces leak check on the TLS variant.
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, c := range []string{"CANARY-CERT-PEM", "CANARY-KEY-PEM",
+		base64.StdEncoding.EncodeToString([]byte("CANARY-CERT-PEM")),
+		base64.StdEncoding.EncodeToString([]byte("CANARY-KEY-PEM")),
+	} {
+		if strings.Contains(string(raw), c) {
+			t.Fatalf("TLS Secret value leaked: %q in %s", c, raw)
+		}
+	}
+}
+
+func TestSecretToEvent_NamespacelessFallsBack(t *testing.T) {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "rogue"},
+		Type:       corev1.SecretTypeOpaque,
+	}
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/Secret/default/rogue" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+}

--- a/operator/internal/entity/service.go
+++ b/operator/internal/entity/service.go
@@ -1,0 +1,68 @@
+// service.go: corev1.Service -> Event mapper.
+//
+// Topology note: Service does NOT emit SELECTS edges. Resolving "which Pods
+// does this Service select" is the Endpoints controller's job (it consumes
+// the API server's authoritative subsets list, instead of re-evaluating the
+// label selector locally). See issue #158 §Topology edges.
+package entity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EntityKindService is the K8s kind segment in Service external_ids.
+const EntityKindService = "Service"
+
+// ServiceToEvent maps a corev1.Service plus an action into an Event. Pure;
+// no I/O, no clients. The metadata allow-list is closed and does not include
+// user-controlled labels or annotations — see issue #158 §ACL invariant.
+//
+// Carried metadata (allow-list, exact):
+//   - cluster, namespace, name, kind, emitter (base)
+//   - service_type ("ClusterIP", "LoadBalancer", …)
+//   - cluster_ip (the kube-allocated VIP; not user input)
+//   - selector (deterministic "k=v,…" rendering of spec.selector — empty for
+//     headless services with no selector)
+//   - port_count (count of spec.ports as a string)
+//
+// Notably absent: spec.externalIPs, spec.loadBalancerIP, status.loadBalancer
+// .ingress[].ip — all settable by tenant code paths and out of v0.2 scope.
+func ServiceToEvent(svc *corev1.Service, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(svc.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindService, svc.Name)
+	meta["service_type"] = string(svc.Spec.Type)
+	meta["cluster_ip"] = svc.Spec.ClusterIP
+	meta["selector"] = renderStringMapSorted(svc.Spec.Selector)
+	meta["port_count"] = strconv.Itoa(len(svc.Spec.Ports))
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(EntityKindService, namespace, svc.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindService, svc.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// renderStringMapSorted is the small string-map -> "k=v,…" helper used by
+// ServiceToEvent. Defined locally rather than in common.go because the
+// LabelSelector path uses a richer renderer (matchExpressions) — this is the
+// flat case.
+func renderStringMapSorted(m map[string]string) string {
+	keys := sortedKeys(m)
+	out := ""
+	for i, k := range keys {
+		if i > 0 {
+			out += ","
+		}
+		out += k + "=" + m[k]
+	}
+	return out
+}

--- a/operator/internal/entity/service_test.go
+++ b/operator/internal/entity/service_test.go
@@ -1,0 +1,85 @@
+package entity_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func newService(namespace, name string, selector map[string]string, t corev1.ServiceType) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			// Hostile labels & annotations — must be ignored.
+			Labels:      map[string]string{"adversarial.example.com/spy": "no"},
+			Annotations: map[string]string{"omniscience.io/workspace-id": "00000000-DEAD-BEEF-DEAD-000000000000"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      t,
+			ClusterIP: "10.0.0.42",
+			Selector:  selector,
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80},
+				{Name: "https", Port: 443},
+			},
+		},
+	}
+}
+
+func TestServiceToEvent_HappyPath(t *testing.T) {
+	svc := newService("team-a", "checkout", map[string]string{"app": "checkout", "tier": "frontend"}, corev1.ServiceTypeClusterIP)
+	ev := entity.ServiceToEvent(svc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/Service/team-a/checkout" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.URI != "kube://prod-eu/team-a/Service/checkout" {
+		t.Fatalf("uri = %q", ev.URI)
+	}
+	if ev.Metadata["service_type"] != "ClusterIP" {
+		t.Fatalf("service_type = %q", ev.Metadata["service_type"])
+	}
+	if ev.Metadata["cluster_ip"] != "10.0.0.42" {
+		t.Fatalf("cluster_ip = %q", ev.Metadata["cluster_ip"])
+	}
+	if ev.Metadata["selector"] != "app=checkout,tier=frontend" {
+		t.Fatalf("selector = %q", ev.Metadata["selector"])
+	}
+	if ev.Metadata["port_count"] != "2" {
+		t.Fatalf("port_count = %q", ev.Metadata["port_count"])
+	}
+	if len(ev.TopologyEdges) != 0 {
+		t.Fatalf("Service must NOT emit edges; got %d", len(ev.TopologyEdges))
+	}
+	// Hostile keys must NOT appear in metadata.
+	for k := range ev.Metadata {
+		if strings.HasPrefix(k, "adversarial") || k == "omniscience.io/workspace-id" {
+			t.Fatalf("hostile metadata key leaked: %q", k)
+		}
+	}
+}
+
+func TestServiceToEvent_HeadlessNoSelector(t *testing.T) {
+	svc := newService("team-a", "headless", nil, corev1.ServiceTypeClusterIP)
+	svc.Spec.ClusterIP = "None"
+	ev := entity.ServiceToEvent(svc, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.Metadata["selector"] != "" {
+		t.Fatalf("empty selector should render as \"\"; got %q", ev.Metadata["selector"])
+	}
+	if ev.Metadata["cluster_ip"] != "None" {
+		t.Fatalf("cluster_ip = %q", ev.Metadata["cluster_ip"])
+	}
+}
+
+func TestServiceToEvent_NamespacelessFallsBack(t *testing.T) {
+	svc := newService("", "rogue", nil, corev1.ServiceTypeClusterIP)
+	ev := entity.ServiceToEvent(svc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/Service/default/rogue" {
+		t.Fatalf("external_id = %q (expected default fallback)", ev.ExternalID)
+	}
+}


### PR DESCRIPTION
Closes #158. Wave 2 of epic #98.

## What's in

- **6 new controllers** under `operator/internal/controller/`:
  - `service_controller.go`, `endpoints_controller.go`, `ingress_controller.go`, `networkpolicy_controller.go`, `configmap_controller.go`, `secret_controller.go`
- **6 new pure-function mappers** under `operator/internal/entity/` (each + sibling `_test.go`)
- **External-ID convention**: `k8s_resource/{Kind}/{namespace}/{name}`

## DESIGN CENTER — Secret quirk (hard rule)

`secret_controller.go::SecretToEvent` emits **metadata only**: `external_id`, `kind`, `namespace`, `name`, `labels`, `annotations`, `creationTimestamp`, `type`. **NEVER `data` or `stringData`. NEVER base64 blobs.**

A structural test JSON-marshals the emitted event and searches the serialized payload to assert no data values leak.

## ConfigMap

Metadata only by default. Values emitted ONLY when annotation `omniscience.io/index-data == "true"` (per-ConfigMap opt-in). Tested.

## Topology edges (from K8s-native fields)

- `Service` -[SELECTS]→ `Pod` (resolved via Endpoints backend list, not by re-evaluating selectors)
- `Ingress` -[ROUTES_TO]→ `Service` (from `spec.rules[].http.paths[].backend.service.name`)
- `NetworkPolicy` -[APPLIES_TO]→ `Pod` (from `spec.podSelector` via Endpoints)
- `Pod` -[CONSUMES]→ `ConfigMap`/`Secret` — Pod-side; deferred to Wave 3 follow-up

## RBAC delta

`get`/`list`/`watch` on `services`/`endpoints`/`configmaps`/`secrets` (core), `ingresses`/`networkpolicies` (`networking.k8s.io`). `secrets` get/list is unavoidable; mapper drops values. Documented in `NOTES.txt`.

## New docs

`docs/connectors/k8s-operator-secrets.md` — justifies why values are forbidden.

## Verification

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test -count=1 ./...` — **25 tests passed across 5 packages** (including the Secret-leak structural test)
- `helm lint helm/omniscience-operator` — passes

## Non-goals (per scope)

- Pod-side CONSUMES edges — deferred (Pod controller's territory)
- Reconciliation worker — #163

## Test plan

- [x] Mapper tests cover all 6 kinds
- [x] **Secret values dropped** — structural test JSON-search asserts no leak
- [x] **ConfigMap values gated by annotation** — both branches tested
- [x] Topology edges from native K8s fields
- [x] Edge cases: Service with no selector (headless), Endpoints with no subsets, Ingress with no rules