### PR TITLE
feat: operator multi-cluster identity — cluster_id re-keying (#167)

### DIFF
--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -110,7 +110,7 @@ func run() error {
 		return fmt.Errorf("manager init: %w", err)
 	}
 
-	rec, err := controller.NewPodReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	rec, err := controller.NewPodReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("pod reconciler init: %w", err)
 	}
@@ -124,7 +124,7 @@ func run() error {
 	// order (Deployment → ReplicaSet → StatefulSet → DaemonSet → Job) but
 	// the manager itself runs them concurrently — order here only affects
 	// startup logging, not runtime semantics.
-	depRec, err := controller.NewDeploymentReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	depRec, err := controller.NewDeploymentReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("deployment reconciler init: %w", err)
 	}
@@ -132,7 +132,7 @@ func run() error {
 		return fmt.Errorf("deployment reconciler setup: %w", err)
 	}
 
-	rsRec, err := controller.NewReplicaSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	rsRec, err := controller.NewReplicaSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("replicaset reconciler init: %w", err)
 	}
@@ -140,7 +140,7 @@ func run() error {
 		return fmt.Errorf("replicaset reconciler setup: %w", err)
 	}
 
-	ssRec, err := controller.NewStatefulSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	ssRec, err := controller.NewStatefulSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("statefulset reconciler init: %w", err)
 	}
@@ -148,7 +148,7 @@ func run() error {
 		return fmt.Errorf("statefulset reconciler setup: %w", err)
 	}
 
-	dsRec, err := controller.NewDaemonSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	dsRec, err := controller.NewDaemonSetReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("daemonset reconciler init: %w", err)
 	}
@@ -156,7 +156,7 @@ func run() error {
 		return fmt.Errorf("daemonset reconciler setup: %w", err)
 	}
 
-	jobRec, err := controller.NewJobReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	jobRec, err := controller.NewJobReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("job reconciler init: %w", err)
 	}
@@ -170,7 +170,7 @@ func run() error {
 	// runtime resolves dependencies at start time. Each Setup* call returns
 	// a wrapped error so a single line in kubectl logs identifies which
 	// kind failed to register.
-	if err := setupNetworkingAndConfigWatchers(mgr, pub, cfg.WorkspaceID, cfg.ClusterName); err != nil {
+	if err := setupNetworkingAndConfigWatchers(mgr, pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName); err != nil {
 		return err
 	}
 	// ── end #158 ──────────────────────────────────────────────────────────
@@ -180,7 +180,7 @@ func run() error {
 	// CRD is not installed we log INFO and skip registration. A truly
 	// transient discovery failure (5xx, connection refused) is propagated so
 	// startup does not silently disable the watcher on a flaky API server.
-	if err := setupArgoRolloutsWatcher(mgr, pub, cfg.WorkspaceID, cfg.ClusterName, logger); err != nil {
+	if err := setupArgoRolloutsWatcher(mgr, pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName, logger); err != nil {
 		return err
 	}
 	// ── end #161 ──────────────────────────────────────────────────────────
@@ -190,7 +190,7 @@ func run() error {
 	// PersistentVolume, StorageClass). Each follows the same constructor /
 	// SetupWithManager shape as the Pod reconciler above; failure on any of
 	// them is a hard startup error so the operator never runs partial.
-	nodeRec, err := controller.NewNodeReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	nodeRec, err := controller.NewNodeReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("node reconciler init: %w", err)
 	}
@@ -198,7 +198,7 @@ func run() error {
 		return fmt.Errorf("node reconciler setup: %w", err)
 	}
 
-	nsRec, err := controller.NewNamespaceReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	nsRec, err := controller.NewNamespaceReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("namespace reconciler init: %w", err)
 	}
@@ -206,7 +206,7 @@ func run() error {
 		return fmt.Errorf("namespace reconciler setup: %w", err)
 	}
 
-	pvRec, err := controller.NewPersistentVolumeReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	pvRec, err := controller.NewPersistentVolumeReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("persistentvolume reconciler init: %w", err)
 	}
@@ -214,7 +214,7 @@ func run() error {
 		return fmt.Errorf("persistentvolume reconciler setup: %w", err)
 	}
 
-	scRec, err := controller.NewStorageClassReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterName)
+	scRec, err := controller.NewStorageClassReconciler(mgr.GetClient(), pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName)
 	if err != nil {
 		return fmt.Errorf("storageclass reconciler init: %w", err)
 	}
@@ -236,7 +236,7 @@ func run() error {
 	argoPresence, argoErr := argocd.DiscoverFromRESTConfig(ctrl.GetConfigOrDie())
 	if argoErr != nil {
 		logger.Error(argoErr, "argocd discovery failed; continuing without ArgoCD watchers")
-	} else if err := controller.SetupArgoCDWatchers(mgr, logger, argoPresence, pub, cfg.WorkspaceID, cfg.ClusterName); err != nil {
+	} else if err := controller.SetupArgoCDWatchers(mgr, logger, argoPresence, pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName); err != nil {
 		return fmt.Errorf("argocd watchers setup: %w", err)
 	}
 	// ─── END issue #160 ───────────────────────────────────────────────────
@@ -258,7 +258,7 @@ func run() error {
 	// in a follow-up that reads from the rest config + a Node sample once
 	// the manager cache is warm. The empty-string strategy keeps this
 	// change small and pure-stamping.
-	anchorPub, err := controller.NewClusterAnchorPublisher(pub, cfg.WorkspaceID, cfg.ClusterName, "", "")
+	anchorPub, err := controller.NewClusterAnchorPublisher(pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName, "", "")
 	if err != nil {
 		return fmt.Errorf("cluster anchor init: %w", err)
 	}
@@ -303,34 +303,35 @@ func setupNetworkingAndConfigWatchers(
 	mgr ctrl.Manager,
 	pub publisher.Publisher,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 ) error {
-	if svc, err := controller.NewServiceReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+	if svc, err := controller.NewServiceReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
 		return fmt.Errorf("service reconciler init: %w", err)
 	} else if err := svc.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("service reconciler setup: %w", err)
 	}
-	if ep, err := controller.NewEndpointsReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+	if ep, err := controller.NewEndpointsReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
 		return fmt.Errorf("endpoints reconciler init: %w", err)
 	} else if err := ep.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("endpoints reconciler setup: %w", err)
 	}
-	if ing, err := controller.NewIngressReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+	if ing, err := controller.NewIngressReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
 		return fmt.Errorf("ingress reconciler init: %w", err)
 	} else if err := ing.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("ingress reconciler setup: %w", err)
 	}
-	if np, err := controller.NewNetworkPolicyReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+	if np, err := controller.NewNetworkPolicyReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
 		return fmt.Errorf("networkpolicy reconciler init: %w", err)
 	} else if err := np.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("networkpolicy reconciler setup: %w", err)
 	}
-	if cm, err := controller.NewConfigMapReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+	if cm, err := controller.NewConfigMapReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
 		return fmt.Errorf("configmap reconciler init: %w", err)
 	} else if err := cm.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("configmap reconciler setup: %w", err)
 	}
-	if sec, err := controller.NewSecretReconciler(mgr.GetClient(), pub, workspaceID, clusterName); err != nil {
+	if sec, err := controller.NewSecretReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
 		return fmt.Errorf("secret reconciler init: %w", err)
 	} else if err := sec.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("secret reconciler setup: %w", err)
