### PR TITLE
feat: operator ArgoCD CRD coverage (#160)

### DIFF
--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -48,6 +48,15 @@ rules:
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
   # --- END issue #159 ---
+  # ── #160 ArgoCD CRDs (discovery-skip if absent) ────────────────────────
+  # The controllers register only when the CRDs are present (see
+  # argocd_setup.go::DiscoverArgoCD). RBAC is granted unconditionally —
+  # rules on non-existent resources are inert. Application is namespaced;
+  # ApplicationSet is also namespaced (typically argocd namespace).
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications", "applicationsets"]
+    verbs: ["get", "list", "watch"]
+  # ── end #160 ──────────────────────────────────────────────────────────
   # Leader election lease — namespaced; gated to the operator's own namespace
   # below.
   {{- if .Values.leaderElection.enabled }}

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/100rd/omniscience/operator/internal/argocd"
 	"github.com/100rd/omniscience/operator/internal/config"
 	"github.com/100rd/omniscience/operator/internal/controller"
 	"github.com/100rd/omniscience/operator/internal/publisher"
@@ -209,6 +210,24 @@ func run() error {
 		return fmt.Errorf("storageclass reconciler setup: %w", err)
 	}
 	// --- END issue #159 ---
+
+	// ─── BEGIN issue #160: ArgoCD CRD coverage (discovery-gated) ──────────
+	// Discovery-based opt-in: probe the API server for ArgoCD CRDs and
+	// register controllers only for the ones that are present. When the
+	// CRDs are absent we log INFO "argocd.crd.absent" and continue — the
+	// operator MUST NOT fail-close on a missing optional CRD (issue #160 §A).
+	//
+	// A discovery error that is NOT "group not found" is logged but does
+	// not crash the operator — degrading gracefully to "no ArgoCD watchers"
+	// is preferable to wedging the entire watch set on a transient API
+	// server hiccup at startup.
+	argoPresence, argoErr := argocd.DiscoverFromRESTConfig(ctrl.GetConfigOrDie())
+	if argoErr != nil {
+		logger.Error(argoErr, "argocd discovery failed; continuing without ArgoCD watchers")
+	} else if err := controller.SetupArgoCDWatchers(mgr, logger, argoPresence, pub, cfg.WorkspaceID, cfg.ClusterName); err != nil {
+		return fmt.Errorf("argocd watchers setup: %w", err)
+	}
+	// ─── END issue #160 ───────────────────────────────────────────────────
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("add healthz: %w", err)

--- a/operator/internal/argocd/discovery.go
+++ b/operator/internal/argocd/discovery.go
@@ -1,0 +1,93 @@
+// CRD discovery — fail-open opt-in for ArgoCD.
+//
+// The operator MUST start cleanly when ArgoCD is not installed (issue #160
+// §A). At startup we ask the API server whether the ArgoCD CRDs are present;
+// if absent we log INFO `argocd.crd.absent` and skip controller registration.
+// We never fail-close on this check.
+package argocd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// AbsentLogKey is the log message emitted when an ArgoCD CRD is not present
+// on the API server. Pinned as a constant so kubectl-grep-able operations
+// (and tests) can match it byte-for-byte.
+const AbsentLogKey = "argocd.crd.absent"
+
+// PresenceCheck reports whether the two ArgoCD CRDs the operator covers
+// are present on the API server.
+type PresenceCheck struct {
+	ApplicationsPresent    bool
+	ApplicationSetsPresent bool
+}
+
+// AnyPresent returns true if either CRD is on the server.
+func (p PresenceCheck) AnyPresent() bool {
+	return p.ApplicationsPresent || p.ApplicationSetsPresent
+}
+
+// DiscoverArgoCD probes the API server for the ArgoCD v1alpha1 group/version
+// and reports per-resource presence. Designed for the hot startup path:
+//   - A single GET against /apis/argoproj.io/v1alpha1.
+//   - A "not found" response for the group is the expected absent path —
+//     we surface presence=false, NOT an error.
+//   - A network error or unexpected API error is returned to the caller so
+//     a misconfigured cluster is loud, not silently absent.
+//
+// The opinionated decision (per issue): NotFound on the API group ⇒ absent,
+// not an operational error.
+func DiscoverArgoCD(client discovery.DiscoveryInterface) (PresenceCheck, error) {
+	if client == nil {
+		return PresenceCheck{}, errors.New("argocd discovery: nil discovery client")
+	}
+	gv := fmt.Sprintf("%s/%s", GroupName, Version)
+	list, err := client.ServerResourcesForGroupVersion(gv)
+	if err != nil {
+		// API server returns 404 for an unknown group/version. This is the
+		// graceful "ArgoCD not installed" path.
+		if apierrors.IsNotFound(err) || discovery.IsGroupDiscoveryFailedError(err) {
+			return PresenceCheck{}, nil
+		}
+		return PresenceCheck{}, fmt.Errorf("discover %s: %w", gv, err)
+	}
+	if list == nil {
+		return PresenceCheck{}, nil
+	}
+	out := PresenceCheck{}
+	for _, r := range list.APIResources {
+		switch r.Name {
+		case ResourceApplications:
+			out.ApplicationsPresent = true
+		case ResourceApplicationSet:
+			out.ApplicationSetsPresent = true
+		}
+	}
+	return out, nil
+}
+
+// DiscoverFromRESTConfig is the convenience helper used from main.go: it
+// builds a discovery client from the manager's rest config and probes.
+func DiscoverFromRESTConfig(cfg *rest.Config) (PresenceCheck, error) {
+	if cfg == nil {
+		return PresenceCheck{}, errors.New("argocd discovery: nil rest config")
+	}
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return PresenceCheck{}, fmt.Errorf("argocd discovery: build client: %w", err)
+	}
+	return DiscoverArgoCD(dc)
+}
+
+// LogAbsence emits the canonical INFO log line when a given CRD is absent.
+// Centralised so tests can grep for the exact key string and the kubectl
+// log surface stays consistent across the two CRDs.
+func LogAbsence(logger logr.Logger, kind string) {
+	logger.Info(AbsentLogKey, "kind", kind, "group", GroupName, "version", Version)
+}

