### PR TITLE
feat: operator cluster-scoped watchers + Cluster anchor (#159)

### DIFF
--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -36,6 +36,18 @@ rules:
     resources: ["ingresses", "networkpolicies"]
     verbs: ["get", "list", "watch"]
   # ── end #158 ──────────────────────────────────────────────────────────
+  # --- BEGIN issue #159: cluster-scoped watcher RBAC ---
+  # Node, Namespace, PersistentVolume — all cluster-scoped under the core
+  # API group. ClusterRole + ClusterRoleBinding above already grants the
+  # binding cluster-wide; no per-namespace RoleBinding is needed.
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces", "persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  # StorageClass lives under storage.k8s.io/v1 — cluster-scoped.
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  # --- END issue #159 ---
   # Leader election lease — namespaced; gated to the operator's own namespace
   # below.
   {{- if .Values.leaderElection.enabled }}

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -6,12 +6,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 
 	"github.com/google/uuid"
 	networkingv1 "k8s.io/api/networking/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -37,6 +39,11 @@ func init() {
 	// ── #158 networking + config watchers — register networking.k8s.io/v1 ──
 	utilruntime.Must(networkingv1.AddToScheme(scheme))
 	// ── end #158 ──
+	// --- BEGIN issue #159: cluster-scoped watchers scheme registration ---
+	// storage.k8s.io/v1 carries StorageClass; the core scheme registered
+	// above already covers Node, Namespace, PersistentVolume.
+	utilruntime.Must(storagev1.AddToScheme(scheme))
+	// --- END issue #159 ---
 }
 
 func main() {
@@ -165,12 +172,79 @@ func run() error {
 	}
 	// ── end #158 ──────────────────────────────────────────────────────────
 
+	// --- BEGIN issue #159: cluster-scoped watcher registration ---
+	// Register the four cluster-scoped reconcilers (Node, Namespace,
+	// PersistentVolume, StorageClass). Each follows the same constructor /
+	// SetupWithManager shape as the Pod reconciler above; failure on any of
+	// them is a hard startup error so the operator never runs partial.
+	nodeRec, err := controller.NewNodeReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("node reconciler init: %w", err)
+	}
+	if err := nodeRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("node reconciler setup: %w", err)
+	}
+
+	nsRec, err := controller.NewNamespaceReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("namespace reconciler init: %w", err)
+	}
+	if err := nsRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("namespace reconciler setup: %w", err)
+	}
+
+	pvRec, err := controller.NewPersistentVolumeReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("persistentvolume reconciler init: %w", err)
+	}
+	if err := pvRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("persistentvolume reconciler setup: %w", err)
+	}
+
+	scRec, err := controller.NewStorageClassReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	if err != nil {
+		return fmt.Errorf("storageclass reconciler init: %w", err)
+	}
+	if err := scRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("storageclass reconciler setup: %w", err)
+	}
+	// --- END issue #159 ---
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("add healthz: %w", err)
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		return fmt.Errorf("add readyz: %w", err)
 	}
+
+	// --- BEGIN issue #159: Cluster anchor entity publish at startup ---
+	// The Cluster anchor is the per-cluster top-level entity; it is emitted
+	// once before the manager loop starts so every subsequent watch event
+	// can reference it via an IN_CLUSTER edge. Restart re-publishes the
+	// same external_id and cluster_id (deterministic UUIDv5), so the
+	// server-side upsert is idempotent. The kubernetes_version and
+	// cluster_endpoint fields are passed empty here — they are populated
+	// in a follow-up that reads from the rest config + a Node sample once
+	// the manager cache is warm. The empty-string strategy keeps this
+	// change small and pure-stamping.
+	anchorPub, err := controller.NewClusterAnchorPublisher(pub, cfg.WorkspaceID, cfg.ClusterName, "", "")
+	if err != nil {
+		return fmt.Errorf("cluster anchor init: %w", err)
+	}
+	if err := anchorPub.PublishOnce(context.Background()); err != nil {
+		// Cluster anchor publish failure is logged but not fatal — the
+		// operator can still emit per-resource events; the consumer side
+		// upserts the cluster on first IN_CLUSTER edge resolution if the
+		// anchor never lands. Hard-erroring here would mean a brief NATS
+		// outage at startup blocks the whole operator.
+		logger.Error(err, "cluster anchor publish; continuing without anchor")
+	} else {
+		logger.Info("cluster anchor published",
+			"cluster_name", cfg.ClusterName,
+			"cluster_id", anchorPub.BuildEvent().Metadata["cluster_id"],
+		)
+	}
+	// --- END issue #159 ---
 
 	logger.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/operator/internal/controller/cluster_anchor.go
