### PR TITLE
feat: complete DRA controllers (#190)

### DIFF
--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -69,6 +69,17 @@ rules:
     resources: ["rollouts"]
     verbs: ["get", "list", "watch"]
   # ── end #161 ──────────────────────────────────────────────────────────
+  # ── #190 DRA resource handles (discovery-skip if absent) ──────────────
+  # Dynamic Resource Allocation went GA in Kubernetes 1.31. Watchers are
+  # registered only when the resource.k8s.io/v1beta1 group is served (see
+  # dra_setup.go::IsDRAAPIInstalled). RBAC is granted unconditionally —
+  # rules on non-existent resources are inert. ResourceClaim is namespaced;
+  # ResourceClaimTemplate is namespaced; ResourceSlice is cluster-scoped;
+  # DeviceClass is cluster-scoped. Verbs are read-only.
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims", "resourceclaimtemplates", "resourceslices", "deviceclasses"]
+    verbs: ["get", "list", "watch"]
+  # ── end #190 ──────────────────────────────────────────────────────────
   # Leader election lease — namespaced; gated to the operator's own namespace
   # below.
   {{- if .Values.leaderElection.enabled }}

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -14,6 +14,7 @@ import (
 	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/google/uuid"
 	networkingv1 "k8s.io/api/networking/v1"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -184,6 +185,14 @@ func run() error {
 		return err
 	}
 	// ── end #161 ──────────────────────────────────────────────────────────
+
+	// ── #190 DRA resource handles — discovery-gated registration ──────────
+	// Probe the API server for resource.k8s.io/v1beta1; absent → log INFO
+	// and skip all 4 DRA controllers. Same fail-open posture as #161.
+	if err := setupDRAWatchers(mgr, pub, cfg.WorkspaceID, cfg.ClusterName, logger); err != nil {
+		return err
+	}
+	// ── end #190 ──────────────────────────────────────────────────────────
 
 	// --- BEGIN issue #159: cluster-scoped watcher registration ---
 	// Register the four cluster-scoped reconcilers (Node, Namespace,
@@ -405,3 +414,88 @@ func setupArgoRolloutsWatcher(
 }
 
 // ── end #161 ───────────────────────────────────────────────────────────────
+
+// ── #190 DRA resource handles — registration helper ───────────────────────
+//
+// setupDRAWatchers probes the API server for resource.k8s.io/v1beta1 via
+// client-go's discovery interface. Three outcomes:
+//
+//  1. API present → register the v1beta1 type with the manager scheme and
+//     wire all four DRA reconcilers (ResourceClaim, ResourceClaimTemplate,
+//     ResourceSlice, DeviceClass).
+//  2. API absent  → INFO-log "dra.api.absent" and return nil. The rest of
+//     the operator continues to start normally on K8s 1.30 or older.
+//  3. Discovery error → return the error so manager startup fails loudly.
+//     Silently disabling the watchers on a flaky API server would leave
+//     GPU-cluster operators running blind.
+func setupDRAWatchers(
+	mgr ctrl.Manager,
+	pub publisher.Publisher,
+	workspaceID uuid.UUID,
+	clusterName string,
+	logger interface {
+		Info(msg string, keysAndValues ...interface{})
+	},
+) error {
+	disc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+	if err != nil {
+		return fmt.Errorf("dra: discovery client init: %w", err)
+	}
+
+	present, perr := controller.IsDRAAPIInstalled(disc)
+	if perr != nil {
+		return fmt.Errorf("dra: discovery probe: %w", perr)
+	}
+	if !present {
+		logger.Info(controller.DRAAPIAbsentLogKey+" — DRA API not served; skipping watcher registration",
+			"event", controller.DRAAPIAbsentLogKey,
+			"group_version", controller.DRAGroupVersion,
+		)
+		return nil
+	}
+
+	// API is present — register the typed scheme and wire all 4 reconcilers.
+	if err := resourcev1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("dra: add to scheme: %w", err)
+	}
+
+	rcRec, err := controller.NewResourceClaimReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+	if err != nil {
+		return fmt.Errorf("dra: resourceclaim reconciler init: %w", err)
+	}
+	if err := rcRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("dra: resourceclaim reconciler setup: %w", err)
+	}
+
+	rctRec, err := controller.NewResourceClaimTemplateReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+	if err != nil {
+		return fmt.Errorf("dra: resourceclaimtemplate reconciler init: %w", err)
+	}
+	if err := rctRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("dra: resourceclaimtemplate reconciler setup: %w", err)
+	}
+
+	rsRec, err := controller.NewResourceSliceReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+	if err != nil {
+		return fmt.Errorf("dra: resourceslice reconciler init: %w", err)
+	}
+	if err := rsRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("dra: resourceslice reconciler setup: %w", err)
+	}
+
+	dcRec, err := controller.NewDeviceClassReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+	if err != nil {
+		return fmt.Errorf("dra: deviceclass reconciler init: %w", err)
+	}
+	if err := dcRec.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("dra: deviceclass reconciler setup: %w", err)
+	}
+
+	logger.Info("dra.api.present — DRA watchers registered",
+		"event", "dra.api.present",
+		"group_version", controller.DRAGroupVersion,
+	)
+	return nil
+}
+
+// ── end #190 ──────────────────────────────────────────────────────────────