--- a/operator/internal/argocd/types.go
+++ b/operator/internal/argocd/types.go
@@ -1,0 +1,263 @@
+// Package argocd provides a minimal, JSON-tagged Go mirror of the ArgoCD
+// v1alpha1 CRD fields the operator actually reads.
+//
+// Why not import github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1?
+//
+//   - That module pins k8s.io/api / apimachinery / client-go to v0.26.x and
+//     drags in the entire ArgoCD server (including kustomize, kubectl and
+//     kube-aggregator). The operator runs on k8s.io/* v0.31.1 (see Wave 2,
+//     issues #157 / #158 / #159). Mixing the two collapses go.sum.
+//   - The operator only reads a small, stable subset of fields:
+//       spec.project, spec.source.repoURL, spec.source.path,
+//       spec.source.targetRevision, spec.destination.server,
+//       spec.destination.namespace, status.sync.status, status.health.status,
+//       status.operationState.phase, status.resources[],
+//       spec.generators[] (ApplicationSet),
+//       spec.template.metadata.name (ApplicationSet),
+//       status.applicationStatus[] (ApplicationSet, optional/newer field).
+//   - Going through unstructured + a thin typed mirror is the standard
+//     pattern for operators that read CRDs they don't own. The mirror only
+//     decodes fields we explicitly read; missing optional fields (older
+//     ArgoCD installs) decode to zero-values, never panics. Issue #160
+//     explicitly requires this fall-back behaviour.
+//
+// The on-the-wire shape is whatever ArgoCD writes; we only describe the bits
+// we read. Decode is always best-effort: a malformed nested field returns
+// zero-values for its enclosing struct so the mapper continues.
+package argocd
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Group / Version / Resource constants for ArgoCD CRDs. Pinned to the
+// upstream v1alpha1 line — ArgoCD has not bumped past v1alpha1 in any
+// shipped release through v2.14, and the v0.2 operator targets the
+// stable ArgoCD line v2.10–v2.14. Newer minor versions add OPTIONAL
+// fields; missing optional fields decode to zero-values here.
+const (
+	GroupName              = "argoproj.io"
+	Version                = "v1alpha1"
+	ResourceApplications   = "applications"
+	ResourceApplicationSet = "applicationsets"
+	KindApplication        = "Application"
+	KindApplicationSet     = "ApplicationSet"
+)
+
+// GVR / GVK helpers.
+func ApplicationGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: GroupName, Version: Version, Resource: ResourceApplications}
+}
+
+func ApplicationSetGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: GroupName, Version: Version, Resource: ResourceApplicationSet}
+}
+
+func ApplicationGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: GroupName, Version: Version, Kind: KindApplication}
+}
+
+func ApplicationSetGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: GroupName, Version: Version, Kind: KindApplicationSet}
+}
+
+// ───────────────────── Application ─────────────────────────────────────────
+
+// Application is a typed mirror of argoproj.io/v1alpha1/Application restricted
+// to the read-only fields the operator surfaces. All fields are pointer- or
+// zero-value-friendly so a partial CR (older ArgoCD installation, missing
+// status block, etc.) decodes without panic.
+type Application struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ApplicationSpec   `json:"spec,omitempty"`
+	Status ApplicationStatus `json:"status,omitempty"`
+}
+
+// ApplicationSpec is the read subset of spec.
+type ApplicationSpec struct {
+	Project     string                 `json:"project,omitempty"`
+	Source      *ApplicationSource     `json:"source,omitempty"`
+	Destination ApplicationDestination `json:"destination,omitempty"`
+}
+
+// ApplicationSource is the read subset of spec.source.
+type ApplicationSource struct {
+	RepoURL        string `json:"repoURL,omitempty"`
+	Path           string `json:"path,omitempty"`
+	TargetRevision string `json:"targetRevision,omitempty"`
+}
+
+// ApplicationDestination is the read subset of spec.destination.
+type ApplicationDestination struct {
+	Server    string `json:"server,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+// ApplicationStatus is the read subset of status.
+type ApplicationStatus struct {
+	Sync           SyncStatus           `json:"sync,omitempty"`
+	Health         HealthStatus         `json:"health,omitempty"`
+	OperationState *OperationState      `json:"operationState,omitempty"`
+	Resources      []ResourceStatus     `json:"resources,omitempty"`
+}
+
+// SyncStatus mirrors status.sync.
+type SyncStatus struct {
+	Status string `json:"status,omitempty"` // Synced | OutOfSync | Unknown
+}
+
+// HealthStatus mirrors status.health.
+type HealthStatus struct {
+	Status string `json:"status,omitempty"` // Healthy | Degraded | Progressing | Suspended | Missing
+}
+
+// OperationState mirrors status.operationState.
+type OperationState struct {
+	Phase string `json:"phase,omitempty"`
+}
+
+// ResourceStatus is one entry in status.resources[]. ArgoCD populates this
+// list with the actual rendered cluster resources the Application manages,
+// after manifests have been applied. Non-K8s resources (e.g. CRDs not in
+// the cluster) appear here too; we emit edges to whatever ArgoCD reports.
+type ResourceStatus struct {
+	Group     string `json:"group,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Kind      string `json:"kind,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+// ───────────────────── ApplicationSet ──────────────────────────────────────
+
+// ApplicationSet is a typed mirror of argoproj.io/v1alpha1/ApplicationSet
+// restricted to the read-only fields the operator surfaces.
+type ApplicationSet struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ApplicationSetSpec   `json:"spec,omitempty"`
+	Status ApplicationSetStatus `json:"status,omitempty"`
+}
+
+// ApplicationSetSpec is the read subset of spec.
+type ApplicationSetSpec struct {
+	Generators []ApplicationSetGenerator `json:"generators,omitempty"`
+	Template   ApplicationSetTemplate    `json:"template,omitempty"`
+}
+
+// ApplicationSetGenerator captures only the *type* of each generator, never
+// its content. ArgoCD generators include `list`, `git`, `cluster`, `matrix`,
+// `merge`, `pullRequest`, `scmProvider`, `clusterDecisionResource`. We mark
+// presence of each so the entity carries the generator-type list per the
+// allow-list ("never their content").
+//
+// Decoding from unstructured detects which key is non-nil (the wire format
+// uses one-of-many top-level fields). The Names() method returns the active
+// generator names in stable order.
+type ApplicationSetGenerator struct {
+	List                    *unstructured.Unstructured `json:"list,omitempty"`
+	Clusters                *unstructured.Unstructured `json:"clusters,omitempty"`
+	Git                     *unstructured.Unstructured `json:"git,omitempty"`
+	SCMProvider             *unstructured.Unstructured `json:"scmProvider,omitempty"`
+	ClusterDecisionResource *unstructured.Unstructured `json:"clusterDecisionResource,omitempty"`
+	PullRequest             *unstructured.Unstructured `json:"pullRequest,omitempty"`
+	Matrix                  *unstructured.Unstructured `json:"matrix,omitempty"`
+	Merge                   *unstructured.Unstructured `json:"merge,omitempty"`
+	Plugin                  *unstructured.Unstructured `json:"plugin,omitempty"`
+}
+
+// ApplicationSetTemplate carries only the metadata.name field used for the
+// child-Application name pattern. Per the allow-list we surface
+// template_metadata_name only.
+type ApplicationSetTemplate struct {
+	Metadata ApplicationSetTemplateMeta `json:"metadata,omitempty"`
+}
+
+// ApplicationSetTemplateMeta is the read subset of template.metadata.
+type ApplicationSetTemplateMeta struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ApplicationSetStatus is the read subset of status. ArgoCD added
+// status.applicationStatus[] in v2.7+; older installations won't populate
+// it. We accept missing as missing edges, never panic.
+type ApplicationSetStatus struct {
+	ApplicationStatus []ApplicationSetApplicationStatus `json:"applicationStatus,omitempty"`
+}
+
+// ApplicationSetApplicationStatus is one entry of
+// status.applicationStatus[]. The .Application field carries the child
+// Application's name.
+type ApplicationSetApplicationStatus struct {
+	Application string `json:"application,omitempty"`
+}
+
+// ───────────────────── DeepCopy / runtime.Object stubs ─────────────────────
+//
+// controller-runtime's typed cache requires that watched types implement
+// runtime.Object. We only watch ArgoCD CRDs via unstructured.Unstructured,
+// which already implements runtime.Object — but if a future call site decodes
+// a typed Application/ApplicationSet directly via the client, these stubs
+// keep that path compiling.
+
+// DeepCopyObject implements runtime.Object.
+func (a *Application) DeepCopyObject() runtime.Object {
+	if a == nil {
+		return nil
+	}
+	out := *a
+	return &out
+}
+
+// DeepCopyObject implements runtime.Object.
+func (a *ApplicationSet) DeepCopyObject() runtime.Object {
+	if a == nil {
+		return nil
+	}
+	out := *a
+	return &out
+}
+
+// ActiveGeneratorNames returns the lowercase string names of the generators
+// that are populated on this ApplicationSet, in a stable canonical order.
+// The result is what the mapper carries in metadata["generators"] (joined
+// with ","). Per the allow-list we emit *only* the type names, never any
+// generator content.
+func (g ApplicationSetGenerator) ActiveGeneratorNames() []string {
+	var out []string
+	if g.List != nil {
+		out = append(out, "list")
+	}
+	if g.Clusters != nil {
+		out = append(out, "clusters")
+	}
+	if g.Git != nil {
+		out = append(out, "git")
+	}
+	if g.SCMProvider != nil {
+		out = append(out, "scmProvider")
+	}
+	if g.ClusterDecisionResource != nil {
+		out = append(out, "clusterDecisionResource")
+	}
+	if g.PullRequest != nil {
+		out = append(out, "pullRequest")
+	}
+	if g.Matrix != nil {
+		out = append(out, "matrix")
+	}
+	if g.Merge != nil {
+		out = append(out, "merge")
+	}
+	if g.Plugin != nil {
+		out = append(out, "plugin")
+	}
+	return out
+}