@@ -361,6 +362,7 @@ func setupArgoRolloutsWatcher(
 	mgr ctrl.Manager,
 	pub publisher.Publisher,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	logger interface {
 		Info(msg string, keysAndValues ...interface{})
@@ -390,7 +392,7 @@ func setupArgoRolloutsWatcher(
 		return fmt.Errorf("argo-rollouts: add to scheme: %w", err)
 	}
 
-	rec, err := controller.NewArgoRolloutReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+	rec, err := controller.NewArgoRolloutReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName)
 	if err != nil {
 		return fmt.Errorf("argo-rollouts: reconciler init: %w", err)
 	}

--- a/operator/internal/config/config.go
+++ b/operator/internal/config/config.go
@@ -20,6 +20,16 @@ import (
 const (
 	envWorkspaceID = "OMNISCIENCE_WORKSPACE_ID"
 	envClusterName = "OMNISCIENCE_CLUSTER_NAME"
+	// envClusterID is the multi-cluster identity disambiguator (issue #167).
+	// Required when OMNISCIENCE_WORKSPACE_ID is shared across multiple
+	// operators (the multi-cluster case). Optional in single-cluster
+	// deployments; when unset the operator derives a deterministic
+	// uuid5(workspace_id, cluster_name) — back-compat with v0.2 deployments.
+	// MUST be a valid UUID and MUST come from a mounted Secret. Validation
+	// CANNOT enforce that two operators in different clusters use distinct
+	// values — that is the platform team's discipline; the server-side
+	// collision detector is the second line of defence.
+	envClusterID   = "OMNISCIENCE_CLUSTER_ID"
 	envNATSURL     = "OMNISCIENCE_NATS_URL"
 	// envNATSCreds is the env var name for the credentials file path; the
 	// value is a path on disk, never a credential body. The #nosec
@@ -65,6 +75,14 @@ type Config struct {
 	// ClusterName is a human-readable label included in entity metadata. Not
 	// security-bearing — only used for display and lineage.
 	ClusterName string
+
+	// ClusterID is the multi-cluster identity (issue #167). Stamped into
+	// every emitted entity's external_id so the same Kind+namespace+name in
+	// two clusters under one workspace produce DISTINCT graph entities.
+	// When OMNISCIENCE_CLUSTER_ID is unset, Load derives the deterministic
+	// default uuid5(workspace_id, cluster_name) — preserves v0.2 single-
+	// cluster identity stability across operator restarts.
+	ClusterID uuid.UUID
 
 	// NATSURL is the JetStream endpoint. Single URL; the operator does not
 	// perform DNS heroics. Example: "nats://omniscience-nats:4222".
@@ -124,6 +142,23 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("config: %s is required (used as entity metadata label)", envClusterName)
 	}
 
+	// ClusterID resolution (issue #167):
+	//   - Explicit OMNISCIENCE_CLUSTER_ID — parse, fail-closed on malformed.
+	//   - Unset — derive uuid5(workspace_id, cluster_name) so single-cluster
+	//     deployments keep stable identity across restarts. The deterministic
+	//     default matches the v0.2 #159 cluster_id derivation, so existing
+	//     v0.2 graph data lines up byte-for-byte after the re-keying once
+	//     the migration script runs (deferred to a separate sub-issue).
+	if cidRaw := os.Getenv(envClusterID); cidRaw != "" {
+		cid, cerr := uuid.Parse(cidRaw)
+		if cerr != nil {
+			return nil, fmt.Errorf("config: %s is not a valid UUID: %w", envClusterID, cerr)
+		}
+		cfg.ClusterID = cid
+	} else {
+		cfg.ClusterID = deriveDefaultClusterID(cfg.WorkspaceID, cfg.ClusterName)
+	}
+
 	if raw := os.Getenv(envResyncSec); raw != "" {
 		secs, perr := time.ParseDuration(raw + "s")
 		if perr != nil {
@@ -143,4 +178,20 @@ func envOrDefault(name, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// nsClusterIDDefault is the fixed UUID namespace used to derive the
+// deterministic-default cluster_id from (workspace_id, cluster_name) when
+// OMNISCIENCE_CLUSTER_ID is unset. Matches the namespace used by
+// entity.DeriveClusterID so the value is byte-equal to the #159 v0.2
+// derivation — single-cluster v0.2 deployments retain identity continuity
+// when the operator picks up #167.
+var nsClusterIDDefault = uuid.MustParse("d6c4a5b1-3e7f-4a92-9c2d-7e1f8b6c4a5b")
+
+// deriveDefaultClusterID returns uuid5(workspaceID, "cluster/" + workspaceID
+// + "/" + clusterName). The "cluster/" prefix matches entity.DeriveClusterID
+// — both derivations live in lockstep so the deterministic default is
+// observable in tests without importing a server-side helper.
+func deriveDefaultClusterID(workspaceID uuid.UUID, clusterName string) uuid.UUID {
+	return uuid.NewSHA1(nsClusterIDDefault, []byte("cluster/"+workspaceID.String()+"/"+clusterName))
 }

--- a/operator/internal/controller/argo_rollout_controller.go
+++ b/operator/internal/controller/argo_rollout_controller.go
@@ -46,13 +46,14 @@ type ArgoRolloutReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewArgoRolloutReconciler returns a reconciler with sane defaults and the
 // same precondition checks the other reconcilers enforce.
-func NewArgoRolloutReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ArgoRolloutReconciler, error) {
+func NewArgoRolloutReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ArgoRolloutReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -69,6 +70,7 @@ func NewArgoRolloutReconciler(c client.Client, pub publisher.Publisher, workspac
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -85,7 +87,7 @@ func (r *ArgoRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	err := r.Client.Get(ctx, req.NamespacedName, &ro)
 	switch {
 	case err == nil:
-		ev := entity.RolloutToEvent(&ro, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.RolloutToEvent(&ro, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish rollout event: %w", perr)
@@ -97,7 +99,7 @@ func (r *ArgoRolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		stub := &rolloutsv1alpha1.Rollout{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.RolloutToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.RolloutToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish rollout deletion: %w", perr)

--- a/operator/internal/controller/argocd_application_controller.go
+++ b/operator/internal/controller/argocd_application_controller.go
@@ -41,13 +41,14 @@ type ArgoCDApplicationReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewArgoCDApplicationReconciler returns a reconciler with sane defaults
 // and the same precondition checks the workload reconcilers enforce.
-func NewArgoCDApplicationReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ArgoCDApplicationReconciler, error) {
+func NewArgoCDApplicationReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ArgoCDApplicationReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -64,6 +65,7 @@ func NewArgoCDApplicationReconciler(c client.Client, pub publisher.Publisher, wo
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -85,7 +87,7 @@ func (r *ArgoCDApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			logger.Error(derr, "decode application failed; skipping reconcile")
 			return ctrl.Result{}, nil
 		}
-		ev := entity.ApplicationToEvent(app, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ApplicationToEvent(app, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish application event: %w", perr)
@@ -97,7 +99,7 @@ func (r *ArgoCDApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		stub := &argocd.Application{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ApplicationToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ApplicationToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish application deletion: %w", perr)

--- a/operator/internal/controller/argocd_applicationset_controller.go
+++ b/operator/internal/controller/argocd_applicationset_controller.go
@@ -27,12 +27,13 @@ type ArgoCDApplicationSetReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewArgoCDApplicationSetReconciler returns a reconciler with sane defaults.
-func NewArgoCDApplicationSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ArgoCDApplicationSetReconciler, error) {
+func NewArgoCDApplicationSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ArgoCDApplicationSetReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -49,6 +50,7 @@ func NewArgoCDApplicationSetReconciler(c client.Client, pub publisher.Publisher,
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -70,7 +72,7 @@ func (r *ArgoCDApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl
 			logger.Error(derr, "decode applicationset failed; skipping reconcile")
 			return ctrl.Result{}, nil
 		}
-		ev := entity.ApplicationSetToEvent(appset, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ApplicationSetToEvent(appset, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish applicationset event: %w", perr)
@@ -82,7 +84,7 @@ func (r *ArgoCDApplicationSetReconciler) Reconcile(ctx context.Context, req ctrl
 		stub := &argocd.ApplicationSet{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ApplicationSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ApplicationSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish applicationset deletion: %w", perr)

--- a/operator/internal/controller/argocd_setup.go
+++ b/operator/internal/controller/argocd_setup.go
@@ -34,6 +34,7 @@ func SetupArgoCDWatchers(
 	presence argocd.PresenceCheck,
 	pub publisher.Publisher,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 ) error {
 	if !presence.AnyPresent() {
@@ -44,7 +45,7 @@ func SetupArgoCDWatchers(
 	}
 
 	if presence.ApplicationsPresent {
-		appRec, err := NewArgoCDApplicationReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+		appRec, err := NewArgoCDApplicationReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName)
 		if err != nil {
 			return fmt.Errorf("argocd application reconciler init: %w", err)
 		}
@@ -57,7 +58,7 @@ func SetupArgoCDWatchers(
 	}
 
 	if presence.ApplicationSetsPresent {
-		setRec, err := NewArgoCDApplicationSetReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+		setRec, err := NewArgoCDApplicationSetReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName)
 		if err != nil {
 			return fmt.Errorf("argocd applicationset reconciler init: %w", err)
 		}

--- a/operator/internal/controller/cluster_anchor.go
+++ b/operator/internal/controller/cluster_anchor.go
@@ -32,6 +32,7 @@ import (
 type ClusterAnchorPublisher struct {
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 
 	// KubernetesVersion and ClusterEndpoint are optional cluster facts
@@ -49,7 +50,7 @@ type ClusterAnchorPublisher struct {
 // the watcher reconcilers do — workspace must be a non-zero UUID, cluster
 // name must be set, publisher must be non-nil. Returning an error rather
 // than panicking lets main.go exit non-zero with a useful message.
-func NewClusterAnchorPublisher(pub publisher.Publisher, workspaceID uuid.UUID, clusterName, kubernetesVersion, clusterEndpoint string) (*ClusterAnchorPublisher, error) {
+func NewClusterAnchorPublisher(pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName, kubernetesVersion, clusterEndpoint string) (*ClusterAnchorPublisher, error) {
 	if pub == nil {
 		return nil, errors.New("cluster anchor: publisher must not be nil")
 	}
@@ -62,6 +63,7 @@ func NewClusterAnchorPublisher(pub publisher.Publisher, workspaceID uuid.UUID, c
 	return &ClusterAnchorPublisher{
 		Publisher:         pub,
 		WorkspaceID:       workspaceID,
+		ClusterID:         clusterID,
 		ClusterName:       clusterName,
 		KubernetesVersion: kubernetesVersion,
 		ClusterEndpoint:   clusterEndpoint,
@@ -77,6 +79,7 @@ func (p *ClusterAnchorPublisher) PublishOnce(ctx context.Context) error {
 	ev := entity.ClusterToEvent(
 		entity.ActionCreated,
 		p.WorkspaceID,
+		p.ClusterID,
 		p.ClusterName,
 		p.KubernetesVersion,
 		p.ClusterEndpoint,
@@ -97,6 +100,7 @@ func (p *ClusterAnchorPublisher) BuildEvent() *entity.Event {
 	return entity.ClusterToEvent(
 		entity.ActionCreated,
 		p.WorkspaceID,
+		p.ClusterID,
 		p.ClusterName,
 		p.KubernetesVersion,
 		p.ClusterEndpoint,

--- a/operator/internal/controller/cluster_anchor_test.go
+++ b/operator/internal/controller/cluster_anchor_test.go
@@ -39,6 +39,7 @@ func (f *anchorFakePublisher) snapshot() []*entity.Event {
 
 var (
 	fixedWorkspace = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	fixedClusterID = uuid.MustParse("99999999-8888-7777-6666-555555555555")
 	fixedNow       = time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
 )
 
@@ -49,7 +50,7 @@ var (
 // produce events with the same external_id, cluster_id, and source_id.
 func TestClusterAnchorPublisher_PublishOnceIsIdempotent(t *testing.T) {
 	pub1 := &anchorFakePublisher{}
-	p1, err := controller.NewClusterAnchorPublisher(pub1, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443")
+	p1, err := controller.NewClusterAnchorPublisher(pub1, fixedWorkspace, fixedClusterID, "prod-eu", "v1.31.1", "https://api:6443")
 	if err != nil {
 		t.Fatalf("new pub1: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestClusterAnchorPublisher_PublishOnceIsIdempotent(t *testing.T) {
 
 	// Second "restart": fresh publisher instance, same config.
 	pub2 := &anchorFakePublisher{}
-	p2, err := controller.NewClusterAnchorPublisher(pub2, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443")
+	p2, err := controller.NewClusterAnchorPublisher(pub2, fixedWorkspace, fixedClusterID, "prod-eu", "v1.31.1", "https://api:6443")
 	if err != nil {
 		t.Fatalf("new pub2: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestClusterAnchorPublisher_PublishOnceIsIdempotent(t *testing.T) {
 	if a.ExternalID != b.ExternalID {
 		t.Fatalf("external_id drift: %q vs %q", a.ExternalID, b.ExternalID)
 	}
-	if a.ExternalID != "k8s_resource/Cluster/prod-eu" {
+	if a.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/prod-eu" {
 		t.Fatalf("external_id = %q", a.ExternalID)
 	}
 	if a.SourceID != b.SourceID {
@@ -100,17 +101,17 @@ func TestClusterAnchorPublisher_PublishOnceIsIdempotent(t *testing.T) {
 // workspace UUID would publish an event the publisher then rejects. Fail
 // closed at construction time so the operator surfaces the misconfiguration.
 func TestClusterAnchorPublisher_RejectsZeroWorkspace(t *testing.T) {
-	_, err := controller.NewClusterAnchorPublisher(&anchorFakePublisher{}, uuid.Nil, "prod-eu", "", "")
+	_, err := controller.NewClusterAnchorPublisher(&anchorFakePublisher{}, uuid.Nil, fixedClusterID, "prod-eu", "", "")
 	if err == nil {
 		t.Fatalf("expected error for zero workspace UUID")
 	}
 }
 
 // TestClusterAnchorPublisher_RejectsEmptyClusterName — ensures we never
-// publish an anchor with external_id "k8s_resource/Cluster/" (trailing
+// publish an anchor with external_id "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/" (trailing
 // slash) which would collide trivially across workspaces.
 func TestClusterAnchorPublisher_RejectsEmptyClusterName(t *testing.T) {
-	_, err := controller.NewClusterAnchorPublisher(&anchorFakePublisher{}, fixedWorkspace, "", "", "")
+	_, err := controller.NewClusterAnchorPublisher(&anchorFakePublisher{}, fixedWorkspace, fixedClusterID, "", "", "")
 	if err == nil {
 		t.Fatalf("expected error for empty clusterName")
 	}
@@ -118,7 +119,7 @@ func TestClusterAnchorPublisher_RejectsEmptyClusterName(t *testing.T) {
 
 // TestClusterAnchorPublisher_RejectsNilPublisher — defence-in-depth.
 func TestClusterAnchorPublisher_RejectsNilPublisher(t *testing.T) {
-	_, err := controller.NewClusterAnchorPublisher(nil, fixedWorkspace, "prod-eu", "", "")
+	_, err := controller.NewClusterAnchorPublisher(nil, fixedWorkspace, fixedClusterID, "prod-eu", "", "")
 	if err == nil {
 		t.Fatalf("expected error for nil publisher")
 	}

--- a/operator/internal/controller/configmap_controller.go
+++ b/operator/internal/controller/configmap_controller.go
@@ -27,12 +27,13 @@ type ConfigMapReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewConfigMapReconciler returns a reconciler with sane defaults.
-func NewConfigMapReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ConfigMapReconciler, error) {
+func NewConfigMapReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ConfigMapReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -49,6 +50,7 @@ func NewConfigMapReconciler(c client.Client, pub publisher.Publisher, workspaceI
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -65,7 +67,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err := r.Client.Get(ctx, req.NamespacedName, &cm)
 	switch {
 	case err == nil:
-		ev := entity.ConfigMapToEvent(&cm, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ConfigMapToEvent(&cm, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish configmap event: %w", perr)
@@ -77,7 +79,7 @@ func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		stub := &corev1.ConfigMap{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ConfigMapToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ConfigMapToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish configmap deletion: %w", perr)

--- a/operator/internal/controller/daemonset_controller.go
+++ b/operator/internal/controller/daemonset_controller.go
@@ -23,12 +23,13 @@ type DaemonSetReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewDaemonSetReconciler validates inputs identically to NewPodReconciler.
-func NewDaemonSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*DaemonSetReconciler, error) {
+func NewDaemonSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*DaemonSetReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -45,6 +46,7 @@ func NewDaemonSetReconciler(c client.Client, pub publisher.Publisher, workspaceI
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -61,7 +63,7 @@ func (r *DaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err := r.Client.Get(ctx, req.NamespacedName, &ds)
 	switch {
 	case err == nil:
-		ev := entity.DaemonSetToEvent(&ds, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.DaemonSetToEvent(&ds, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish daemonset event: %w", perr)
@@ -73,7 +75,7 @@ func (r *DaemonSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		stub := &appsv1.DaemonSet{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.DaemonSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.DaemonSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish daemonset deletion: %w", perr)

--- a/operator/internal/controller/deployment_controller.go
+++ b/operator/internal/controller/deployment_controller.go
@@ -25,6 +25,7 @@ type DeploymentReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
@@ -32,7 +33,7 @@ type DeploymentReconciler struct {
 // NewDeploymentReconciler returns a reconciler with sane defaults and the
 // same precondition checks PodReconciler enforces (non-nil client, non-nil
 // publisher, non-zero workspace, non-empty cluster name).
-func NewDeploymentReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*DeploymentReconciler, error) {
+func NewDeploymentReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*DeploymentReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -49,6 +50,7 @@ func NewDeploymentReconciler(c client.Client, pub publisher.Publisher, workspace
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -65,7 +67,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	err := r.Client.Get(ctx, req.NamespacedName, &d)
 	switch {
 	case err == nil:
-		ev := entity.DeploymentToEvent(&d, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.DeploymentToEvent(&d, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish deployment event: %w", perr)
@@ -77,7 +79,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		stub := &appsv1.Deployment{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.DeploymentToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.DeploymentToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish deployment deletion: %w", perr)

--- a/operator/internal/controller/dra_resourceclaim_controller.go
+++ b/operator/internal/controller/dra_resourceclaim_controller.go
@@ -33,13 +33,14 @@ type ResourceClaimReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewResourceClaimReconciler returns a reconciler with sane defaults.
 // Validation matches every other reconciler in this package.
-func NewResourceClaimReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ResourceClaimReconciler, error) {
+func NewResourceClaimReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ResourceClaimReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -56,6 +57,7 @@ func NewResourceClaimReconciler(c client.Client, pub publisher.Publisher, worksp
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -74,7 +76,7 @@ func (r *ResourceClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	err := r.Client.Get(ctx, req.NamespacedName, &rc)
 	switch {
 	case err == nil:
-		ev := entity.ResourceClaimToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ResourceClaimToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish resourceclaim event: %w", perr)
@@ -86,7 +88,7 @@ func (r *ResourceClaimReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		stub := &resourcev1beta1.ResourceClaim{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ResourceClaimToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ResourceClaimToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish resourceclaim deletion: %w", perr)

--- a/operator/internal/controller/endpoints_controller.go
+++ b/operator/internal/controller/endpoints_controller.go
@@ -26,12 +26,13 @@ type EndpointsReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewEndpointsReconciler returns a reconciler with sane defaults.
-func NewEndpointsReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*EndpointsReconciler, error) {
+func NewEndpointsReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*EndpointsReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -48,6 +49,7 @@ func NewEndpointsReconciler(c client.Client, pub publisher.Publisher, workspaceI
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -64,7 +66,7 @@ func (r *EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err := r.Client.Get(ctx, req.NamespacedName, &ep)
 	switch {
 	case err == nil:
-		ev := entity.EndpointsToEvent(&ep, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.EndpointsToEvent(&ep, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish endpoints event: %w", perr)
@@ -76,7 +78,7 @@ func (r *EndpointsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		stub := &corev1.Endpoints{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.EndpointsToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.EndpointsToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish endpoints deletion: %w", perr)

--- a/operator/internal/controller/ingress_controller.go
+++ b/operator/internal/controller/ingress_controller.go
@@ -23,12 +23,13 @@ type IngressReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewIngressReconciler returns a reconciler with sane defaults.
-func NewIngressReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*IngressReconciler, error) {
+func NewIngressReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*IngressReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -45,6 +46,7 @@ func NewIngressReconciler(c client.Client, pub publisher.Publisher, workspaceID 
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -61,7 +63,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	err := r.Client.Get(ctx, req.NamespacedName, &ing)
 	switch {
 	case err == nil:
-		ev := entity.IngressToEvent(&ing, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.IngressToEvent(&ing, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish ingress event: %w", perr)
@@ -73,7 +75,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		stub := &networkingv1.Ingress{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.IngressToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.IngressToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish ingress deletion: %w", perr)

--- a/operator/internal/controller/job_controller.go
+++ b/operator/internal/controller/job_controller.go
@@ -24,12 +24,13 @@ type JobReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewJobReconciler validates inputs identically to NewPodReconciler.
-func NewJobReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*JobReconciler, error) {
+func NewJobReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*JobReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -46,6 +47,7 @@ func NewJobReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -62,7 +64,7 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	err := r.Client.Get(ctx, req.NamespacedName, &j)
 	switch {
 	case err == nil:
-		ev := entity.JobToEvent(&j, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.JobToEvent(&j, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish job event: %w", perr)
@@ -74,7 +76,7 @@ func (r *JobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		stub := &batchv1.Job{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.JobToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.JobToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish job deletion: %w", perr)

--- a/operator/internal/controller/namespace_controller.go
+++ b/operator/internal/controller/namespace_controller.go
@@ -27,12 +27,13 @@ type NamespaceReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewNamespaceReconciler returns a reconciler with sane defaults.
-func NewNamespaceReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*NamespaceReconciler, error) {
+func NewNamespaceReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*NamespaceReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -49,6 +50,7 @@ func NewNamespaceReconciler(c client.Client, pub publisher.Publisher, workspaceI
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -65,7 +67,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	err := r.Client.Get(ctx, req.NamespacedName, &ns)
 	switch {
 	case err == nil:
-		ev := entity.NamespaceToEvent(&ns, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.NamespaceToEvent(&ns, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish namespace event: %w", perr)
@@ -76,7 +78,7 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	case apierrors.IsNotFound(err):
 		stub := &corev1.Namespace{}
 		stub.Name = req.Name
-		ev := entity.NamespaceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.NamespaceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish namespace deletion: %w", perr)

--- a/operator/internal/controller/networkpolicy_controller.go
+++ b/operator/internal/controller/networkpolicy_controller.go
@@ -23,12 +23,13 @@ type NetworkPolicyReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewNetworkPolicyReconciler returns a reconciler with sane defaults.
-func NewNetworkPolicyReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*NetworkPolicyReconciler, error) {
+func NewNetworkPolicyReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*NetworkPolicyReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -45,6 +46,7 @@ func NewNetworkPolicyReconciler(c client.Client, pub publisher.Publisher, worksp
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -61,7 +63,7 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	err := r.Client.Get(ctx, req.NamespacedName, &np)
 	switch {
 	case err == nil:
-		ev := entity.NetworkPolicyToEvent(&np, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.NetworkPolicyToEvent(&np, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish networkpolicy event: %w", perr)
@@ -73,7 +75,7 @@ func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		stub := &networkingv1.NetworkPolicy{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.NetworkPolicyToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.NetworkPolicyToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish networkpolicy deletion: %w", perr)

--- a/operator/internal/controller/node_controller.go
+++ b/operator/internal/controller/node_controller.go
@@ -28,13 +28,14 @@ type NodeReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewNodeReconciler returns a reconciler with sane defaults. Symmetric with
 // NewPodReconciler — same validation, same defaults.
-func NewNodeReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*NodeReconciler, error) {
+func NewNodeReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*NodeReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -51,6 +52,7 @@ func NewNodeReconciler(c client.Client, pub publisher.Publisher, workspaceID uui
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -69,7 +71,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	err := r.Client.Get(ctx, req.NamespacedName, &node)
 	switch {
 	case err == nil:
-		ev := entity.NodeToEvent(&node, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.NodeToEvent(&node, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish node event: %w", perr)
@@ -80,7 +82,7 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	case apierrors.IsNotFound(err):
 		stub := &corev1.Node{}
 		stub.Name = req.Name
-		ev := entity.NodeToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.NodeToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish node deletion: %w", perr)

--- a/operator/internal/controller/persistentvolume_controller.go
+++ b/operator/internal/controller/persistentvolume_controller.go
@@ -27,12 +27,13 @@ type PersistentVolumeReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewPersistentVolumeReconciler returns a reconciler with sane defaults.
-func NewPersistentVolumeReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*PersistentVolumeReconciler, error) {
+func NewPersistentVolumeReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*PersistentVolumeReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -49,6 +50,7 @@ func NewPersistentVolumeReconciler(c client.Client, pub publisher.Publisher, wor
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -65,7 +67,7 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	err := r.Client.Get(ctx, req.NamespacedName, &pv)
 	switch {
 	case err == nil:
-		ev := entity.PersistentVolumeToEvent(&pv, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.PersistentVolumeToEvent(&pv, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish pv event: %w", perr)
@@ -76,7 +78,7 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	case apierrors.IsNotFound(err):
 		stub := &corev1.PersistentVolume{}
 		stub.Name = req.Name
-		ev := entity.PersistentVolumeToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.PersistentVolumeToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish pv deletion: %w", perr)

--- a/operator/internal/controller/pod_controller.go
+++ b/operator/internal/controller/pod_controller.go
@@ -31,6 +31,7 @@ type PodReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	// Now is the clock function used for event timestamps. Injectable so
 	// tests can pin time deterministically.
@@ -38,7 +39,7 @@ type PodReconciler struct {
 }
 
 // NewPodReconciler returns a reconciler with sane defaults.
-func NewPodReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*PodReconciler, error) {
+func NewPodReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*PodReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -55,6 +56,7 @@ func NewPodReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -83,7 +85,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		// external_id), so emitting "updated" for both create and update
 		// is correct. A more precise mapping requires a finalizer or an
 		// in-memory cache and is deferred to a follow-up issue.
-		ev := entity.PodToEvent(&pod, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.PodToEvent(&pod, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish pod event: %w", perr)
@@ -100,7 +102,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		stub := &corev1.Pod{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.PodToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.PodToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish pod deletion: %w", perr)

--- a/operator/internal/controller/replicaset_controller.go
+++ b/operator/internal/controller/replicaset_controller.go
@@ -23,12 +23,13 @@ type ReplicaSetReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewReplicaSetReconciler validates inputs identically to NewPodReconciler.
-func NewReplicaSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ReplicaSetReconciler, error) {
+func NewReplicaSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ReplicaSetReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -45,6 +46,7 @@ func NewReplicaSetReconciler(c client.Client, pub publisher.Publisher, workspace
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -61,7 +63,7 @@ func (r *ReplicaSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	err := r.Client.Get(ctx, req.NamespacedName, &rs)
 	switch {
 	case err == nil:
-		ev := entity.ReplicaSetToEvent(&rs, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ReplicaSetToEvent(&rs, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish replicaset event: %w", perr)
@@ -73,7 +75,7 @@ func (r *ReplicaSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		stub := &appsv1.ReplicaSet{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ReplicaSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ReplicaSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish replicaset deletion: %w", perr)

--- a/operator/internal/controller/secret_controller.go
+++ b/operator/internal/controller/secret_controller.go
@@ -30,12 +30,13 @@ type SecretReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewSecretReconciler returns a reconciler with sane defaults.
-func NewSecretReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*SecretReconciler, error) {
+func NewSecretReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*SecretReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -52,6 +53,7 @@ func NewSecretReconciler(c client.Client, pub publisher.Publisher, workspaceID u
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -68,7 +70,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	err := r.Client.Get(ctx, req.NamespacedName, &s)
 	switch {
 	case err == nil:
-		ev := entity.SecretToEvent(&s, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.SecretToEvent(&s, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish secret event: %w", perr)
@@ -84,7 +86,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		stub := &corev1.Secret{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.SecretToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.SecretToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish secret deletion: %w", perr)

--- a/operator/internal/controller/service_controller.go
+++ b/operator/internal/controller/service_controller.go
@@ -28,12 +28,13 @@ type ServiceReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewServiceReconciler returns a reconciler with sane defaults.
-func NewServiceReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ServiceReconciler, error) {
+func NewServiceReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ServiceReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -50,6 +51,7 @@ func NewServiceReconciler(c client.Client, pub publisher.Publisher, workspaceID 
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -66,7 +68,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	err := r.Client.Get(ctx, req.NamespacedName, &svc)
 	switch {
 	case err == nil:
-		ev := entity.ServiceToEvent(&svc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ServiceToEvent(&svc, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish service event: %w", perr)
@@ -78,7 +80,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		stub := &corev1.Service{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ServiceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ServiceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish service deletion: %w", perr)

--- a/operator/internal/controller/statefulset_controller.go
+++ b/operator/internal/controller/statefulset_controller.go
@@ -23,12 +23,13 @@ type StatefulSetReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewStatefulSetReconciler validates inputs identically to NewPodReconciler.
-func NewStatefulSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*StatefulSetReconciler, error) {
+func NewStatefulSetReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*StatefulSetReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -45,6 +46,7 @@ func NewStatefulSetReconciler(c client.Client, pub publisher.Publisher, workspac
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -61,7 +63,7 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	err := r.Client.Get(ctx, req.NamespacedName, &ss)
 	switch {
 	case err == nil:
-		ev := entity.StatefulSetToEvent(&ss, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.StatefulSetToEvent(&ss, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish statefulset event: %w", perr)
@@ -73,7 +75,7 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		stub := &appsv1.StatefulSet{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.StatefulSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.StatefulSetToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish statefulset deletion: %w", perr)

--- a/operator/internal/controller/storageclass_controller.go
+++ b/operator/internal/controller/storageclass_controller.go
@@ -25,12 +25,13 @@ type StorageClassReconciler struct {
 	Client      client.Client
 	Publisher   publisher.Publisher
 	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
 	ClusterName string
 	Now         func() time.Time
 }
 
 // NewStorageClassReconciler returns a reconciler with sane defaults.
-func NewStorageClassReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*StorageClassReconciler, error) {
+func NewStorageClassReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*StorageClassReconciler, error) {
 	if c == nil {
 		return nil, errors.New("controller: client must not be nil")
 	}
@@ -47,6 +48,7 @@ func NewStorageClassReconciler(c client.Client, pub publisher.Publisher, workspa
 		Client:      c,
 		Publisher:   pub,
 		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
 		ClusterName: clusterName,
 		Now:         time.Now,
 	}, nil
@@ -63,7 +65,7 @@ func (r *StorageClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	err := r.Client.Get(ctx, req.NamespacedName, &sc)
 	switch {
 	case err == nil:
-		ev := entity.StorageClassToEvent(&sc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.StorageClassToEvent(&sc, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish storageclass event: %w", perr)
@@ -74,7 +76,7 @@ func (r *StorageClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	case apierrors.IsNotFound(err):
 		stub := &storagev1.StorageClass{}
 		stub.Name = req.Name
-		ev := entity.StorageClassToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.StorageClassToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish storageclass deletion: %w", perr)

--- a/operator/internal/controller/workload_controllers_test.go
+++ b/operator/internal/controller/workload_controllers_test.go
@@ -91,7 +91,7 @@ func req(namespace, name string) ctrl.Request {
 func TestNewDeploymentReconciler_RejectsZeroWorkspace(t *testing.T) {
 	s := newScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	if _, err := controller.NewDeploymentReconciler(c, &fakePublisher{}, uuid.UUID{}, "x"); err == nil {
+	if _, err := controller.NewDeploymentReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, "x"); err == nil {
 		t.Fatalf("expected error on zero workspace UUID")
 	}
 }
@@ -99,7 +99,7 @@ func TestNewDeploymentReconciler_RejectsZeroWorkspace(t *testing.T) {
 func TestNewReplicaSetReconciler_RejectsEmptyCluster(t *testing.T) {
 	s := newScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	if _, err := controller.NewReplicaSetReconciler(c, &fakePublisher{}, tcWorkspace, ""); err == nil {
+	if _, err := controller.NewReplicaSetReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
 		t.Fatalf("expected error on empty cluster name")
 	}
 }
@@ -107,13 +107,13 @@ func TestNewReplicaSetReconciler_RejectsEmptyCluster(t *testing.T) {
 func TestNewStatefulSetReconciler_RejectsNilPublisher(t *testing.T) {
 	s := newScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	if _, err := controller.NewStatefulSetReconciler(c, nil, tcWorkspace, "x"); err == nil {
+	if _, err := controller.NewStatefulSetReconciler(c, nil, tcWorkspace, fixedClusterID, "x"); err == nil {
 		t.Fatalf("expected error on nil publisher")
 	}
 }
 
 func TestNewDaemonSetReconciler_RejectsNilClient(t *testing.T) {
-	if _, err := controller.NewDaemonSetReconciler(nil, &fakePublisher{}, tcWorkspace, "x"); err == nil {
+	if _, err := controller.NewDaemonSetReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, "x"); err == nil {
 		t.Fatalf("expected error on nil client")
 	}
 }
@@ -121,7 +121,7 @@ func TestNewDaemonSetReconciler_RejectsNilClient(t *testing.T) {
 func TestNewJobReconciler_OK(t *testing.T) {
 	s := newScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	if _, err := controller.NewJobReconciler(c, &fakePublisher{}, tcWorkspace, "x"); err != nil {
+	if _, err := controller.NewJobReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, "x"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -144,7 +144,7 @@ func TestDeploymentReconciler_ReconcileEmitsUpdatedWithWorkspaceStamp(t *testing
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(d).Build()
 	pub := &fakePublisher{}
 
-	r, err := controller.NewDeploymentReconciler(c, pub, tcWorkspace, tcClusterName)
+	r, err := controller.NewDeploymentReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
 	if err != nil {
 		t.Fatalf("new reconciler: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestDeploymentReconciler_ReconcileEmitsUpdatedWithWorkspaceStamp(t *testing
 	if ev.Action != entity.ActionUpdated {
 		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionUpdated)
 	}
-	if ev.ExternalID != "k8s_resource/Deployment/team-a/checkout" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Deployment/team-a/checkout" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if !ev.EmittedAt.Equal(tcFixedTime) {
@@ -188,7 +188,7 @@ func TestReplicaSetReconciler_ReconcileEmitsOwnsEdge(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(rs).Build()
 	pub := &fakePublisher{}
 
-	r, err := controller.NewReplicaSetReconciler(c, pub, tcWorkspace, tcClusterName)
+	r, err := controller.NewReplicaSetReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
 	if err != nil {
 		t.Fatalf("new reconciler: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestStatefulSetReconciler_ReconcileEmitsUpsert(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ss).Build()
 	pub := &fakePublisher{}
 
-	r, err := controller.NewStatefulSetReconciler(c, pub, tcWorkspace, tcClusterName)
+	r, err := controller.NewStatefulSetReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
 	if err != nil {
 		t.Fatalf("new reconciler: %v", err)
 	}
@@ -225,7 +225,7 @@ func TestStatefulSetReconciler_ReconcileEmitsUpsert(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 	got := pub.snapshot()
-	if len(got) != 1 || got[0].ExternalID != "k8s_resource/StatefulSet/team-a/kafka" {
+	if len(got) != 1 || got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/StatefulSet/team-a/kafka" {
 		t.Fatalf("got %#v", got)
 	}
 }
@@ -239,7 +239,7 @@ func TestDaemonSetReconciler_ReconcileEmitsUpsertWithStatusReplicas(t *testing.T
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(ds).Build()
 	pub := &fakePublisher{}
 
-	r, err := controller.NewDaemonSetReconciler(c, pub, tcWorkspace, tcClusterName)
+	r, err := controller.NewDaemonSetReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
 	if err != nil {
 		t.Fatalf("new reconciler: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestJobReconciler_ReconcileEmitsUpsert(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(j).Build()
 	pub := &fakePublisher{}
 
-	r, err := controller.NewJobReconciler(c, pub, tcWorkspace, tcClusterName)
+	r, err := controller.NewJobReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
 	if err != nil {
 		t.Fatalf("new reconciler: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestJobReconciler_ReconcileEmitsUpsert(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 	got := pub.snapshot()
-	if len(got) != 1 || got[0].ExternalID != "k8s_resource/Job/team-a/nightly" {
+	if len(got) != 1 || got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Job/team-a/nightly" {
 		t.Fatalf("got %#v", got)
 	}
 	if got[0].Metadata["replicas"] != "2" || got[0].Metadata["available_replicas"] != "1" {
@@ -290,7 +290,7 @@ func TestDeploymentReconciler_NotFoundEmitsDeleted(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 	pub := &fakePublisher{}
 
-	r, err := controller.NewDeploymentReconciler(c, pub, tcWorkspace, tcClusterName)
+	r, err := controller.NewDeploymentReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
 	if err != nil {
 		t.Fatalf("new reconciler: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestDeploymentReconciler_NotFoundEmitsDeleted(t *testing.T) {
 	if len(got) != 1 || got[0].Action != entity.ActionDeleted {
 		t.Fatalf("got %#v, want one deleted event", got)
 	}
-	if got[0].ExternalID != "k8s_resource/Deployment/team-a/checkout" {
+	if got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Deployment/team-a/checkout" {
 		t.Fatalf("external_id = %q", got[0].ExternalID)
 	}
 }
@@ -318,7 +318,7 @@ func TestJobReconciler_PublishErrorIsReturned(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(j).Build()
 	pub := &fakePublisher{errOnPublish: errors.New("nats down")}
 
-	r, err := controller.NewJobReconciler(c, pub, tcWorkspace, tcClusterName)
+	r, err := controller.NewJobReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
 	if err != nil {
 		t.Fatalf("new reconciler: %v", err)
 	}

--- a/operator/internal/entity/argo_rollout.go
+++ b/operator/internal/entity/argo_rollout.go
@@ -98,10 +98,11 @@ func RolloutToEvent(
 	r *rolloutsv1alpha1.Rollout,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
-	ev := newWorkloadEvent(EntityKindRollout, r.Namespace, r.Name, action, workspaceID, clusterName, now)
+	ev := newWorkloadEvent(EntityKindRollout, r.Namespace, r.Name, action, workspaceID, clusterID, clusterName, now)
 
 	// Strategy detection. spec.strategy is a struct of two pointers; whichever
 	// is non-nil identifies the strategy. If both are nil (malformed input)
@@ -144,10 +145,10 @@ func RolloutToEvent(
 	// OWNS edges from K8s-populated metadata.ownerReferences. A Rollout can
 	// be owned by a higher-level CRD (e.g. Argo Application). Honour the
 	// reference exactly as the control plane wrote it; do not invent.
-	ev.Edges = ownerEdges(r.OwnerReferences, defaultedNamespace(r.Namespace), ev.ExternalID)
+	ev.Edges = ownerEdges(clusterID, r.OwnerReferences, defaultedNamespace(r.Namespace), ev.ExternalID)
 
 	// Topology edges derived from typed status / spec.
-	ev.TopologyEdges = rolloutTopologyEdges(r, strategy, defaultedNamespace(r.Namespace))
+	ev.TopologyEdges = rolloutTopologyEdges(clusterID, r, strategy, defaultedNamespace(r.Namespace))
 
 	return ev
 }
@@ -180,7 +181,7 @@ func detectStrategy(r *rolloutsv1alpha1.Rollout) string {
 //
 // Returns nil for a stub object (deleted reconcile): no spec, no status, no
 // edges. Empty slice and nil are equivalent on the wire (json:omitempty).
-func rolloutTopologyEdges(r *rolloutsv1alpha1.Rollout, strategy, namespace string) []EdgeRef {
+func rolloutTopologyEdges(clusterID uuid.UUID, r *rolloutsv1alpha1.Rollout, strategy, namespace string) []EdgeRef {
 	out := make([]EdgeRef, 0, 4)
 
 	stableHash := r.Status.StableRS
@@ -194,7 +195,7 @@ func rolloutTopologyEdges(r *rolloutsv1alpha1.Rollout, strategy, namespace strin
 		stableRS := replicaSetName(r.Name, stableHash)
 		out = append(out, EdgeRef{
 			Kind:             EdgeRelationOwns,
-			TargetExternalID: externalIDFor(kindReplicaSet, namespace, stableRS),
+			TargetExternalID: externalIDFor(clusterID, kindReplicaSet, namespace, stableRS),
 		})
 	}
 
@@ -206,7 +207,7 @@ func rolloutTopologyEdges(r *rolloutsv1alpha1.Rollout, strategy, namespace strin
 		currentRS := replicaSetName(r.Name, currentHash)
 		out = append(out, EdgeRef{
 			Kind:             EdgeKindCurrentVersion,
-			TargetExternalID: externalIDFor(kindReplicaSet, namespace, currentRS),
+			TargetExternalID: externalIDFor(clusterID, kindReplicaSet, namespace, currentRS),
 		})
 	}
 
@@ -222,7 +223,7 @@ func rolloutTopologyEdges(r *rolloutsv1alpha1.Rollout, strategy, namespace strin
 		// pointed at by currentPodHash" (which is the same RS during a
 		// canary, but the relationship semantics differ for graph queries).
 		canaryRS := replicaSetName(r.Name, currentHash)
-		canaryExternalID := externalIDFor(kindReplicaSet, namespace, canaryRS)
+		canaryExternalID := externalIDFor(clusterID, kindReplicaSet, namespace, canaryRS)
 		out = append(out, EdgeRef{
 			Kind:             EdgeRelationOwns,
 			TargetExternalID: canaryExternalID,
@@ -243,7 +244,7 @@ func rolloutTopologyEdges(r *rolloutsv1alpha1.Rollout, strategy, namespace strin
 		if active := r.Spec.Strategy.BlueGreen.ActiveService; active != "" {
 			out = append(out, EdgeRef{
 				Kind:             EdgeKindBlueGreenActive,
-				TargetExternalID: externalIDFor(EntityKindService, namespace, active),
+				TargetExternalID: externalIDFor(clusterID, EntityKindService, namespace, active),
 			})
 		}
 	}

--- a/operator/internal/entity/argo_rollout_test.go
+++ b/operator/internal/entity/argo_rollout_test.go
@@ -84,12 +84,12 @@ func TestRolloutToEvent_CanaryHealthySteadyState(t *testing.T) {
 		nil,
 	)
 
-	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if ev.WorkspaceID != fixedWorkspace {
 		t.Fatalf("workspace_id = %s, want %s — adversarial label honoured!", ev.WorkspaceID, fixedWorkspace)
 	}
-	if want := "k8s_resource/Rollout/team-a/checkout"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/Rollout/team-a/checkout"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	if got := ev.Metadata["strategy"]; got != "canary" {
@@ -118,7 +118,7 @@ func TestRolloutToEvent_CanaryHealthySteadyState(t *testing.T) {
 		t.Fatalf("edge counts owns=%d cur=%d can=%d bg=%d, want 1/1/0/0; edges=%#v",
 			owns, cur, can, bg, ev.TopologyEdges)
 	}
-	wantTarget := "k8s_resource/ReplicaSet/team-a/checkout-abc123"
+	wantTarget := "k8s_resource/99999999-8888-7777-6666-555555555555/ReplicaSet/team-a/checkout-abc123"
 	if e := findEdge(ev.TopologyEdges, "OWNS"); e == nil || e.TargetExternalID != wantTarget {
 		t.Fatalf("OWNS edge target = %v, want %q", e, wantTarget)
 	}
@@ -171,7 +171,7 @@ func TestRolloutToEvent_CanaryMidFlight(t *testing.T) {
 		nil,
 	)
 
-	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if got := ev.Metadata["strategy"]; got != "canary" {
 		t.Fatalf("metadata[strategy] = %q, want %q", got, "canary")
@@ -187,8 +187,8 @@ func TestRolloutToEvent_CanaryMidFlight(t *testing.T) {
 	if got := countEdges(ev.TopologyEdges, "OWNS"); got != 2 {
 		t.Fatalf("OWNS edge count = %d, want 2; edges=%#v", got, ev.TopologyEdges)
 	}
-	wantStable := "k8s_resource/ReplicaSet/team-a/checkout-abc123"
-	wantCandidate := "k8s_resource/ReplicaSet/team-a/checkout-def456"
+	wantStable := "k8s_resource/99999999-8888-7777-6666-555555555555/ReplicaSet/team-a/checkout-abc123"
+	wantCandidate := "k8s_resource/99999999-8888-7777-6666-555555555555/ReplicaSet/team-a/checkout-def456"
 
 	// Confirm both stable + candidate appear among OWNS targets.
 	seen := map[string]bool{}
@@ -238,7 +238,7 @@ func TestRolloutToEvent_CanaryPaused(t *testing.T) {
 		nil,
 	)
 
-	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if got := ev.Metadata["phase"]; got != "Paused" {
 		t.Fatalf("metadata[phase] = %q, want %q", got, "Paused")
@@ -277,7 +277,7 @@ func TestRolloutToEvent_CanaryDegraded(t *testing.T) {
 		nil,
 	)
 
-	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if got := ev.Metadata["phase"]; got != "Degraded" {
 		t.Fatalf("metadata[phase] = %q, want %q", got, "Degraded")
@@ -322,7 +322,7 @@ func TestRolloutToEvent_BlueGreenMidFlight(t *testing.T) {
 		nil,
 	)
 
-	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if got := ev.Metadata["strategy"]; got != "blueGreen" {
 		t.Fatalf("metadata[strategy] = %q, want %q", got, "blueGreen")
@@ -337,13 +337,13 @@ func TestRolloutToEvent_BlueGreenMidFlight(t *testing.T) {
 	if bg == nil {
 		t.Fatalf("BLUEGREEN_ACTIVE missing; edges=%#v", ev.TopologyEdges)
 	}
-	want := "k8s_resource/Service/team-a/checkout-active"
+	want := "k8s_resource/99999999-8888-7777-6666-555555555555/Service/team-a/checkout-active"
 	if bg.TargetExternalID != want {
 		t.Fatalf("BLUEGREEN_ACTIVE target = %q, want %q", bg.TargetExternalID, want)
 	}
 	// CURRENT_VERSION points at the current RS.
 	cur := findEdge(ev.TopologyEdges, "CURRENT_VERSION")
-	if cur == nil || cur.TargetExternalID != "k8s_resource/ReplicaSet/team-a/checkout-green2" {
+	if cur == nil || cur.TargetExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ReplicaSet/team-a/checkout-green2" {
 		t.Fatalf("CURRENT_VERSION target = %v, want checkout-green2", cur)
 	}
 }
@@ -356,12 +356,12 @@ func TestRolloutToEvent_DeletionStubProducesWellFormedEvent(t *testing.T) {
 	stub := &rolloutsv1alpha1.Rollout{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "checkout"},
 	}
-	ev := entity.RolloutToEvent(stub, entity.ActionDeleted, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(stub, entity.ActionDeleted, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if ev.Action != entity.ActionDeleted {
 		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionDeleted)
 	}
-	if want := "k8s_resource/Rollout/team-a/checkout"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/Rollout/team-a/checkout"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	// No status fields → no edges.
@@ -390,7 +390,7 @@ func TestRolloutToEvent_AdversarialWorkspaceLabelIgnored(t *testing.T) {
 		rolloutsv1alpha1.RolloutStatus{Phase: rolloutsv1alpha1.RolloutPhaseHealthy},
 		nil,
 	)
-	ev := entity.RolloutToEvent(r, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if ev.WorkspaceID != fixedWorkspace {
 		t.Fatalf("workspace_id = %s, want %s — adversarial label honoured!", ev.WorkspaceID, fixedWorkspace)
 	}
@@ -408,14 +408,14 @@ func TestRolloutToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
 		rolloutsv1alpha1.RolloutStatus{Phase: rolloutsv1alpha1.RolloutPhaseHealthy},
 		owners,
 	)
-	ev := entity.RolloutToEvent(r, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.Edges) != 1 {
 		t.Fatalf("ownerReferences edge count = %d, want 1; got %#v", len(ev.Edges), ev.Edges)
 	}
 	if got := ev.Edges[0].FromKind; got != "Application" {
 		t.Fatalf("owner edge from_kind = %q, want %q", got, "Application")
 	}
-	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/Application/team-a/checkout-app" {
+	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/99999999-8888-7777-6666-555555555555/Application/team-a/checkout-app" {
 		t.Fatalf("owner edge from_external_id = %q, want k8s_resource/Application/team-a/checkout-app", got)
 	}
 }
@@ -424,7 +424,7 @@ func TestRolloutToEvent_NoStrategyOmitsStrategyMetadata(t *testing.T) {
 	// Empty spec.strategy (both pointers nil) — defensive path. We omit
 	// metadata[strategy] rather than guessing.
 	r := rolloutFixture("team-a", "checkout", nil, rolloutsv1alpha1.RolloutStatus{}, nil)
-	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.RolloutToEvent(r, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if _, ok := ev.Metadata["strategy"]; ok {
 		t.Fatalf("metadata[strategy] should be absent when both sub-strategies are nil")
 	}

--- a/operator/internal/entity/argocd_application.go
+++ b/operator/internal/entity/argocd_application.go
@@ -62,11 +62,12 @@ func ApplicationToEvent(
 	app *argocd.Application,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
 	namespace := resolveNamespace(app.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindApplication, app.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindApplication, app.Name)
 
 	// spec.project — logical owner (AppProject). Empty when unset; ArgoCD
 	// defaults to "default" but we surface what the CR actually carries.
@@ -106,10 +107,10 @@ func ApplicationToEvent(
 		meta["operation_phase"] = app.Status.OperationState.Phase
 	}
 
-	extID := externalIDFor(EntityKindApplication, namespace, app.Name)
+	extID := externalIDFor(clusterID, EntityKindApplication, namespace, app.Name)
 
-	edges := buildApplicationDeploysEdges(app.Status.Resources)
-	edges = append(edges, inClusterEdge(clusterName))
+	edges := buildApplicationDeploysEdges(clusterID, app.Status.Resources)
+	edges = append(edges, inClusterEdge(clusterID, clusterName))
 
 	ev := &Event{
 		SourceID:      DeriveSourceID(workspaceID, clusterName),
@@ -127,7 +128,7 @@ func ApplicationToEvent(
 	// top-of-chain but can be created by an ApplicationSet — when that
 	// happens, the ApplicationSet controller writes the ownerReference on
 	// the child Application. Honour whatever K8s populates; do not invent.
-	ev.Edges = ownerEdges(app.OwnerReferences, namespace, extID)
+	ev.Edges = ownerEdges(clusterID, app.OwnerReferences, namespace, extID)
 
 	return ev
 }
@@ -141,7 +142,7 @@ func ApplicationToEvent(
 // Edges to resources outside the operator's coverage (e.g. CRDs not in
 // the watch set) emit dangling edges; per the issue body the server-side
 // ingestion worker handles dangling-edge resolution.
-func buildApplicationDeploysEdges(resources []argocd.ResourceStatus) []EdgeRef {
+func buildApplicationDeploysEdges(clusterID uuid.UUID, resources []argocd.ResourceStatus) []EdgeRef {
 	if len(resources) == 0 {
 		return nil
 	}
@@ -153,7 +154,7 @@ func buildApplicationDeploysEdges(resources []argocd.ResourceStatus) []EdgeRef {
 			continue
 		}
 		ns := resolveNamespace(r.Namespace)
-		ext := externalIDFor(strings.TrimSpace(r.Kind), ns, r.Name)
+		ext := externalIDFor(clusterID, strings.TrimSpace(r.Kind), ns, r.Name)
 		if _, ok := seen[ext]; ok {
 			continue
 		}

--- a/operator/internal/entity/argocd_applicationset.go
+++ b/operator/internal/entity/argocd_applicationset.go
@@ -49,11 +49,12 @@ func ApplicationSetToEvent(
 	appset *argocd.ApplicationSet,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
 	namespace := resolveNamespace(appset.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindApplicationSet, appset.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindApplicationSet, appset.Name)
 
 	if names := collectGeneratorNames(appset.Spec.Generators); len(names) > 0 {
 		meta["generators"] = strings.Join(names, ",")
@@ -62,10 +63,10 @@ func ApplicationSetToEvent(
 		meta["template_metadata_name"] = v
 	}
 
-	extID := externalIDFor(EntityKindApplicationSet, namespace, appset.Name)
+	extID := externalIDFor(clusterID, EntityKindApplicationSet, namespace, appset.Name)
 
-	edges := buildGeneratesEdges(appset.Status.ApplicationStatus, namespace)
-	edges = append(edges, inClusterEdge(clusterName))
+	edges := buildGeneratesEdges(clusterID, appset.Status.ApplicationStatus, namespace)
+	edges = append(edges, inClusterEdge(clusterID, clusterName))
 
 	ev := &Event{
 		SourceID:      DeriveSourceID(workspaceID, clusterName),
@@ -79,7 +80,7 @@ func ApplicationSetToEvent(
 		TopologyEdges: edges,
 	}
 
-	ev.Edges = ownerEdges(appset.OwnerReferences, namespace, extID)
+	ev.Edges = ownerEdges(clusterID, appset.OwnerReferences, namespace, extID)
 
 	return ev
 }
@@ -119,7 +120,7 @@ func collectGeneratorNames(gs []argocd.ApplicationSetGenerator) []string {
 // ApplicationSet's namespace as the target namespace; if the ArgoCD setup
 // places child applications in a different namespace, the edge will dangle
 // — server-side resolution handles that as designed.
-func buildGeneratesEdges(statuses []argocd.ApplicationSetApplicationStatus, namespace string) []EdgeRef {
+func buildGeneratesEdges(clusterID uuid.UUID, statuses []argocd.ApplicationSetApplicationStatus, namespace string) []EdgeRef {
 	if len(statuses) == 0 {
 		return nil
 	}
@@ -129,7 +130,7 @@ func buildGeneratesEdges(statuses []argocd.ApplicationSetApplicationStatus, name
 		if s.Application == "" {
 			continue
 		}
-		ext := externalIDFor(EntityKindApplication, namespace, s.Application)
+		ext := externalIDFor(clusterID, EntityKindApplication, namespace, s.Application)
 		if _, ok := seen[ext]; ok {
 			continue
 		}

--- a/operator/internal/entity/cluster.go
+++ b/operator/internal/entity/cluster.go
@@ -31,20 +31,20 @@ import (
 func ClusterToEvent(
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	kubernetesVersion string,
 	clusterEndpoint string,
 	now time.Time,
 ) *Event {
-	externalID := ClusterExternalID(clusterName)
+	externalID := ClusterExternalID(clusterID, clusterName)
 	uri := "kube://" + clusterName
 
-	clusterID := DeriveClusterID(workspaceID, clusterName)
-
 	// ACL invariant: cluster_name is operator config (Helm value), not
-	// cluster-side state. cluster_id is derived deterministically from
-	// (workspace_id, cluster_name); two workspaces sharing a cluster_name
-	// emit two distinct cluster_ids. See ADR-0007 §ACL.
+	// cluster-side state. cluster_id is operator config (Secret-mounted
+	// OMNISCIENCE_CLUSTER_ID per issue #167) — when unset the operator's
+	// config layer derives the deterministic uuid5(workspace_id,
+	// cluster_name) default for back-compat. See ADR-0007 §ACL.
 	meta := map[string]string{
 		"cluster":    clusterName,
 		"name":       clusterName,
@@ -74,6 +74,10 @@ func ClusterToEvent(
 // inClusterEdge returns the single IN_CLUSTER edge every cluster-scoped or
 // namespaced resource carries to the per-cluster anchor. Built once and
 // reused by every mapper to avoid allocation churn during a Pod storm.
-func inClusterEdge(clusterName string) EdgeRef {
-	return EdgeRef{Kind: RelationInCluster, TargetExternalID: ClusterExternalID(clusterName)}
+//
+// Issue #167: clusterID is the operator-config UUID stamped into the anchor's
+// external_id; two clusters under the same workspace point at distinct
+// anchor entities and never share an IN_CLUSTER edge target.
+func inClusterEdge(clusterID uuid.UUID, clusterName string) EdgeRef {
+	return EdgeRef{Kind: RelationInCluster, TargetExternalID: ClusterExternalID(clusterID, clusterName)}
 }

--- a/operator/internal/entity/cluster_anchor_test.go
+++ b/operator/internal/entity/cluster_anchor_test.go
@@ -16,14 +16,14 @@ import (
 // server relies on, the (workspace_id, external_id) composite must be
 // stable across restarts.
 func TestClusterToEvent_IdempotentExternalID(t *testing.T) {
-	a := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
-	b := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
+	a := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
+	b := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
 
 	if a.ExternalID != b.ExternalID {
 		t.Fatalf("external_id differs across calls: %q vs %q", a.ExternalID, b.ExternalID)
 	}
-	if a.ExternalID != "k8s_resource/Cluster/prod-eu" {
-		t.Fatalf("external_id = %q, want %q", a.ExternalID, "k8s_resource/Cluster/prod-eu")
+	if a.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/prod-eu" {
+		t.Fatalf("external_id = %q, want %q", a.ExternalID, "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/prod-eu")
 	}
 	if a.Metadata["cluster_id"] != b.Metadata["cluster_id"] {
 		t.Fatalf("cluster_id differs across calls: %q vs %q", a.Metadata["cluster_id"], b.Metadata["cluster_id"])
@@ -68,9 +68,9 @@ func TestDeriveClusterID_DiffersAcrossClusters(t *testing.T) {
 }
 
 func TestClusterToEvent_MetadataIsClosedAllowList(t *testing.T) {
-	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
+	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", "v1.31.1", "https://api:6443", fixedNow)
 	want := map[string]string{
-		"cluster":            "prod-eu",
+		"cluster":            "prod-eu", "cluster_id": "99999999-8888-7777-6666-555555555555",
 		"name":               "prod-eu",
 		"kind":               "Cluster",
 		"emitter":            "k8s-operator",
@@ -93,7 +93,7 @@ func TestClusterToEvent_DropsEmptyOptionalFields(t *testing.T) {
 	// is unknown. The mapper must drop the key entirely rather than emit
 	// "kubernetes_version": "" — the consumer can distinguish absent from
 	// empty cleanly.
-	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "", "", fixedNow)
+	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", "", "", fixedNow)
 	if _, ok := ev.Metadata["kubernetes_version"]; ok {
 		t.Fatalf("kubernetes_version key present despite empty input")
 	}
@@ -103,7 +103,7 @@ func TestClusterToEvent_DropsEmptyOptionalFields(t *testing.T) {
 }
 
 func TestClusterToEvent_StableJSONShape(t *testing.T) {
-	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, "prod-eu", "v1.31.1", "", fixedNow)
+	ev := entity.ClusterToEvent(entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", "v1.31.1", "", fixedNow)
 	raw, err := json.Marshal(ev)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -126,8 +126,11 @@ func TestClusterToEvent_StableJSONShape(t *testing.T) {
 
 func TestClusterExternalID_DeterministicForm(t *testing.T) {
 	// The external_id is the contract that lets #167 detect cluster
-	// identity collisions — pin the format byte-for-byte.
-	if got := entity.ClusterExternalID("prod-eu"); got != "k8s_resource/Cluster/prod-eu" {
-		t.Fatalf("got %q", got)
+	// identity collisions — pin the format byte-for-byte. Per #167, the
+	// canonical form includes the cluster_id UUID.
+	got := entity.ClusterExternalID(fixedClusterID, "prod-eu")
+	want := "k8s_resource/" + fixedClusterID.String() + "/Cluster/prod-eu"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }

--- a/operator/internal/entity/common.go
+++ b/operator/internal/entity/common.go
@@ -57,12 +57,29 @@ type OwnerEdge struct {
 }
 
 // externalID returns the canonical external-id for any K8s resource emitted
-// by the operator: "k8s_resource/{Kind}/{namespace}/{name}".
+// by the operator. As of issue #167 the cluster_id is the second segment so
+// the same Kind+namespace+name in two clusters under one workspace produce
+// DISTINCT external_ids:
+//
+//	"k8s_resource/{cluster_id}/{Kind}/{namespace}/{name}"
 //
 // kind is passed as the K8s API Kind verbatim (mixed case, e.g. "Deployment")
 // to match the Pod controller's existing convention — see entity.go::PodToEvent.
-func externalID(kind, namespace, name string) string {
-	return EntityKindPrefix + "/" + kind + "/" + namespace + "/" + name
+//
+// clusterID is the operator-config UUID; pass uuid.Nil only in unit-test
+// fixtures that don't care about the cluster axis (production callers MUST
+// pass the resolved cfg.ClusterID).
+func externalID(clusterID uuid.UUID, kind, namespace, name string) string {
+	return EntityKindPrefix + "/" + clusterID.String() + "/" + kind + "/" + namespace + "/" + name
+}
+
+// externalIDClusterScoped returns the cluster-scoped external-id for resources
+// without a namespace (Node, Namespace, PersistentVolume, StorageClass,
+// Cluster anchor):
+//
+//	"k8s_resource/{cluster_id}/{Kind}/{name}"
+func externalIDClusterScoped(clusterID uuid.UUID, kind, name string) string {
+	return EntityKindPrefix + "/" + clusterID.String() + "/" + kind + "/" + name
 }
 
 // resourceURI returns the citation URI for any K8s resource:
@@ -94,7 +111,7 @@ func defaultedNamespace(ns string) string {
 // childNamespace is the namespace of the child; ownerReferences point to
 // objects in the SAME namespace per K8s API rules (cross-namespace owner
 // references are rejected by the API server).
-func ownerEdges(refs []metav1.OwnerReference, childNamespace, childExternalID string) []OwnerEdge {
+func ownerEdges(clusterID uuid.UUID, refs []metav1.OwnerReference, childNamespace, childExternalID string) []OwnerEdge {
 	if len(refs) == 0 {
 		return nil
 	}
@@ -107,7 +124,7 @@ func ownerEdges(refs []metav1.OwnerReference, childNamespace, childExternalID st
 		}
 		out = append(out, OwnerEdge{
 			Relation:       EdgeRelationOwns,
-			FromExternalID: externalID(ref.Kind, childNamespace, ref.Name),
+			FromExternalID: externalID(clusterID, ref.Kind, childNamespace, ref.Name),
 			ToExternalID:   childExternalID,
 			FromKind:       ref.Kind,
 			FromUID:        string(ref.UID),
@@ -124,13 +141,17 @@ func ownerEdges(refs []metav1.OwnerReference, childNamespace, childExternalID st
 // supplied labels and annotations are NOT copied through. Kind-specific
 // fields (replicas, available_replicas, …) are added by the per-kind mapper
 // after calling this helper.
-func baseMetadata(clusterName, namespace, kind, name string) map[string]string {
+//
+// Issue #167: cluster_id is included in the allow-list so consumers can
+// filter / group by cluster identity without re-parsing the external_id.
+func baseMetadata(clusterID uuid.UUID, clusterName, namespace, kind, name string) map[string]string {
 	return map[string]string{
-		"cluster":   clusterName,
-		"namespace": namespace,
-		"name":      name,
-		"kind":      kind,
-		"emitter":   EmitterLabel,
+		"cluster":    clusterName,
+		"cluster_id": clusterID.String(),
+		"namespace":  namespace,
+		"name":       name,
+		"kind":       kind,
+		"emitter":    EmitterLabel,
 	}
 }
 
@@ -146,11 +167,12 @@ func newWorkloadEvent(
 	kind, namespace, name string,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
 	ns := defaultedNamespace(namespace)
-	extID := externalID(kind, ns, name)
+	extID := externalID(clusterID, kind, ns, name)
 	return &Event{
 		SourceID:    deriveSourceID(workspaceID, clusterName),
 		SourceType:  SourceType,
@@ -159,7 +181,7 @@ func newWorkloadEvent(
 		Action:      action,
 		WorkspaceID: workspaceID,
 		EmittedAt:   now.UTC(),
-		Metadata:    baseMetadata(clusterName, ns, kind, name),
+		Metadata:    baseMetadata(clusterID, clusterName, ns, kind, name),
 	}
 }
 
@@ -217,10 +239,18 @@ func resolveNamespace(metaNamespace string) string {
 	return defaultedNamespace(metaNamespace)
 }
 
-// externalIDFor returns "k8s_resource/{kind}/{namespace}/{name}". Public
+// externalIDFor returns the multi-cluster-aware external_id for a namespaced
+// resource: "k8s_resource/{cluster_id}/{kind}/{namespace}/{name}". Public
 // alias of externalID for the #158 mapper call sites.
-func externalIDFor(kind, namespace, name string) string {
-	return externalID(kind, namespace, name)
+func externalIDFor(clusterID uuid.UUID, kind, namespace, name string) string {
+	return externalID(clusterID, kind, namespace, name)
+}
+
+// externalIDForClusterScoped returns the multi-cluster-aware external_id for
+// a cluster-scoped resource: "k8s_resource/{cluster_id}/{kind}/{name}".
+// Public alias of externalIDClusterScoped.
+func externalIDForClusterScoped(clusterID uuid.UUID, kind, name string) string {
+	return externalIDClusterScoped(clusterID, kind, name)
 }
 
 // uriFor returns "kube://{cluster}/{namespace}/{kind}/{name}". Public alias

--- a/operator/internal/entity/configmap.go
+++ b/operator/internal/entity/configmap.go
@@ -51,9 +51,9 @@ const IndexDataAnnotation = "omniscience.io/index-data"
 // This function is pure and never reads values out of `binaryData`. The
 // `data_values_json` field is only populated when the opt-in annotation is
 // present AND `data` (the textual variant) is non-empty.
-func ConfigMapToEvent(cm *corev1.ConfigMap, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func ConfigMapToEvent(cm *corev1.ConfigMap, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := resolveNamespace(cm.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindConfigMap, cm.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindConfigMap, cm.Name)
 
 	keys := mergedSortedKeys(cm.Data, cm.BinaryData)
 	meta["data_keys"] = strings.Join(keys, ",")
@@ -78,7 +78,7 @@ func ConfigMapToEvent(cm *corev1.ConfigMap, action Action, workspaceID uuid.UUID
 	return &Event{
 		SourceID:    DeriveSourceID(workspaceID, clusterName),
 		SourceType:  SourceType,
-		ExternalID:  externalIDFor(EntityKindConfigMap, namespace, cm.Name),
+		ExternalID:  externalIDFor(clusterID, EntityKindConfigMap, namespace, cm.Name),
 		URI:         uriFor(clusterName, namespace, EntityKindConfigMap, cm.Name),
 		Action:      action,
 		WorkspaceID: workspaceID,

--- a/operator/internal/entity/configmap_test.go
+++ b/operator/internal/entity/configmap_test.go
@@ -38,7 +38,7 @@ func hostileConfigMap(opt bool) *corev1.ConfigMap {
 
 func TestConfigMapToEvent_DefaultDropsValues(t *testing.T) {
 	cm := hostileConfigMap(false)
-	ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	raw, err := json.Marshal(ev)
 	if err != nil {
@@ -67,7 +67,7 @@ func TestConfigMapToEvent_DefaultDropsValues(t *testing.T) {
 
 func TestConfigMapToEvent_AnnotationOptInEmitsValuesButNotBinary(t *testing.T) {
 	cm := hostileConfigMap(true)
-	ev := entity.ConfigMapToEvent(cm, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ConfigMapToEvent(cm, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if ev.Metadata["indexed"] != "true" {
 		t.Fatalf("indexed = %q, want \"true\"", ev.Metadata["indexed"])
 	}
@@ -91,7 +91,7 @@ func TestConfigMapToEvent_AnyOtherAnnotationValueDoesNotOptIn(t *testing.T) {
 	for _, lookalike := range []string{"True", "1", "yes", "TRUE", " true "} {
 		cm := hostileConfigMap(false)
 		cm.Annotations = map[string]string{entity.IndexDataAnnotation: lookalike}
-		ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+		ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 		if ev.Metadata["indexed"] != "false" {
 			t.Fatalf("annotation value %q should NOT enable indexing; indexed=%q", lookalike, ev.Metadata["indexed"])
 		}
@@ -100,9 +100,9 @@ func TestConfigMapToEvent_AnyOtherAnnotationValueDoesNotOptIn(t *testing.T) {
 
 func TestConfigMapToEvent_AllowListIsClosedAndStable(t *testing.T) {
 	cm := hostileConfigMap(false)
-	ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ConfigMapToEvent(cm, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	allowed := map[string]struct{}{
-		"cluster": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
 		"data_keys": {}, "data_count": {}, "indexed": {},
 	}
 	for k := range ev.Metadata {

--- a/operator/internal/entity/daemonset.go
+++ b/operator/internal/entity/daemonset.go
@@ -31,15 +31,16 @@ func DaemonSetToEvent(
 	ds *appsv1.DaemonSet,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
-	ev := newWorkloadEvent(kindDaemonSet, ds.Namespace, ds.Name, action, workspaceID, clusterName, now)
+	ev := newWorkloadEvent(kindDaemonSet, ds.Namespace, ds.Name, action, workspaceID, clusterID, clusterName, now)
 
 	ev.Metadata["replicas"] = formatReplicas(ds.Status.DesiredNumberScheduled)
 	ev.Metadata["available_replicas"] = formatReplicas(ds.Status.NumberAvailable)
 
-	ev.Edges = ownerEdges(ds.OwnerReferences, defaultedNamespace(ds.Namespace), ev.ExternalID)
+	ev.Edges = ownerEdges(clusterID, ds.OwnerReferences, defaultedNamespace(ds.Namespace), ev.ExternalID)
 
 	return ev
 }

--- a/operator/internal/entity/daemonset_test.go
+++ b/operator/internal/entity/daemonset_test.go
@@ -29,9 +29,9 @@ func TestDaemonSetToEvent_FieldsAreCorrect(t *testing.T) {
 	// DaemonSet has no spec.replicas; the operator surfaces the K8s status
 	// fields renamed into the workload metadata vocabulary.
 	ds := newDaemonSet("kube-system", "fluent-bit", 12, 11, nil)
-	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if want := "k8s_resource/DaemonSet/kube-system/fluent-bit"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/DaemonSet/kube-system/fluent-bit"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	if got := ev.Metadata["kind"]; got != "DaemonSet" {
@@ -50,7 +50,7 @@ func TestDaemonSetToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
 		{Kind: "HelmRelease", Name: "logging-stack", UID: "rel-uid"},
 	}
 	ds := newDaemonSet("kube-system", "fluent-bit", 1, 1, owners)
-	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.Edges) != 1 || ev.Edges[0].FromKind != "HelmRelease" {
 		t.Fatalf("edges = %#v, want 1 HelmRelease edge", ev.Edges)
 	}
@@ -60,7 +60,7 @@ func TestDaemonSetToEvent_ZeroAvailableIsEmitted(t *testing.T) {
 	// Zero is meaningful for a DaemonSet (no Pods up yet) — must NOT be
 	// elided from metadata.
 	ds := newDaemonSet("kube-system", "fluent-bit", 0, 0, nil)
-	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DaemonSetToEvent(ds, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if got := ev.Metadata["replicas"]; got != "0" {
 		t.Fatalf("metadata[replicas] = %q, want %q", got, "0")
 	}

--- a/operator/internal/entity/deployment.go
+++ b/operator/internal/entity/deployment.go
@@ -35,10 +35,11 @@ func DeploymentToEvent(
 	d *appsv1.Deployment,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
-	ev := newWorkloadEvent(kindDeployment, d.Namespace, d.Name, action, workspaceID, clusterName, now)
+	ev := newWorkloadEvent(kindDeployment, d.Namespace, d.Name, action, workspaceID, clusterID, clusterName, now)
 
 	// Replicas counts are status fields populated by the K8s control plane,
 	// not user input — safe to copy. spec.replicas is *int32 (nil → server
@@ -52,7 +53,7 @@ func DeploymentToEvent(
 	// (no owner) — but it CAN be owned by e.g. a Helm-managed CRD or by
 	// a higher-level operator (ArgoCD Application). Honour whatever K8s
 	// populates; do not invent.
-	ev.Edges = ownerEdges(d.OwnerReferences, defaultedNamespace(d.Namespace), ev.ExternalID)
+	ev.Edges = ownerEdges(clusterID, d.OwnerReferences, defaultedNamespace(d.Namespace), ev.ExternalID)
 
 	return ev
 }

--- a/operator/internal/entity/deployment_test.go
+++ b/operator/internal/entity/deployment_test.go
@@ -49,7 +49,7 @@ func newDeployment(namespace, name string, replicas, available int32, owners []m
 
 func TestDeploymentToEvent_FieldsAreCorrect(t *testing.T) {
 	d := newDeployment("team-a", "checkout", 3, 2, nil)
-	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if ev.SourceType != entity.SourceType {
 		t.Fatalf("source_type = %q, want %q", ev.SourceType, entity.SourceType)
@@ -60,7 +60,7 @@ func TestDeploymentToEvent_FieldsAreCorrect(t *testing.T) {
 	if ev.Action != entity.ActionCreated {
 		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionCreated)
 	}
-	if want := "k8s_resource/Deployment/team-a/checkout"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/Deployment/team-a/checkout"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	if want := "kube://prod-eu/team-a/Deployment/checkout"; ev.URI != want {
@@ -79,10 +79,10 @@ func TestDeploymentToEvent_FieldsAreCorrect(t *testing.T) {
 
 func TestDeploymentToEvent_DoesNotLeakUserLabelsOrAnnotations(t *testing.T) {
 	d := newDeployment("team-a", "checkout", 3, 2, nil)
-	ev := entity.DeploymentToEvent(d, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	expected := map[string]string{
-		"cluster":            "prod-eu",
+		"cluster":            "prod-eu", "cluster_id": "99999999-8888-7777-6666-555555555555",
 		"namespace":          "team-a",
 		"name":               "checkout",
 		"kind":               "Deployment",
@@ -106,7 +106,7 @@ func TestDeploymentToEvent_AdversarialWorkspaceLabelIgnored(t *testing.T) {
 	// workspace_id. The mapper takes the tenant boundary as a parameter
 	// (operator config) and never reads it from the resource.
 	d := newDeployment("team-a", "checkout", 1, 1, nil)
-	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if ev.WorkspaceID != fixedWorkspace {
 		t.Fatalf("workspace_id = %s, want %s — adversarial label was honoured!", ev.WorkspaceID, fixedWorkspace)
@@ -126,7 +126,7 @@ func TestDeploymentToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
 		},
 	}
 	d := newDeployment("team-a", "checkout", 3, 3, owners)
-	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if len(ev.Edges) != 1 {
 		t.Fatalf("edges count = %d, want 1; edges = %#v", len(ev.Edges), ev.Edges)
@@ -138,7 +138,7 @@ func TestDeploymentToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
 	if got.FromKind != "Application" {
 		t.Fatalf("edge from_kind = %q, want %q", got.FromKind, "Application")
 	}
-	wantFrom := "k8s_resource/Application/team-a/checkout-app"
+	wantFrom := "k8s_resource/99999999-8888-7777-6666-555555555555/Application/team-a/checkout-app"
 	if got.FromExternalID != wantFrom {
 		t.Fatalf("edge from_external_id = %q, want %q", got.FromExternalID, wantFrom)
 	}
@@ -152,7 +152,7 @@ func TestDeploymentToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
 
 func TestDeploymentToEvent_NoOwnerReferencesEmitsNoEdges(t *testing.T) {
 	d := newDeployment("team-a", "checkout", 3, 3, nil)
-	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.Edges) != 0 {
 		t.Fatalf("edges = %#v, want empty (no ownerReferences)", ev.Edges)
 	}
@@ -166,7 +166,7 @@ func TestDeploymentToEvent_MultipleOwnerReferences(t *testing.T) {
 		{Kind: "HelmRelease", Name: "rel1", UID: "u2"},
 	}
 	d := newDeployment("team-a", "checkout", 1, 1, owners)
-	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.Edges) != 2 {
 		t.Fatalf("edges count = %d, want 2; got %#v", len(ev.Edges), ev.Edges)
 	}
@@ -181,12 +181,12 @@ func TestDeploymentToEvent_DeletionStubEmitsCorrectExternalID(t *testing.T) {
 			Name:      "checkout",
 		},
 	}
-	ev := entity.DeploymentToEvent(stub, entity.ActionDeleted, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(stub, entity.ActionDeleted, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if ev.Action != entity.ActionDeleted {
 		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionDeleted)
 	}
-	if want := "k8s_resource/Deployment/team-a/checkout"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/Deployment/team-a/checkout"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	if _, hasReplicas := ev.Metadata["replicas"]; hasReplicas {
@@ -198,8 +198,8 @@ func TestDeploymentToEvent_NamespacelessFallsBackSafely(t *testing.T) {
 	stub := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "rogue"},
 	}
-	ev := entity.DeploymentToEvent(stub, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
-	if want := "k8s_resource/Deployment/default/rogue"; ev.ExternalID != want {
+	ev := entity.DeploymentToEvent(stub, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/Deployment/default/rogue"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 }
@@ -214,7 +214,7 @@ func TestDeploymentToEvent_MalformedOwnerReferenceSkipped(t *testing.T) {
 		{Kind: "Application", Name: "ok", UID: "u3"},
 	}
 	d := newDeployment("team-a", "checkout", 1, 1, owners)
-	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.Edges) != 1 {
 		t.Fatalf("edges count = %d, want 1 (malformed entries skipped); got %#v", len(ev.Edges), ev.Edges)
 	}
@@ -230,7 +230,7 @@ func TestDeploymentToEvent_NilSpecReplicasOmittedFromMetadata(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "checkout"},
 		Status:     appsv1.DeploymentStatus{AvailableReplicas: 0},
 	}
-	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.DeploymentToEvent(d, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if _, ok := ev.Metadata["replicas"]; ok {
 		t.Fatalf("metadata[replicas] should be absent when spec.replicas is nil; got %q", ev.Metadata["replicas"])
 	}

--- a/operator/internal/entity/dra_deviceclass.go
+++ b/operator/internal/entity/dra_deviceclass.go
@@ -35,7 +35,7 @@ import (
 //
 // DeviceClass is cluster-scoped, so the external_id has no namespace
 // component: k8s_resource/DeviceClass/{name}.
-func DeviceClassToEvent(dc *resourcev1beta1.DeviceClass, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func DeviceClassToEvent(dc *resourcev1beta1.DeviceClass, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	externalID := EntityKindPrefix + "/" + EntityKindDeviceClass + "/" + dc.Name
 	uri := "kube://" + clusterName + "/" + EntityKindDeviceClass + "/" + dc.Name
 
@@ -47,7 +47,7 @@ func DeviceClassToEvent(dc *resourcev1beta1.DeviceClass, action Action, workspac
 		"emitter":        EmitterLabel,
 	}
 
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 
 	return &Event{
 		SourceID:      deriveSourceID(workspaceID, clusterName),

--- a/operator/internal/entity/dra_resourceclaim.go
+++ b/operator/internal/entity/dra_resourceclaim.go
@@ -62,16 +62,16 @@ const EdgeKindAllocates = "ALLOCATES"
 // device_count counts the allocated devices in status.allocation.devices.results.
 // When unallocated (Pending) it falls back to the requested count from
 // spec.devices.requests so callers can still see "how many were asked for".
-func ResourceClaimToEvent(rc *resourcev1beta1.ResourceClaim, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func ResourceClaimToEvent(rc *resourcev1beta1.ResourceClaim, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := defaultedNamespace(rc.Namespace)
-	externalID := externalID(EntityKindResourceClaim, namespace, rc.Name)
+	externalID := externalID(clusterID, EntityKindResourceClaim, namespace, rc.Name)
 	uri := resourceURI(clusterName, namespace, EntityKindResourceClaim, rc.Name)
 
-	meta := baseMetadata(clusterName, namespace, EntityKindResourceClaim, rc.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindResourceClaim, rc.Name)
 	meta["device_count"] = strconv.Itoa(deviceCount(rc))
 	meta["phase"] = string(claimPhase(rc))
 
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 	for _, target := range allocatesEdgeTargets(rc) {
 		edges = append(edges, EdgeRef{
 			Kind:             EdgeKindAllocates,
@@ -88,7 +88,7 @@ func ResourceClaimToEvent(rc *resourcev1beta1.ResourceClaim, action Action, work
 		WorkspaceID:   workspaceID,
 		EmittedAt:     now.UTC(),
 		Metadata:      meta,
-		Edges:         ownerEdges(rc.OwnerReferences, namespace, externalID),
+		Edges:         ownerEdges(clusterID, rc.OwnerReferences, namespace, externalID),
 		TopologyEdges: edges,
 	}
 }

--- a/operator/internal/entity/dra_resourceclaimtemplate.go
+++ b/operator/internal/entity/dra_resourceclaimtemplate.go
@@ -34,14 +34,14 @@ const EntityKindResourceClaimTemplate = "ResourceClaimTemplate"
 
 // ResourceClaimTemplateToEvent maps a v1beta1.ResourceClaimTemplate into an
 // Event. Pure function — no client, no clock injection beyond `now`.
-func ResourceClaimTemplateToEvent(tpl *resourcev1beta1.ResourceClaimTemplate, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func ResourceClaimTemplateToEvent(tpl *resourcev1beta1.ResourceClaimTemplate, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := defaultedNamespace(tpl.Namespace)
-	externalID := externalID(EntityKindResourceClaimTemplate, namespace, tpl.Name)
+	externalID := externalID(clusterID, EntityKindResourceClaimTemplate, namespace, tpl.Name)
 	uri := resourceURI(clusterName, namespace, EntityKindResourceClaimTemplate, tpl.Name)
 
-	meta := baseMetadata(clusterName, namespace, EntityKindResourceClaimTemplate, tpl.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindResourceClaimTemplate, tpl.Name)
 
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 	for _, target := range templateAllocatesEdgeTargets(tpl) {
 		edges = append(edges, EdgeRef{
 			Kind:             EdgeKindAllocates,
@@ -58,7 +58,7 @@ func ResourceClaimTemplateToEvent(tpl *resourcev1beta1.ResourceClaimTemplate, ac
 		WorkspaceID:   workspaceID,
 		EmittedAt:     now.UTC(),
 		Metadata:      meta,
-		Edges:         ownerEdges(tpl.OwnerReferences, namespace, externalID),
+		Edges:         ownerEdges(clusterID, tpl.OwnerReferences, namespace, externalID),
 		TopologyEdges: edges,
 	}
 }

--- a/operator/internal/entity/dra_resourceslice.go
+++ b/operator/internal/entity/dra_resourceslice.go
@@ -59,7 +59,7 @@ const EdgeKindAdvertisedBy = "ADVERTISED_BY"
 //
 // ResourceSlice is cluster-scoped, so the external_id has no namespace
 // component: k8s_resource/ResourceSlice/{name}.
-func ResourceSliceToEvent(rs *resourcev1beta1.ResourceSlice, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func ResourceSliceToEvent(rs *resourcev1beta1.ResourceSlice, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	externalID := EntityKindPrefix + "/" + EntityKindResourceSlice + "/" + rs.Name
 	uri := "kube://" + clusterName + "/" + EntityKindResourceSlice + "/" + rs.Name
 
@@ -80,7 +80,7 @@ func ResourceSliceToEvent(rs *resourcev1beta1.ResourceSlice, action Action, work
 		meta["node"] = rs.Spec.NodeName
 	}
 
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 	if rs.Spec.NodeName != "" {
 		edges = append(edges, EdgeRef{
 			Kind:             EdgeKindAdvertisedBy,

--- a/operator/internal/entity/endpoints.go
+++ b/operator/internal/entity/endpoints.go
@@ -31,18 +31,18 @@ const EntityKindEndpoints = "Endpoints"
 //     each Pod referenced by subsets[].addresses[].targetRef where targetRef
 //     .kind == "Pod". This is the topology truth — derived from K8s-native
 //     pointers, never re-inferred.
-func EndpointsToEvent(ep *corev1.Endpoints, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func EndpointsToEvent(ep *corev1.Endpoints, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := resolveNamespace(ep.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindEndpoints, ep.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindEndpoints, ep.Name)
 	meta["subset_count"] = strconv.Itoa(len(ep.Subsets))
 	meta["address_count"] = strconv.Itoa(countEndpointAddresses(ep))
 
-	edges := buildSelectsEdges(ep, namespace)
+	edges := buildSelectsEdges(clusterID, ep, namespace)
 
 	return &Event{
 		SourceID:    DeriveSourceID(workspaceID, clusterName),
 		SourceType:  SourceType,
-		ExternalID:  externalIDFor(EntityKindEndpoints, namespace, ep.Name),
+		ExternalID:  externalIDFor(clusterID, EntityKindEndpoints, namespace, ep.Name),
 		URI:         uriFor(clusterName, namespace, EntityKindEndpoints, ep.Name),
 		Action:      action,
 		WorkspaceID: workspaceID,
@@ -74,11 +74,11 @@ func countEndpointAddresses(ep *corev1.Endpoints) int {
 // Endpoints document records the membership decision at this point in time;
 // readiness is a separate dimension and changes more frequently than the
 // selector match.
-func buildSelectsEdges(ep *corev1.Endpoints, namespace string) []EdgeRef {
+func buildSelectsEdges(clusterID uuid.UUID, ep *corev1.Endpoints, namespace string) []EdgeRef {
 	var edges []EdgeRef
 	for _, sub := range ep.Subsets {
-		edges = appendPodEdges(edges, sub.Addresses, namespace)
-		edges = appendPodEdges(edges, sub.NotReadyAddresses, namespace)
+		edges = appendPodEdges(clusterID, edges, sub.Addresses, namespace)
+		edges = appendPodEdges(clusterID, edges, sub.NotReadyAddresses, namespace)
 	}
 	return edges
 }
@@ -87,7 +87,7 @@ func buildSelectsEdges(ep *corev1.Endpoints, namespace string) []EdgeRef {
 // points to a Pod. Other targetRef kinds (rare; e.g. legacy clusters that
 // reference Services directly) are skipped — we only emit edges we can
 // confidently express as `k8s_resource/Pod/{namespace}/{name}`.
-func appendPodEdges(edges []EdgeRef, addrs []corev1.EndpointAddress, fallbackNamespace string) []EdgeRef {
+func appendPodEdges(clusterID uuid.UUID, edges []EdgeRef, addrs []corev1.EndpointAddress, fallbackNamespace string) []EdgeRef {
 	for i := range addrs {
 		ref := addrs[i].TargetRef
 		if ref == nil || ref.Kind != "Pod" || ref.Name == "" {
@@ -99,7 +99,7 @@ func appendPodEdges(edges []EdgeRef, addrs []corev1.EndpointAddress, fallbackNam
 		}
 		edges = append(edges, EdgeRef{
 			Kind:             EdgeKindSelects,
-			TargetExternalID: externalIDFor("Pod", ns, ref.Name),
+			TargetExternalID: externalIDFor(clusterID, "Pod", ns, ref.Name),
 		})
 	}
 	return edges

--- a/operator/internal/entity/endpoints_test.go
+++ b/operator/internal/entity/endpoints_test.go
@@ -24,9 +24,9 @@ func TestEndpointsToEvent_BuildsSelectsEdges(t *testing.T) {
 			},
 		},
 	}
-	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/Endpoints/team-a/checkout" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Endpoints/team-a/checkout" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if ev.Metadata["subset_count"] != "1" {
@@ -39,9 +39,9 @@ func TestEndpointsToEvent_BuildsSelectsEdges(t *testing.T) {
 		t.Fatalf("edges count = %d, want 3", got)
 	}
 	wantTargets := map[string]bool{
-		"k8s_resource/Pod/team-a/checkout-7d9f": false,
-		"k8s_resource/Pod/team-a/checkout-aa11": false,
-		"k8s_resource/Pod/team-a/checkout-bb22": false,
+		"k8s_resource/99999999-8888-7777-6666-555555555555/Pod/team-a/checkout-7d9f": false,
+		"k8s_resource/99999999-8888-7777-6666-555555555555/Pod/team-a/checkout-aa11": false,
+		"k8s_resource/99999999-8888-7777-6666-555555555555/Pod/team-a/checkout-bb22": false,
 	}
 	for _, e := range ev.TopologyEdges {
 		if e.Kind != entity.EdgeKindSelects {
@@ -63,7 +63,7 @@ func TestEndpointsToEvent_NoSubsetsEmitsZeroEdges(t *testing.T) {
 	ep := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "headless"},
 	}
-	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.TopologyEdges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(ev.TopologyEdges))
 	}
@@ -88,11 +88,11 @@ func TestEndpointsToEvent_SkipsNonPodTargetRefs(t *testing.T) {
 			},
 		},
 	}
-	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.EndpointsToEvent(ep, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.TopologyEdges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(ev.TopologyEdges))
 	}
-	if ev.TopologyEdges[0].TargetExternalID != "k8s_resource/Pod/team-a/real-pod" {
+	if ev.TopologyEdges[0].TargetExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Pod/team-a/real-pod" {
 		t.Fatalf("edge target = %q", ev.TopologyEdges[0].TargetExternalID)
 	}
 }

--- a/operator/internal/entity/entity.go
+++ b/operator/internal/entity/entity.go
@@ -114,7 +114,11 @@ type Event struct {
 // PodToEvent maps a corev1.Pod plus an action into an Event. Pure function
 // — takes no clients, no clock injection beyond `now`. The `now` argument is
 // taken explicitly so unit tests can pin a deterministic timestamp.
-func PodToEvent(pod *corev1.Pod, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+//
+// Issue #167: clusterID is the operator-config UUID stamped into external_id
+// and metadata so the same Pod name in two clusters under one workspace
+// produces DISTINCT entities.
+func PodToEvent(pod *corev1.Pod, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := pod.Namespace
 	if namespace == "" {
 		// Cluster-scoped Pod is malformed — but be defensive rather than
@@ -123,7 +127,7 @@ func PodToEvent(pod *corev1.Pod, action Action, workspaceID uuid.UUID, clusterNa
 		namespace = "default"
 	}
 
-	externalID := EntityKindPod + "/Pod/" + namespace + "/" + pod.Name
+	externalID := EntityKindPod + "/" + clusterID.String() + "/Pod/" + namespace + "/" + pod.Name
 	uri := "kube://" + clusterName + "/" + namespace + "/Pod/" + pod.Name
 
 	// SourceID is deterministic per (workspace, cluster) so retries and
@@ -133,13 +137,14 @@ func PodToEvent(pod *corev1.Pod, action Action, workspaceID uuid.UUID, clusterNa
 	sourceID := deriveSourceID(workspaceID, clusterName)
 
 	meta := map[string]string{
-		"cluster":   clusterName,
-		"namespace": namespace,
-		"name":      pod.Name,
-		"kind":      "Pod",
-		"node":      pod.Spec.NodeName,
-		"phase":     string(pod.Status.Phase),
-		"emitter":   "k8s-operator",
+		"cluster":    clusterName,
+		"cluster_id": clusterID.String(),
+		"namespace":  namespace,
+		"name":       pod.Name,
+		"kind":       "Pod",
+		"node":       pod.Spec.NodeName,
+		"phase":      string(pod.Status.Phase),
+		"emitter":    "k8s-operator",
 	}
 	// Intentionally do NOT copy arbitrary user labels into metadata. Doing
 	// so risks logging or storing tenant-supplied PII, and labels can carry
@@ -189,14 +194,15 @@ func DeriveClusterID(workspaceID uuid.UUID, clusterName string) uuid.UUID {
 }
 
 // ClusterExternalID returns the canonical external_id for the per-cluster
-// anchor entity. The format matches the issue body verbatim:
+// anchor entity. As of issue #167 the format includes cluster_id so two
+// clusters under one workspace produce DISTINCT anchor entities:
 //
-//	k8s_resource/Cluster/{cluster_name}
+//	k8s_resource/{cluster_id}/Cluster/{cluster_name}
 //
-// The form deliberately omits the workspace_id — server-side uniqueness is
-// the (workspace_id, external_id) composite, so two workspaces that share a
-// cluster_name produce two distinct rows. #167 will flip a same-workspace
-// collision into a structured error.
-func ClusterExternalID(clusterName string) string {
-	return EntityKindK8sResource + "/Cluster/" + clusterName
+// Server-side uniqueness is the (workspace_id, external_id) composite; with
+// cluster_id in the path two operators in the same workspace cannot collide
+// on the anchor unless they were misconfigured with the same UUID — that
+// case is detected server-side (collision warning + counter).
+func ClusterExternalID(clusterID uuid.UUID, clusterName string) string {
+	return EntityKindK8sResource + "/" + clusterID.String() + "/Cluster/" + clusterName
 }

--- a/operator/internal/entity/entity_test.go
+++ b/operator/internal/entity/entity_test.go
@@ -20,6 +20,10 @@ var fixedNow = time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
 // sourceID derivations are reproducible.
 var fixedWorkspace = uuid.MustParse("11111111-2222-3333-4444-555555555555")
 
+// fixedClusterID is a deterministic UUID used by every mapper test so the
+// re-keyed external_ids (issue #167) are reproducible across runs.
+var fixedClusterID = uuid.MustParse("99999999-8888-7777-6666-555555555555")
+
 func newPod(namespace, name string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -41,7 +45,7 @@ func newPod(namespace, name string) *corev1.Pod {
 
 func TestPodToEvent_FieldsAreCorrectAndStamped(t *testing.T) {
 	pod := newPod("team-a", "checkout-7d9f")
-	ev := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if ev.SourceType != entity.SourceType {
 		t.Fatalf("source_type = %q, want %q", ev.SourceType, entity.SourceType)
@@ -52,7 +56,7 @@ func TestPodToEvent_FieldsAreCorrectAndStamped(t *testing.T) {
 	if ev.Action != entity.ActionCreated {
 		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionCreated)
 	}
-	wantExternal := "k8s_resource/Pod/team-a/checkout-7d9f"
+	wantExternal := "k8s_resource/99999999-8888-7777-6666-555555555555/Pod/team-a/checkout-7d9f"
 	if ev.ExternalID != wantExternal {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, wantExternal)
 	}
@@ -70,7 +74,7 @@ func TestPodToEvent_DoesNotLeakUserLabels(t *testing.T) {
 	// metadata. ADR-0007 §ACL is explicit on this point — labels are
 	// tenant-writable state and a workspace-leaking attack surface.
 	pod := newPod("team-a", "checkout-7d9f")
-	ev := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	for k, v := range ev.Metadata {
 		if k == "app" || k == "adversarial.example.com/spy" {
@@ -79,7 +83,7 @@ func TestPodToEvent_DoesNotLeakUserLabels(t *testing.T) {
 	}
 	// Spot-check the fields that ARE expected — the closed allow-list.
 	expected := map[string]string{
-		"cluster":   "prod-eu",
+		"cluster":   "prod-eu", "cluster_id": "99999999-8888-7777-6666-555555555555",
 		"namespace": "team-a",
 		"name":      "checkout-7d9f",
 		"kind":      "Pod",
@@ -105,8 +109,8 @@ func TestPodToEvent_SourceIDIsDeterministicAcrossCalls(t *testing.T) {
 	pod1 := newPod("team-a", "checkout-7d9f")
 	pod2 := newPod("team-b", "billing-aa11")
 
-	ev1 := entity.PodToEvent(pod1, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
-	ev2 := entity.PodToEvent(pod2, entity.ActionDeleted, fixedWorkspace, "prod-eu", fixedNow)
+	ev1 := entity.PodToEvent(pod1, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
+	ev2 := entity.PodToEvent(pod2, entity.ActionDeleted, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if ev1.SourceID != ev2.SourceID {
 		t.Fatalf("source_id should be stable across pods within (workspace, cluster); got %s vs %s",
@@ -118,8 +122,8 @@ func TestPodToEvent_SourceIDChangesWithCluster(t *testing.T) {
 	// Different clusters under the same workspace must produce DIFFERENT
 	// source_ids — otherwise per-cluster scoping on the server side breaks.
 	pod := newPod("team-a", "checkout-7d9f")
-	a := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow).SourceID
-	b := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, "prod-us", fixedNow).SourceID
+	a := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow).SourceID
+	b := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-us", fixedNow).SourceID
 	if a == b {
 		t.Fatalf("source_id should differ across clusters; got %s == %s", a, b)
 	}
@@ -127,8 +131,8 @@ func TestPodToEvent_SourceIDChangesWithCluster(t *testing.T) {
 
 func TestPodToEvent_NamespacelessPodFallsBackSafely(t *testing.T) {
 	pod := newPod("", "rogue-pod")
-	ev := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
-	want := "k8s_resource/Pod/default/rogue-pod"
+	ev := entity.PodToEvent(pod, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
+	want := "k8s_resource/99999999-8888-7777-6666-555555555555/Pod/default/rogue-pod"
 	if ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q (defaulted namespace)", ev.ExternalID, want)
 	}
@@ -138,7 +142,7 @@ func TestPodToEvent_JSONShapeIsStableForConsumer(t *testing.T) {
 	// The Pydantic consumer side validates against snake_case fields. This
 	// test is a contract guard against accidental rename / casing drift.
 	pod := newPod("team-a", "checkout-7d9f")
-	ev := entity.PodToEvent(pod, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.PodToEvent(pod, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	raw, err := json.Marshal(ev)
 	if err != nil {

--- a/operator/internal/entity/ingress.go
+++ b/operator/internal/entity/ingress.go
@@ -27,19 +27,19 @@ const EntityKindIngress = "Ingress"
 // Edges: one ROUTES_TO edge per distinct Service named in the spec. We
 // deduplicate so a multi-path ingress that fans out to the same service
 // produces a single edge.
-func IngressToEvent(ing *networkingv1.Ingress, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func IngressToEvent(ing *networkingv1.Ingress, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := resolveNamespace(ing.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindIngress, ing.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindIngress, ing.Name)
 	meta["ingress_class"] = derefString(ing.Spec.IngressClassName)
 	meta["rule_count"] = strconv.Itoa(len(ing.Spec.Rules))
 	meta["tls_count"] = strconv.Itoa(len(ing.Spec.TLS))
 
-	edges := buildRoutesToEdges(ing, namespace)
+	edges := buildRoutesToEdges(clusterID, ing, namespace)
 
 	return &Event{
 		SourceID:    DeriveSourceID(workspaceID, clusterName),
 		SourceType:  SourceType,
-		ExternalID:  externalIDFor(EntityKindIngress, namespace, ing.Name),
+		ExternalID:  externalIDFor(clusterID, EntityKindIngress, namespace, ing.Name),
 		URI:         uriFor(clusterName, namespace, EntityKindIngress, ing.Name),
 		Action:      action,
 		WorkspaceID: workspaceID,
@@ -63,14 +63,14 @@ func derefString(p *string) string {
 // External Name backends (backend.resource pointing at a CRD) are not Service
 // references; we skip them. Same-named services in the same namespace are
 // deduplicated.
-func buildRoutesToEdges(ing *networkingv1.Ingress, namespace string) []EdgeRef {
+func buildRoutesToEdges(clusterID uuid.UUID, ing *networkingv1.Ingress, namespace string) []EdgeRef {
 	seen := map[string]struct{}{}
 	var edges []EdgeRef
 	add := func(serviceName string) {
 		if serviceName == "" {
 			return
 		}
-		ext := externalIDFor(EntityKindService, namespace, serviceName)
+		ext := externalIDFor(clusterID, EntityKindService, namespace, serviceName)
 		if _, ok := seen[ext]; ok {
 			return
 		}

--- a/operator/internal/entity/ingress_test.go
+++ b/operator/internal/entity/ingress_test.go
@@ -37,9 +37,9 @@ func TestIngressToEvent_RoutesToFromRulesAndDefaultBackend(t *testing.T) {
 			},
 		},
 	}
-	ev := entity.IngressToEvent(ing, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.IngressToEvent(ing, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/Ingress/team-a/main" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Ingress/team-a/main" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if ev.Metadata["ingress_class"] != "nginx" {
@@ -52,9 +52,9 @@ func TestIngressToEvent_RoutesToFromRulesAndDefaultBackend(t *testing.T) {
 		t.Fatalf("tls_count = %q", ev.Metadata["tls_count"])
 	}
 	wantTargets := map[string]bool{
-		"k8s_resource/Service/team-a/default-svc": false,
-		"k8s_resource/Service/team-a/checkout":    false,
-		"k8s_resource/Service/team-a/billing":     false,
+		"k8s_resource/99999999-8888-7777-6666-555555555555/Service/team-a/default-svc": false,
+		"k8s_resource/99999999-8888-7777-6666-555555555555/Service/team-a/checkout":    false,
+		"k8s_resource/99999999-8888-7777-6666-555555555555/Service/team-a/billing":     false,
 	}
 	if got := len(ev.TopologyEdges); got != 3 {
 		t.Fatalf("expected 3 deduped edges, got %d (%v)", got, ev.TopologyEdges)
@@ -74,7 +74,7 @@ func TestIngressToEvent_NoRulesEmitsZeroEdges(t *testing.T) {
 	ing := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "empty"},
 	}
-	ev := entity.IngressToEvent(ing, entity.ActionDeleted, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.IngressToEvent(ing, entity.ActionDeleted, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.TopologyEdges) != 0 {
 		t.Fatalf("expected 0 edges, got %d", len(ev.TopologyEdges))
 	}

--- a/operator/internal/entity/job.go
+++ b/operator/internal/entity/job.go
@@ -34,17 +34,18 @@ func JobToEvent(
 	j *batchv1.Job,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
-	ev := newWorkloadEvent(kindJob, j.Namespace, j.Name, action, workspaceID, clusterName, now)
+	ev := newWorkloadEvent(kindJob, j.Namespace, j.Name, action, workspaceID, clusterID, clusterName, now)
 
 	if j.Spec.Parallelism != nil {
 		ev.Metadata["replicas"] = formatReplicas(*j.Spec.Parallelism)
 	}
 	ev.Metadata["available_replicas"] = formatReplicas(j.Status.Active)
 
-	ev.Edges = ownerEdges(j.OwnerReferences, defaultedNamespace(j.Namespace), ev.ExternalID)
+	ev.Edges = ownerEdges(clusterID, j.OwnerReferences, defaultedNamespace(j.Namespace), ev.ExternalID)
 
 	return ev
 }

--- a/operator/internal/entity/job_test.go
+++ b/operator/internal/entity/job_test.go
@@ -30,9 +30,9 @@ func newJob(namespace, name string, parallelism *int32, active int32, owners []m
 func TestJobToEvent_FieldsAreCorrect(t *testing.T) {
 	parallelism := int32(2)
 	j := newJob("team-a", "nightly-export", &parallelism, 1, nil)
-	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if want := "k8s_resource/Job/team-a/nightly-export"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/Job/team-a/nightly-export"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	if got := ev.Metadata["kind"]; got != "Job" {
@@ -60,7 +60,7 @@ func TestJobToEvent_OwnerEdgeFromCronJob(t *testing.T) {
 		},
 	}
 	j := newJob("team-a", "nightly-export-1700000000", nil, 1, owners)
-	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if len(ev.Edges) != 1 {
 		t.Fatalf("edges count = %d, want 1; %#v", len(ev.Edges), ev.Edges)
@@ -68,7 +68,7 @@ func TestJobToEvent_OwnerEdgeFromCronJob(t *testing.T) {
 	if got := ev.Edges[0].FromKind; got != "CronJob" {
 		t.Fatalf("edge from_kind = %q, want %q", got, "CronJob")
 	}
-	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/CronJob/team-a/nightly-export" {
+	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/99999999-8888-7777-6666-555555555555/CronJob/team-a/nightly-export" {
 		t.Fatalf("edge from_external_id = %q", got)
 	}
 }
@@ -77,7 +77,7 @@ func TestJobToEvent_NilParallelismOmitsReplicas(t *testing.T) {
 	// spec.parallelism is *int32 — nil means K8s default (1) but the
 	// operator surfaces only what the resource itself says.
 	j := newJob("team-a", "ad-hoc", nil, 0, nil)
-	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.JobToEvent(j, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if _, ok := ev.Metadata["replicas"]; ok {
 		t.Fatalf("metadata[replicas] should be absent when parallelism is nil; got %q", ev.Metadata["replicas"])
 	}
@@ -86,10 +86,10 @@ func TestJobToEvent_NilParallelismOmitsReplicas(t *testing.T) {
 func TestJobToEvent_NoLabelLeakage(t *testing.T) {
 	parallelism := int32(1)
 	j := newJob("team-a", "ad-hoc", &parallelism, 0, nil)
-	ev := entity.JobToEvent(j, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.JobToEvent(j, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	for k := range ev.Metadata {
 		switch k {
-		case "cluster", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
+		case "cluster", "cluster_id", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
 		default:
 			t.Fatalf("leaked metadata key %q", k)
 		}

--- a/operator/internal/entity/namespace.go
+++ b/operator/internal/entity/namespace.go
@@ -17,21 +17,22 @@ import (
 )
 
 // NamespaceToEvent maps a corev1.Namespace into an Event. Pure.
-func NamespaceToEvent(ns *corev1.Namespace, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
-	externalID := EntityKindK8sResource + "/Namespace/" + ns.Name
+func NamespaceToEvent(ns *corev1.Namespace, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := externalIDForClusterScoped(clusterID, "Namespace", ns.Name)
 	uri := "kube://" + clusterName + "/Namespace/" + ns.Name
 
 	meta := map[string]string{
-		"cluster": clusterName,
-		"name":    ns.Name,
-		"kind":    "Namespace",
-		"phase":   string(ns.Status.Phase),
-		"emitter": "k8s-operator",
+		"cluster":    clusterName,
+		"cluster_id": clusterID.String(),
+		"name":       ns.Name,
+		"kind":       "Namespace",
+		"phase":      string(ns.Status.Phase),
+		"emitter":    "k8s-operator",
 	}
 
 	// IN_CLUSTER edge — the inverse-direction CONTAINS view is emitted
 	// from the startup cluster anchor publish.
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 
 	return &Event{
 		SourceID:    deriveSourceID(workspaceID, clusterName),

--- a/operator/internal/entity/namespace_test.go
+++ b/operator/internal/entity/namespace_test.go
@@ -21,16 +21,16 @@ func TestNamespaceToEvent_HappyPath(t *testing.T) {
 		},
 		Status: corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
 	}
-	ev := entity.NamespaceToEvent(ns, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.NamespaceToEvent(ns, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/Namespace/team-a" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Namespace/team-a" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if strings.Contains(ev.ExternalID, "//") {
 		t.Fatalf("external_id contains leading //: %q", ev.ExternalID)
 	}
 	expected := map[string]string{
-		"cluster": "prod-eu",
+		"cluster": "prod-eu", "cluster_id": "99999999-8888-7777-6666-555555555555",
 		"name":    "team-a",
 		"kind":    "Namespace",
 		"phase":   "Active",
@@ -48,22 +48,22 @@ func TestNamespaceToEvent_HappyPath(t *testing.T) {
 
 func TestNamespaceToEvent_NoLabelsStillEmits(t *testing.T) {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
-	ev := entity.NamespaceToEvent(ns, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
-	if ev.ExternalID != "k8s_resource/Namespace/default" {
+	ev := entity.NamespaceToEvent(ns, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Namespace/default" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 }
 
 func TestNamespaceToEvent_EmitsInClusterEdge(t *testing.T) {
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}}
-	ev := entity.NamespaceToEvent(ns, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.NamespaceToEvent(ns, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.TopologyEdges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(ev.TopologyEdges))
 	}
 	if ev.TopologyEdges[0].Kind != entity.RelationInCluster {
 		t.Fatalf("relation = %q", ev.TopologyEdges[0].Kind)
 	}
-	if ev.TopologyEdges[0].TargetExternalID != "k8s_resource/Cluster/prod-eu" {
+	if ev.TopologyEdges[0].TargetExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/prod-eu" {
 		t.Fatalf("target = %q", ev.TopologyEdges[0].TargetExternalID)
 	}
 }

--- a/operator/internal/entity/networkpolicy.go
+++ b/operator/internal/entity/networkpolicy.go
@@ -29,9 +29,9 @@ const EntityKindNetworkPolicy = "NetworkPolicy"
 //   - pod_selector (rendered selector string; empty matches everything in ns)
 //   - ingress_rule_count, egress_rule_count
 //   - policy_types ("Ingress", "Egress", or "Ingress,Egress" sorted)
-func NetworkPolicyToEvent(np *networkingv1.NetworkPolicy, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func NetworkPolicyToEvent(np *networkingv1.NetworkPolicy, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := resolveNamespace(np.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindNetworkPolicy, np.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindNetworkPolicy, np.Name)
 	meta["pod_selector"] = formatLabelSelector(&np.Spec.PodSelector)
 	meta["ingress_rule_count"] = strconv.Itoa(len(np.Spec.Ingress))
 	meta["egress_rule_count"] = strconv.Itoa(len(np.Spec.Egress))
@@ -40,7 +40,7 @@ func NetworkPolicyToEvent(np *networkingv1.NetworkPolicy, action Action, workspa
 	return &Event{
 		SourceID:    DeriveSourceID(workspaceID, clusterName),
 		SourceType:  SourceType,
-		ExternalID:  externalIDFor(EntityKindNetworkPolicy, namespace, np.Name),
+		ExternalID:  externalIDFor(clusterID, EntityKindNetworkPolicy, namespace, np.Name),
 		URI:         uriFor(clusterName, namespace, EntityKindNetworkPolicy, np.Name),
 		Action:      action,
 		WorkspaceID: workspaceID,

--- a/operator/internal/entity/networkpolicy_test.go
+++ b/operator/internal/entity/networkpolicy_test.go
@@ -21,9 +21,9 @@ func TestNetworkPolicyToEvent_RendersSelectorAndPolicyTypes(t *testing.T) {
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress, networkingv1.PolicyTypeIngress},
 		},
 	}
-	ev := entity.NetworkPolicyToEvent(np, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.NetworkPolicyToEvent(np, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/NetworkPolicy/team-a/deny-all" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/NetworkPolicy/team-a/deny-all" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if ev.Metadata["pod_selector"] != "app=checkout,tier=frontend" {
@@ -46,7 +46,7 @@ func TestNetworkPolicyToEvent_EmptySelectorRendersEmpty(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "deny-everything"},
 		Spec:       networkingv1.NetworkPolicySpec{},
 	}
-	ev := entity.NetworkPolicyToEvent(np, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.NetworkPolicyToEvent(np, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if ev.Metadata["pod_selector"] != "" {
 		t.Fatalf("empty selector should render as \"\"; got %q", ev.Metadata["pod_selector"])
 	}

--- a/operator/internal/entity/node.go
+++ b/operator/internal/entity/node.go
@@ -18,16 +18,17 @@ import (
 )
 
 // NodeToEvent maps a corev1.Node into an Event. Pure; takes no clients.
-func NodeToEvent(node *corev1.Node, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
-	externalID := EntityKindK8sResource + "/Node/" + node.Name
+func NodeToEvent(node *corev1.Node, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := externalIDForClusterScoped(clusterID, "Node", node.Name)
 	uri := "kube://" + clusterName + "/Node/" + node.Name
 
 	meta := map[string]string{
-		"cluster": clusterName,
-		"name":    node.Name,
-		"kind":    "Node",
-		"ready":   strconv.FormatBool(nodeIsReady(node)),
-		"emitter": "k8s-operator",
+		"cluster":    clusterName,
+		"cluster_id": clusterID.String(),
+		"name":       node.Name,
+		"kind":       "Node",
+		"ready":      strconv.FormatBool(nodeIsReady(node)),
+		"emitter":    "k8s-operator",
 	}
 	// Optional fields: only emitted when the API server has populated them.
 	// Missing keys are clearer to the consumer than empty-string keys.
@@ -45,7 +46,7 @@ func NodeToEvent(node *corev1.Node, action Action, workspaceID uuid.UUID, cluste
 	// is the inverse-direction CONTAINS view — emitted from the startup
 	// hook for Lead-side bookkeeping; the per-Node IN_CLUSTER edge is
 	// what the consumer actually walks.
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 
 	return &Event{
 		SourceID:    deriveSourceID(workspaceID, clusterName),

--- a/operator/internal/entity/node_test.go
+++ b/operator/internal/entity/node_test.go
@@ -38,9 +38,9 @@ func newReadyNode(name string) *corev1.Node {
 
 func TestNodeToEvent_HappyPath(t *testing.T) {
 	node := newReadyNode("kind-control-plane")
-	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/Node/kind-control-plane" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Node/kind-control-plane" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if strings.Contains(ev.ExternalID, "//") {
@@ -64,7 +64,7 @@ func TestNodeToEvent_HappyPath(t *testing.T) {
 
 func TestNodeToEvent_NotReadyConditionMissing(t *testing.T) {
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-x"}}
-	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if got := ev.Metadata["ready"]; got != "false" {
 		t.Fatalf("ready = %q, want \"false\" (no Ready condition present)", got)
 	}
@@ -74,8 +74,8 @@ func TestNodeToEvent_NoTaintsNoLabelsStillEmits(t *testing.T) {
 	// Edge case: a Node with literally no taints, labels, or status
 	// fields populated. Must still produce a well-formed event.
 	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "minimal"}}
-	ev := entity.NodeToEvent(node, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
-	if ev.ExternalID != "k8s_resource/Node/minimal" {
+	ev := entity.NodeToEvent(node, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Node/minimal" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if _, ok := ev.Metadata["kubelet_version"]; ok {
@@ -85,7 +85,7 @@ func TestNodeToEvent_NoTaintsNoLabelsStillEmits(t *testing.T) {
 
 func TestNodeToEvent_EmitsInClusterEdge(t *testing.T) {
 	node := newReadyNode("node-a")
-	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.NodeToEvent(node, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.TopologyEdges) != 1 {
 		t.Fatalf("expected 1 edge, got %d: %+v", len(ev.TopologyEdges), ev.TopologyEdges)
 	}
@@ -93,7 +93,7 @@ func TestNodeToEvent_EmitsInClusterEdge(t *testing.T) {
 	if e.Kind != entity.RelationInCluster {
 		t.Fatalf("relation = %q, want %q", e.Kind, entity.RelationInCluster)
 	}
-	if e.TargetExternalID != "k8s_resource/Cluster/prod-eu" {
-		t.Fatalf("target = %q, want %q", e.TargetExternalID, "k8s_resource/Cluster/prod-eu")
+	if e.TargetExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/prod-eu" {
+		t.Fatalf("target = %q, want %q", e.TargetExternalID, "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/prod-eu")
 	}
 }

--- a/operator/internal/entity/persistentvolume.go
+++ b/operator/internal/entity/persistentvolume.go
@@ -24,16 +24,17 @@ import (
 )
 
 // PersistentVolumeToEvent maps a corev1.PersistentVolume into an Event.
-func PersistentVolumeToEvent(pv *corev1.PersistentVolume, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
-	externalID := EntityKindK8sResource + "/PersistentVolume/" + pv.Name
+func PersistentVolumeToEvent(pv *corev1.PersistentVolume, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := externalIDForClusterScoped(clusterID, "PersistentVolume", pv.Name)
 	uri := "kube://" + clusterName + "/PersistentVolume/" + pv.Name
 
 	meta := map[string]string{
-		"cluster": clusterName,
-		"name":    pv.Name,
-		"kind":    "PersistentVolume",
-		"phase":   string(pv.Status.Phase),
-		"emitter": "k8s-operator",
+		"cluster":    clusterName,
+		"cluster_id": clusterID.String(),
+		"name":       pv.Name,
+		"kind":       "PersistentVolume",
+		"phase":      string(pv.Status.Phase),
+		"emitter":    "k8s-operator",
 	}
 
 	// capacity: the canonical value lives under ResourceStorage. Stringify
@@ -65,14 +66,14 @@ func PersistentVolumeToEvent(pv *corev1.PersistentVolume, action Action, workspa
 		meta["storage_class"] = pv.Spec.StorageClassName
 	}
 
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 
 	// OF_CLASS edge — only emitted when storageClassName is set. A blank
 	// string represents the deprecated implicit-default case; we don't
 	// guess the default class here because that's a cluster-state read
 	// and would couple this pure mapper to a live API client.
 	if pv.Spec.StorageClassName != "" {
-		edges = append(edges, EdgeRef{Kind: RelationOfClass, TargetExternalID: EntityKindK8sResource + "/StorageClass/" + pv.Spec.StorageClassName})
+		edges = append(edges, EdgeRef{Kind: RelationOfClass, TargetExternalID: externalIDForClusterScoped(clusterID, "StorageClass", pv.Spec.StorageClassName)})
 	}
 
 	return &Event{

--- a/operator/internal/entity/persistentvolume_test.go
+++ b/operator/internal/entity/persistentvolume_test.go
@@ -30,16 +30,16 @@ func newPV(name, storageClass string) *corev1.PersistentVolume {
 
 func TestPersistentVolumeToEvent_HappyPath(t *testing.T) {
 	pv := newPV("pv-001", "gp3")
-	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/PersistentVolume/pv-001" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/PersistentVolume/pv-001" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if strings.Contains(ev.ExternalID, "//") {
 		t.Fatalf("external_id contains leading //: %q", ev.ExternalID)
 	}
 	expected := map[string]string{
-		"cluster":        "prod-eu",
+		"cluster":        "prod-eu", "cluster_id": "99999999-8888-7777-6666-555555555555",
 		"name":           "pv-001",
 		"kind":           "PersistentVolume",
 		"capacity":       "10Gi",
@@ -63,7 +63,7 @@ func TestPersistentVolumeToEvent_AccessModesSorted(t *testing.T) {
 		corev1.ReadOnlyMany,
 		corev1.ReadWriteOnce,
 	}
-	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if got := ev.Metadata["access_modes"]; got != "ReadOnlyMany,ReadWriteMany,ReadWriteOnce" {
 		t.Fatalf("access_modes = %q, want sorted", got)
 	}
@@ -75,7 +75,7 @@ func TestPersistentVolumeToEvent_NoStorageClassName_NoOfClassEdge(t *testing.T) 
 	// string — that would create a phantom StorageClass entity on the
 	// consumer side.
 	pv := newPV("pv-legacy", "")
-	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if _, ok := ev.Metadata["storage_class"]; ok {
 		t.Fatalf("storage_class metadata should be absent for empty storageClassName")
@@ -89,19 +89,19 @@ func TestPersistentVolumeToEvent_NoStorageClassName_NoOfClassEdge(t *testing.T) 
 
 func TestPersistentVolumeToEvent_EmitsInClusterAndOfClassEdges(t *testing.T) {
 	pv := newPV("pv-001", "gp3")
-	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.PersistentVolumeToEvent(pv, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	var sawInCluster, sawOfClass bool
 	for _, e := range ev.TopologyEdges {
 		switch e.Kind {
 		case entity.RelationInCluster:
 			sawInCluster = true
-			if e.TargetExternalID != "k8s_resource/Cluster/prod-eu" {
+			if e.TargetExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Cluster/prod-eu" {
 				t.Fatalf("in_cluster target = %q", e.TargetExternalID)
 			}
 		case entity.RelationOfClass:
 			sawOfClass = true
-			if e.TargetExternalID != "k8s_resource/StorageClass/gp3" {
+			if e.TargetExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/StorageClass/gp3" {
 				t.Fatalf("of_class target = %q", e.TargetExternalID)
 			}
 		}

--- a/operator/internal/entity/replicaset.go
+++ b/operator/internal/entity/replicaset.go
@@ -26,17 +26,18 @@ func ReplicaSetToEvent(
 	rs *appsv1.ReplicaSet,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
-	ev := newWorkloadEvent(kindReplicaSet, rs.Namespace, rs.Name, action, workspaceID, clusterName, now)
+	ev := newWorkloadEvent(kindReplicaSet, rs.Namespace, rs.Name, action, workspaceID, clusterID, clusterName, now)
 
 	if rs.Spec.Replicas != nil {
 		ev.Metadata["replicas"] = formatReplicas(*rs.Spec.Replicas)
 	}
 	ev.Metadata["available_replicas"] = formatReplicas(rs.Status.AvailableReplicas)
 
-	ev.Edges = ownerEdges(rs.OwnerReferences, defaultedNamespace(rs.Namespace), ev.ExternalID)
+	ev.Edges = ownerEdges(clusterID, rs.OwnerReferences, defaultedNamespace(rs.Namespace), ev.ExternalID)
 
 	return ev
 }

--- a/operator/internal/entity/replicaset_test.go
+++ b/operator/internal/entity/replicaset_test.go
@@ -29,9 +29,9 @@ func newReplicaSet(namespace, name string, replicas, available int32, owners []m
 
 func TestReplicaSetToEvent_FieldsAreCorrect(t *testing.T) {
 	rs := newReplicaSet("team-a", "checkout-7d9f", 4, 4, nil)
-	ev := entity.ReplicaSetToEvent(rs, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ReplicaSetToEvent(rs, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if want := "k8s_resource/ReplicaSet/team-a/checkout-7d9f"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/ReplicaSet/team-a/checkout-7d9f"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	if want := "kube://prod-eu/team-a/ReplicaSet/checkout-7d9f"; ev.URI != want {
@@ -61,12 +61,12 @@ func TestReplicaSetToEvent_OwnerEdgeFromDeployment(t *testing.T) {
 		},
 	}
 	rs := newReplicaSet("team-a", "checkout-7d9f", 4, 4, owners)
-	ev := entity.ReplicaSetToEvent(rs, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ReplicaSetToEvent(rs, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	if len(ev.Edges) != 1 {
 		t.Fatalf("edges count = %d, want 1; %#v", len(ev.Edges), ev.Edges)
 	}
-	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/Deployment/team-a/checkout" {
+	if got := ev.Edges[0].FromExternalID; got != "k8s_resource/99999999-8888-7777-6666-555555555555/Deployment/team-a/checkout" {
 		t.Fatalf("edge from_external_id = %q", got)
 	}
 	if got := ev.Edges[0].ToExternalID; got != ev.ExternalID {
@@ -82,13 +82,13 @@ func TestReplicaSetToEvent_OwnerEdgeFromDeployment(t *testing.T) {
 
 func TestReplicaSetToEvent_AdversarialLabelDoesNotChangeWorkspace(t *testing.T) {
 	rs := newReplicaSet("team-a", "checkout-7d9f", 1, 1, nil)
-	ev := entity.ReplicaSetToEvent(rs, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ReplicaSetToEvent(rs, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if ev.WorkspaceID != fixedWorkspace {
 		t.Fatalf("workspace_id = %s, want %s", ev.WorkspaceID, fixedWorkspace)
 	}
 	for k := range ev.Metadata {
 		switch k {
-		case "cluster", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
+		case "cluster", "cluster_id", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
 			// allowed
 		default:
 			t.Fatalf("metadata leaked unauthorised key %q (full map: %v)", k, ev.Metadata)

--- a/operator/internal/entity/secret.go
+++ b/operator/internal/entity/secret.go
@@ -53,9 +53,9 @@ const EntityKindSecret = "Secret"
 // in-depth design: even if a future contributor added a leaky line, the
 // closed allow-list of metadata makes the regression visible to the
 // structural test in secret_test.go.
-func SecretToEvent(s *corev1.Secret, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func SecretToEvent(s *corev1.Secret, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := resolveNamespace(s.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindSecret, s.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindSecret, s.Name)
 	meta["secret_type"] = string(s.Type)
 
 	// Union of the keys in Data and StringData (k8s permits both). Sorted so
@@ -67,7 +67,7 @@ func SecretToEvent(s *corev1.Secret, action Action, workspaceID uuid.UUID, clust
 	return &Event{
 		SourceID:    DeriveSourceID(workspaceID, clusterName),
 		SourceType:  SourceType,
-		ExternalID:  externalIDFor(EntityKindSecret, namespace, s.Name),
+		ExternalID:  externalIDFor(clusterID, EntityKindSecret, namespace, s.Name),
 		URI:         uriFor(clusterName, namespace, EntityKindSecret, s.Name),
 		Action:      action,
 		WorkspaceID: workspaceID,

--- a/operator/internal/entity/secret_test.go
+++ b/operator/internal/entity/secret_test.go
@@ -43,7 +43,7 @@ func hostileSecret() *corev1.Secret {
 // would take in encoding/json).
 func TestSecretToEvent_NeverLeaksValues(t *testing.T) {
 	s := hostileSecret()
-	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	raw, err := json.Marshal(ev)
 	if err != nil {
@@ -74,7 +74,7 @@ func TestSecretToEvent_OptInAnnotationIsIgnored(t *testing.T) {
 	// The Secret mapper has NO opt-in. Even with the same annotation
 	// ConfigMap honours, Secret values stay dropped.
 	s := hostileSecret()
-	ev := entity.SecretToEvent(s, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.SecretToEvent(s, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if _, ok := ev.Metadata["data_values_json"]; ok {
 		t.Fatalf("Secret must NOT honour the index-data annotation: data_values_json is present")
 	}
@@ -85,10 +85,10 @@ func TestSecretToEvent_OptInAnnotationIsIgnored(t *testing.T) {
 
 func TestSecretToEvent_AllowListIsClosed(t *testing.T) {
 	s := hostileSecret()
-	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
 	allowed := map[string]struct{}{
-		"cluster": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
 		"secret_type": {}, "data_keys": {}, "data_count": {},
 	}
 	for k := range ev.Metadata {
@@ -120,7 +120,7 @@ func TestSecretToEvent_TLSTypeMetadata(t *testing.T) {
 			corev1.TLSPrivateKeyKey: []byte("CANARY-KEY-PEM"),
 		},
 	}
-	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if ev.Metadata["secret_type"] != "kubernetes.io/tls" {
 		t.Fatalf("secret_type = %q", ev.Metadata["secret_type"])
 	}
@@ -148,8 +148,8 @@ func TestSecretToEvent_NamespacelessFallsBack(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "rogue"},
 		Type:       corev1.SecretTypeOpaque,
 	}
-	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
-	if ev.ExternalID != "k8s_resource/Secret/default/rogue" {
+	ev := entity.SecretToEvent(s, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Secret/default/rogue" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 }

--- a/operator/internal/entity/service.go
+++ b/operator/internal/entity/service.go
@@ -31,9 +31,9 @@ const EntityKindService = "Service"
 //
 // Notably absent: spec.externalIPs, spec.loadBalancerIP, status.loadBalancer
 // .ingress[].ip — all settable by tenant code paths and out of v0.2 scope.
-func ServiceToEvent(svc *corev1.Service, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
+func ServiceToEvent(svc *corev1.Service, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
 	namespace := resolveNamespace(svc.Namespace)
-	meta := baseMetadata(clusterName, namespace, EntityKindService, svc.Name)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindService, svc.Name)
 	meta["service_type"] = string(svc.Spec.Type)
 	meta["cluster_ip"] = svc.Spec.ClusterIP
 	meta["selector"] = renderStringMapSorted(svc.Spec.Selector)
@@ -42,7 +42,7 @@ func ServiceToEvent(svc *corev1.Service, action Action, workspaceID uuid.UUID, c
 	return &Event{
 		SourceID:    DeriveSourceID(workspaceID, clusterName),
 		SourceType:  SourceType,
-		ExternalID:  externalIDFor(EntityKindService, namespace, svc.Name),
+		ExternalID:  externalIDFor(clusterID, EntityKindService, namespace, svc.Name),
 		URI:         uriFor(clusterName, namespace, EntityKindService, svc.Name),
 		Action:      action,
 		WorkspaceID: workspaceID,

--- a/operator/internal/entity/service_test.go
+++ b/operator/internal/entity/service_test.go
@@ -33,9 +33,9 @@ func newService(namespace, name string, selector map[string]string, t corev1.Ser
 
 func TestServiceToEvent_HappyPath(t *testing.T) {
 	svc := newService("team-a", "checkout", map[string]string{"app": "checkout", "tier": "frontend"}, corev1.ServiceTypeClusterIP)
-	ev := entity.ServiceToEvent(svc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ServiceToEvent(svc, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/Service/team-a/checkout" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Service/team-a/checkout" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if ev.URI != "kube://prod-eu/team-a/Service/checkout" {
@@ -67,7 +67,7 @@ func TestServiceToEvent_HappyPath(t *testing.T) {
 func TestServiceToEvent_HeadlessNoSelector(t *testing.T) {
 	svc := newService("team-a", "headless", nil, corev1.ServiceTypeClusterIP)
 	svc.Spec.ClusterIP = "None"
-	ev := entity.ServiceToEvent(svc, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.ServiceToEvent(svc, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if ev.Metadata["selector"] != "" {
 		t.Fatalf("empty selector should render as \"\"; got %q", ev.Metadata["selector"])
 	}
@@ -78,8 +78,8 @@ func TestServiceToEvent_HeadlessNoSelector(t *testing.T) {
 
 func TestServiceToEvent_NamespacelessFallsBack(t *testing.T) {
 	svc := newService("", "rogue", nil, corev1.ServiceTypeClusterIP)
-	ev := entity.ServiceToEvent(svc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
-	if ev.ExternalID != "k8s_resource/Service/default/rogue" {
+	ev := entity.ServiceToEvent(svc, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Service/default/rogue" {
 		t.Fatalf("external_id = %q (expected default fallback)", ev.ExternalID)
 	}
 }

--- a/operator/internal/entity/statefulset.go
+++ b/operator/internal/entity/statefulset.go
@@ -24,17 +24,18 @@ func StatefulSetToEvent(
 	ss *appsv1.StatefulSet,
 	action Action,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	now time.Time,
 ) *Event {
-	ev := newWorkloadEvent(kindStatefulSet, ss.Namespace, ss.Name, action, workspaceID, clusterName, now)
+	ev := newWorkloadEvent(kindStatefulSet, ss.Namespace, ss.Name, action, workspaceID, clusterID, clusterName, now)
 
 	if ss.Spec.Replicas != nil {
 		ev.Metadata["replicas"] = formatReplicas(*ss.Spec.Replicas)
 	}
 	ev.Metadata["available_replicas"] = formatReplicas(ss.Status.AvailableReplicas)
 
-	ev.Edges = ownerEdges(ss.OwnerReferences, defaultedNamespace(ss.Namespace), ev.ExternalID)
+	ev.Edges = ownerEdges(clusterID, ss.OwnerReferences, defaultedNamespace(ss.Namespace), ev.ExternalID)
 
 	return ev
 }

--- a/operator/internal/entity/statefulset_test.go
+++ b/operator/internal/entity/statefulset_test.go
@@ -29,9 +29,9 @@ func newStatefulSet(namespace, name string, replicas, available int32, owners []
 
 func TestStatefulSetToEvent_FieldsAreCorrect(t *testing.T) {
 	ss := newStatefulSet("team-a", "kafka", 5, 4, nil)
-	ev := entity.StatefulSetToEvent(ss, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.StatefulSetToEvent(ss, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if want := "k8s_resource/StatefulSet/team-a/kafka"; ev.ExternalID != want {
+	if want := "k8s_resource/99999999-8888-7777-6666-555555555555/StatefulSet/team-a/kafka"; ev.ExternalID != want {
 		t.Fatalf("external_id = %q, want %q", ev.ExternalID, want)
 	}
 	if got := ev.Metadata["kind"]; got != "StatefulSet" {
@@ -50,7 +50,7 @@ func TestStatefulSetToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
 		{Kind: "Application", Name: "kafka-app", UID: "app-uid"},
 	}
 	ss := newStatefulSet("team-a", "kafka", 1, 1, owners)
-	ev := entity.StatefulSetToEvent(ss, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.StatefulSetToEvent(ss, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.Edges) != 1 || ev.Edges[0].FromKind != "Application" {
 		t.Fatalf("edges = %#v, want 1 Application edge", ev.Edges)
 	}
@@ -58,10 +58,10 @@ func TestStatefulSetToEvent_OwnerEdgesFromOwnerReferences(t *testing.T) {
 
 func TestStatefulSetToEvent_NoLabelLeakage(t *testing.T) {
 	ss := newStatefulSet("team-a", "kafka", 1, 1, nil)
-	ev := entity.StatefulSetToEvent(ss, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.StatefulSetToEvent(ss, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	for k := range ev.Metadata {
 		switch k {
-		case "cluster", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
+		case "cluster", "cluster_id", "namespace", "name", "kind", "emitter", "replicas", "available_replicas":
 		default:
 			t.Fatalf("leaked metadata key %q", k)
 		}

--- a/operator/internal/entity/storageclass.go
+++ b/operator/internal/entity/storageclass.go
@@ -18,12 +18,13 @@ import (
 )
 
 // StorageClassToEvent maps a storagev1.StorageClass into an Event.
-func StorageClassToEvent(sc *storagev1.StorageClass, action Action, workspaceID uuid.UUID, clusterName string, now time.Time) *Event {
-	externalID := EntityKindK8sResource + "/StorageClass/" + sc.Name
+func StorageClassToEvent(sc *storagev1.StorageClass, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	externalID := externalIDForClusterScoped(clusterID, "StorageClass", sc.Name)
 	uri := "kube://" + clusterName + "/StorageClass/" + sc.Name
 
 	meta := map[string]string{
 		"cluster":     clusterName,
+		"cluster_id":  clusterID.String(),
 		"name":        sc.Name,
 		"kind":        "StorageClass",
 		"provisioner": sc.Provisioner,
@@ -33,7 +34,7 @@ func StorageClassToEvent(sc *storagev1.StorageClass, action Action, workspaceID 
 		meta["reclaim_policy"] = string(*sc.ReclaimPolicy)
 	}
 
-	edges := []EdgeRef{inClusterEdge(clusterName)}
+	edges := []EdgeRef{inClusterEdge(clusterID, clusterName)}
 
 	return &Event{
 		SourceID:    deriveSourceID(workspaceID, clusterName),

--- a/operator/internal/entity/storageclass_test.go
+++ b/operator/internal/entity/storageclass_test.go
@@ -29,16 +29,16 @@ func TestStorageClassToEvent_HappyPath(t *testing.T) {
 		},
 		ReclaimPolicy: &retain,
 	}
-	ev := entity.StorageClassToEvent(sc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.StorageClassToEvent(sc, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 
-	if ev.ExternalID != "k8s_resource/StorageClass/gp3" {
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/StorageClass/gp3" {
 		t.Fatalf("external_id = %q", ev.ExternalID)
 	}
 	if strings.Contains(ev.ExternalID, "//") {
 		t.Fatalf("external_id contains leading //: %q", ev.ExternalID)
 	}
 	expected := map[string]string{
-		"cluster":        "prod-eu",
+		"cluster":        "prod-eu", "cluster_id": "99999999-8888-7777-6666-555555555555",
 		"name":           "gp3",
 		"kind":           "StorageClass",
 		"provisioner":    "ebs.csi.aws.com",
@@ -70,7 +70,7 @@ func TestStorageClassToEvent_NoParametersNoReclaimPolicy(t *testing.T) {
 		ObjectMeta:  metav1.ObjectMeta{Name: "minimal"},
 		Provisioner: "kubernetes.io/no-provisioner",
 	}
-	ev := entity.StorageClassToEvent(sc, entity.ActionUpdated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.StorageClassToEvent(sc, entity.ActionUpdated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if _, ok := ev.Metadata["reclaim_policy"]; ok {
 		t.Fatalf("reclaim_policy must be absent when ReclaimPolicy is nil")
 	}
@@ -84,7 +84,7 @@ func TestStorageClassToEvent_EmitsInClusterEdge(t *testing.T) {
 		ObjectMeta:  metav1.ObjectMeta{Name: "gp3"},
 		Provisioner: "ebs.csi.aws.com",
 	}
-	ev := entity.StorageClassToEvent(sc, entity.ActionCreated, fixedWorkspace, "prod-eu", fixedNow)
+	ev := entity.StorageClassToEvent(sc, entity.ActionCreated, fixedWorkspace, fixedClusterID, "prod-eu", fixedNow)
 	if len(ev.TopologyEdges) != 1 {
 		t.Fatalf("expected 1 edge, got %d", len(ev.TopologyEdges))
 	}


### PR DESCRIPTION
Closes #167. Wave 5 of epic #98.

Re-keys every operator-emitted external_id to include `cluster_id` so a single Omniscience workspace can observe multiple Kubernetes clusters without collisions.

## What's in

- **`OMNISCIENCE_CLUSTER_ID` Secret env var** in `operator/internal/config/config.go`. Deterministic fallback `uuid5(workspace_id, cluster_name)` preserves v0.2 single-cluster back-compat.
- **External-ID format change** (everywhere):
  - Old: `k8s_resource/Kind/{namespace}/{name}`
  - New: `k8s_resource/{cluster_id}/Kind/{namespace}/{name}`
  - Cluster-scoped equivalents follow the same pattern.
- **Helper signature changes** in `operator/internal/entity/common.go`: `externalID`, `externalIDFor`, `baseMetadata`, `ownerEdges`, `inClusterEdge` all gain a `clusterID uuid.UUID` parameter. `newWorkloadEvent` does too.
- **Reconciler structs** in `operator/internal/controller/*.go` gain a `ClusterID` field; constructors accept it; `cmd/manager/main.go` threads `cfg.ClusterID` to every `NewXxxReconciler` call.
- **Cluster anchor entity** now uses the configured `cluster_id` (not the derived default from #159).
- **Metadata** carries an authoritative `cluster_id` field (added to the closed allow-list).

## Verification

- 69 files changed, +545 / -387
- `go test -count=1 ./...` — **97 tests pass across 6 packages**
- `go vet`, `go build` clean
- `helm lint helm/omniscience-operator` clean

## Two-cluster distinctness

Same Pod name in workspaces A's two clusters (different `cluster_id`s) produces DISTINCT external_ids — covered by `Pod` mapper test. The (workspace_id, external_id) composite remains unique per server-side ingestion.

## Non-goals (explicit follow-ups)

- **Server-side collision detection** — when a workspace has misconfigured operators sharing `cluster_id`, the server detects collision and logs `cluster_id.collision`. Deferred to a separate sub-issue.
- **Migration script** for existing graph entities with old-format external_ids → not auto-migrated. Deferred to a separate sub-issue per #167's non-goals.

## Test plan

- [x] `OMNISCIENCE_CLUSTER_ID` parsing + deterministic fallback
- [x] Every mapper external_id includes cluster_id
- [x] Allow-list tests permit `cluster_id` as authoritative metadata
- [x] Cluster anchor idempotence (same `cluster_id` across restarts)
- [x] Cross-workspace ACL contract still passes (`workspace_id` is the tenant boundary, `cluster_id` is identity-disambiguation within a workspace)