--- a/operator/internal/controller/dra_deviceclass_controller.go
+++ b/operator/internal/controller/dra_deviceclass_controller.go
@@ -1,0 +1,109 @@
+// Package controller — DeviceClassReconciler.
+//
+// Watches resource.k8s.io/v1beta1 DeviceClass (namespaced) and emits one
+// Event per reconcile. The shape mirrors PodReconciler exactly so a reader
+// who already understands Pod can read this in one pass; the only differences
+// are the kind being watched, the mapper invoked, and the API version.
+//
+// Registration is gated on DRA-API discovery in main.go — when the cluster
+// does not serve resource.k8s.io/v1beta1 (operator on a 1.30 cluster, or 1.31
+// without the feature gate), this reconciler is never instantiated and the
+// operator runs without DRA. See cmd/manager/main.go for the discovery path.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// DeviceClassReconciler watches DeviceClasss and publishes change events.
+type DeviceClassReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewDeviceClassReconciler returns a reconciler with sane defaults.
+// Validation matches every other reconciler in this package.
+func NewDeviceClassReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*DeviceClassReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &DeviceClassReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile follows the Pod reconciler's exact semantics. GET success →
+// upsert event; NotFound → deletion event with a stub bearing only the
+// identifying metadata; other error → requeue.
+func (r *DeviceClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"deviceclass", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var rc resourcev1beta1.DeviceClass
+	err := r.Client.Get(ctx, req.NamespacedName, &rc)
+	switch {
+	case err == nil:
+		ev := entity.DeviceClassToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish deviceclass event: %w", perr)
+		}
+		logger.V(1).Info("published deviceclass upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &resourcev1beta1.DeviceClass{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.DeviceClassToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish deviceclass deletion: %w", perr)
+		}
+		logger.V(1).Info("published deviceclass deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get deviceclass failed")
+		return ctrl.Result{}, fmt.Errorf("get deviceclass %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *DeviceClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&resourcev1beta1.DeviceClass{}).
+		Named("deviceclass-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/dra_resourceclaimtemplate_controller.go
+++ b/operator/internal/controller/dra_resourceclaimtemplate_controller.go
@@ -1,0 +1,109 @@
+// Package controller — ResourceClaimTemplateReconciler.
+//
+// Watches resource.k8s.io/v1beta1 ResourceClaimTemplate (namespaced) and emits one
+// Event per reconcile. The shape mirrors PodReconciler exactly so a reader
+// who already understands Pod can read this in one pass; the only differences
+// are the kind being watched, the mapper invoked, and the API version.
+//
+// Registration is gated on DRA-API discovery in main.go — when the cluster
+// does not serve resource.k8s.io/v1beta1 (operator on a 1.30 cluster, or 1.31
+// without the feature gate), this reconciler is never instantiated and the
+// operator runs without DRA. See cmd/manager/main.go for the discovery path.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ResourceClaimTemplateReconciler watches ResourceClaimTemplates and publishes change events.
+type ResourceClaimTemplateReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewResourceClaimTemplateReconciler returns a reconciler with sane defaults.
+// Validation matches every other reconciler in this package.
+func NewResourceClaimTemplateReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ResourceClaimTemplateReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ResourceClaimTemplateReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile follows the Pod reconciler's exact semantics. GET success →
+// upsert event; NotFound → deletion event with a stub bearing only the
+// identifying metadata; other error → requeue.
+func (r *ResourceClaimTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"resourceclaimtemplate", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var rc resourcev1beta1.ResourceClaimTemplate
+	err := r.Client.Get(ctx, req.NamespacedName, &rc)
+	switch {
+	case err == nil:
+		ev := entity.ResourceClaimTemplateToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish resourceclaimtemplate event: %w", perr)
+		}
+		logger.V(1).Info("published resourceclaimtemplate upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &resourcev1beta1.ResourceClaimTemplate{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ResourceClaimTemplateToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish resourceclaimtemplate deletion: %w", perr)
+		}
+		logger.V(1).Info("published resourceclaimtemplate deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get resourceclaimtemplate failed")
+		return ctrl.Result{}, fmt.Errorf("get resourceclaimtemplate %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *ResourceClaimTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&resourcev1beta1.ResourceClaimTemplate{}).
+		Named("resourceclaimtemplate-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/dra_resourceslice_controller.go
+++ b/operator/internal/controller/dra_resourceslice_controller.go
@@ -1,0 +1,109 @@
+// Package controller — ResourceSliceReconciler.
+//
+// Watches resource.k8s.io/v1beta1 ResourceSlice (namespaced) and emits one
+// Event per reconcile. The shape mirrors PodReconciler exactly so a reader
+// who already understands Pod can read this in one pass; the only differences
+// are the kind being watched, the mapper invoked, and the API version.
+//
+// Registration is gated on DRA-API discovery in main.go — when the cluster
+// does not serve resource.k8s.io/v1beta1 (operator on a 1.30 cluster, or 1.31
+// without the feature gate), this reconciler is never instantiated and the
+// operator runs without DRA. See cmd/manager/main.go for the discovery path.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ResourceSliceReconciler watches ResourceSlices and publishes change events.
+type ResourceSliceReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewResourceSliceReconciler returns a reconciler with sane defaults.
+// Validation matches every other reconciler in this package.
+func NewResourceSliceReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterName string) (*ResourceSliceReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ResourceSliceReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile follows the Pod reconciler's exact semantics. GET success →
+// upsert event; NotFound → deletion event with a stub bearing only the
+// identifying metadata; other error → requeue.
+func (r *ResourceSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"resourceslice", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var rc resourcev1beta1.ResourceSlice
+	err := r.Client.Get(ctx, req.NamespacedName, &rc)
+	switch {
+	case err == nil:
+		ev := entity.ResourceSliceToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish resourceslice event: %w", perr)
+		}
+		logger.V(1).Info("published resourceslice upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &resourcev1beta1.ResourceSlice{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ResourceSliceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish resourceslice deletion: %w", perr)
+		}
+		logger.V(1).Info("published resourceslice deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get resourceslice failed")
+		return ctrl.Result{}, fmt.Errorf("get resourceslice %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with controller-runtime.
+func (r *ResourceSliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&resourcev1beta1.ResourceSlice{}).
+		Named("resourceslice-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/dra_setup.go
+++ b/operator/internal/controller/dra_setup.go
@@ -1,0 +1,63 @@
+// dra_setup.go — discovery probe for the Dynamic Resource Allocation (DRA)
+// API group. DRA is GA in Kubernetes 1.31; on 1.30 or older clusters the
+// API group is absent and we skip registration of all four DRA controllers
+// (#190 follow-up to #162). The probe pattern mirrors
+// IsArgoRolloutsCRDInstalled — fail-open on absent, propagate transient
+// failures so a flaky API server at boot doesn't silently disable the
+// watchers.
+package controller
+
+import (
+	"errors"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+)
+
+// DRAGroupVersion is the API group/version this controller probes for at
+// startup. Pinned as a string constant rather than imported from the
+// k8s.io/api/resource module so the discovery probe never fails closed on a
+// module-version mismatch — the wire-level group/version is the stable
+// contract.
+const DRAGroupVersion = "resource.k8s.io/v1beta1"
+
+// DRAAPIAbsentLogKey is the structured log key emitted at INFO when the DRA
+// API group is not served by the API server. Tools that grep `kubectl logs`
+// for "dra.api.absent" rely on this exact spelling.
+const DRAAPIAbsentLogKey = "dra.api.absent"
+
+// IsDRAAPIInstalled returns true when the API server reports the
+// resource.k8s.io/v1beta1 group with at least the resourceclaims resource
+// listed. Returns false (nil error) on the documented "absent" path: the
+// API server returns NotFound / NoMatchError. Returns false plus a non-nil
+// error on truly transient failures so the caller can fail-loud at boot.
+//
+// Why this signature: the discovery probe is the only place the fail-open
+// vs fail-closed policy is decided. Returning (bool, error) keeps that
+// policy at the call site (cmd/manager/main.go) where it is most reviewable.
+func IsDRAAPIInstalled(d discovery.DiscoveryInterface) (bool, error) {
+	if d == nil {
+		return false, errors.New("controller: discovery client must not be nil")
+	}
+	rl, err := d.ServerResourcesForGroupVersion(DRAGroupVersion)
+	switch {
+	case err == nil:
+		// Group/version is registered. Confirm the canonical resource is
+		// listed — a registered group with no resources is treated as absent
+		// (the watchers would have nothing to watch).
+		for _, r := range rl.APIResources {
+			if r.Name == "resourceclaims" {
+				return true, nil
+			}
+		}
+		return false, nil
+	case apierrors.IsNotFound(err):
+		// Group/version is not registered. This is the documented
+		// "DRA not installed" path — fail-open, no error.
+		return false, nil
+	default:
+		// Transient discovery failure. Caller decides retry vs fatal.
+		return false, fmt.Errorf("discovery probe %s: %w", DRAGroupVersion, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #190. Completes the DRA mapper coverage that PR #189 (issue #162) left as a deliberate partial: ships the remaining three controllers and the discovery-skip probe so the operator works on clusters without DRA installed.

### What's new
- **3 new controllers**: `dra_resourceclaimtemplate_controller.go`, `dra_resourceslice_controller.go`, `dra_deviceclass_controller.go` — same shape as the existing `dra_resourceclaim_controller.go` from #162.
- **Discovery probe**: `dra_setup.go::IsDRAAPIInstalled` — checks `resource.k8s.io/v1beta1` is served and lists `resourceclaims`. Returns `(bool, error)` so the fail-open vs fail-closed policy lives at the call site (`cmd/manager/main.go::setupDRAWatchers`).
- **Manager wiring**: `setupDRAWatchers` registers all four reconcilers when DRA is present, logs `dra.api.absent` at INFO and skips when absent. Transient discovery errors propagate (fail-loud at boot).
- **RBAC**: cluster-scoped `get/list/watch` on `resource.k8s.io` for all four resources. Granted unconditionally — rules on absent resources are inert.

### Behavior matrix

| Cluster state | Operator behavior |
|---------------|-------------------|
| K8s 1.31+ with DRA | All 4 controllers register and reconcile |
| K8s 1.30 or DRA disabled | Skip registration, log `dra.api.absent`, operator boots fine |
| API server flaky at boot | Surface error to caller (fail-loud), don't silently disable |

### ADR alignment
- ADR-0007 §ACL: observation-only — verbs strictly `get/list/watch`.
- Mirrors the discovery-skip pattern from #160 (ArgoCD) and #161 (Argo Rollouts).

## Test plan
- [x] `go build ./...` clean
- [x] `go test -count=1 ./...` — all 97 tests pass across 6 packages
- [x] `helm lint helm/omniscience-operator` clean
- [x] `helm template` renders DRA RBAC stanza
- [ ] CI green on the branch