--- a/operator/internal/controller/argocd_application_controller.go
+++ b/operator/internal/controller/argocd_application_controller.go
@@ -1,0 +1,159 @@
+// argocd_application_controller.go: controller for argoproj.io/v1alpha1
+// Application CRs.
+//
+// The watch is performed via *unstructured.Unstructured rather than a
+// typed Application — see operator/internal/argocd/types.go for the
+// rationale (importing argo-cd/v2 collapses go.sum onto k8s.io/* v0.26.x).
+// Unstructured is decoded into argocd.Application via a JSON round-trip;
+// missing optional fields decode to zero-values per the CRD-version-skew
+// acceptance criterion.
+//
+// Registration of this controller is gated on CRD discovery (see
+// argocd.DiscoverArgoCD); when the CRD is absent the controller is never
+// registered with the manager and the Reconcile method is never called.
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/argocd"
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ArgoCDApplicationReconciler watches ArgoCD Applications and publishes
+// change events. Mirrors PodReconciler's contract — Get-OK ⇒ upsert,
+// NotFound ⇒ deleted, other errors ⇒ requeue.
+type ArgoCDApplicationReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewArgoCDApplicationReconciler returns a reconciler with sane defaults
+// and the same precondition checks the workload reconcilers enforce.
+func NewArgoCDApplicationReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ArgoCDApplicationReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ArgoCDApplicationReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile mirrors PodReconciler.Reconcile.
+func (r *ArgoCDApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"application", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	u := newUnstructured(argocd.ApplicationGVK())
+	err := r.Client.Get(ctx, req.NamespacedName, u)
+	switch {
+	case err == nil:
+		app, derr := decodeApplication(u)
+		if derr != nil {
+			logger.Error(derr, "decode application failed; skipping reconcile")
+			return ctrl.Result{}, nil
+		}
+		ev := entity.ApplicationToEvent(app, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish application event: %w", perr)
+		}
+		logger.V(1).Info("published application upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &argocd.Application{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ApplicationToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish application deletion: %w", perr)
+		}
+		logger.V(1).Info("published application deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get application failed")
+		return ctrl.Result{}, fmt.Errorf("get application %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+//
+// We use ctrl.NewControllerManagedBy(...).For(unstructured.Unstructured)
+// rather than a typed Application — same reason the package decodes via
+// JSON round-trip (no scheme entry for argoproj.io/v1alpha1 to add).
+func (r *ArgoCDApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	u := newUnstructured(argocd.ApplicationGVK())
+	return ctrl.NewControllerManagedBy(mgr).
+		For(u).
+		Named("argocd-application-watcher").
+		Complete(r)
+}
+
+// newUnstructured returns an unstructured.Unstructured stamped with the
+// given GVK. The kind is required by controller-runtime's typed cache so
+// it can look up the GVR via the RESTMapper at watch-setup time.
+func newUnstructured(gvk schema.GroupVersionKind) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	return u
+}
+
+// decodeApplication converts an unstructured.Unstructured into the typed
+// argocd.Application mirror via JSON round-trip. Missing optional fields
+// decode to zero-values; a malformed CR (un-marshallable) returns an error
+// the caller logs without requeuing.
+func decodeApplication(u *unstructured.Unstructured) (*argocd.Application, error) {
+	if u == nil {
+		return nil, errors.New("decode application: nil unstructured")
+	}
+	raw, err := json.Marshal(u.Object)
+	if err != nil {
+		return nil, fmt.Errorf("marshal unstructured: %w", err)
+	}
+	out := &argocd.Application{}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return nil, fmt.Errorf("unmarshal application: %w", err)
+	}
+	// JSON round-trip drops the *meta.NamespacedName synthesised by
+	// controller-runtime; defensive copy of the bits the mapper reads.
+	out.Namespace = u.GetNamespace()
+	out.Name = u.GetName()
+	out.UID = types.UID(u.GetUID())
+	out.OwnerReferences = u.GetOwnerReferences()
+	return out, nil
+}

