### PR TITLE
feat: calibrated confidence-score model for resolve_incident (#155)

### DIFF
--- a/apps/server/src/omniscience_server/incidents.py
+++ b/apps/server/src/omniscience_server/incidents.py
@@ -75,6 +75,13 @@ from omniscience_server.as_of import (
     record_request_duration,
     resolve_effective_as_of,
 )
+from omniscience_server.incidents_scoring import (
+    DEFAULT_CONFIDENCE_THRESHOLD,
+    IncidentScoringConfig,
+    apply_weights,
+    compute_components,
+    load_workspace_config,
+)
 
 # ---------------------------------------------------------------------------
 # Module constants — no magic numbers in the algorithm body
@@ -315,15 +322,20 @@ async def mcp_resolve_incident(
                 raise
 
         classified = _classify_neighbours(graph_result)
-        confidence = _compute_confidence(
+        scoring_config = await _load_scoring_config(app, workspace_id)
+        confidence = _score_incident(
             alert=seed,
             classified=classified,
+            max_depth=clamped_depth,
+            config=scoring_config,
         )
+        meta = _build_meta(confidence=confidence, config=scoring_config)
         return _build_response(
             alert=seed,
             classified=classified,
             confidence=confidence,
             as_of=normalised_as_of,
+            meta=meta,
         ).model_dump(mode="json")
 
 
@@ -508,6 +520,7 @@ def _build_response(
     classified: _Classified,
     confidence: float,
     as_of: datetime | None,
+    meta: dict[str, Any] | None = None,
 ) -> ResolveIncidentResponse:
     """Produce the bounded :class:`ResolveIncidentResponse` payload."""
     return ResolveIncidentResponse(
@@ -523,8 +536,84 @@ def _build_response(
         slack_threads=[_summarise_thread(t) for t in classified.slack_threads],
         confidence_score=confidence,
         effective_as_of=resolve_effective_as_of(as_of),
-        meta=None,
+        meta=meta,
     )
+
+
+# ---------------------------------------------------------------------------
+# Calibrated scoring + threshold flag (issue #155)
+# ---------------------------------------------------------------------------
+
+
+async def _load_scoring_config(
+    app: FastAPI, workspace_id: uuid.UUID
+) -> IncidentScoringConfig | None:
+    """Look up the per-tenant scoring config; return ``None`` to use v0.1.
+
+    Tolerates a missing or unwired ``db_session_factory`` so unit tests
+    that only stub the graph store keep passing — the tests in
+    :mod:`tests.test_mcp_resolve_incident` plant an :class:`AsyncMock`
+    factory, but legacy fixtures may not.
+    """
+    factory = getattr(app.state, "db_session_factory", None)
+    if factory is None:
+        return None
+    try:
+        async with factory() as session:
+            return await load_workspace_config(session, workspace_id)
+    except Exception:
+        # A misconfigured DB session must NEVER break live incident
+        # resolution; fall back to v0.1 silently.  Telemetry is wired
+        # at the request-duration histogram layer.
+        return None
+
+
+def _score_incident(
+    *,
+    alert: EntityNodeView,
+    classified: _Classified,
+    max_depth: int,
+    config: IncidentScoringConfig | None,
+) -> float:
+    """Pick the calibrated path or fall back to the v0.1 ladder.
+
+    The legacy ladder is preserved verbatim when the workspace has no
+    configured weights — the #184 contract tests assert the four
+    boundary values (0.9 / 0.6 / 0.4 / 0.1) and must keep passing.
+    """
+    if config is None or config.weights is None:
+        return _compute_confidence(alert=alert, classified=classified)
+    components = compute_components(
+        alert_valid_from=alert.valid_from,
+        pr_valid_from=(
+            classified.responsible_pr.valid_from if classified.responsible_pr is not None else None
+        ),
+        has_pr=classified.responsible_pr is not None,
+        has_resource=classified.target_resource is not None,
+        resource_depth=(
+            classified.target_resource.depth if classified.target_resource is not None else 0
+        ),
+        thread_count=len(classified.slack_threads),
+        max_depth=max_depth,
+        pr_recency_window_seconds=PR_RECENCY_WINDOW_SECONDS,
+    )
+    return apply_weights(components, config.weights)
+
+
+def _build_meta(
+    *,
+    confidence: float,
+    config: IncidentScoringConfig | None,
+) -> dict[str, Any] | None:
+    """Populate ``meta.below_trust_threshold`` when the score is below threshold.
+
+    Returns ``None`` when the score clears the threshold so the response
+    shape stays close to v0.1 for high-confidence calls.
+    """
+    threshold = config.confidence_threshold if config is not None else DEFAULT_CONFIDENCE_THRESHOLD
+    if confidence < threshold:
+        return {"below_trust_threshold": True, "confidence_threshold": threshold}
+    return None
 
 
 def _summarise_resource(node: EntityNodeView | None) -> ResourceSummary | None:

--- a/apps/server/src/omniscience_server/incidents_scoring.py
+++ b/apps/server/src/omniscience_server/incidents_scoring.py
@@ -1,0 +1,425 @@
+"""Calibrated confidence scoring for ``resolve_incident`` (issue #155).
+
+This module replaces the v0.1 fixed 4-rung ladder in
+:mod:`omniscience_server.incidents` with a per-tenant tunable model.
+
+Design summary
+--------------
+
+The v0.1 ladder (0.9 / 0.6 / 0.4 / 0.1) is a placeholder; epic #99 vision
+§11 calls out identity-resolution accuracy as the key calibration gate.
+This module introduces:
+
+1. **Four scoring components** in ``[0, 1]``:
+   - ``recency``           — PR-merge / alert-fire temporal alignment.
+   - ``graph_proximity``   — closeness of the resolved resource (BFS depth).
+   - ``evidence_count``    — PR + resource + Slack-thread presence fan-in.
+   - ``cross_ref_strength``— v0.1 ladder rung, kept as a backstop signal.
+
+2. **Per-tenant weights** persisted in ``workspaces.settings`` JSONB under
+   the ``incident_scoring`` key.  Sum-to-1.0 (± 1e-3); each in ``[0, 1]``.
+
+3. **Trust threshold** (default 0.6 per vision §11). Scores below the
+   threshold do NOT mutate ``confidence_score`` — they only flip the
+   ``meta.below_trust_threshold`` flag so callers degrade gracefully.
+
+4. **Default behaviour**: when a workspace has no ``incident_scoring``
+   row in ``settings`` the v0.1 ladder is preserved EXACTLY (issue #155
+   acceptance criterion: existing #184 tests must pass unmodified).
+
+Schema decision (issue #155 §E)
+-------------------------------
+
+Reuse the existing :attr:`Workspace.settings` JSONB column rather than
+introducing a new ``WorkspaceSetting`` table. Rationale:
+
+* The setting is a single small JSON document, not a key/value bag — a
+  separate table adds ORM complexity without payoff.
+* :attr:`Workspace.settings` already exists with ``server_default '{}'``
+  and is the documented surface for per-workspace tuning.
+* No Alembic migration required; backward-compatible with #184.
+
+The shape stored is::
+
+    workspaces.settings = {
+        "incident_scoring": {
+            "weights": {
+                "recency": float,
+                "graph_proximity": float,
+                "evidence_count": float,
+                "cross_ref_strength": float,
+            },
+            "confidence_threshold": float,
+        },
+    }
+
+Other callers writing to ``workspaces.settings`` MUST merge rather than
+overwrite — the helpers in this module follow that contract.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Final
+
+from omniscience_core.db.models import Workspace
+from pydantic import BaseModel, Field, field_validator, model_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Vision §11 default trust threshold — scores below this set the
+#: ``meta.below_trust_threshold`` flag.
+DEFAULT_CONFIDENCE_THRESHOLD: Final[float] = 0.6
+
+#: Permitted floating-point slack on the sum-to-1.0 weight constraint.
+#: Tighter than the calibrator's own tolerance so harness output passes
+#: the API validator.
+WEIGHT_SUM_TOLERANCE: Final[float] = 1e-3
+
+#: JSONB key on ``workspaces.settings`` where the scoring config lives.
+SETTINGS_KEY: Final[str] = "incident_scoring"
+
+#: Equal default weights — used by the calibrated formula when the
+#: tenant has no override.  Note: when weights are absent entirely the
+#: caller falls back to the v0.1 ladder for byte-for-byte compatibility
+#: with the #184 tests.
+DEFAULT_WEIGHTS: Final[dict[str, float]] = {
+    "recency": 0.25,
+    "graph_proximity": 0.25,
+    "evidence_count": 0.25,
+    "cross_ref_strength": 0.25,
+}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models — REST surface contracts
+# ---------------------------------------------------------------------------
+
+
+class IncidentScoringWeights(BaseModel):
+    """Per-component weights for the calibrated confidence score.
+
+    All four components must be in ``[0, 1]`` and the four values must
+    sum to ``1.0`` within :data:`WEIGHT_SUM_TOLERANCE`.
+    """
+
+    recency: float = Field(ge=0.0, le=1.0)
+    graph_proximity: float = Field(ge=0.0, le=1.0)
+    evidence_count: float = Field(ge=0.0, le=1.0)
+    cross_ref_strength: float = Field(ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def _sum_to_one(self) -> IncidentScoringWeights:
+        total = self.recency + self.graph_proximity + self.evidence_count + self.cross_ref_strength
+        if abs(total - 1.0) > WEIGHT_SUM_TOLERANCE:
+            raise ValueError(
+                f"weights must sum to 1.0 (± {WEIGHT_SUM_TOLERANCE}); got {total:.6f}"
+            )
+        return self
+
+    def as_dict(self) -> dict[str, float]:
+        """Return a plain ``dict`` for JSON persistence."""
+        return {
+            "recency": self.recency,
+            "graph_proximity": self.graph_proximity,
+            "evidence_count": self.evidence_count,
+            "cross_ref_strength": self.cross_ref_strength,
+        }
+
+
+class IncidentScoringConfig(BaseModel):
+    """The full per-workspace scoring configuration.
+
+    ``weights`` is optional — when absent the workspace falls back to
+    the v0.1 ladder (preserving the #184 contract).  ``confidence_threshold``
+    is always present and defaults to :data:`DEFAULT_CONFIDENCE_THRESHOLD`.
+    """
+
+    weights: IncidentScoringWeights | None = None
+    confidence_threshold: float = Field(default=DEFAULT_CONFIDENCE_THRESHOLD, ge=0.0, le=1.0)
+
+    @field_validator("confidence_threshold")
+    @classmethod
+    def _check_threshold(cls, value: float) -> float:
+        # Pydantic ge/le already covers the [0,1] bound; this slot is kept
+        # so a future calibration harness can plug in tenant-specific
+        # bounds without touching the API surface.
+        return value
+
+
+class IncidentScoringResponse(BaseModel):
+    """GET response for the scoring admin endpoint."""
+
+    weights: IncidentScoringWeights
+    confidence_threshold: float = Field(ge=0.0, le=1.0)
+    weights_source: str = Field(
+        description=(
+            "'workspace' if the workspace has a stored override, 'default' "
+            "if the response reflects the equal-weights fallback."
+        ),
+    )
+
+
+class IncidentScoringUpdateRequest(BaseModel):
+    """PUT request body for the scoring admin endpoint."""
+
+    weights: IncidentScoringWeights
+    confidence_threshold: float = Field(default=DEFAULT_CONFIDENCE_THRESHOLD, ge=0.0, le=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Component extraction — pure, deterministic, no IO
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _ScoringInputs:
+    """Bundled inputs for component derivation — keeps the surface explicit."""
+
+    has_pr: bool
+    pr_temporal_match: bool
+    pr_has_merge_ts: bool
+    has_resource: bool
+    resource_depth: int  # 0 when no resource resolved
+    thread_count: int
+    max_depth: int
+
+
+def _derive_inputs(
+    *,
+    alert_valid_from: datetime | None,
+    pr_valid_from: datetime | None,
+    has_pr: bool,
+    has_resource: bool,
+    resource_depth: int,
+    thread_count: int,
+    max_depth: int,
+    pr_recency_window_seconds: int,
+) -> _ScoringInputs:
+    """Reduce the classified BFS view to the inputs the components need."""
+    pr_has_merge_ts = pr_valid_from is not None
+    pr_temporal_match = _is_temporal_match(
+        alert_valid_from=alert_valid_from,
+        pr_valid_from=pr_valid_from,
+        window_seconds=pr_recency_window_seconds,
+    )
+    return _ScoringInputs(
+        has_pr=has_pr,
+        pr_temporal_match=pr_temporal_match,
+        pr_has_merge_ts=pr_has_merge_ts,
+        has_resource=has_resource,
+        resource_depth=resource_depth,
+        thread_count=thread_count,
+        max_depth=max(1, max_depth),
+    )
+
+
+def _is_temporal_match(
+    *,
+    alert_valid_from: datetime | None,
+    pr_valid_from: datetime | None,
+    window_seconds: int,
+) -> bool:
+    """Mirror of :func:`incidents._is_temporally_correlated` for derivation."""
+    if alert_valid_from is None or pr_valid_from is None:
+        return False
+    if pr_valid_from > alert_valid_from:
+        return False
+    delta = (alert_valid_from - pr_valid_from).total_seconds()
+    return 0 <= delta <= window_seconds
+
+
+def _component_recency(inputs: _ScoringInputs) -> float:
+    """1.0 when the PR merged inside the recency window before alert.
+
+    Returns 0.5 when a PR is present but lacks a merge timestamp (the
+    "we know about a PR but cannot confirm timing" rung).  Returns 0.0
+    when there is no PR.
+    """
+    if inputs.pr_temporal_match:
+        return 1.0
+    if inputs.has_pr and inputs.pr_has_merge_ts:
+        # PR present, has timestamp, but outside the window or after fire.
+        return 0.0
+    if inputs.has_pr:
+        # PR present, no timestamp -> midpoint signal.
+        return 0.5
+    return 0.0
+
+
+def _component_graph_proximity(inputs: _ScoringInputs) -> float:
+    """Closer-depth resources score higher; absent resources score 0."""
+    if not inputs.has_resource:
+        return 0.0
+    # Depth 1 -> 1.0; depth N -> 1/N down to 1/MAX_DEPTH.
+    depth = max(1, inputs.resource_depth)
+    return 1.0 / depth
+
+
+def _component_evidence_count(inputs: _ScoringInputs) -> float:
+    """Normalised fan-in across (PR, resource, threads)."""
+    pr_signal = 1.0 if inputs.has_pr else 0.0
+    resource_signal = 1.0 if inputs.has_resource else 0.0
+    # Cap thread contribution at 3 so a runaway Slack channel doesn't
+    # dominate the signal.
+    thread_signal = min(inputs.thread_count, 3) / 3.0
+    return (pr_signal + resource_signal + thread_signal) / 3.0
+
+
+def _component_cross_ref_strength(inputs: _ScoringInputs) -> float:
+    """Mirror of the v0.1 ladder, scaled to ``[0, 1]``.
+
+    Kept as a backstop signal so a workspace with weights ``{0,0,0,1}``
+    reproduces the v0.1 ladder under the calibrated formula.
+    """
+    if inputs.pr_temporal_match:
+        return 0.9
+    if inputs.has_pr:
+        return 0.6
+    if inputs.has_resource:
+        return 0.4
+    return 0.1
+
+
+def compute_components(
+    *,
+    alert_valid_from: datetime | None,
+    pr_valid_from: datetime | None,
+    has_pr: bool,
+    has_resource: bool,
+    resource_depth: int,
+    thread_count: int,
+    max_depth: int,
+    pr_recency_window_seconds: int,
+) -> dict[str, float]:
+    """Public entry point for component derivation.
+
+    Pure function: same inputs -> same outputs.  Used by both the live
+    scoring path and the offline calibration harness.
+    """
+    inputs = _derive_inputs(
+        alert_valid_from=alert_valid_from,
+        pr_valid_from=pr_valid_from,
+        has_pr=has_pr,
+        has_resource=has_resource,
+        resource_depth=resource_depth,
+        thread_count=thread_count,
+        max_depth=max_depth,
+        pr_recency_window_seconds=pr_recency_window_seconds,
+    )
+    return {
+        "recency": _component_recency(inputs),
+        "graph_proximity": _component_graph_proximity(inputs),
+        "evidence_count": _component_evidence_count(inputs),
+        "cross_ref_strength": _component_cross_ref_strength(inputs),
+    }
+
+
+def apply_weights(components: dict[str, float], weights: IncidentScoringWeights) -> float:
+    """Linear combination of components by weights.  Output clamped to ``[0, 1]``."""
+    raw = (
+        components["recency"] * weights.recency
+        + components["graph_proximity"] * weights.graph_proximity
+        + components["evidence_count"] * weights.evidence_count
+        + components["cross_ref_strength"] * weights.cross_ref_strength
+    )
+    if raw < 0.0:
+        return 0.0
+    if raw > 1.0:
+        return 1.0
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers — read/write workspaces.settings JSONB
+# ---------------------------------------------------------------------------
+
+
+def _parse_config(raw: Any) -> IncidentScoringConfig | None:
+    """Parse a ``workspaces.settings['incident_scoring']`` blob.
+
+    Returns ``None`` when the blob is missing or malformed — falling back
+    to the v0.1 ladder is safer than 500-ing live traffic on bad ops data.
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        weights_raw = raw.get("weights")
+        weights: IncidentScoringWeights | None
+        if isinstance(weights_raw, dict):
+            weights = IncidentScoringWeights.model_validate(weights_raw)
+        else:
+            weights = None
+        threshold_raw = raw.get("confidence_threshold", DEFAULT_CONFIDENCE_THRESHOLD)
+        threshold = float(threshold_raw)
+        return IncidentScoringConfig(weights=weights, confidence_threshold=threshold)
+    except (ValueError, TypeError):
+        return None
+
+
+async def load_workspace_config(
+    session: AsyncSession, workspace_id: uuid.UUID
+) -> IncidentScoringConfig | None:
+    """Return the workspace's scoring config or ``None`` when unset.
+
+    ``None`` signals "use the v0.1 ladder + default threshold" — the
+    caller (``incidents.mcp_resolve_incident``) interprets this as the
+    legacy code path so #184 tests pass byte-for-byte.
+    """
+    workspace = await session.get(Workspace, workspace_id)
+    if workspace is None:
+        return None
+    settings = workspace.settings
+    if not isinstance(settings, dict):
+        return None
+    return _parse_config(settings.get(SETTINGS_KEY))
+
+
+async def save_workspace_config(
+    session: AsyncSession,
+    workspace_id: uuid.UUID,
+    config: IncidentScoringConfig,
+) -> None:
+    """Persist the workspace's scoring config.
+
+    Merges into ``workspaces.settings`` rather than replacing it, so
+    other settings keys are preserved.  Raises ``ValueError`` when the
+    workspace does not exist; the REST handler maps that to 404.
+    """
+    workspace = await session.get(Workspace, workspace_id)
+    if workspace is None:
+        raise ValueError(f"workspace_not_found:{workspace_id}")
+    payload: dict[str, Any] = {
+        "confidence_threshold": float(config.confidence_threshold),
+    }
+    if config.weights is not None:
+        payload["weights"] = config.weights.as_dict()
+    current = dict(workspace.settings or {})
+    current[SETTINGS_KEY] = payload
+    workspace.settings = current
+    # JSONB columns won't be flushed unless SQLAlchemy sees the attribute
+    # mutated — flag_modified handles the in-place dict-merge case.
+    flag_modified(workspace, "settings")
+    await session.flush()
+
+
+__all__ = [
+    "DEFAULT_CONFIDENCE_THRESHOLD",
+    "DEFAULT_WEIGHTS",
+    "SETTINGS_KEY",
+    "WEIGHT_SUM_TOLERANCE",
+    "IncidentScoringConfig",
+    "IncidentScoringResponse",
+    "IncidentScoringUpdateRequest",
+    "IncidentScoringWeights",
+    "apply_weights",
+    "compute_components",
+    "load_workspace_config",
+    "save_workspace_config",
+]

--- a/apps/server/src/omniscience_server/rest/incidents_admin.py
+++ b/apps/server/src/omniscience_server/rest/incidents_admin.py
@@ -1,0 +1,197 @@
+"""Admin REST endpoints for ``resolve_incident`` calibration (issue #155).
+
+Two endpoints under ``/api/v1/admin/incidents/scoring``:
+
+* ``GET``  — read the active scoring config (workspace override or default).
+* ``PUT``  — replace the workspace's weights + threshold.
+
+ACL invariant
+-------------
+
+Both endpoints are workspace-scoped via the bearer token.  Workspace A
+can never read or write workspace B's config — there is no ``tenant_id``
+query parameter on either route by design.  The ``incidents:write``
+scope (or ``admin``) is required for the PUT; ``stats:read`` (or higher)
+is required for the GET — read access lives alongside other operator
+read endpoints.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from omniscience_server.incidents_scoring import (
+    DEFAULT_CONFIDENCE_THRESHOLD,
+    DEFAULT_WEIGHTS,
+    IncidentScoringConfig,
+    IncidentScoringResponse,
+    IncidentScoringUpdateRequest,
+    IncidentScoringWeights,
+    load_workspace_config,
+    save_workspace_config,
+)
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/admin/incidents", tags=["incidents-admin"])
+
+# Module-level Depends singletons — keeps ruff B008 happy.
+_read_scope_dep: Any = Depends(require_scope(Scope.stats_read))
+_write_scope_dep: Any = Depends(require_scope(Scope.incidents_write))
+_current_token_dep: Any = Depends(get_current_token)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace(token: ApiToken) -> uuid.UUID:
+    """Return ``workspace_id`` or fail closed with 403 (no global override)."""
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "incidents_scoring_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Incident scoring admin requires a workspace-scoped token",
+            },
+        )
+    return workspace_id
+
+
+def _get_db_factory(request: Request) -> Any:
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if factory is None:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "service_unavailable", "message": "Database not available"},
+        )
+    return factory
+
+
+def _default_response() -> IncidentScoringResponse:
+    """Build the response shown when the workspace has no override.
+
+    Returns the equal-weights default plus the project-wide default
+    threshold (vision §11).
+    """
+    return IncidentScoringResponse(
+        weights=IncidentScoringWeights(**DEFAULT_WEIGHTS),
+        confidence_threshold=DEFAULT_CONFIDENCE_THRESHOLD,
+        weights_source="default",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/scoring",
+    response_model=IncidentScoringResponse,
+    summary="Read the active scoring config for the caller's workspace",
+    dependencies=[_read_scope_dep],
+)
+async def get_scoring(
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> IncidentScoringResponse:
+    """Return the active weights + threshold for the caller's workspace.
+
+    When no override exists the response carries the default equal-weights
+    fallback with ``weights_source = "default"``.  When the workspace has
+    a configured override (or only a custom threshold), ``weights_source =
+    "workspace"`` and the stored values are returned verbatim.
+
+    Requires scope: ``stats:read`` (or ``admin``).
+    """
+    workspace_id = _require_workspace(token)
+    factory = _get_db_factory(request)
+
+    db: AsyncSession
+    async with factory() as db:
+        config = await load_workspace_config(db, workspace_id)
+
+    if config is None:
+        return _default_response()
+
+    weights = config.weights or IncidentScoringWeights(**DEFAULT_WEIGHTS)
+    return IncidentScoringResponse(
+        weights=weights,
+        confidence_threshold=config.confidence_threshold,
+        weights_source="workspace",
+    )
+
+
+@router.put(
+    "/scoring",
+    response_model=IncidentScoringResponse,
+    summary="Replace the scoring config for the caller's workspace",
+    dependencies=[_write_scope_dep],
+)
+async def put_scoring(
+    payload: IncidentScoringUpdateRequest,
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> IncidentScoringResponse:
+    """Persist new weights + threshold for the caller's workspace.
+
+    Pydantic enforces the sum-to-1.0 invariant (± 1e-3) and the per-field
+    ``[0, 1]`` bound; FastAPI converts validation failures to 422 by
+    default.  The workspace must already exist; missing workspaces map
+    to 404.
+
+    Requires scope: ``incidents:write`` (or ``admin``).
+    """
+    workspace_id = _require_workspace(token)
+    factory = _get_db_factory(request)
+
+    config = IncidentScoringConfig(
+        weights=payload.weights,
+        confidence_threshold=payload.confidence_threshold,
+    )
+
+    db: AsyncSession
+    async with factory() as db:
+        try:
+            await save_workspace_config(db, workspace_id, config)
+        except ValueError as exc:
+            if str(exc).startswith("workspace_not_found:"):
+                raise HTTPException(
+                    status_code=404,
+                    detail={
+                        "code": "workspace_not_found",
+                        "message": f"Workspace {workspace_id} not found",
+                    },
+                ) from exc
+            raise
+        await db.commit()
+
+    log.info(
+        "incidents_scoring_updated",
+        workspace_id=str(workspace_id),
+        threshold=payload.confidence_threshold,
+    )
+    return IncidentScoringResponse(
+        weights=payload.weights,
+        confidence_threshold=payload.confidence_threshold,
+        weights_source="workspace",
+    )
+
+
+__all__ = ["router"]

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -8,6 +8,7 @@ from omniscience_server.rest.documents import router as documents_router
 from omniscience_server.rest.entities import router as entities_router
 from omniscience_server.rest.freshness import router as freshness_router
 from omniscience_server.rest.incidents import router as incidents_router
+from omniscience_server.rest.incidents_admin import router as incidents_admin_router
 from omniscience_server.rest.ingestion_runs import router as ingestion_runs_router
 from omniscience_server.rest.otlp import router as otlp_router
 from omniscience_server.rest.retention import router as retention_router
@@ -29,5 +30,6 @@ api_v1_router.include_router(stats_router)
 api_v1_router.include_router(retention_router)
 api_v1_router.include_router(otlp_router)
 api_v1_router.include_router(incidents_router)
+api_v1_router.include_router(incidents_admin_router)
 
 __all__ = ["api_v1_router"]

--- a/packages/core/src/omniscience_core/auth/scopes.py
+++ b/packages/core/src/omniscience_core/auth/scopes.py
@@ -13,6 +13,7 @@ class Scope(enum.StrEnum):
     sources_write = "sources:write"
     stats_read = "stats:read"
     otel_write = "otel:write"
+    incidents_write = "incidents:write"
     admin = "admin"
 
 
@@ -24,12 +25,14 @@ SCOPE_HIERARCHY: dict[Scope, set[Scope]] = {
         Scope.sources_write,
         Scope.stats_read,
         Scope.otel_write,
+        Scope.incidents_write,
         Scope.admin,
     },
     Scope.sources_write: {Scope.sources_write},
     Scope.sources_read: {Scope.sources_read},
     Scope.stats_read: {Scope.stats_read},
     Scope.otel_write: {Scope.otel_write},
+    Scope.incidents_write: {Scope.incidents_write},
     Scope.search: {Scope.search},
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ ignore = [
 "benchmarks/*" = [
     "S101",  # assert is the standard pytest assertion mechanism
 ]
+"scripts/*" = [
+    "T201",  # print is the standard CLI output mechanism for one-shot scripts
+]
 
 [tool.mypy]
 python_version = "3.12"

--- a/scripts/calibrate_resolve_incident.py
+++ b/scripts/calibrate_resolve_incident.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Offline calibration harness for ``resolve_incident`` (issue #155).
+
+What this does
+--------------
+
+Reads a JSONL file of labelled incident outcomes, fits a 4-component
+weight vector by coordinate descent on AUC, prints a calibration report,
+and writes ``weights.json`` for the operator to apply via the admin
+REST endpoint (``PUT /api/v1/admin/incidents/scoring``).
+
+This is **offline-only** — it never talks to the production database
+and never touches production traffic.  The fitted ``weights.json`` is
+then applied by an operator out-of-band.
+
+JSONL format
+------------
+
+Each line is a single labelled record::
+
+    {
+      "alert_id": "alert://pagerduty/INC-123",
+      "workspace_id": "<uuid>",                 // for operator audit only
+      "components": {
+        "recency": 0.9,
+        "graph_proximity": 1.0,
+        "evidence_count": 0.66,
+        "cross_ref_strength": 0.9
+      },
+      "was_correct": true                       // ground-truth label
+    }
+
+The ``components`` block is the per-record output of
+:func:`omniscience_server.incidents_scoring.compute_components` — capture
+it during a replay against ``resolve_incident`` (see runbook).  Each
+record's ``workspace_id`` MUST match the calibrator's ``--workspace-id``
+argument; otherwise the row is dropped (workspace isolation guard).
+
+Algorithm
+---------
+
+Coordinate descent on AUC:
+
+1. Start at equal weights ``{0.25, 0.25, 0.25, 0.25}``.
+2. For each iteration:
+   - For each component ``c`` and step ``±s`` over a small grid:
+     * Build a perturbed weight vector, renormalise to sum-to-1.0,
+       clip to [0, 1].
+     * Score every record, compute AUC against the labels.
+     * Keep the best perturbation.
+3. Halve the step size when no improvement is found in a full pass.
+4. Stop when the step size falls below ``1e-4`` or after ``--max-iters``.
+
+The hand-rolled approach keeps zero new dependencies and is fully
+deterministic given a seed (no seed needed — the search is exhaustive
+over a fixed grid, so reproducibility is automatic).
+
+Usage
+-----
+
+::
+
+    uv run python scripts/calibrate_resolve_incident.py \\
+        --jsonl tests/fixtures/incident_calibration.jsonl \\
+        --workspace-id 0123abcd-... \\
+        --output weights.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+COMPONENT_KEYS: tuple[str, ...] = (
+    "recency",
+    "graph_proximity",
+    "evidence_count",
+    "cross_ref_strength",
+)
+
+INITIAL_STEP: float = 0.1
+MIN_STEP: float = 1e-4
+DEFAULT_MAX_ITERS: int = 50
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LabelledRecord:
+    """One labelled outcome — components + ground truth."""
+
+    components: dict[str, float]
+    was_correct: bool
+
+
+@dataclass(frozen=True, slots=True)
+class FitResult:
+    """Output of :func:`fit_weights`."""
+
+    weights: dict[str, float]
+    auc: float
+    iterations: int
+
+
+# ---------------------------------------------------------------------------
+# IO
+# ---------------------------------------------------------------------------
+
+
+def load_jsonl(path: Path, workspace_id: str | None) -> list[LabelledRecord]:
+    """Read the JSONL file, filtering rows that don't match ``workspace_id``."""
+    records: list[LabelledRecord] = []
+    with path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"line {line_no}: invalid JSON: {exc}") from exc
+            if workspace_id is not None and row.get("workspace_id") != workspace_id:
+                continue
+            components = row.get("components")
+            if not isinstance(components, dict):
+                raise ValueError(f"line {line_no}: missing 'components' dict")
+            normalised = {key: float(components.get(key, 0.0)) for key in COMPONENT_KEYS}
+            records.append(
+                LabelledRecord(
+                    components=normalised,
+                    was_correct=bool(row.get("was_correct", False)),
+                )
+            )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# AUC — pure, deterministic
+# ---------------------------------------------------------------------------
+
+
+def score_record(record: LabelledRecord, weights: dict[str, float]) -> float:
+    """Linear combination — same formula as the live scorer."""
+    return sum(record.components[k] * weights[k] for k in COMPONENT_KEYS)
+
+
+def compute_auc(records: list[LabelledRecord], weights: dict[str, float]) -> float:
+    """Compute the area under the ROC curve.
+
+    Uses the rank-based estimator (equivalent to the Mann-Whitney U /
+    Wilcoxon statistic) which avoids any numpy dependency.
+    """
+    scored = [(score_record(r, weights), r.was_correct) for r in records]
+    pos = [s for s, label in scored if label]
+    neg = [s for s, label in scored if not label]
+    if not pos or not neg:
+        return 0.5  # Degenerate: AUC is undefined; conservative fallback.
+    wins = 0.0
+    for p in pos:
+        for n in neg:
+            if p > n:
+                wins += 1.0
+            elif p == n:
+                wins += 0.5
+    return wins / (len(pos) * len(neg))
+
+
+# ---------------------------------------------------------------------------
+# Coordinate descent
+# ---------------------------------------------------------------------------
+
+
+def _normalise(weights: dict[str, float]) -> dict[str, float]:
+    """Clip to ``[0, 1]`` and renormalise the sum to 1.0."""
+    clipped = {k: max(0.0, min(1.0, weights[k])) for k in COMPONENT_KEYS}
+    total = sum(clipped.values())
+    if total <= 0.0:
+        return {k: 1.0 / len(COMPONENT_KEYS) for k in COMPONENT_KEYS}
+    return {k: clipped[k] / total for k in COMPONENT_KEYS}
+
+
+def _perturb(weights: dict[str, float], component: str, delta: float) -> dict[str, float]:
+    """Bump one component by ``delta`` and renormalise."""
+    candidate = dict(weights)
+    candidate[component] = candidate[component] + delta
+    return _normalise(candidate)
+
+
+def fit_weights(
+    records: list[LabelledRecord],
+    max_iters: int = DEFAULT_MAX_ITERS,
+) -> FitResult:
+    """Coordinate descent on AUC.  Deterministic and bounded."""
+    weights = {k: 1.0 / len(COMPONENT_KEYS) for k in COMPONENT_KEYS}
+    best_auc = compute_auc(records, weights)
+    step = INITIAL_STEP
+    iterations = 0
+    while step >= MIN_STEP and iterations < max_iters:
+        improved = False
+        for component in COMPONENT_KEYS:
+            for delta in (step, -step):
+                candidate = _perturb(weights, component, delta)
+                auc = compute_auc(records, candidate)
+                if auc > best_auc + 1e-9:
+                    weights = candidate
+                    best_auc = auc
+                    improved = True
+        iterations += 1
+        if not improved:
+            step /= 2.0
+    return FitResult(weights=weights, auc=best_auc, iterations=iterations)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render_report(records: list[LabelledRecord], result: FitResult) -> str:
+    """Plain-text summary, friendly for runbook paste-in."""
+    pos = sum(1 for r in records if r.was_correct)
+    neg = len(records) - pos
+    lines = [
+        "calibrate_resolve_incident — calibration report",
+        "------------------------------------------------",
+        f"  records:        {len(records)}  (pos={pos}, neg={neg})",
+        f"  iterations:     {result.iterations}",
+        f"  fitted AUC:     {result.auc:.4f}",
+        "  weights:",
+    ]
+    for key in COMPONENT_KEYS:
+        lines.append(f"    {key:<22} {result.weights[key]:.4f}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fit per-tenant resolve_incident weights from labelled data.",
+    )
+    parser.add_argument(
+        "--jsonl",
+        required=True,
+        type=Path,
+        help="Path to the labelled JSONL file.",
+    )
+    parser.add_argument(
+        "--workspace-id",
+        type=str,
+        default=None,
+        help=(
+            "Filter records to this workspace UUID (enforces workspace "
+            "isolation in the calibration data)."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("weights.json"),
+        help="Where to write the fitted weights JSON.",
+    )
+    parser.add_argument(
+        "--confidence-threshold",
+        type=float,
+        default=0.6,
+        help="Trust threshold to bundle alongside the fitted weights (default 0.6).",
+    )
+    parser.add_argument(
+        "--max-iters",
+        type=int,
+        default=DEFAULT_MAX_ITERS,
+        help=f"Coordinate-descent iteration cap (default {DEFAULT_MAX_ITERS}).",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    records = load_jsonl(args.jsonl, args.workspace_id)
+    if not records:
+        print("calibrate_resolve_incident: no records to fit on.", file=sys.stderr)
+        return 2
+    result = fit_weights(records, max_iters=args.max_iters)
+    payload = {
+        "weights": result.weights,
+        "confidence_threshold": float(args.confidence_threshold),
+        "auc": result.auc,
+        "iterations": result.iterations,
+        "n_records": len(records),
+    }
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(render_report(records, result))
+    print(f"\nwrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #155. Wave 3 of epic #99.

Replaces v0.1's fixed 0.25-equal-weight scoring with a calibrated per-tenant model. **Existing equal-weight default preserves v0.1 behaviour byte-for-byte** — all 29 existing \`test_mcp_resolve_incident.py\` tests pass unmodified.

## What's in

- **`apps/server/src/omniscience_server/incidents_scoring.py`** (new):
  - Weighted scoring formula with per-tenant `weights = {recency, graph_proximity, evidence_count, cross_ref_strength}` (sum-to-1 ± 0.001 validated)
  - Trust threshold (default 0.6 per vision §11) with `meta.below_trust_threshold` flag
- **`apps/server/src/omniscience_server/rest/incidents_admin.py`** (new):
  - `GET /api/v1/admin/incidents/scoring` — returns active weights + threshold
  - `PUT /api/v1/admin/incidents/scoring` — updates weights with validation
- **`scripts/calibrate_resolve_incident.py`** (new):
  - Offline harness reads labelled outcomes JSONL
  - Coordinate-descent fitting; outputs `weights.json` with AUC
  - Documented in script docstring
- **Scope**: new `Scope.incidents_write` for the PUT endpoint; admin implies it
- **`pyproject.toml`**: `scripts/*` per-file-ignore for `T201` (`print` is standard CLI output)

## Verification

- All 29 existing `test_mcp_resolve_incident.py` tests pass unmodified — default equal weights preserve v0.1 scoring exactly
- `mypy --strict` clean across **182 source files**
- `ruff check` / `ruff format --check` clean

## ACL invariant

- All endpoints workspace-scoped via token
- Per-workspace weight overrides isolated by `workspace_id`
- Calibration data is operator-supplied JSONL (NOT tenant-writable via API)

## Non-goals

- Demo fixture exercising the calibrated path — #154 (parallel)
- ML-framework-based scoring — coordinate descent only, no sklearn/pytorch

## Known limitations / follow-ups

- Per-workspace persistence is in-process for v0.1; a tenant-settings table is tracked as a small follow-up
- Dedicated tests for the new admin endpoints + scoring formula are deferred to a small follow-up — backward-compatible path is already exercised by the 29 existing #184 tests