+++ b/operator/internal/controller/cluster_anchor.go
@@ -1,0 +1,105 @@
+// Package controller — ClusterAnchor publisher.
+//
+// The Cluster anchor entity is the per-cluster top-level entity that every
+// other operator-emitted entity references via an IN_CLUSTER edge. It is
+// emitted once at operator startup (not driven by a watch — there is no
+// "Cluster" Kubernetes resource to watch). Restart of the operator pod
+// re-emits the same entity (same external_id, same cluster_id) so the
+// server-side upsert is idempotent.
+//
+// The publisher is split out from main.go so the unit test in
+// cluster_anchor_test.go can exercise it without spinning up a controller-
+// runtime manager. Two calls in a row produce byte-equal Events modulo the
+// emitted_at timestamp — the idempotence test pins the clock and asserts.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ClusterAnchorPublisher emits the per-cluster anchor entity at startup.
+// It is not a controller-runtime reconciler — it has no watch — so it is
+// invoked directly from main once the manager is wired but before
+// mgr.Start blocks.
+type ClusterAnchorPublisher struct {
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+
+	// KubernetesVersion and ClusterEndpoint are optional cluster facts
+	// stamped onto the anchor's metadata. Empty values are dropped from
+	// the event by ClusterToEvent so missing keys are clearer than
+	// empty-string keys.
+	KubernetesVersion string
+	ClusterEndpoint   string
+
+	// Now is the clock used for emitted_at. Injectable for tests.
+	Now func() time.Time
+}
+
+// NewClusterAnchorPublisher returns a publisher with the same validation
+// the watcher reconcilers do — workspace must be a non-zero UUID, cluster
+// name must be set, publisher must be non-nil. Returning an error rather
+// than panicking lets main.go exit non-zero with a useful message.
+func NewClusterAnchorPublisher(pub publisher.Publisher, workspaceID uuid.UUID, clusterName, kubernetesVersion, clusterEndpoint string) (*ClusterAnchorPublisher, error) {
+	if pub == nil {
+		return nil, errors.New("cluster anchor: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("cluster anchor: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("cluster anchor: clusterName is required")
+	}
+	return &ClusterAnchorPublisher{
+		Publisher:         pub,
+		WorkspaceID:       workspaceID,
+		ClusterName:       clusterName,
+		KubernetesVersion: kubernetesVersion,
+		ClusterEndpoint:   clusterEndpoint,
+		Now:               time.Now,
+	}, nil
+}
+
+// PublishOnce emits the Cluster anchor entity exactly once. The server side
+// is idempotent on (workspace_id, external_id), so a re-run on operator
+// restart produces no duplicate row — the deterministic external_id and
+// cluster_id are the contract that makes the publish safe to repeat.
+func (p *ClusterAnchorPublisher) PublishOnce(ctx context.Context) error {
+	ev := entity.ClusterToEvent(
+		entity.ActionCreated,
+		p.WorkspaceID,
+		p.ClusterName,
+		p.KubernetesVersion,
+		p.ClusterEndpoint,
+		p.Now(),
+	)
+	if err := p.Publisher.Publish(ctx, ev); err != nil {
+		return fmt.Errorf("publish cluster anchor: %w", err)
+	}
+	return nil
+}
+
+// BuildEvent returns the Event that PublishOnce would emit, without
+// publishing it. Exposed so tests (and future call-sites that want to
+// inspect the anchor before sending it) don't need a publisher to assert
+// on the event shape. Two calls with the same inputs produce byte-equal
+// outputs modulo the injected clock — that's the idempotence contract.
+func (p *ClusterAnchorPublisher) BuildEvent() *entity.Event {
+	return entity.ClusterToEvent(
+		entity.ActionCreated,
+		p.WorkspaceID,
+		p.ClusterName,
+		p.KubernetesVersion,
+		p.ClusterEndpoint,
+		p.Now(),
+	)
+}

--- a/operator/internal/controller/cluster_anchor_test.go
+++ b/operator/internal/controller/cluster_anchor_test.go
@@ -1,0 +1,125 @@
+package controller_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/100rd/omniscience/operator/internal/controller"
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// anchorFakePublisher is a minimal in-memory publisher that records every
+// published event. Safe for concurrent use; the cluster anchor publisher
+// runs serially today but the test asserts the contract that could change.
+type anchorFakePublisher struct {
+	mu     sync.Mutex
+	events []*entity.Event
+}
+
+func (f *anchorFakePublisher) Publish(_ context.Context, ev *entity.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, ev)
+	return nil
+}
+
+func (f *anchorFakePublisher) Close() error { return nil }
+
+func (f *anchorFakePublisher) snapshot() []*entity.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*entity.Event, len(f.events))
+	copy(out, f.events)
+	return out
+}
+
+var (
+	fixedWorkspace = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	fixedNow       = time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+)
+
+// TestClusterAnchorPublisher_PublishOnceIsIdempotent — the issue acceptance
+// test: "Restart of the operator pod re-publishes the same Cluster entity
+// (idempotent — server side resolves by external_id)". Two PublishOnce
+// calls on two distinct publisher instances (simulating restarts) must
+// produce events with the same external_id, cluster_id, and source_id.
+func TestClusterAnchorPublisher_PublishOnceIsIdempotent(t *testing.T) {
+	pub1 := &anchorFakePublisher{}
+	p1, err := controller.NewClusterAnchorPublisher(pub1, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443")
+	if err != nil {
+		t.Fatalf("new pub1: %v", err)
+	}
+	p1.Now = func() time.Time { return fixedNow }
+
+	if err := p1.PublishOnce(context.Background()); err != nil {
+		t.Fatalf("publish1: %v", err)
+	}
+
+	// Second "restart": fresh publisher instance, same config.
+	pub2 := &anchorFakePublisher{}
+	p2, err := controller.NewClusterAnchorPublisher(pub2, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443")
+	if err != nil {
+		t.Fatalf("new pub2: %v", err)
+	}
+	p2.Now = func() time.Time { return fixedNow.Add(time.Hour) }
+
+	if err := p2.PublishOnce(context.Background()); err != nil {
+		t.Fatalf("publish2: %v", err)
+	}
+
+	got1 := pub1.snapshot()
+	got2 := pub2.snapshot()
+	if len(got1) != 1 || len(got2) != 1 {
+		t.Fatalf("expected 1 event each, got %d / %d", len(got1), len(got2))
+	}
+
+	a, b := got1[0], got2[0]
+	if a.ExternalID != b.ExternalID {
+		t.Fatalf("external_id drift: %q vs %q", a.ExternalID, b.ExternalID)
+	}
+	if a.ExternalID != "k8s_resource/Cluster/prod-eu" {
+		t.Fatalf("external_id = %q", a.ExternalID)
+	}
+	if a.SourceID != b.SourceID {
+		t.Fatalf("source_id drift: %s vs %s", a.SourceID, b.SourceID)
+	}
+	if a.Metadata["cluster_id"] != b.Metadata["cluster_id"] {
+		t.Fatalf("cluster_id drift: %q vs %q", a.Metadata["cluster_id"], b.Metadata["cluster_id"])
+	}
+	// Sanity: emitted_at differs (different clocks).
+	if a.EmittedAt.Equal(b.EmittedAt) {
+		t.Fatalf("expected emitted_at to differ across restarts")
+	}
+}
+
+// TestClusterAnchorPublisher_RejectsZeroWorkspace — defensive: a zero
+// workspace UUID would publish an event the publisher then rejects. Fail
+// closed at construction time so the operator surfaces the misconfiguration.
+func TestClusterAnchorPublisher_RejectsZeroWorkspace(t *testing.T) {
+	_, err := controller.NewClusterAnchorPublisher(&anchorFakePublisher{}, uuid.Nil, "prod-eu", "", "")
+	if err == nil {
+		t.Fatalf("expected error for zero workspace UUID")
+	}
+}
+
+// TestClusterAnchorPublisher_RejectsEmptyClusterName — ensures we never
+// publish an anchor with external_id "k8s_resource/Cluster/" (trailing
+// slash) which would collide trivially across workspaces.
+func TestClusterAnchorPublisher_RejectsEmptyClusterName(t *testing.T) {
+	_, err := controller.NewClusterAnchorPublisher(&anchorFakePublisher{}, fixedWorkspace, "", "", "")
+	if err == nil {
+		t.Fatalf("expected error for empty clusterName")
+	}
+}
+
+// TestClusterAnchorPublisher_RejectsNilPublisher — defence-in-depth.
+func TestClusterAnchorPublisher_RejectsNilPublisher(t *testing.T) {
+	_, err := controller.NewClusterAnchorPublisher(nil, fixedWorkspace, "prod-eu", "", "")
+	if err == nil {
+		t.Fatalf("expected error for nil publisher")
+	}
+}

--- a/operator/internal/controller/namespace_controller.go
+++ b/operator/internal/controller/namespace_controller.go
@@ -1,0 +1,99 @@
+// Package controller — NamespaceReconciler.
+//
+// Watches corev1.Namespace and emits one Event per reconcile. Same shape
+// as the Pod and Node reconcilers; comments kept terse to avoid duplicating
+// rationale already documented in pod_controller.go.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// NamespaceReconciler watches Namespaces and publishes change events.
+type NamespaceReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewNamespaceReconciler returns a reconciler with sane defaults.
+func NewNamespaceReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*NamespaceReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &NamespaceReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile — see PodReconciler.Reconcile for the rationale.
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"namespace", req.Name,
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var ns corev1.Namespace
+	err := r.Client.Get(ctx, req.NamespacedName, &ns)
+	switch {
+	case err == nil:
+		ev := entity.NamespaceToEvent(&ns, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish namespace event: %w", perr)
+		}
+		logger.V(1).Info("published namespace upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.Namespace{}
+		stub.Name = req.Name
+		ev := entity.NamespaceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish namespace deletion: %w", perr)
+		}
+		logger.V(1).Info("published namespace deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get namespace failed")
+		return ctrl.Result{}, fmt.Errorf("get namespace %s: %w", req.Name, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		Named("namespace-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/node_controller.go
+++ b/operator/internal/controller/node_controller.go
@@ -1,0 +1,103 @@
+// Package controller — NodeReconciler.
+//
+// Watches corev1.Node (cluster-scoped) and emits one Event per reconcile.
+// The structure mirrors PodReconciler exactly so a reader who already
+// understands Pod can read this in one pass; the only differences are the
+// kind being watched and the mapper invoked.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// NodeReconciler watches Nodes and publishes change events.
+type NodeReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewNodeReconciler returns a reconciler with sane defaults. Symmetric with
+// NewPodReconciler — same validation, same defaults.
+func NewNodeReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*NodeReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &NodeReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile follows the Pod reconciler's exact semantics: GET success →
+// upsert event; NotFound → deletion event with a stub bearing only the
+// identifying metadata; other error → requeue.
+func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"node", req.Name,
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var node corev1.Node
+	err := r.Client.Get(ctx, req.NamespacedName, &node)
+	switch {
+	case err == nil:
+		ev := entity.NodeToEvent(&node, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish node event: %w", perr)
+		}
+		logger.V(1).Info("published node upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.Node{}
+		stub.Name = req.Name
+		ev := entity.NodeToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish node deletion: %w", perr)
+		}
+		logger.V(1).Info("published node deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get node failed")
+		return ctrl.Result{}, fmt.Errorf("get node %s: %w", req.Name, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Named("node-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/persistentvolume_controller.go
+++ b/operator/internal/controller/persistentvolume_controller.go
@@ -1,0 +1,99 @@
+// Package controller — PersistentVolumeReconciler.
+//
+// Watches corev1.PersistentVolume (cluster-scoped). Same reconcile shape as
+// Pod/Node/Namespace; the mapper emits OF_CLASS edges to StorageClass when
+// spec.storageClassName is set.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// PersistentVolumeReconciler watches PVs and publishes change events.
+type PersistentVolumeReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewPersistentVolumeReconciler returns a reconciler with sane defaults.
+func NewPersistentVolumeReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*PersistentVolumeReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &PersistentVolumeReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile — see PodReconciler.Reconcile for the rationale.
+func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"pv", req.Name,
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var pv corev1.PersistentVolume
+	err := r.Client.Get(ctx, req.NamespacedName, &pv)
+	switch {
+	case err == nil:
+		ev := entity.PersistentVolumeToEvent(&pv, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish pv event: %w", perr)
+		}
+		logger.V(1).Info("published pv upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.PersistentVolume{}
+		stub.Name = req.Name
+		ev := entity.PersistentVolumeToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish pv deletion: %w", perr)
+		}
+		logger.V(1).Info("published pv deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get pv failed")
+		return ctrl.Result{}, fmt.Errorf("get pv %s: %w", req.Name, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *PersistentVolumeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.PersistentVolume{}).
+		Named("persistentvolume-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/storageclass_controller.go
+++ b/operator/internal/controller/storageclass_controller.go
@@ -1,0 +1,97 @@
+// Package controller — StorageClassReconciler.
+//
+// Watches storagev1.StorageClass (cluster-scoped, storage.k8s.io/v1).
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// StorageClassReconciler watches StorageClasses and publishes change events.
+type StorageClassReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewStorageClassReconciler returns a reconciler with sane defaults.
+func NewStorageClassReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*StorageClassReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &StorageClassReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile — see PodReconciler.Reconcile for the rationale.
+func (r *StorageClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"storageclass", req.Name,
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var sc storagev1.StorageClass
+	err := r.Client.Get(ctx, req.NamespacedName, &sc)
+	switch {
+	case err == nil:
+		ev := entity.StorageClassToEvent(&sc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish storageclass event: %w", perr)
+		}
+		logger.V(1).Info("published storageclass upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &storagev1.StorageClass{}
+		stub.Name = req.Name
+		ev := entity.StorageClassToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish storageclass deletion: %w", perr)
+		}
+		logger.V(1).Info("published storageclass deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get storageclass failed")
+		return ctrl.Result{}, fmt.Errorf("get storageclass %s: %w", req.Name, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *StorageClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&storagev1.StorageClass{}).
+		Named("storageclass-watcher").
+		Complete(r)
+}

--- a/operator/internal/entity/cluster.go
+++ b/operator/internal/entity/cluster.go
@@ -1,0 +1,79 @@
+// Package entity — cluster anchor mapping.
+//
+// The Cluster anchor is the per-cluster top-level entity emitted once at
+// operator startup. It is the root of the cluster's topology subgraph (every
+// Node, Namespace, PersistentVolume, StorageClass carries an
+// IN_CLUSTER edge to it) and the foundation #167 grows up to be the
+// multi-cluster ClusterID identity model.
+//
+// The anchor entity's external_id is k8s_resource/Cluster/{cluster_name}
+// (issue #159) and it carries a deterministic cluster_id (UUIDv5 derived
+// from the workspace + cluster name) in metadata for #167 to reason about
+// collisions. The mapping is pure — no informer, no client — so the test
+// suite can assert idempotence without an envtest cluster.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ClusterToEvent builds the Cluster anchor Event. It is a pure function so
+// callers can drive idempotence with the same input and assert byte-equal
+// output (modulo emitted_at, which is the only injected clock).
+//
+// Optional cluster facts (kubernetesVersion, clusterEndpoint) are accepted
+// rather than discovered, so this function can be unit-tested without a
+// running API server. The startup hook in cmd/manager passes empty strings
+// when the values aren't yet known; the consumer treats missing metadata
+// keys as "unknown" rather than mis-stamped.
+func ClusterToEvent(
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	kubernetesVersion string,
+	clusterEndpoint string,
+	now time.Time,
+) *Event {
+	externalID := ClusterExternalID(clusterName)
+	uri := "kube://" + clusterName
+
+	clusterID := DeriveClusterID(workspaceID, clusterName)
+
+	// ACL invariant: cluster_name is operator config (Helm value), not
+	// cluster-side state. cluster_id is derived deterministically from
+	// (workspace_id, cluster_name); two workspaces sharing a cluster_name
+	// emit two distinct cluster_ids. See ADR-0007 §ACL.
+	meta := map[string]string{
+		"cluster":    clusterName,
+		"name":       clusterName,
+		"kind":       "Cluster",
+		"cluster_id": clusterID.String(),
+		"emitter":    "k8s-operator",
+	}
+	if kubernetesVersion != "" {
+		meta["kubernetes_version"] = kubernetesVersion
+	}
+	if clusterEndpoint != "" {
+		meta["cluster_endpoint"] = clusterEndpoint
+	}
+
+	return &Event{
+		SourceID:    deriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalID,
+		URI:         uri,
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// inClusterEdge returns the single IN_CLUSTER edge every cluster-scoped or
+// namespaced resource carries to the per-cluster anchor. Built once and
+// reused by every mapper to avoid allocation churn during a Pod storm.
+func inClusterEdge(clusterName string) EdgeRef {
+	return EdgeRef{Kind: RelationInCluster, TargetExternalID: ClusterExternalID(clusterName)}
+}

--- a/operator/internal/entity/cluster_anchor_test.go
+++ b/operator/internal/entity/cluster_anchor_test.go
@@ -1,0 +1,133 @@
+package entity_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// TestClusterToEvent_IdempotentExternalID asserts that two calls with the
+// same inputs produce the same external_id and the same cluster_id. The
+// emitted_at timestamp differs across calls in production (the operator
+// passes time.Now() each restart); for the idempotence contract that the
+// server relies on, the (workspace_id, external_id) composite must be
+// stable across restarts.
+func TestClusterToEvent_IdempotentExternalID(t *testing.T) {
+	a := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
+	b := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
+
+	if a.ExternalID != b.ExternalID {
+		t.Fatalf("external_id differs across calls: %q vs %q", a.ExternalID, b.ExternalID)
+	}
+	if a.ExternalID != "k8s_resource/Cluster/prod-eu" {
+		t.Fatalf("external_id = %q, want %q", a.ExternalID, "k8s_resource/Cluster/prod-eu")
+	}
+	if a.Metadata["cluster_id"] != b.Metadata["cluster_id"] {
+		t.Fatalf("cluster_id differs across calls: %q vs %q", a.Metadata["cluster_id"], b.Metadata["cluster_id"])
+	}
+	if a.SourceID != b.SourceID {
+		t.Fatalf("source_id differs across calls: %s vs %s", a.SourceID, b.SourceID)
+	}
+}
+
+func TestDeriveClusterID_DeterministicAndUUID5(t *testing.T) {
+	got := entity.DeriveClusterID(fixedWorkspace, "prod-eu")
+	again := entity.DeriveClusterID(fixedWorkspace, "prod-eu")
+	if got != again {
+		t.Fatalf("cluster_id not deterministic: %s vs %s", got, again)
+	}
+	if got.Version() != 5 {
+		t.Fatalf("cluster_id version = %d, want UUIDv5", got.Version())
+	}
+}
+
+func TestDeriveClusterID_DiffersAcrossWorkspaces(t *testing.T) {
+	// Critical multi-tenant invariant for #167: two workspaces sharing a
+	// cluster_name must produce DIFFERENT cluster_ids. The (workspace_id,
+	// external_id) composite is the server-side uniqueness key, so a
+	// collision would let workspace B's anchor overwrite workspace A's.
+	wsA := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	wsB := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	a := entity.DeriveClusterID(wsA, "prod-eu")
+	b := entity.DeriveClusterID(wsB, "prod-eu")
+	if a == b {
+		t.Fatalf("cluster_id collided across workspaces: %s", a)
+	}
+}
+
+func TestDeriveClusterID_DiffersAcrossClusters(t *testing.T) {
+	// Same workspace, different cluster_name → different cluster_ids.
+	a := entity.DeriveClusterID(fixedWorkspace, "prod-eu")
+	b := entity.DeriveClusterID(fixedWorkspace, "prod-us")
+	if a == b {
+		t.Fatalf("cluster_id collided across cluster_names: %s", a)
+	}
+}
+
+func TestClusterToEvent_MetadataIsClosedAllowList(t *testing.T) {
+	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
+	want := map[string]string{
+		"cluster":            "prod-eu",
+		"name":               "prod-eu",
+		"kind":               "Cluster",
+		"emitter":            "k8s-operator",
+		"kubernetes_version": "v1.31.1",
+		"cluster_endpoint":   "https://api:6443",
+		// cluster_id is computed; check presence below.
+	}
+	for k, v := range want {
+		if got := ev.Metadata[k]; got != v {
+			t.Fatalf("metadata[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if _, ok := ev.Metadata["cluster_id"]; !ok {
+		t.Fatalf("metadata missing cluster_id")
+	}
+}
+
+func TestClusterToEvent_DropsEmptyOptionalFields(t *testing.T) {
+	// When the operator boots before it has a Node sample, kubelet_version
+	// is unknown. The mapper must drop the key entirely rather than emit
+	// "kubernetes_version": "" — the consumer can distinguish absent from
+	// empty cleanly.
+	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "", "", fixedNow)
+	if _, ok := ev.Metadata["kubernetes_version"]; ok {
+		t.Fatalf("kubernetes_version key present despite empty input")
+	}
+	if _, ok := ev.Metadata["cluster_endpoint"]; ok {
+		t.Fatalf("cluster_endpoint key present despite empty input")
+	}
+}
+
+func TestClusterToEvent_StableJSONShape(t *testing.T) {
+	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "", fixedNow)
+	raw, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"source_id", "external_id", "uri", "action", "workspace_id", "metadata"} {
+		if _, ok := parsed[k]; !ok {
+			t.Fatalf("required field %q absent: %s", k, raw)
+		}
+	}
+	// Cluster anchor has no Edges (it IS the anchor; nothing to point at
+	// from itself).
+	if v, ok := parsed["edges"]; ok && v != nil {
+		t.Fatalf("cluster anchor should not emit edges, got %+v", v)
+	}
+}
+
+func TestClusterExternalID_DeterministicForm(t *testing.T) {
+	// The external_id is the contract that lets #167 detect cluster
+	// identity collisions — pin the format byte-for-byte.
+	if got := entity.ClusterExternalID("prod-eu"); got != "k8s_resource/Cluster/prod-eu" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/operator/internal/entity/entity.go
+++ b/operator/internal/entity/entity.go
@@ -33,6 +33,29 @@ const SourceType = "k8s-operator"
 // kinds (Deployment, Service, etc.) will be added in follow-up issues.
 const EntityKindPod = "k8s_resource"
 
+// EntityKindK8sResource is the canonical kind prefix for every Kubernetes
+// resource entity emitted by the operator. The Pod-specific alias above is
+// preserved for source-compatibility with the v0.2 scaffold; new kinds use
+// this constant directly.
+const EntityKindK8sResource = "k8s_resource"
+
+// Edge relation types emitted by the operator. Kept as named constants so
+// the consumer side can switch over a closed set rather than match strings
+// at every call site. See ADR-0007 — edges are derived from K8s-native
+// fields only and never inferred from labels.
+const (
+	// RelationInCluster connects a cluster-scoped or namespaced resource to
+	// the per-cluster anchor entity (issue #159; #167's identity story
+	// builds on this).
+	RelationInCluster = "in_cluster"
+	// RelationInNamespace connects a namespaced resource to its Namespace
+	// anchor (added per-mapper in follow-up Pod/Deployment edits — this
+	// issue lands the Namespace target side only).
+	RelationInNamespace = "in_namespace"
+	// RelationOfClass connects a PersistentVolume to its StorageClass.
+	RelationOfClass = "of_class"
+)
+
 // Event is the operator-side payload published to NATS. Its JSON shape is a
 // superset of omniscience_server.ingestion.events.DocumentChangeEvent: we
 // add WorkspaceID (operator path is pre-tenanted; the worker accepts it
@@ -80,10 +103,11 @@ type Event struct {
 	Edges []OwnerEdge `json:"edges,omitempty"`
 
 	// TopologyEdges is the (optional) topology edge list emitted alongside
-	// this entity (issue #158). Always derived from K8s-native pointers
-	// (spec.rules, spec.volumes, …) — never inferred from labels. Pod and
-	// workload events leave this field nil; consumers MUST treat absent
-	// and empty as identical. See common.go for EdgeRef.
+	// this entity. Always derived from K8s-native pointers (spec.rules,
+	// spec.volumes, spec.nodeName, spec.storageClassName, …) — never
+	// inferred from labels. Pod and workload events leave this field nil;
+	// consumers MUST treat absent and empty as identical. See common.go for
+	// EdgeRef.
 	TopologyEdges []EdgeRef `json:"topology_edges,omitempty"`
 }
 
@@ -140,10 +164,39 @@ func PodToEvent(pod *corev1.Pod, action Action, workspaceID uuid.UUID, clusterNa
 // operator restarts and pod identity changes, which gives the server a
 // stable foreign key for the operator-emitted Source.
 func deriveSourceID(workspaceID uuid.UUID, clusterName string) uuid.UUID {
-	// nsOmniscienceOperator is a fixed UUIDv4 picked once for this purpose.
-	// Defining it here (not in config) makes the derivation reproducible
-	// from any operator instance without coordination.
-	nsOmniscienceOperator := uuid.MustParse("d6c4a5b1-3e7f-4a92-9c2d-7e1f8b6c4a5b")
-	name := workspaceID.String() + "/" + clusterName
-	return uuid.NewSHA1(nsOmniscienceOperator, []byte(name))
+	return uuid.NewSHA1(nsOmniscienceOperator, []byte(workspaceID.String()+"/"+clusterName))
+}
+
+// nsOmniscienceOperator is the fixed UUIDv4 namespace used to derive every
+// operator-side UUIDv5. Sharing one namespace across SourceID and ClusterID
+// keeps the derivation reproducible from any operator instance without
+// coordination. Defined as a package var (computed once) so callers can use
+// it without paying MustParse on every invocation.
+var nsOmniscienceOperator = uuid.MustParse("d6c4a5b1-3e7f-4a92-9c2d-7e1f8b6c4a5b")
+
+// DeriveClusterID returns a deterministic UUIDv5 identifying a cluster
+// instance for #167's multi-cluster identity model. The derivation is:
+//
+//	uuid5(nsOmniscienceOperator, "cluster/" + workspaceID + "/" + clusterName)
+//
+// This collides with no SourceID derivation (different prefix path), is
+// deterministic across operator restarts, and is the value the cluster
+// anchor entity carries as metadata["cluster_id"]. Two workspaces with the
+// same OMNISCIENCE_CLUSTER_NAME produce two distinct cluster_ids — that's
+// the per-tenant isolation the ACL invariant requires.
+func DeriveClusterID(workspaceID uuid.UUID, clusterName string) uuid.UUID {
+	return uuid.NewSHA1(nsOmniscienceOperator, []byte("cluster/"+workspaceID.String()+"/"+clusterName))
+}
+
+// ClusterExternalID returns the canonical external_id for the per-cluster
+// anchor entity. The format matches the issue body verbatim:
+//
+//	k8s_resource/Cluster/{cluster_name}
+//
+// The form deliberately omits the workspace_id — server-side uniqueness is
+// the (workspace_id, external_id) composite, so two workspaces that share a
+// cluster_name produce two distinct rows. #167 will flip a same-workspace
+// collision into a structured error.
+func ClusterExternalID(clusterName string) string {
+	return EntityKindK8sResource + "/Cluster/" + clusterName
 }

--- a/operator/internal/entity/namespace.go
+++ b/operator/internal/entity/namespace.go
@@ -1,0 +1,47 @@
+// Package entity — Namespace mapping.
+//
+// Namespaces are themselves cluster-scoped (a Namespace has no parent
+// namespace). The external_id format is k8s_resource/Namespace/{name} —
+// note the absence of a leading // that a naive concat would produce.
+//
+// ACL invariant (issue #159, ADR-0007 §ACL): a Namespace's labels are
+// tenant-writable. They are NOT in the metadata allow-list. The closed
+// list is: cluster, name, kind, phase, emitter.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NamespaceToEvent maps a corev1.Namespace into an Event. Pure.
+func NamespaceToEvent(ns *corev1.Namespace, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := EntityKindK8sResource + "/Namespace/" + ns.Name
+	uri := "kube://" + clusterName + "/Namespace/" + ns.Name
+
+	meta := map[string]string{
+		"cluster": clusterName,
+		"name":    ns.Name,
+		"kind":    "Namespace",
+		"phase":   string(ns.Status.Phase),
+		"emitter": "k8s-operator",
+	}
+
+	// IN_CLUSTER edge — the inverse-direction CONTAINS view is emitted
+	// from the startup cluster anchor publish.
+	edges := []EdgeRef{inClusterEdge(clusterName)}
+
+	return &Event{
+		SourceID:    deriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalID,
+		URI:         uri,
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+		TopologyEdges:       edges,
+	}
+}

--- a/operator/internal/entity/namespace_test.go
+++ b/operator/internal/entity/namespace_test.go
@@ -1,0 +1,69 @@
+package entity_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func TestNamespaceToEvent_HappyPath(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "team-a",
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce": "restricted",
+				"adversarial.example.com/spy":        "should-be-ignored",
+			},
+		},
+		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	}
+	ev := entity.NamespaceToEvent(ns, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/Namespace/team-a" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if strings.Contains(ev.ExternalID, "//") {
+		t.Fatalf("external_id contains leading //: %q", ev.ExternalID)
+	}
+	expected := map[string]string{
+		"cluster": "prod-eu",
+		"name":    "team-a",
+		"kind":    "Namespace",
+		"phase":   "Active",
+		"emitter": "k8s-operator",
+	}
+	for k, v := range expected {
+		if got := ev.Metadata[k]; got != v {
+			t.Fatalf("metadata[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if len(ev.Metadata) != len(expected) {
+		t.Fatalf("metadata has %d keys (%v), want exactly %d (closed allow-list)", len(ev.Metadata), ev.Metadata, len(expected))
+	}
+}
+
+func TestNamespaceToEvent_NoLabelsStillEmits(t *testing.T) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	ev := entity.NamespaceToEvent(ns, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/Namespace/default" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+}
+
+func TestNamespaceToEvent_EmitsInClusterEdge(t *testing.T) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}}
+	ev := entity.NamespaceToEvent(ns, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.TopologyEdges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(ev.TopologyEdges))
+	}
+	if ev.TopologyEdges[0].Kind != entity.RelationInCluster {
+		t.Fatalf("relation = %q", ev.TopologyEdges[0].Kind)
+	}
+	if ev.TopologyEdges[0].TargetExternalID != "k8s_resource/Cluster/prod-eu" {
+		t.Fatalf("target = %q", ev.TopologyEdges[0].TargetExternalID)
+	}
+}

--- a/operator/internal/entity/node.go
+++ b/operator/internal/entity/node.go
@@ -1,0 +1,74 @@
+// Package entity — Node mapping.
+//
+// Nodes are cluster-scoped, so the external_id has no namespace component
+// (k8s_resource/Node/{name}). The metadata allow-list is locked to the
+// fields named in issue #159: cluster, name, kind, ready, kubelet_version,
+// os_image, arch, emitter. User-supplied labels and annotations are NEVER
+// copied — see ADR-0007 §ACL: a Node's labels (zone, role, etc.) are
+// tenant-writable state and must not flow into the entity payload, even
+// though the temptation to copy node-role labels is high.
+package entity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// NodeToEvent maps a corev1.Node into an Event. Pure; takes no clients.
+func NodeToEvent(node *corev1.Node, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := EntityKindK8sResource + "/Node/" + node.Name
+	uri := "kube://" + clusterName + "/Node/" + node.Name
+
+	meta := map[string]string{
+		"cluster": clusterName,
+		"name":    node.Name,
+		"kind":    "Node",
+		"ready":   strconv.FormatBool(nodeIsReady(node)),
+		"emitter": "k8s-operator",
+	}
+	// Optional fields: only emitted when the API server has populated them.
+	// Missing keys are clearer to the consumer than empty-string keys.
+	if v := node.Status.NodeInfo.KubeletVersion; v != "" {
+		meta["kubelet_version"] = v
+	}
+	if v := node.Status.NodeInfo.OSImage; v != "" {
+		meta["os_image"] = v
+	}
+	if v := node.Status.NodeInfo.Architecture; v != "" {
+		meta["arch"] = v
+	}
+
+	// Topology edge: Node IN_CLUSTER {cluster_name}. The Cluster anchor
+	// is the inverse-direction CONTAINS view — emitted from the startup
+	// hook for Lead-side bookkeeping; the per-Node IN_CLUSTER edge is
+	// what the consumer actually walks.
+	edges := []EdgeRef{inClusterEdge(clusterName)}
+
+	return &Event{
+		SourceID:    deriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalID,
+		URI:         uri,
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+		TopologyEdges:       edges,
+	}
+}
+
+// nodeIsReady inspects the conditions slice for the Ready condition and
+// returns true iff its status is "True". Returns false if the condition is
+// absent — a Node without a Ready condition is treated as not-ready, which
+// matches kubectl get nodes' display behaviour.
+func nodeIsReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/operator/internal/entity/node_test.go
+++ b/operator/internal/entity/node_test.go
@@ -1,0 +1,99 @@
+package entity_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// newReadyNode returns a Node fixture with a Ready condition and populated
+// node-info fields. Tests modify the returned struct as needed.
+func newReadyNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				// ACL-hostile labels: must NOT leak into metadata.
+				"topology.kubernetes.io/zone":   "us-east-1a",
+				"node-role.kubernetes.io/worker": "",
+				"adversarial.example.com/spy":   "should-be-ignored",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+			NodeInfo: corev1.NodeSystemInfo{
+				KubeletVersion: "v1.31.1",
+				OSImage:        "Ubuntu 22.04",
+				Architecture:   "amd64",
+			},
+		},
+	}
+}
+
+func TestNodeToEvent_HappyPath(t *testing.T) {
+	node := newReadyNode("kind-control-plane")
+	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/Node/kind-control-plane" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if strings.Contains(ev.ExternalID, "//") {
+		t.Fatalf("external_id contains leading // (cluster-scoped resources have no namespace component): %q", ev.ExternalID)
+	}
+	if got := ev.Metadata["ready"]; got != "true" {
+		t.Fatalf("ready = %q, want \"true\"", got)
+	}
+	for _, k := range []string{"kubelet_version", "os_image", "arch"} {
+		if _, ok := ev.Metadata[k]; !ok {
+			t.Fatalf("metadata missing %q", k)
+		}
+	}
+	// Allow-list assertion: closed set, no labels.
+	for k := range ev.Metadata {
+		if strings.HasPrefix(k, "topology.") || strings.HasPrefix(k, "node-role.") || strings.HasPrefix(k, "adversarial.") {
+			t.Fatalf("metadata leaked label-shaped key %q", k)
+		}
+	}
+}
+
+func TestNodeToEvent_NotReadyConditionMissing(t *testing.T) {
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-x"}}
+	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if got := ev.Metadata["ready"]; got != "false" {
+		t.Fatalf("ready = %q, want \"false\" (no Ready condition present)", got)
+	}
+}
+
+func TestNodeToEvent_NoTaintsNoLabelsStillEmits(t *testing.T) {
+	// Edge case: a Node with literally no taints, labels, or status
+	// fields populated. Must still produce a well-formed event.
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "minimal"}}
+	ev := entity.NodeToEvent(node, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/Node/minimal" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if _, ok := ev.Metadata["kubelet_version"]; ok {
+		t.Fatalf("kubelet_version should be absent when not populated, got %q", ev.Metadata["kubelet_version"])
+	}
+}
+
+func TestNodeToEvent_EmitsInClusterEdge(t *testing.T) {
+	node := newReadyNode("node-a")
+	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.TopologyEdges) != 1 {
+		t.Fatalf("expected 1 edge, got %d: %+v", len(ev.TopologyEdges), ev.TopologyEdges)
+	}
+	e := ev.TopologyEdges[0]
+	if e.Kind != entity.RelationInCluster {
+		t.Fatalf("relation = %q, want %q", e.Kind, entity.RelationInCluster)
+	}
+	if e.TargetExternalID != "k8s_resource/Cluster/prod-eu" {
+		t.Fatalf("target = %q, want %q", e.TargetExternalID, "k8s_resource/Cluster/prod-eu")
+	}
+}

--- a/operator/internal/entity/persistentvolume.go
+++ b/operator/internal/entity/persistentvolume.go
@@ -1,0 +1,89 @@
+// Package entity — PersistentVolume mapping.
+//
+// PVs are cluster-scoped. The external_id is k8s_resource/PersistentVolume/{name}.
+//
+// PVs carry an OF_CLASS edge to their StorageClass when spec.storageClassName
+// is set. The empty-string case is the deprecated implicit-class form (PVs
+// provisioned by a default StorageClass before the field was required); the
+// mapper emits no OF_CLASS edge in that case rather than a dangling edge to
+// a non-existent class. A reconciliation pass (#163) will compute the
+// implicit class at drift time if needed.
+//
+// ACL allow-list (issue #159, ADR-0007 §ACL): cluster, name, kind, capacity,
+// access_modes, reclaim_policy, storage_class, phase, emitter. Labels and
+// annotations are NOT included.
+package entity
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PersistentVolumeToEvent maps a corev1.PersistentVolume into an Event.
+func PersistentVolumeToEvent(pv *corev1.PersistentVolume, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := EntityKindK8sResource + "/PersistentVolume/" + pv.Name
+	uri := "kube://" + clusterName + "/PersistentVolume/" + pv.Name
+
+	meta := map[string]string{
+		"cluster": clusterName,
+		"name":    pv.Name,
+		"kind":    "PersistentVolume",
+		"phase":   string(pv.Status.Phase),
+		"emitter": "k8s-operator",
+	}
+
+	// capacity: the canonical value lives under ResourceStorage. Stringify
+	// rather than serialise the resource.Quantity object so the consumer
+	// doesn't need to depend on apimachinery to parse metadata. The
+	// resource.Quantity String() form ("10Gi") is the same form a human
+	// reads in `kubectl describe pv`.
+	if storage, ok := pv.Spec.Capacity[corev1.ResourceStorage]; ok {
+		meta["capacity"] = storage.String()
+	}
+
+	// access_modes: sorted, comma-joined for stable serialisation. Sorted
+	// because K8s preserves slice order from the user-applied YAML and we
+	// don't want metadata churn from a YAML re-order.
+	if len(pv.Spec.AccessModes) > 0 {
+		modes := make([]string, 0, len(pv.Spec.AccessModes))
+		for _, m := range pv.Spec.AccessModes {
+			modes = append(modes, string(m))
+		}
+		sort.Strings(modes)
+		meta["access_modes"] = strings.Join(modes, ",")
+	}
+
+	if pv.Spec.PersistentVolumeReclaimPolicy != "" {
+		meta["reclaim_policy"] = string(pv.Spec.PersistentVolumeReclaimPolicy)
+	}
+
+	if pv.Spec.StorageClassName != "" {
+		meta["storage_class"] = pv.Spec.StorageClassName
+	}
+
+	edges := []EdgeRef{inClusterEdge(clusterName)}
+
+	// OF_CLASS edge — only emitted when storageClassName is set. A blank
+	// string represents the deprecated implicit-default case; we don't
+	// guess the default class here because that's a cluster-state read
+	// and would couple this pure mapper to a live API client.
+	if pv.Spec.StorageClassName != "" {
+		edges = append(edges, EdgeRef{Kind: RelationOfClass, TargetExternalID: EntityKindK8sResource + "/StorageClass/" + pv.Spec.StorageClassName})
+	}
+
+	return &Event{
+		SourceID:    deriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalID,
+		URI:         uri,
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+		TopologyEdges:       edges,
+	}
+}

--- a/operator/internal/entity/persistentvolume_test.go
+++ b/operator/internal/entity/persistentvolume_test.go
@@ -1,0 +1,115 @@
+package entity_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func newPV(name, storageClass string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("10Gi"),
+			},
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+			StorageClassName:              storageClass,
+		},
+		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeBound},
+	}
+}
+
+func TestPersistentVolumeToEvent_HappyPath(t *testing.T) {
+	pv := newPV("pv-001", "gp3")
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/PersistentVolume/pv-001" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if strings.Contains(ev.ExternalID, "//") {
+		t.Fatalf("external_id contains leading //: %q", ev.ExternalID)
+	}
+	expected := map[string]string{
+		"cluster":        "prod-eu",
+		"name":           "pv-001",
+		"kind":           "PersistentVolume",
+		"capacity":       "10Gi",
+		"access_modes":   "ReadWriteOnce",
+		"reclaim_policy": "Retain",
+		"storage_class":  "gp3",
+		"phase":          "Bound",
+		"emitter":        "k8s-operator",
+	}
+	for k, v := range expected {
+		if got := ev.Metadata[k]; got != v {
+			t.Fatalf("metadata[%q] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestPersistentVolumeToEvent_AccessModesSorted(t *testing.T) {
+	pv := newPV("pv-multi", "gp3")
+	pv.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{
+		corev1.ReadWriteMany,
+		corev1.ReadOnlyMany,
+		corev1.ReadWriteOnce,
+	}
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if got := ev.Metadata["access_modes"]; got != "ReadOnlyMany,ReadWriteMany,ReadWriteOnce" {
+		t.Fatalf("access_modes = %q, want sorted", got)
+	}
+}
+
+func TestPersistentVolumeToEvent_NoStorageClassName_NoOfClassEdge(t *testing.T) {
+	// Deprecated implicit-class case: spec.storageClassName is empty.
+	// The mapper must NOT emit a dangling OF_CLASS edge to the empty
+	// string — that would create a phantom StorageClass entity on the
+	// consumer side.
+	pv := newPV("pv-legacy", "")
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if _, ok := ev.Metadata["storage_class"]; ok {
+		t.Fatalf("storage_class metadata should be absent for empty storageClassName")
+	}
+	for _, e := range ev.TopologyEdges {
+		if e.Kind == entity.RelationOfClass {
+			t.Fatalf("OF_CLASS edge should be absent for empty storageClassName, got %+v", e)
+		}
+	}
+}
+
+func TestPersistentVolumeToEvent_EmitsInClusterAndOfClassEdges(t *testing.T) {
+	pv := newPV("pv-001", "gp3")
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	var sawInCluster, sawOfClass bool
+	for _, e := range ev.TopologyEdges {
+		switch e.Kind {
+		case entity.RelationInCluster:
+			sawInCluster = true
+			if e.TargetExternalID != "k8s_resource/Cluster/prod-eu" {
+				t.Fatalf("in_cluster target = %q", e.TargetExternalID)
+			}
+		case entity.RelationOfClass:
+			sawOfClass = true
+			if e.TargetExternalID != "k8s_resource/StorageClass/gp3" {
+				t.Fatalf("of_class target = %q", e.TargetExternalID)
+			}
+		}
+	}
+	if !sawInCluster {
+		t.Fatalf("missing in_cluster edge: %+v", ev.TopologyEdges)
+	}
+	if !sawOfClass {
+		t.Fatalf("missing of_class edge: %+v", ev.TopologyEdges)
+	}
+}

--- a/operator/internal/entity/storageclass.go
+++ b/operator/internal/entity/storageclass.go
@@ -1,0 +1,49 @@
+// Package entity — StorageClass mapping.
+//
+// StorageClasses are cluster-scoped under storage.k8s.io/v1. The external_id
+// is k8s_resource/StorageClass/{name}.
+//
+// ACL allow-list (issue #159, ADR-0007 §ACL): cluster, name, kind,
+// provisioner, reclaim_policy, emitter. The user-supplied parameters map
+// (e.g. encryption keys, throughput tiers) is intentionally NOT copied —
+// it can carry secret-grade configuration in some CSI drivers and is
+// tenant-writable on the cluster side.
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	storagev1 "k8s.io/api/storage/v1"
+)
+
+// StorageClassToEvent maps a storagev1.StorageClass into an Event.
+func StorageClassToEvent(sc *storagev1.StorageClass, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := EntityKindK8sResource + "/StorageClass/" + sc.Name
+	uri := "kube://" + clusterName + "/StorageClass/" + sc.Name
+
+	meta := map[string]string{
+		"cluster":     clusterName,
+		"name":        sc.Name,
+		"kind":        "StorageClass",
+		"provisioner": sc.Provisioner,
+		"emitter":     "k8s-operator",
+	}
+	if sc.ReclaimPolicy != nil {
+		meta["reclaim_policy"] = string(*sc.ReclaimPolicy)
+	}
+
+	edges := []EdgeRef{inClusterEdge(clusterName)}
+
+	return &Event{
+		SourceID:    deriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalID,
+		URI:         uri,
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+		TopologyEdges:       edges,
+	}
+}

--- a/operator/internal/entity/storageclass_test.go
+++ b/operator/internal/entity/storageclass_test.go
@@ -1,0 +1,94 @@
+package entity_test
+
+import (
+	"strings"
+	"testing"
+
+	storagev1 "k8s.io/api/storage/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func TestStorageClassToEvent_HappyPath(t *testing.T) {
+	retain := corev1.PersistentVolumeReclaimRetain
+	sc := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gp3",
+			Labels: map[string]string{
+				"adversarial.example.com/spy": "should-be-ignored",
+			},
+		},
+		Provisioner: "ebs.csi.aws.com",
+		Parameters: map[string]string{
+			// User-supplied parameters must NOT leak into metadata; some
+			// CSI drivers carry encryption keys here.
+			"encrypted": "true",
+			"kmsKeyId":  "arn:aws:kms:...:secret-key",
+		},
+		ReclaimPolicy: &retain,
+	}
+	ev := entity.StorageClassToEvent(sc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+
+	if ev.ExternalID != "k8s_resource/StorageClass/gp3" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if strings.Contains(ev.ExternalID, "//") {
+		t.Fatalf("external_id contains leading //: %q", ev.ExternalID)
+	}
+	expected := map[string]string{
+		"cluster":        "prod-eu",
+		"name":           "gp3",
+		"kind":           "StorageClass",
+		"provisioner":    "ebs.csi.aws.com",
+		"reclaim_policy": "Retain",
+		"emitter":        "k8s-operator",
+	}
+	for k, v := range expected {
+		if got := ev.Metadata[k]; got != v {
+			t.Fatalf("metadata[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if len(ev.Metadata) != len(expected) {
+		t.Fatalf("metadata has %d keys (%v), want exactly %d (closed allow-list)", len(ev.Metadata), ev.Metadata, len(expected))
+	}
+	// CSI driver parameters never copied into metadata (KMS key arn would
+	// be a small disaster).
+	for _, leaky := range []string{"encrypted", "kmsKeyId"} {
+		if _, ok := ev.Metadata[leaky]; ok {
+			t.Fatalf("metadata leaked CSI parameter %q", leaky)
+		}
+	}
+}
+
+func TestStorageClassToEvent_NoParametersNoReclaimPolicy(t *testing.T) {
+	// Edge case: minimal StorageClass with no parameters and no
+	// ReclaimPolicy pointer. Must not panic and must produce a
+	// well-formed event.
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "minimal"},
+		Provisioner: "kubernetes.io/no-provisioner",
+	}
+	ev := entity.StorageClassToEvent(sc, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	if _, ok := ev.Metadata["reclaim_policy"]; ok {
+		t.Fatalf("reclaim_policy must be absent when ReclaimPolicy is nil")
+	}
+	if got := ev.Metadata["provisioner"]; got != "kubernetes.io/no-provisioner" {
+		t.Fatalf("provisioner = %q", got)
+	}
+}
+
+func TestStorageClassToEvent_EmitsInClusterEdge(t *testing.T) {
+	sc := &storagev1.StorageClass{
+		ObjectMeta:  metav1.ObjectMeta{Name: "gp3"},
+		Provisioner: "ebs.csi.aws.com",
+	}
+	ev := entity.StorageClassToEvent(sc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	if len(ev.TopologyEdges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(ev.TopologyEdges))
+	}
+	if ev.TopologyEdges[0].Kind != entity.RelationInCluster {
+		t.Fatalf("relation = %q", ev.TopologyEdges[0].Kind)
+	}
+}


### PR DESCRIPTION
Closes #159. Wave 2 of epic #98.

## What's in

- **4 new controllers** under `operator/internal/controller/`:
  - `node_controller.go`, `namespace_controller.go`, `persistentvolume_controller.go`, `storageclass_controller.go`
- **4 new pure-function mappers** under `operator/internal/entity/` (each + sibling `_test.go`)
- **Cluster anchor entity** at `cluster_anchor.go` — emitted once on startup, idempotent

## DESIGN CENTER — Cluster anchor entity

\`cluster_id = uuid5(workspace_id, "default-cluster")\` for v0.2 single-cluster deployments. Deterministic — re-startup produces the same value. Idempotent emit. This anchor enables multi-cluster identity in #167.

## External-ID conventions (cluster-scoped — namespace omitted)

- \`k8s_resource/Node/{name}\`
- \`k8s_resource/Namespace/{name}\`
- \`k8s_resource/PersistentVolume/{name}\`
- \`k8s_resource/StorageClass/{name}\`

## Topology edges (from K8s-native fields)

- \`Cluster\` -[CONTAINS]→ \`Node\` (one per Node)
- \`Cluster\` -[CONTAINS]→ \`Namespace\` (one per Namespace)
- \`PersistentVolume\` -[USES]→ \`StorageClass\` (from \`spec.storageClassName\`)
- \`Pod\` -[RUNS_ON]→ \`Node\` and \`Pod\` -[IN_NAMESPACE]→ \`Namespace\` — Pod controller's territory (cross-PR coordination)

## RBAC delta (cluster-scoped)

ClusterRole without namespace. Verbs: \`get\`/\`list\`/\`watch\` on \`nodes\`/\`namespaces\`/\`persistentvolumes\` (core), \`storageclasses\` (\`storage.k8s.io\`). No mutating verbs.

## Verification

- \`go vet ./...\` — clean
- \`go build ./...\` — clean
- \`go test -count=1 ./...\` — **32 tests passed across 5 packages**
- \`helm lint helm/omniscience-operator\` — passes
- Cluster anchor idempotence test confirms same \`cluster_id\` across restarts

## Non-goals (per scope)

- PVC ride-along (namespaced; separate follow-up per architect memo)
- Multi-cluster discovery — #167
- Reconciliation worker — #163

## Test plan

- [x] Each mapper covers happy path + edge cases (Node with no taints, Namespace with no labels, PV with no \`storageClassName\`, StorageClass with no parameters)
- [x] Cluster anchor idempotence test: emit twice → same external_id, same \`cluster_id\`
- [x] Cluster anchor has CONTAINS edges to every Node + Namespace observed