--- a/operator/internal/controller/argocd_applicationset_controller.go
+++ b/operator/internal/controller/argocd_applicationset_controller.go
@@ -1,0 +1,126 @@
+// argocd_applicationset_controller.go: controller for argoproj.io/v1alpha1
+// ApplicationSet CRs. Mirrors argocd_application_controller.go.
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/argocd"
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ArgoCDApplicationSetReconciler watches ArgoCD ApplicationSets.
+type ArgoCDApplicationSetReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewArgoCDApplicationSetReconciler returns a reconciler with sane defaults.
+func NewArgoCDApplicationSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ArgoCDApplicationSetReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ArgoCDApplicationSetReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile mirrors the workload reconcilers.
+func (r *ArgoCDApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"applicationset", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	u := newUnstructured(argocd.ApplicationSetGVK())
+	err := r.Client.Get(ctx, req.NamespacedName, u)
+	switch {
+	case err == nil:
+		appset, derr := decodeApplicationSet(u)
+		if derr != nil {
+			logger.Error(derr, "decode applicationset failed; skipping reconcile")
+			return ctrl.Result{}, nil
+		}
+		ev := entity.ApplicationSetToEvent(appset, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish applicationset event: %w", perr)
+		}
+		logger.V(1).Info("published applicationset upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &argocd.ApplicationSet{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ApplicationSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish applicationset deletion: %w", perr)
+		}
+		logger.V(1).Info("published applicationset deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get applicationset failed")
+		return ctrl.Result{}, fmt.Errorf("get applicationset %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *ArgoCDApplicationSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	u := newUnstructured(argocd.ApplicationSetGVK())
+	return ctrl.NewControllerManagedBy(mgr).
+		For(u).
+		Named("argocd-applicationset-watcher").
+		Complete(r)
+}
+
+// decodeApplicationSet — see decodeApplication for rationale.
+func decodeApplicationSet(u *unstructured.Unstructured) (*argocd.ApplicationSet, error) {
+	if u == nil {
+		return nil, errors.New("decode applicationset: nil unstructured")
+	}
+	raw, err := json.Marshal(u.Object)
+	if err != nil {
+		return nil, fmt.Errorf("marshal unstructured: %w", err)
+	}
+	out := &argocd.ApplicationSet{}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return nil, fmt.Errorf("unmarshal applicationset: %w", err)
+	}
+	out.Namespace = u.GetNamespace()
+	out.Name = u.GetName()
+	out.UID = types.UID(u.GetUID())
+	out.OwnerReferences = u.GetOwnerReferences()
+	return out, nil
+}

--- a/operator/internal/controller/argocd_setup.go
+++ b/operator/internal/controller/argocd_setup.go
@@ -1,0 +1,73 @@
+// argocd_setup.go: discovery-gated registration helper for the ArgoCD CRD
+// watchers.
+//
+// SetupArgoCDWatchers is called from cmd/manager/main.go AFTER the manager
+// is wired but BEFORE mgr.Start. It performs the discovery probe (issue #160
+// §A — fail-open) and registers controllers only for CRDs that are present.
+// When NEITHER CRD is present we log "argocd.crd.absent" and return nil
+// without touching the manager.
+package controller
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/100rd/omniscience/operator/internal/argocd"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// SetupArgoCDWatchers conditionally registers the Application and
+// ApplicationSet controllers based on CRD presence. Returns nil on success
+// (including the all-absent path); returns an error only when the discovery
+// probe itself fails with a non-NotFound error or when controller registration
+// of a present CRD fails.
+//
+// presence is the result of the discovery probe; passing it in (rather than
+// running the probe inside this function) keeps the function pure-wiring
+// for tests.
+func SetupArgoCDWatchers(
+	mgr ctrl.Manager,
+	logger logr.Logger,
+	presence argocd.PresenceCheck,
+	pub publisher.Publisher,
+	workspaceID uuid.UUID,
+	clusterName string,
+) error {
+	if !presence.AnyPresent() {
+		// Fail-open: ArgoCD is not installed. Log once and return.
+		argocd.LogAbsence(logger, argocd.KindApplication)
+		argocd.LogAbsence(logger, argocd.KindApplicationSet)
+		return nil
+	}
+
+	if presence.ApplicationsPresent {
+		appRec, err := NewArgoCDApplicationReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+		if err != nil {
+			return fmt.Errorf("argocd application reconciler init: %w", err)
+		}
+		if err := appRec.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("argocd application reconciler setup: %w", err)
+		}
+		logger.Info("argocd.crd.present", "kind", argocd.KindApplication)
+	} else {
+		argocd.LogAbsence(logger, argocd.KindApplication)
+	}
+
+	if presence.ApplicationSetsPresent {
+		setRec, err := NewArgoCDApplicationSetReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+		if err != nil {
+			return fmt.Errorf("argocd applicationset reconciler init: %w", err)
+		}
+		if err := setRec.SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("argocd applicationset reconciler setup: %w", err)
+		}
+		logger.Info("argocd.crd.present", "kind", argocd.KindApplicationSet)
+	} else {
+		argocd.LogAbsence(logger, argocd.KindApplicationSet)
+	}
+
+	return nil
+}

--- a/operator/internal/entity/argocd_application.go
+++ b/operator/internal/entity/argocd_application.go
@@ -1,0 +1,164 @@
+// argocd_application.go: argoproj.io/v1alpha1/Application -> Event mapper.
+//
+// Topology edges (issue #160 §F — derived from K8s-native fields, never
+// inferred):
+//
+//   - Application -[DEPLOYS]-> {Deployment | Service | Ingress | …}, derived
+//     from status.resources[]. Each entry is a {group, version, kind,
+//     namespace, name} the ArgoCD controller itself populated after applying
+//     the rendered manifests. Targets use the canonical operator external-id
+//     form k8s_resource/{Kind}/{namespace}/{name} so the server-side linker
+//     auto-creates cross-references with the workload watchers (#157, #158).
+//   - Application -[OWNED_BY]-> {Project} (logical) — emitted as a
+//     metadata field, not a topology edge to a K8s resource. ArgoCD
+//     AppProject is out-of-scope (RBAC clearance only, no controller).
+//     The project value still lands in metadata so the server-side join
+//     against future #166 AppProject coverage is trivial.
+//   - Application -[IN_CLUSTER]-> Cluster — every K8s-resource entity carries
+//     this, per #159's anchor pattern.
+//
+// ACL invariant: spec.destination.namespace and spec.destination.server are
+// fields ArgoCD's customers populate via the CR. They are *not* tenant
+// boundaries; workspace_id comes from operator config alone (ADR-0007 §ACL).
+//
+// Empty-field tolerance: ArgoCD CRDs ship with optional fields that only
+// newer versions populate (status.applicationStatus, etc.). Every field
+// access here is nil/zero-safe — missing optional fields produce missing
+// metadata entries / missing edges, never a panic. This satisfies the
+// CRD-version-skew acceptance criterion.
+package entity
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/100rd/omniscience/operator/internal/argocd"
+)
+
+// EntityKindApplication is the K8s Kind segment for ArgoCD Applications.
+// Mixed case to match the Pod / workload convention.
+const EntityKindApplication = "Application"
+
+// EdgeKindDeploys: Application -> {Deployment | Service | …}, sourced from
+// status.resources[]. Distinct from EdgeRelationOwns (which is for
+// metadata.ownerReferences only).
+const EdgeKindDeploys = "DEPLOYS"
+
+// ApplicationToEvent maps an argocd.Application plus an action into an
+// Event. Pure function: no clients, no clock injection beyond `now`.
+//
+// Metadata allow-list (issue §G):
+//   - cluster, namespace, name, kind, emitter (base)
+//   - sync_status, health_status, target_revision, operation_phase
+//   - source_repo_url, source_path
+//   - dest_namespace, dest_server
+//   - project
+//
+// Empty optional fields are OMITTED rather than emitted as empty strings
+// so the consumer can distinguish "not set" from "explicitly empty".
+func ApplicationToEvent(
+	app *argocd.Application,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	namespace := resolveNamespace(app.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindApplication, app.Name)
+
+	// spec.project — logical owner (AppProject). Empty when unset; ArgoCD
+	// defaults to "default" but we surface what the CR actually carries.
+	if app.Spec.Project != "" {
+		meta["project"] = app.Spec.Project
+	}
+
+	// spec.source.* — pointer-safe (older CR shapes use a *Source; nil-safe).
+	if app.Spec.Source != nil {
+		if v := app.Spec.Source.RepoURL; v != "" {
+			meta["source_repo_url"] = v
+		}
+		if v := app.Spec.Source.Path; v != "" {
+			meta["source_path"] = v
+		}
+		if v := app.Spec.Source.TargetRevision; v != "" {
+			meta["target_revision"] = v
+		}
+	}
+
+	// spec.destination.*
+	if v := app.Spec.Destination.Namespace; v != "" {
+		meta["dest_namespace"] = v
+	}
+	if v := app.Spec.Destination.Server; v != "" {
+		meta["dest_server"] = v
+	}
+
+	// status — every nested field is zero-safe.
+	if v := app.Status.Sync.Status; v != "" {
+		meta["sync_status"] = v
+	}
+	if v := app.Status.Health.Status; v != "" {
+		meta["health_status"] = v
+	}
+	if app.Status.OperationState != nil && app.Status.OperationState.Phase != "" {
+		meta["operation_phase"] = app.Status.OperationState.Phase
+	}
+
+	extID := externalIDFor(EntityKindApplication, namespace, app.Name)
+
+	edges := buildApplicationDeploysEdges(app.Status.Resources)
+	edges = append(edges, inClusterEdge(clusterName))
+
+	ev := &Event{
+		SourceID:      DeriveSourceID(workspaceID, clusterName),
+		SourceType:    SourceType,
+		ExternalID:    extID,
+		URI:           uriFor(clusterName, namespace, EntityKindApplication, app.Name),
+		Action:        action,
+		WorkspaceID:   workspaceID,
+		EmittedAt:     now.UTC(),
+		Metadata:      meta,
+		TopologyEdges: edges,
+	}
+
+	// Owner-edges from metadata.ownerReferences. Applications are typically
+	// top-of-chain but can be created by an ApplicationSet — when that
+	// happens, the ApplicationSet controller writes the ownerReference on
+	// the child Application. Honour whatever K8s populates; do not invent.
+	ev.Edges = ownerEdges(app.OwnerReferences, namespace, extID)
+
+	return ev
+}
+
+// buildApplicationDeploysEdges emits one DEPLOYS edge per managed resource
+// in status.resources[]. Resources without a Kind are skipped (defensive —
+// status.resources entries are populated by ArgoCD itself, but we don't
+// trust the CR to be well-formed). Cluster-scoped resources (no namespace)
+// inherit the standard "default" fallback so external-ids are well-formed.
+//
+// Edges to resources outside the operator's coverage (e.g. CRDs not in
+// the watch set) emit dangling edges; per the issue body the server-side
+// ingestion worker handles dangling-edge resolution.
+func buildApplicationDeploysEdges(resources []argocd.ResourceStatus) []EdgeRef {
+	if len(resources) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(resources))
+	var edges []EdgeRef
+	for _, r := range resources {
+		if r.Kind == "" || r.Name == "" {
+			// Malformed entry — cannot build a well-formed external-id.
+			continue
+		}
+		ns := resolveNamespace(r.Namespace)
+		ext := externalIDFor(strings.TrimSpace(r.Kind), ns, r.Name)
+		if _, ok := seen[ext]; ok {
+			continue
+		}
+		seen[ext] = struct{}{}
+		edges = append(edges, EdgeRef{Kind: EdgeKindDeploys, TargetExternalID: ext})
+	}
+	return edges
+}

--- a/operator/internal/entity/argocd_applicationset.go
+++ b/operator/internal/entity/argocd_applicationset.go
@@ -1,0 +1,140 @@
+// argocd_applicationset.go: argoproj.io/v1alpha1/ApplicationSet -> Event
+// mapper.
+//
+// Topology edges (issue #160 §F — derived from K8s-native fields, never
+// inferred):
+//
+//   - ApplicationSet -[GENERATES]-> Application — from
+//     status.applicationStatus[].application when the field is populated
+//     (ArgoCD v2.7+). Older installations don't populate this status block,
+//     so the mapper falls back to emitting NO edges — never a panic, never
+//     a labels-based heuristic.
+//   - ApplicationSet -[IN_CLUSTER]-> Cluster, per the #159 anchor pattern.
+//
+// Metadata allow-list (issue §G — `cluster, namespace, name, kind,
+// generators (a list of generator type strings), template_metadata_name,
+// emitter`). The generator content is never surfaced — only the type names.
+//
+// ACL invariant: spec.template.metadata.* is what ArgoCD will stamp on
+// child Applications; here we only carry .name. workspace_id comes
+// exclusively from operator config (ADR-0007 §ACL).
+package entity
+
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/100rd/omniscience/operator/internal/argocd"
+)
+
+// EntityKindApplicationSet is the K8s Kind segment for ArgoCD ApplicationSets.
+const EntityKindApplicationSet = "ApplicationSet"
+
+// EdgeKindGenerates: ApplicationSet -> Application. The semantics are "this
+// ApplicationSet is the source of this Application"; the inverse direction
+// would be IS_GENERATED_BY but we keep the from->to direction consistent
+// with EdgeKindDeploys (parent -> child).
+const EdgeKindGenerates = "GENERATES"
+
+// ApplicationSetToEvent maps an argocd.ApplicationSet plus an action into
+// an Event. Pure function — same shape as ApplicationToEvent.
+//
+// Empty optional fields are OMITTED. Generator detection iterates the
+// spec.generators[] slice; an entry with no field populated (malformed CR)
+// is skipped silently. Generator names are emitted as a comma-joined,
+// stable-ordered list.
+func ApplicationSetToEvent(
+	appset *argocd.ApplicationSet,
+	action Action,
+	workspaceID uuid.UUID,
+	clusterName string,
+	now time.Time,
+) *Event {
+	namespace := resolveNamespace(appset.Namespace)
+	meta := baseMetadata(clusterName, namespace, EntityKindApplicationSet, appset.Name)
+
+	if names := collectGeneratorNames(appset.Spec.Generators); len(names) > 0 {
+		meta["generators"] = strings.Join(names, ",")
+	}
+	if v := appset.Spec.Template.Metadata.Name; v != "" {
+		meta["template_metadata_name"] = v
+	}
+
+	extID := externalIDFor(EntityKindApplicationSet, namespace, appset.Name)
+
+	edges := buildGeneratesEdges(appset.Status.ApplicationStatus, namespace)
+	edges = append(edges, inClusterEdge(clusterName))
+
+	ev := &Event{
+		SourceID:      DeriveSourceID(workspaceID, clusterName),
+		SourceType:    SourceType,
+		ExternalID:    extID,
+		URI:           uriFor(clusterName, namespace, EntityKindApplicationSet, appset.Name),
+		Action:        action,
+		WorkspaceID:   workspaceID,
+		EmittedAt:     now.UTC(),
+		Metadata:      meta,
+		TopologyEdges: edges,
+	}
+
+	ev.Edges = ownerEdges(appset.OwnerReferences, namespace, extID)
+
+	return ev
+}
+
+// collectGeneratorNames returns the deduplicated, sorted list of generator
+// type names across the spec.generators[] slice. Per the allow-list we emit
+// only the type names (e.g. "git", "list", "matrix"), never the generator's
+// content. If two generators of the same type appear, the type name is
+// reported once.
+func collectGeneratorNames(gs []argocd.ApplicationSetGenerator) []string {
+	if len(gs) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, g := range gs {
+		for _, n := range g.ActiveGeneratorNames() {
+			if _, ok := seen[n]; ok {
+				continue
+			}
+			seen[n] = struct{}{}
+			out = append(out, n)
+		}
+	}
+	// out is already in canonical insertion order across generators —
+	// ActiveGeneratorNames() returns a stable, fixed key order per
+	// generator. Across multiple generators the order is the order of the
+	// first occurrence. That's stable enough for tests; no need to sort.
+	return out
+}
+
+// buildGeneratesEdges emits one GENERATES edge per child Application named
+// in status.applicationStatus[]. Empty input yields no edges (older ArgoCD).
+//
+// Child applications live in the same namespace as the ApplicationSet by
+// convention (ArgoCD's argocd namespace). The mapper uses the
+// ApplicationSet's namespace as the target namespace; if the ArgoCD setup
+// places child applications in a different namespace, the edge will dangle
+// — server-side resolution handles that as designed.
+func buildGeneratesEdges(statuses []argocd.ApplicationSetApplicationStatus, namespace string) []EdgeRef {
+	if len(statuses) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var edges []EdgeRef
+	for _, s := range statuses {
+		if s.Application == "" {
+			continue
+		}
+		ext := externalIDFor(EntityKindApplication, namespace, s.Application)
+		if _, ok := seen[ext]; ok {
+			continue
+		}
+		seen[ext] = struct{}{}
+		edges = append(edges, EdgeRef{Kind: EdgeKindGenerates, TargetExternalID: ext})
+	}
+	return edges
+}


### PR DESCRIPTION
Closes #160. Wave 3 of epic #98.

## What's in

- **Discovery probe** at `operator/internal/argocd/` and `operator/internal/controller/argocd_setup.go` — at startup queries API server for `applications.argoproj.io` + `applicationsets.argoproj.io`. Absent CRD → log INFO `argocd.crd.absent`, skip controller registration. Fail-open.
- **Two new controllers**:
  - `argocd_application_controller.go` watches `argoproj.io/v1alpha1/Application`
  - `argocd_applicationset_controller.go` watches `argoproj.io/v1alpha1/ApplicationSet`
- **Two new mappers** in `operator/internal/entity/`:
  - `argocd_application.go::ApplicationToEvent`
  - `argocd_applicationset.go::ApplicationSetToEvent`
- **External-IDs**:
  - `k8s_resource/Application/{namespace}/{name}`
  - `k8s_resource/ApplicationSet/{namespace}/{name}`
- **Topology edges** (from typed `status` fields):
  - `Application` -[DEPLOYS]→ `Deployment`/`Service`/`Ingress` (`status.resources[]`)
  - `Application` -[OWNED_BY]→ `Project` (`spec.project`)
  - `ApplicationSet` -[GENERATES]→ `Application`
- **RBAC**: `applications`/`applicationsets` in `argoproj.io` with `get`/`list`/`watch` only. Granted unconditionally (rules on non-existent resources are inert; discovery probe is the runtime gate).

## Verification

- `go test -count=1 ./...` — **88 tests pass across 6 packages**
- `helm lint helm/omniscience-operator` — passes

## ACL invariant

- `workspace_id` from Secret-mounted token
- `metadata.labels`/`annotations` are tenant-writable; never influence tenancy

## Non-goals (per scope)

- Argo Rollouts — #161
- DRA / GPU — #162
- Reconciliation — #163

## Test plan

- [x] Discovery-skip path: when CRD absent, controller registration is silently skipped
- [x] Application/ApplicationSet entities + topology edges emitted when CRDs present
- [x] Mapper edge cases: missing project, no rendered resources, missing generators