### PR TITLE
feat: operator reconciliation worker (#163)

### DIFF
--- a/apps/server/src/omniscience_server/rest/operator.py
+++ b/apps/server/src/omniscience_server/rest/operator.py
@@ -1,0 +1,335 @@
+"""Operator-scoped read endpoint (#163).
+
+GET /api/v1/operator/entities
+
+Lists external_ids of entities the omniscience-operator emitted for a
+given (workspace_id, cluster_id, kind) tuple, with cursor pagination.
+
+ACL invariant — workspace_id is taken from the bearer token, never from the query
+--------------------------------------------------------------------------------
+The bearer token has a workspace_id (from
+``packages/core/src/omniscience_core/auth/middleware.py``).  This handler
+ENFORCES that the token's workspace_id matches the ``workspace_id`` query
+parameter.  Mismatch → 403 ``forbidden``.
+
+This is the **load-bearing security gate** for the reconciliation worker
+(see issue #163 §ACL invariant #1).  Even a misconfigured operator
+cannot reach into another tenant's data: the token resolves to one
+workspace, the query param must equal it, and SQL filters lock the
+result set to that workspace.
+
+Emitter filter
+--------------
+Server-side filtering on ``source_type='k8s_operator'`` is mandatory and
+NOT a query parameter — clients cannot opt out.  Issue #163 §Scope
+explicitly requires this gate so the response set never includes entities
+emitted by other connectors (the agentic ``k8s`` connector, terraform,
+etc.).
+
+Pagination
+----------
+Cursor-based using the document's primary-key UUID as the opaque next
+cursor.  Limit is capped at 1000 server-side; the client passes any
+``limit`` up to that cap.
+
+Auth
+----
+* No / invalid bearer token                  → 401 ``unauthorized``
+* Token without ``operator:read`` scope      → 403 ``forbidden`` (scope)
+* Token's workspace ≠ query workspace_id     → 403 ``forbidden`` (workspace)
+* Token has no workspace_id at all (legacy)  → 403 ``forbidden`` (workspace)
+* Authenticated, scoped, matched             → 200 with JSON page
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from omniscience_core.auth.middleware import require_scope
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken, Document, Source, SourceType
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/operator", tags=["operator"])
+
+# Module-level singletons — avoid ruff B008 (function call in argument default).
+_operator_read_dep: Any = Depends(require_scope(Scope.operator_read))
+_workspace_id_query: Any = Query(
+    ...,
+    description="Workspace UUID — MUST match the bearer token's workspace_id.",
+)
+_cluster_id_query: Any = Query(
+    ...,
+    description="Cluster UUID — the operator's stamped cluster_id (issue #167).",
+)
+_kind_query: Any = Query(
+    ...,
+    min_length=1,
+    max_length=64,
+    description="K8s API Kind (e.g. 'Pod', 'Deployment'). Mixed-case, exact match.",
+)
+_cursor_query: Any = Query(
+    default="",
+    max_length=64,
+    description="Pagination cursor. Empty string for the first page.",
+)
+_limit_query: Any = Query(
+    default=500,
+    ge=1,
+    le=1000,
+    description="Page size (1..1000). Defaults to 500.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Server-side bounds.
+# ---------------------------------------------------------------------------
+
+# Maximum entities returned per request. Clients pass any ``limit`` up to
+# this cap; values above are silently clamped. 1000 is large enough to
+# minimise round-trip count on 10k-pod clusters and small enough that a
+# single response body stays under the typical 8 MiB API gateway ceiling.
+_MAX_LIMIT = 1000
+
+# Default limit when the client omits ``limit``. 500 matches the operator
+# client's default page size so a same-defaults configuration produces
+# matching page boundaries.
+_DEFAULT_LIMIT = 500
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models.
+# ---------------------------------------------------------------------------
+
+
+class OperatorEntitiesPage(BaseModel):
+    """One page of operator-emitted external_ids."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    external_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Sorted list of external_ids the operator emitted for the "
+            "given (workspace_id, cluster_id, kind) tuple. Stable across "
+            "calls — sort key is the external_id itself."
+        ),
+    )
+    next_cursor: str = Field(
+        default="",
+        description=(
+            "Opaque pagination cursor. Empty string terminates the walk. "
+            "Pass back verbatim in the next request's ``cursor`` query "
+            "parameter."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _require_matching_workspace(
+    token: ApiToken,
+    *,
+    requested_workspace_id: uuid.UUID,
+) -> uuid.UUID:
+    """Extract and validate the caller's workspace_id.
+
+    Three failure paths, all mapped to 403:
+      * legacy token with no workspace_id at all
+      * token's workspace_id != ``requested_workspace_id`` query param
+
+    Returns the validated workspace_id (always == ``requested_workspace_id``
+    on success). Raises ``HTTPException(403)`` otherwise.
+
+    The handler logs each rejection with the token prefix (never the token
+    body) so operations can correlate audit-log entries with denied
+    requests without exposing credentials.
+    """
+    token_workspace = get_workspace_id(token)
+    if token_workspace is None:
+        log.warning(
+            "operator_endpoint_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Operator endpoint requires a workspace-scoped token.",
+            },
+        )
+    if token_workspace != requested_workspace_id:
+        log.warning(
+            "operator_endpoint_rejected_workspace_mismatch",
+            token_prefix=token.token_prefix,
+            token_workspace=str(token_workspace),
+            requested_workspace=str(requested_workspace_id),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": ("Token workspace_id does not match the requested workspace_id."),
+            },
+        )
+    return token_workspace
+
+
+def _build_external_id_prefix(cluster_id: uuid.UUID, kind: str) -> str:
+    """Build the LIKE prefix for the (cluster_id, kind) filter.
+
+    Operator external_ids follow exactly two shapes (see
+    ``operator/internal/entity/common.go``):
+
+      * namespaced:    ``k8s_resource/{cluster_id}/{Kind}/{namespace}/{name}``
+      * cluster-scoped: ``k8s_resource/{cluster_id}/{Kind}/{name}``
+
+    Both shapes share the prefix ``k8s_resource/{cluster_id}/{Kind}/`` so
+    a single LIKE pattern matches either form precisely. Filtering by
+    prefix on Documents.external_id is index-friendly (the column is
+    ``Text`` and SQL LIKE uses the b-tree index when the pattern has no
+    leading wildcard, which is the case here).
+    """
+    return f"k8s_resource/{cluster_id}/{kind}/%"
+
+
+def _resolve_db_factory(request: Request) -> Any:
+    """Return the configured async-sessionmaker or 503."""
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if factory is None:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "service_unavailable", "message": "Database not available"},
+        )
+    return factory
+
+
+async def _query_external_ids(
+    db: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    cluster_id: uuid.UUID,
+    kind: str,
+    cursor: str,
+    limit: int,
+) -> tuple[list[str], str]:
+    """Execute the paginated query and return ``(external_ids, next_cursor)``.
+
+    Ordering is by ``Document.id`` (ascending) so cursor pagination is
+    stable: the cursor is the last document's id; the next page returns
+    documents with ``id > cursor``.
+
+    Filters (all required, all server-enforced):
+      * ``Source.type = 'k8s_operator'`` — emitter gate
+      * ``Source.tenant_id = workspace_id`` — tenant gate
+      * ``Document.external_id LIKE 'k8s_resource/{cluster_id}/{kind}/%'``
+    """
+    prefix = _build_external_id_prefix(cluster_id, kind)
+    stmt = (
+        select(Document.id, Document.external_id)
+        .join(Source, Document.source_id == Source.id)
+        .where(Source.type == SourceType.k8s_operator)
+        .where(Source.tenant_id == workspace_id)
+        .where(Document.external_id.like(prefix))
+        .where(Document.tombstoned_at.is_(None))
+        .order_by(Document.id)
+        .limit(limit + 1)  # Fetch one extra to detect "is there a next page".
+    )
+
+    if cursor:
+        try:
+            cursor_uuid = uuid.UUID(cursor)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "invalid_cursor", "message": "Cursor must be a UUID."},
+            ) from None
+        stmt = stmt.where(Document.id > cursor_uuid)
+
+    rows = (await db.execute(stmt)).all()
+
+    has_next = len(rows) > limit
+    rows = rows[:limit]
+    external_ids = [row.external_id for row in rows]
+    next_cursor = ""
+    if has_next and rows:
+        # Cursor is the last *included* row's id; the next page starts strictly
+        # after it. Stable across server restarts because Document.id is a
+        # uuid4 primary key — values do not shuffle.
+        next_cursor = str(rows[-1].id)
+
+    return external_ids, next_cursor
+
+
+# ---------------------------------------------------------------------------
+# Route.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/entities",
+    summary="List operator-emitted entity external_ids (workspace + cluster + kind)",
+    response_model=OperatorEntitiesPage,
+    dependencies=[_operator_read_dep],
+)
+async def list_operator_entities(
+    request: Request,
+    workspace_id: uuid.UUID = _workspace_id_query,
+    cluster_id: uuid.UUID = _cluster_id_query,
+    kind: str = _kind_query,
+    cursor: str = _cursor_query,
+    limit: int = _limit_query,
+    token: ApiToken = _operator_read_dep,
+) -> OperatorEntitiesPage:
+    """Return one page of external_ids for the given filter.
+
+    Fails closed at three layers:
+      1. Bearer auth (handled by Depends)
+      2. ``operator:read`` scope (handled by Depends)
+      3. Workspace match (this body) — token's workspace MUST equal the
+         ``workspace_id`` query parameter, otherwise 403.
+
+    Server-side filters that are NOT exposed as query params (deliberately):
+      * ``source_type='k8s_operator'`` — clients cannot opt out
+      * ``Source.tenant_id = workspace_id`` — second layer of tenant
+        isolation, even if a future migration loosens the SQL above
+
+    The first failure raises HTTPException; the success body is a
+    :class:`OperatorEntitiesPage`.
+    """
+    # Workspace gate (load-bearing ACL check — see ADR-0007 §ACL).
+    _require_matching_workspace(token, requested_workspace_id=workspace_id)
+
+    factory = _resolve_db_factory(request)
+    async with factory() as db:
+        external_ids, next_cursor = await _query_external_ids(
+            db,
+            workspace_id=workspace_id,
+            cluster_id=cluster_id,
+            kind=kind,
+            cursor=cursor,
+            limit=limit,
+        )
+
+    log.info(
+        "operator_entities_listed",
+        token_prefix=token.token_prefix,
+        workspace_id=str(workspace_id),
+        cluster_id=str(cluster_id),
+        kind=kind,
+        count=len(external_ids),
+        cursor_in=bool(cursor),
+        cursor_out=bool(next_cursor),
+    )
+    return OperatorEntitiesPage(external_ids=external_ids, next_cursor=next_cursor)

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -10,6 +10,7 @@ from omniscience_server.rest.freshness import router as freshness_router
 from omniscience_server.rest.incidents import router as incidents_router
 from omniscience_server.rest.incidents_admin import router as incidents_admin_router
 from omniscience_server.rest.ingestion_runs import router as ingestion_runs_router
+from omniscience_server.rest.operator import router as operator_router
 from omniscience_server.rest.otlp import router as otlp_router
 from omniscience_server.rest.retention import router as retention_router
 from omniscience_server.rest.search import router as search_router
@@ -29,6 +30,7 @@ api_v1_router.include_router(freshness_router)
 api_v1_router.include_router(stats_router)
 api_v1_router.include_router(retention_router)
 api_v1_router.include_router(otlp_router)
+api_v1_router.include_router(operator_router)
 api_v1_router.include_router(incidents_router)
 api_v1_router.include_router(incidents_admin_router)
 

--- a/helm/omniscience-operator/templates/deployment.yaml
+++ b/helm/omniscience-operator/templates/deployment.yaml
@@ -48,6 +48,11 @@ spec:
             - name: OMNISCIENCE_NATS_CREDS_FILE
               value: /etc/nats/creds/nats.creds
             {{- end }}
+            # ── #163 reconciliation worker ────────────────────────────────
+            - name: OMNISCIENCE_RECONCILE_INTERVAL
+              value: {{ .Values.reconciler.interval | quote }}
+            - name: OMNISCIENCE_RECONCILE_DRY_RUN
+              value: {{ .Values.reconciler.dryRun | quote }}
           envFrom:
             - secretRef:
                 name: {{ include "omniscience-operator.fullname" . }}-config

--- a/helm/omniscience-operator/templates/secret.yaml
+++ b/helm/omniscience-operator/templates/secret.yaml
@@ -28,6 +28,14 @@ stringData:
   OMNISCIENCE_CLUSTER_NAME: {{ .Values.clusterName | quote }}
   OMNISCIENCE_NATS_URL: {{ .Values.nats.url | quote }}
   OMNISCIENCE_NATS_SUBJECT: {{ .Values.nats.subjectPrefix | quote }}
+  # ── #163 reconciliation read-API client ───────────────────────────────────
+  # Both fields are intentionally optional at chart-install time — empty
+  # baseUrl disables the reconciliation worker (the watch path continues
+  # to work), and the operator fails closed if baseUrl is set but
+  # bearerToken is empty (config.Load() returns an error). The bearer
+  # token MUST come from this Secret per ADR-0007 §ACL.
+  OMNISCIENCE_API_BASE_URL: {{ .Values.api.baseUrl | quote }}
+  OMNISCIENCE_API_BEARER_TOKEN: {{ .Values.api.bearerToken | quote }}
 {{- if .Values.nats.credentials }}
 ---
 apiVersion: v1

--- a/helm/omniscience-operator/values.yaml
+++ b/helm/omniscience-operator/values.yaml
@@ -112,6 +112,31 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# ── Reconciliation worker (#163) ──────────────────────────────────────────────
+# Drift detector that periodically compares cluster state against the
+# Omniscience graph slice for (workspaceId, clusterId) and emits corrective
+# events. See operator/internal/reconciler for the implementation.
+reconciler:
+  # Period between reconcile cycles. 15 minutes is the issue #163 default —
+  # balances drift recovery latency against read-API + cluster-list cost.
+  # Format is any time.ParseDuration value (e.g. "15m", "30m", "1h").
+  interval: 15m
+  # Dry-run mode: log diff and increment metrics, emit ZERO events. Used
+  # for first-time-on-customer-cluster validation before flipping to live.
+  dryRun: false
+
+# Omniscience server read API. The reconciler queries this surface to learn
+# which entities the graph believes exist for (workspaceId, clusterId).
+api:
+  # Absolute base URL of the Omniscience server. Empty disables the
+  # reconciler entirely; the rest of the operator continues to start.
+  baseUrl: ""
+  # Bearer token authenticating the operator to the read API. MUST come
+  # from a Secret-mounted file. The server gates the workspaceId query
+  # parameter against the token's workspace and 403s on mismatch — this
+  # is the load-bearing ACL gate (ADR-0007 §ACL, issue #163).
+  bearerToken: ""
+
 # ── Annotations / labels ──────────────────────────────────────────────────────
 podAnnotations: {}
 podLabels: {}

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/100rd/omniscience/operator/internal/config"
 	"github.com/100rd/omniscience/operator/internal/controller"
 	"github.com/100rd/omniscience/operator/internal/publisher"
+	"github.com/100rd/omniscience/operator/internal/reconciler"
 )
 
 // scheme is the runtime scheme used by the manager's client and cache.
@@ -189,7 +190,7 @@ func run() error {
 	// ── #190 DRA resource handles — discovery-gated registration ──────────
 	// Probe the API server for resource.k8s.io/v1beta1; absent → log INFO
 	// and skip all 4 DRA controllers. Same fail-open posture as #161.
-	if err := setupDRAWatchers(mgr, pub, cfg.WorkspaceID, cfg.ClusterName, logger); err != nil {
+	if err := setupDRAWatchers(mgr, pub, cfg.WorkspaceID, cfg.ClusterID, cfg.ClusterName, logger); err != nil {
 		return err
 	}
 	// ── end #190 ──────────────────────────────────────────────────────────
@@ -249,6 +250,56 @@ func run() error {
 		return fmt.Errorf("argocd watchers setup: %w", err)
 	}
 	// ─── END issue #160 ───────────────────────────────────────────────────
+
+	// ── #163 reconciliation worker ────────────────────────────────────────
+	// Drift detector that periodically compares cluster state against the
+	// graph slice for (workspace_id, cluster_id) and emits corrective
+	// events. Implements manager.LeaderElectionRunnable, so the manager
+	// only ticks the worker on the leader replica when LeaderElect=true.
+	//
+	// Config knobs (all with safe defaults; see internal/config):
+	//   OMNISCIENCE_RECONCILE_INTERVAL  — default 15m
+	//   OMNISCIENCE_RECONCILE_DRY_RUN   — default false
+	//   OMNISCIENCE_API_BASE_URL        — required to enable
+	//   OMNISCIENCE_API_BEARER_TOKEN    — required to enable (Secret-mounted)
+	//
+	// Empty API URL disables the worker entirely — the rest of the
+	// operator continues to start normally. This preserves the watch path
+	// as the single source of truth in deployments that have not yet
+	// rolled out the read API endpoint server-side.
+	if cfg.APIBaseURL == "" {
+		logger.Info("reconciler.disabled — OMNISCIENCE_API_BASE_URL is empty",
+			"event", "reconciler.disabled",
+		)
+	} else {
+		apiClient, ierr := reconciler.NewHTTPEntitiesClient(cfg.APIBaseURL, cfg.APIBearerToken)
+		if ierr != nil {
+			return fmt.Errorf("reconciler: api client init: %w", ierr)
+		}
+		worker, ierr := reconciler.New(reconciler.Options{
+			K8sClient:   mgr.GetClient(),
+			APIClient:   apiClient,
+			Publisher:   pub,
+			WorkspaceID: cfg.WorkspaceID,
+			ClusterID:   cfg.ClusterID,
+			ClusterName: cfg.ClusterName,
+			Interval:    cfg.ReconcileInterval,
+			DryRun:      cfg.ReconcileDryRun,
+		})
+		if ierr != nil {
+			return fmt.Errorf("reconciler: worker init: %w", ierr)
+		}
+		if ierr := mgr.Add(worker); ierr != nil {
+			return fmt.Errorf("reconciler: mgr.Add: %w", ierr)
+		}
+		logger.Info("reconciler.enabled",
+			"event", "reconciler.enabled",
+			"interval", cfg.ReconcileInterval.String(),
+			"dry_run", cfg.ReconcileDryRun,
+			"api_base_url", cfg.APIBaseURL,
+		)
+	}
+	// ── end #163 ──────────────────────────────────────────────────────────
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("add healthz: %w", err)
@@ -434,6 +485,7 @@ func setupDRAWatchers(
 	mgr ctrl.Manager,
 	pub publisher.Publisher,
 	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
 	clusterName string,
 	logger interface {
 		Info(msg string, keysAndValues ...interface{})
@@ -461,7 +513,7 @@ func setupDRAWatchers(
 		return fmt.Errorf("dra: add to scheme: %w", err)
 	}
 
-	rcRec, err := controller.NewResourceClaimReconciler(mgr.GetClient(), pub, workspaceID, clusterName)
+	rcRec, err := controller.NewResourceClaimReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName)
 	if err != nil {
 		return fmt.Errorf("dra: resourceclaim reconciler init: %w", err)
 	}

--- a/operator/internal/config/config.go
+++ b/operator/internal/config/config.go
@@ -41,6 +41,26 @@ const (
 	envMetricsAddr = "OMNISCIENCE_METRICS_ADDR"
 	envProbeAddr   = "OMNISCIENCE_PROBE_ADDR"
 	envLeaderElect = "OMNISCIENCE_LEADER_ELECT"
+
+	// ── #163 reconciliation worker ───────────────────────────────────────
+	// envReconcileInterval is the period between reconcile cycles. Default
+	// 15m (issue #163 §Goal). Format is any time.ParseDuration value.
+	envReconcileInterval = "OMNISCIENCE_RECONCILE_INTERVAL"
+	// envReconcileDryRun, when "true", suppresses event emission. Used for
+	// first-time-on-customer-cluster validation per issue #163 §Scope.
+	envReconcileDryRun = "OMNISCIENCE_RECONCILE_DRY_RUN"
+	// envAPIBaseURL is the absolute URL of the Omniscience server, e.g.
+	// "https://omniscience.example". The read API endpoint
+	// "/api/v1/operator/entities" is appended at request time.
+	envAPIBaseURL = "OMNISCIENCE_API_BASE_URL"
+	// envAPIBearerToken is the operator's bearer token for the read API.
+	// MUST come from a Secret-mounted file (see ADR-0007 §ACL); the
+	// server gates the workspace_id query param against the token's
+	// workspace and 403s on mismatch — this is the load-bearing ACL gate.
+	// The #nosec annotation suppresses gosec G101 on the literal substring
+	// "TOKEN" (which it flags as a potential hardcoded credential).
+	envAPIBearerToken = "OMNISCIENCE_API_BEARER_TOKEN" //nolint:gosec // env var name, not a secret
+	// ── end #163 ──────────────────────────────────────────────────────────
 )
 
 // Defaults chosen for v0.2 single-replica operator. Each is named in the
@@ -63,6 +83,12 @@ const (
 
 	// defaultProbeAddr is the health/readiness probe bind address.
 	defaultProbeAddr = ":8081"
+
+	// defaultReconcileInterval is the default period between reconciliation
+	// worker cycles (issue #163 §Goal). 15 minutes is a balance between
+	// drift recovery latency and read-API + cluster-list cost on large
+	// clusters. Tunable via OMNISCIENCE_RECONCILE_INTERVAL.
+	defaultReconcileInterval = 15 * time.Minute
 )
 
 // Config is the resolved operator configuration. All fields are immutable
@@ -104,6 +130,25 @@ type Config struct {
 	MetricsAddr  string
 	ProbeAddr    string
 	LeaderElect  bool
+
+	// ── #163 reconciliation worker ───────────────────────────────────────
+	// ReconcileInterval is the period between reconcile cycles. 15m default.
+	ReconcileInterval time.Duration
+
+	// ReconcileDryRun, when true, suppresses event emission from the
+	// reconciler. Watch-path emission is unaffected.
+	ReconcileDryRun bool
+
+	// APIBaseURL is the absolute URL of the Omniscience read API. Empty
+	// disables the reconciler entirely (the worker is a no-op).
+	APIBaseURL string
+
+	// APIBearerToken authenticates the operator to the read API. MUST come
+	// from a Secret-mounted file (ADR-0007 §ACL). Empty disables the
+	// reconciler when APIBaseURL is also empty; an empty token with a
+	// non-empty URL is a misconfiguration and Load returns an error.
+	APIBearerToken string
+	// ── end #163 ──────────────────────────────────────────────────────────
 }
 
 // Load reads the operator configuration from process environment.
@@ -169,6 +214,30 @@ func Load() (*Config, error) {
 		}
 		cfg.ResyncPeriod = secs
 	}
+
+	// ── #163 reconciliation worker config ────────────────────────────────
+	cfg.ReconcileInterval = defaultReconcileInterval
+	if raw := os.Getenv(envReconcileInterval); raw != "" {
+		d, perr := time.ParseDuration(raw)
+		if perr != nil {
+			return nil, fmt.Errorf("config: %s is not a valid duration: %w", envReconcileInterval, perr)
+		}
+		if d <= 0 {
+			return nil, fmt.Errorf("config: %s must be positive", envReconcileInterval)
+		}
+		cfg.ReconcileInterval = d
+	}
+	cfg.ReconcileDryRun = os.Getenv(envReconcileDryRun) == "true"
+	cfg.APIBaseURL = os.Getenv(envAPIBaseURL)
+	cfg.APIBearerToken = os.Getenv(envAPIBearerToken)
+	// Fail-closed misconfiguration check: a base URL without a token is
+	// always wrong. The reverse (token without URL) is also wrong but
+	// rejecting only the URL+no-token combination is enough — an empty
+	// URL disables the reconciler entirely (worker startup logs that).
+	if cfg.APIBaseURL != "" && cfg.APIBearerToken == "" {
+		return nil, fmt.Errorf("config: %s set but %s is empty (reconciler requires both)", envAPIBaseURL, envAPIBearerToken)
+	}
+	// ── end #163 ──────────────────────────────────────────────────────────
 
 	return cfg, nil
 }

--- a/operator/internal/controller/dra_deviceclass_controller.go
+++ b/operator/internal/controller/dra_deviceclass_controller.go
@@ -74,7 +74,13 @@ func (r *DeviceClassReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	err := r.Client.Get(ctx, req.NamespacedName, &rc)
 	switch {
 	case err == nil:
-		ev := entity.DeviceClassToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		// Derived cluster_id (issue #167); the DRA reconciler does not yet
+		// carry a ClusterID field — the v0.2 deterministic uuid5 derivation
+		// gives the same value the operator config would compute, keeping
+		// the watch path's external_ids stable for single-cluster deployments.
+		// Multi-cluster DRA coverage requires a follow-up that plumbs
+		// cfg.ClusterID through this constructor.
+		ev := entity.DeviceClassToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, entity.DeriveClusterID(r.WorkspaceID, r.ClusterName), r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish deviceclass event: %w", perr)
@@ -86,7 +92,7 @@ func (r *DeviceClassReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		stub := &resourcev1beta1.DeviceClass{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.DeviceClassToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.DeviceClassToEvent(stub, entity.ActionDeleted, r.WorkspaceID, entity.DeriveClusterID(r.WorkspaceID, r.ClusterName), r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish deviceclass deletion: %w", perr)

--- a/operator/internal/controller/dra_resourceclaimtemplate_controller.go
+++ b/operator/internal/controller/dra_resourceclaimtemplate_controller.go
@@ -74,7 +74,9 @@ func (r *ResourceClaimTemplateReconciler) Reconcile(ctx context.Context, req ctr
 	err := r.Client.Get(ctx, req.NamespacedName, &rc)
 	switch {
 	case err == nil:
-		ev := entity.ResourceClaimTemplateToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		// Derived cluster_id (issue #167); see dra_deviceclass_controller.go
+		// for the rationale. Follow-up plumbs cfg.ClusterID through.
+		ev := entity.ResourceClaimTemplateToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, entity.DeriveClusterID(r.WorkspaceID, r.ClusterName), r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish resourceclaimtemplate event: %w", perr)
@@ -86,7 +88,7 @@ func (r *ResourceClaimTemplateReconciler) Reconcile(ctx context.Context, req ctr
 		stub := &resourcev1beta1.ResourceClaimTemplate{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ResourceClaimTemplateToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ResourceClaimTemplateToEvent(stub, entity.ActionDeleted, r.WorkspaceID, entity.DeriveClusterID(r.WorkspaceID, r.ClusterName), r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish resourceclaimtemplate deletion: %w", perr)

--- a/operator/internal/controller/dra_resourceslice_controller.go
+++ b/operator/internal/controller/dra_resourceslice_controller.go
@@ -74,7 +74,8 @@ func (r *ResourceSliceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	err := r.Client.Get(ctx, req.NamespacedName, &rc)
 	switch {
 	case err == nil:
-		ev := entity.ResourceSliceToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, r.ClusterName, r.Now())
+		// Derived cluster_id (issue #167); see dra_deviceclass_controller.go.
+		ev := entity.ResourceSliceToEvent(&rc, entity.ActionUpdated, r.WorkspaceID, entity.DeriveClusterID(r.WorkspaceID, r.ClusterName), r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish resourceslice event: %w", perr)
@@ -86,7 +87,7 @@ func (r *ResourceSliceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		stub := &resourcev1beta1.ResourceSlice{}
 		stub.Namespace = req.Namespace
 		stub.Name = req.Name
-		ev := entity.ResourceSliceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterName, r.Now())
+		ev := entity.ResourceSliceToEvent(stub, entity.ActionDeleted, r.WorkspaceID, entity.DeriveClusterID(r.WorkspaceID, r.ClusterName), r.ClusterName, r.Now())
 		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
 			logger.Error(perr, "publish deletion failed; will requeue")
 			return ctrl.Result{}, fmt.Errorf("publish resourceslice deletion: %w", perr)

--- a/operator/internal/reconciler/client.go
+++ b/operator/internal/reconciler/client.go
@@ -1,0 +1,226 @@
+// HTTP client for the Omniscience read API surface added in issue #163.
+//
+// The reconciler queries the server's operator-scoped read endpoint to
+// discover which entities the graph believes exist for a given
+// (workspace_id, cluster_id, kind) tuple. The endpoint is bearer-
+// authenticated with a token that carries the workspace_id; the server
+// 403s on any mismatch between the token's workspace and the
+// workspace_id query parameter — this is the load-bearing ACL gate.
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EntitiesAPIClient is the narrow interface the reconciler needs from the
+// Omniscience read API. Defined as an interface so tests can substitute a
+// stubbed implementation without spinning up an httptest.Server in the
+// hot path of pure unit tests. The reconciler test suite does spin up an
+// httptest.Server because it exercises end-to-end paginated walks.
+type EntitiesAPIClient interface {
+	// ListExternalIDs returns every external_id the graph believes exists
+	// for (workspaceID, clusterID, kind), filtered server-side to entities
+	// emitted by the operator (emitter=k8s-operator). The implementation
+	// MUST follow pagination cursors to completion.
+	ListExternalIDs(
+		ctx context.Context,
+		workspaceID uuid.UUID,
+		clusterID uuid.UUID,
+		kind string,
+	) ([]string, error)
+}
+
+// HTTPEntitiesClient is the production EntitiesAPIClient. Configured at
+// startup from env vars (OMNISCIENCE_API_BASE_URL, OMNISCIENCE_API_BEARER_TOKEN).
+// A single client instance is reused across reconcile cycles so HTTP
+// keep-alive and connection pooling carry across runs.
+type HTTPEntitiesClient struct {
+	// baseURL is the absolute server URL, e.g. "https://omniscience.example".
+	// The endpoint path "/api/v1/operator/entities" is appended at request
+	// time. Trailing slash is normalised away in NewHTTPEntitiesClient so
+	// callers cannot accidentally produce double-slash URLs.
+	baseURL string
+
+	// bearerToken authenticates the operator. MUST come from a Secret-
+	// mounted file (see ADR-0007 §ACL); never from cluster-side state.
+	// The token's workspace_id field gates the server's ACL check —
+	// passing the wrong token is a 403, not a silent cross-workspace read.
+	bearerToken string
+
+	// httpClient is the underlying transport. Tests inject one with a
+	// custom RoundTripper; production uses NewHTTPEntitiesClient's default.
+	httpClient *http.Client
+
+	// pageLimit is the per-request entity cap. Server caps it server-side
+	// too; this is the operator's polite cap that minimises memory
+	// transient on the operator side. 500 is a balance between request
+	// count and JSON-decode buffer size.
+	pageLimit int
+}
+
+// HTTPEntitiesClientOption customises a client at construction time. Used
+// in tests to inject the httptest.Server's HTTP client.
+type HTTPEntitiesClientOption func(*HTTPEntitiesClient)
+
+// WithHTTPClient replaces the underlying *http.Client. Tests pass the one
+// from httptest.NewServer().Client(); production code never needs this.
+func WithHTTPClient(c *http.Client) HTTPEntitiesClientOption {
+	return func(h *HTTPEntitiesClient) {
+		h.httpClient = c
+	}
+}
+
+// WithPageLimit overrides the default page size. Tests use this to force
+// pagination boundary cases without needing thousands of stubbed entities.
+func WithPageLimit(n int) HTTPEntitiesClientOption {
+	return func(h *HTTPEntitiesClient) {
+		if n > 0 {
+			h.pageLimit = n
+		}
+	}
+}
+
+// NewHTTPEntitiesClient validates inputs and returns a configured client.
+// The bearer token is held in memory and never logged — even on error
+// paths the implementation only logs the request URL, never the token.
+func NewHTTPEntitiesClient(baseURL, bearerToken string, opts ...HTTPEntitiesClientOption) (*HTTPEntitiesClient, error) {
+	if baseURL == "" {
+		return nil, errors.New("reconciler: api base url is required")
+	}
+	if bearerToken == "" {
+		return nil, errors.New("reconciler: api bearer token is required")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("reconciler: invalid api base url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("reconciler: api base url must be http(s): got %q", parsed.Scheme)
+	}
+	c := &HTTPEntitiesClient{
+		baseURL:     strings.TrimRight(baseURL, "/"),
+		bearerToken: bearerToken,
+		// 30s per-request timeout — generous enough to cover paginated
+		// walks against a slow server, tight enough that a wedged
+		// reconcile cycle never holds up a leader-election lease.
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		pageLimit:  500,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// entitiesPage is the JSON shape returned by the read API. The field names
+// match the server-side Pydantic model verbatim. Forward-compatible: extra
+// fields the server adds later are ignored by Go's json decoder.
+type entitiesPage struct {
+	ExternalIDs []string `json:"external_ids"`
+	NextCursor  string   `json:"next_cursor"`
+}
+
+// ListExternalIDs walks every page of the read API and returns the
+// concatenated external_id list for the given (workspaceID, clusterID,
+// kind) scope. Server-side filtering on emitter=k8s-operator is mandatory;
+// the client trusts the server to enforce it (the server is the source of
+// truth for the emitter filter, not the client).
+//
+// Pagination protocol: an empty next_cursor on a response terminates the
+// walk. The client refuses to follow more than a hard cap of pages so a
+// server bug producing infinite pagination cannot wedge the reconciler.
+func (c *HTTPEntitiesClient) ListExternalIDs(
+	ctx context.Context,
+	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
+	kind string,
+) ([]string, error) {
+	if kind == "" {
+		return nil, errors.New("reconciler: kind is required")
+	}
+
+	const maxPages = 1000 // 1000 * pageLimit(500) = 500k entities per kind, plenty.
+	var (
+		out     []string
+		cursor  string
+		pageIdx int
+	)
+	for {
+		page, err := c.fetchPage(ctx, workspaceID, clusterID, kind, cursor)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page.ExternalIDs...)
+		if page.NextCursor == "" {
+			return out, nil
+		}
+		cursor = page.NextCursor
+		pageIdx++
+		if pageIdx >= maxPages {
+			return nil, fmt.Errorf("reconciler: pagination exceeded %d pages for kind=%s", maxPages, kind)
+		}
+	}
+}
+
+// fetchPage performs one HTTP GET and decodes the JSON response. Errors
+// are wrapped with the request URL (no token, no body content) so log
+// scrapers can trace failures without exposing the bearer.
+func (c *HTTPEntitiesClient) fetchPage(
+	ctx context.Context,
+	workspaceID uuid.UUID,
+	clusterID uuid.UUID,
+	kind string,
+	cursor string,
+) (*entitiesPage, error) {
+	q := url.Values{}
+	q.Set("workspace_id", workspaceID.String())
+	q.Set("cluster_id", clusterID.String())
+	q.Set("kind", kind)
+	q.Set("limit", strconv.Itoa(c.pageLimit))
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+
+	reqURL := c.baseURL + "/api/v1/operator/entities?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reconciler: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.bearerToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Note: deliberately do NOT wrap with the URL's query string in
+		// case it ever embeds anything sensitive. Path is sufficient.
+		return nil, fmt.Errorf("reconciler: GET %s/api/v1/operator/entities: %w", c.baseURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		// Read a small bounded prefix of the body so a server-side bug
+		// returning a 100MiB error page cannot OOM the operator.
+		bodyPrefix, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf(
+			"reconciler: GET %s/api/v1/operator/entities returned %d: %s",
+			c.baseURL, resp.StatusCode, strings.TrimSpace(string(bodyPrefix)),
+		)
+	}
+
+	var page entitiesPage
+	if derr := json.NewDecoder(resp.Body).Decode(&page); derr != nil {
+		return nil, fmt.Errorf("reconciler: decode response: %w", derr)
+	}
+	return &page, nil
+}

--- a/operator/internal/reconciler/client_test.go
+++ b/operator/internal/reconciler/client_test.go
@@ -1,0 +1,194 @@
+// Tests for HTTPEntitiesClient — paginated walk, bearer auth, error paths.
+// Each test spins up an httptest.Server and asserts the client's request
+// shape and pagination behaviour.
+package reconciler_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/100rd/omniscience/operator/internal/reconciler"
+)
+
+// recorder captures requests so tests can assert on what the client sent.
+type recorder struct {
+	mu       sync.Mutex
+	requests []*http.Request
+}
+
+func (r *recorder) record(req *http.Request) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	clone := req.Clone(req.Context())
+	r.requests = append(r.requests, clone)
+}
+
+func (r *recorder) snapshot() []*http.Request {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*http.Request, len(r.requests))
+	copy(out, r.requests)
+	return out
+}
+
+func TestHTTPEntitiesClient_HappyPath_Pagination(t *testing.T) {
+	rec := &recorder{}
+	wsID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	cidID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rec.record(req)
+
+		// Assert authentication header.
+		if got, want := req.Header.Get("Authorization"), "Bearer test-token"; got != want {
+			t.Errorf("Authorization header = %q, want %q", got, want)
+		}
+
+		// Assert query params.
+		q := req.URL.Query()
+		if got := q.Get("workspace_id"); got != wsID.String() {
+			t.Errorf("workspace_id = %q, want %q", got, wsID.String())
+		}
+		if got := q.Get("cluster_id"); got != cidID.String() {
+			t.Errorf("cluster_id = %q, want %q", got, cidID.String())
+		}
+		if got := q.Get("kind"); got != "Pod" {
+			t.Errorf("kind = %q, want Pod", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		// Three pages: cursor=="" → page1, "p2" → page2, "p3" → page3 with empty next.
+		switch q.Get("cursor") {
+		case "":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"external_ids": []string{"k8s_resource/cid/Pod/ns/a", "k8s_resource/cid/Pod/ns/b"},
+				"next_cursor":  "p2",
+			})
+		case "p2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"external_ids": []string{"k8s_resource/cid/Pod/ns/c"},
+				"next_cursor":  "p3",
+			})
+		case "p3":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"external_ids": []string{"k8s_resource/cid/Pod/ns/d"},
+				"next_cursor":  "",
+			})
+		default:
+			t.Fatalf("unexpected cursor %q", q.Get("cursor"))
+		}
+	}))
+	defer server.Close()
+
+	c, err := reconciler.NewHTTPEntitiesClient(server.URL, "test-token", reconciler.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("client init: %v", err)
+	}
+	got, err := c.ListExternalIDs(context.Background(), wsID, cidID, "Pod")
+	if err != nil {
+		t.Fatalf("ListExternalIDs: %v", err)
+	}
+	want := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+		"k8s_resource/cid/Pod/ns/c",
+		"k8s_resource/cid/Pod/ns/d",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (got=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if n := len(rec.snapshot()); n != 3 {
+		t.Errorf("server saw %d requests, want 3", n)
+	}
+}
+
+func TestHTTPEntitiesClient_RejectsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":{"code":"forbidden","message":"workspace mismatch"}}`))
+	}))
+	defer server.Close()
+
+	c, err := reconciler.NewHTTPEntitiesClient(server.URL, "test-token", reconciler.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("client init: %v", err)
+	}
+	_, err = c.ListExternalIDs(context.Background(), uuid.New(), uuid.New(), "Pod")
+	if err == nil {
+		t.Fatalf("expected error on 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error must mention 403; got: %v", err)
+	}
+	// Verify the bearer token is NEVER in the wrapped error message.
+	if strings.Contains(err.Error(), "test-token") {
+		t.Errorf("error must not leak bearer token; got: %v", err)
+	}
+}
+
+func TestHTTPEntitiesClient_RejectsMalformedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	c, err := reconciler.NewHTTPEntitiesClient(server.URL, "tok", reconciler.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("client init: %v", err)
+	}
+	_, err = c.ListExternalIDs(context.Background(), uuid.New(), uuid.New(), "Pod")
+	if err == nil {
+		t.Fatalf("expected decode error, got nil")
+	}
+}
+
+func TestHTTPEntitiesClient_PaginationCapped(t *testing.T) {
+	// Force a server that always returns next_cursor → pagination loop must
+	// terminate via the maxPages cap, never hang.
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"external_ids":["x"],"next_cursor":"%d"}`, atomic.LoadInt32(&calls))
+	}))
+	defer server.Close()
+
+	c, err := reconciler.NewHTTPEntitiesClient(server.URL, "tok", reconciler.WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatalf("client init: %v", err)
+	}
+	_, err = c.ListExternalIDs(context.Background(), uuid.New(), uuid.New(), "Pod")
+	if err == nil {
+		t.Fatalf("expected pagination cap error, got nil")
+	}
+	if !strings.Contains(err.Error(), "pagination exceeded") {
+		t.Errorf("error must mention pagination cap; got: %v", err)
+	}
+}
+
+func TestNewHTTPEntitiesClient_ValidatesInputs(t *testing.T) {
+	if _, err := reconciler.NewHTTPEntitiesClient("", "tok"); err == nil {
+		t.Errorf("expected error on empty url")
+	}
+	if _, err := reconciler.NewHTTPEntitiesClient("https://x", ""); err == nil {
+		t.Errorf("expected error on empty token")
+	}
+	if _, err := reconciler.NewHTTPEntitiesClient("ftp://x", "tok"); err == nil {
+		t.Errorf("expected error on non-http scheme")
+	}
+}

--- a/operator/internal/reconciler/cross_workspace_test.go
+++ b/operator/internal/reconciler/cross_workspace_test.go
@@ -133,7 +133,7 @@ func TestCrossWorkspaceIsolation_NoCrossTalk(t *testing.T) {
 		ClusterName: "cluster-a",
 		Interval:    1 * time.Hour,
 		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
-		Now:         func() time.Time { return time.Now() },
+		Now:         time.Now,
 	})
 	if err != nil {
 		t.Fatalf("workerA: %v", err)
@@ -147,7 +147,7 @@ func TestCrossWorkspaceIsolation_NoCrossTalk(t *testing.T) {
 		ClusterName: "cluster-b",
 		Interval:    1 * time.Hour,
 		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
-		Now:         func() time.Time { return time.Now() },
+		Now:         time.Now,
 	})
 	if err != nil {
 		t.Fatalf("workerB: %v", err)
@@ -241,7 +241,7 @@ func TestCrossWorkspaceIsolation_ServerRejectsMismatchedWorkspace(t *testing.T) 
 		ClusterName: "cluster",
 		Interval:    1 * time.Hour,
 		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
-		Now:         func() time.Time { return time.Now() },
+		Now:         time.Now,
 	})
 	if err != nil {
 		t.Fatalf("worker: %v", err)

--- a/operator/internal/reconciler/cross_workspace_test.go
+++ b/operator/internal/reconciler/cross_workspace_test.go
@@ -1,0 +1,278 @@
+// Cross-workspace isolation test for the reconciliation worker.
+//
+// This is the load-bearing security regression for issue #163. The
+// scenario: two operators in two distinct workspaces (A and B), each
+// configured with its OWN bearer token and its OWN read-API endpoint.
+// Each reconciler in workspace A MUST query only A's stubbed server, and
+// MUST emit zero events scoped to workspace B. Symmetric for B.
+//
+// We model the server-side ACL gate by having each httptest.Server
+// reject any token that does not belong to its own workspace, and by
+// having each server return a manufactured payload that DOES include
+// adversarial cross-workspace external_ids the operator must NEVER
+// publish (because they never appear in workspace A's diff, by virtue
+// of the server-side filter).
+//
+// If anyone refactors the worker so it pools requests across workspaces
+// or reads from the wrong stub, this test fails loudly.
+package reconciler_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/reconciler"
+)
+
+// workspaceServer wraps an httptest.Server with token+workspace gating.
+// Tokens are bound to their workspace; a request whose Authorization does
+// not match the bound token, OR whose workspace_id query param does not
+// match the bound workspace, is 403'd.
+type workspaceServer struct {
+	*httptest.Server
+	bearer       string
+	workspaceID  uuid.UUID
+	ourGraphIDs  []string
+	rejectCount  atomic.Int32
+	queryCount   atomic.Int32
+	receivedAuth atomic.Pointer[string]
+}
+
+func newWorkspaceServer(t *testing.T, ws uuid.UUID, bearer string, graphIDs []string) *workspaceServer {
+	t.Helper()
+	ws_ := &workspaceServer{
+		bearer:      bearer,
+		workspaceID: ws,
+		ourGraphIDs: graphIDs,
+	}
+	ws_.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ws_.queryCount.Add(1)
+		auth := req.Header.Get("Authorization")
+		ws_.receivedAuth.Store(&auth)
+		// ACL gate #1: token must match.
+		if auth != "Bearer "+bearer {
+			ws_.rejectCount.Add(1)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = fmt.Fprint(w, `{"detail":{"code":"unauthorized"}}`)
+			return
+		}
+		// ACL gate #2: workspace_id query param must match the token's
+		// workspace. This is what the SERVER-side handler does in
+		// production; we mirror it here so the test exercises the same
+		// 403-on-mismatch flow.
+		got := req.URL.Query().Get("workspace_id")
+		if got != ws.String() {
+			ws_.rejectCount.Add(1)
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = fmt.Fprint(w, `{"detail":{"code":"forbidden","message":"workspace mismatch"}}`)
+			return
+		}
+		// Happy path: return our graph IDs.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"external_ids": graphIDs,
+			"next_cursor":  "",
+		})
+	}))
+	t.Cleanup(ws_.Close)
+	return ws_
+}
+
+func TestCrossWorkspaceIsolation_NoCrossTalk(t *testing.T) {
+	wsA := uuid.MustParse("aaaaaaaa-1111-1111-1111-111111111111")
+	wsB := uuid.MustParse("bbbbbbbb-2222-2222-2222-222222222222")
+	cidA := uuid.MustParse("cccccccc-1111-1111-1111-111111111111")
+	cidB := uuid.MustParse("cccccccc-2222-2222-2222-222222222222")
+
+	// Each workspace's stub server claims a graph entry that, if leaked,
+	// would prove cross-talk: workspace A's server returns an entity
+	// purportedly belonging to workspace B's cluster_id, and vice versa.
+	// The reconciler MUST NOT emit those — its diff input for A includes
+	// only A's claimed entries; it never sees B's.
+	graphA := []string{"k8s_resource/" + cidA.String() + "/Pod/ns/a-only"}
+	graphB := []string{"k8s_resource/" + cidB.String() + "/Pod/ns/b-only"}
+
+	srvA := newWorkspaceServer(t, wsA, "token-a", graphA)
+	srvB := newWorkspaceServer(t, wsB, "token-b", graphB)
+
+	// Each operator has its own cluster K8s client (fake, empty). With
+	// empty clusters and one entry in each graph, missing-in-cluster diff
+	// produces exactly one deletion event per operator — directed at
+	// THEIR OWN cluster_id, never the other's.
+	cA := newFakeClient()
+	cB := newFakeClient()
+
+	apiA, err := reconciler.NewHTTPEntitiesClient(srvA.URL, "token-a", reconciler.WithHTTPClient(srvA.Client()))
+	if err != nil {
+		t.Fatalf("apiA: %v", err)
+	}
+	apiB, err := reconciler.NewHTTPEntitiesClient(srvB.URL, "token-b", reconciler.WithHTTPClient(srvB.Client()))
+	if err != nil {
+		t.Fatalf("apiB: %v", err)
+	}
+
+	pubA := &fakePublisher{}
+	pubB := &fakePublisher{}
+
+	workerA, err := reconciler.New(reconciler.Options{
+		K8sClient:   cA,
+		APIClient:   apiA,
+		Publisher:   pubA,
+		WorkspaceID: wsA,
+		ClusterID:   cidA,
+		ClusterName: "cluster-a",
+		Interval:    1 * time.Hour,
+		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
+		Now:         func() time.Time { return time.Now() },
+	})
+	if err != nil {
+		t.Fatalf("workerA: %v", err)
+	}
+	workerB, err := reconciler.New(reconciler.Options{
+		K8sClient:   cB,
+		APIClient:   apiB,
+		Publisher:   pubB,
+		WorkspaceID: wsB,
+		ClusterID:   cidB,
+		ClusterName: "cluster-b",
+		Interval:    1 * time.Hour,
+		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
+		Now:         func() time.Time { return time.Now() },
+	})
+	if err != nil {
+		t.Fatalf("workerB: %v", err)
+	}
+
+	workerA.RunOnce(context.Background())
+	workerB.RunOnce(context.Background())
+
+	// --- Assertion 1: each pubA/pubB emitted exactly one event ---
+	evA := pubA.snapshot()
+	evB := pubB.snapshot()
+	if len(evA) != 1 {
+		t.Fatalf("workspace A: expected 1 event, got %d", len(evA))
+	}
+	if len(evB) != 1 {
+		t.Fatalf("workspace B: expected 1 event, got %d", len(evB))
+	}
+
+	// --- Assertion 2: every event for A carries A's workspace+cluster_id ---
+	for _, ev := range evA {
+		if ev.WorkspaceID != wsA {
+			t.Errorf("workspace A event leaked workspace: %s vs %s", ev.WorkspaceID, wsA)
+		}
+		if got := ev.Metadata["cluster_id"]; got != cidA.String() {
+			t.Errorf("workspace A event leaked cluster_id: %s vs %s", got, cidA)
+		}
+		// And critically, the external_id MUST contain A's cluster_id, never B's.
+		if !contains(ev.ExternalID, cidA.String()) {
+			t.Errorf("workspace A event external_id missing A's cluster_id: %s", ev.ExternalID)
+		}
+		if contains(ev.ExternalID, cidB.String()) {
+			t.Errorf("workspace A event external_id contained B's cluster_id: %s", ev.ExternalID)
+		}
+	}
+	for _, ev := range evB {
+		if ev.WorkspaceID != wsB {
+			t.Errorf("workspace B event leaked workspace: %s vs %s", ev.WorkspaceID, wsB)
+		}
+		if got := ev.Metadata["cluster_id"]; got != cidB.String() {
+			t.Errorf("workspace B event leaked cluster_id: %s vs %s", got, cidB)
+		}
+		if !contains(ev.ExternalID, cidB.String()) {
+			t.Errorf("workspace B event external_id missing B's cluster_id: %s", ev.ExternalID)
+		}
+		if contains(ev.ExternalID, cidA.String()) {
+			t.Errorf("workspace B event external_id contained A's cluster_id: %s", ev.ExternalID)
+		}
+	}
+
+	// --- Assertion 3: each server saw only its own bearer token ---
+	if got := srvA.receivedAuth.Load(); got == nil || *got != "Bearer token-a" {
+		t.Errorf("server A saw wrong auth: %v", got)
+	}
+	if got := srvB.receivedAuth.Load(); got == nil || *got != "Bearer token-b" {
+		t.Errorf("server B saw wrong auth: %v", got)
+	}
+
+	// --- Assertion 4: server-side ACL did not 403 anyone ---
+	if r := srvA.rejectCount.Load(); r != 0 {
+		t.Errorf("server A rejected %d requests; expected 0 (workspace match)", r)
+	}
+	if r := srvB.rejectCount.Load(); r != 0 {
+		t.Errorf("server B rejected %d requests; expected 0", r)
+	}
+}
+
+func TestCrossWorkspaceIsolation_ServerRejectsMismatchedWorkspace(t *testing.T) {
+	// Negative path: confirm the ACL gate fires when the operator's token
+	// is wired to query a workspace that does not match. This proves the
+	// server-side check is the load-bearing line of defence — even a
+	// misconfigured operator (or a buggy refactor) cannot reach into
+	// another tenant's data.
+	wsA := uuid.MustParse("aaaaaaaa-1111-1111-1111-111111111111")
+	wsB := uuid.MustParse("bbbbbbbb-2222-2222-2222-222222222222")
+	srvA := newWorkspaceServer(t, wsA, "token-a", []string{})
+
+	// Build a client whose bearer matches wsA's token but whose worker is
+	// configured for workspace B — the server MUST 403 on the workspace_id
+	// query param mismatch.
+	apiClient, err := reconciler.NewHTTPEntitiesClient(srvA.URL, "token-a", reconciler.WithHTTPClient(srvA.Client()))
+	if err != nil {
+		t.Fatalf("api client: %v", err)
+	}
+	pub := &fakePublisher{}
+	worker, err := reconciler.New(reconciler.Options{
+		K8sClient:   newFakeClient(),
+		APIClient:   apiClient,
+		Publisher:   pub,
+		WorkspaceID: wsB, // <-- mismatch with token's workspace
+		ClusterID:   uuid.New(),
+		ClusterName: "cluster",
+		Interval:    1 * time.Hour,
+		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
+		Now:         func() time.Time { return time.Now() },
+	})
+	if err != nil {
+		t.Fatalf("worker: %v", err)
+	}
+
+	worker.RunOnce(context.Background())
+
+	// Worker swallows the 403 (logged, runs_total{result=error} incremented).
+	// The critical assertion: zero events emitted, server saw a rejected
+	// request.
+	if n := len(pub.snapshot()); n != 0 {
+		t.Fatalf("expected 0 events on ACL rejection, got %d", n)
+	}
+	if r := srvA.rejectCount.Load(); r == 0 {
+		t.Fatalf("expected server to reject mismatched workspace; saw %d rejections", r)
+	}
+}
+
+// contains is a tiny string helper — the standard library has strings.Contains
+// but using it here would add an extra import to a test file that already
+// has plenty. Inline keeps the assertions readable.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// We never want to instantiate metav1.ObjectMeta in this file but the test
+// helpers require corev1; keep the import live.
+var _ = metav1.ObjectMeta{}
+var _ = corev1.Pod{}

--- a/operator/internal/reconciler/diff.go
+++ b/operator/internal/reconciler/diff.go
@@ -1,0 +1,79 @@
+// Package reconciler implements the operator's drift-detection worker.
+//
+// It periodically compares the set of external_ids the operator emits for a
+// given (workspace_id, cluster_id, kind) tuple in the Omniscience graph
+// against the actual list of resources in the cluster, and re-asserts the
+// difference by emitting synthetic events through the existing publisher.
+//
+// The reconciler is the *graph-vs-cluster* drift detector. It is distinct
+// from controller-runtime's per-resource Reconcile loop, which handles
+// individual watch events. The two cooperate: watchers keep the graph live
+// at single-event granularity; the reconciler closes any drift that opened
+// up during operator downtime, NATS outages, or transient API-server
+// hiccups.
+//
+// Field-level drift (a Pod's phase differs between graph and cluster) is
+// out of scope here per ADR-0007 §Decision and issue #163 — this worker
+// reconciles topology only.
+//
+// ACL invariant: every external_id passed to Diff is already scoped to the
+// caller's (workspace_id, cluster_id) pair — see issue #163 §ACL. Diff is a
+// pure set operation with no notion of workspace; the caller MUST NOT mix
+// inputs from different (workspace_id, cluster_id) pairs.
+package reconciler
+
+import "sort"
+
+// Diff computes the symmetric set difference between in-cluster and
+// in-graph external_id sets and returns the two corrective sides:
+//
+//   - missingInGraph: external_ids present in the cluster but absent from
+//     the graph. The reconciler should emit a synthetic "created" event
+//     for each.
+//   - missingInCluster: external_ids present in the graph but absent from
+//     the cluster. The reconciler should emit a "deleted" event for each.
+//
+// Both result slices are sorted lexicographically so the caller's emit
+// order is deterministic — easier to reason about in logs and tests.
+//
+// Empty inputs are valid and produce empty outputs symmetrically. The two
+// inputs MUST already share the same (workspace_id, cluster_id, kind)
+// scope; Diff treats them as opaque strings.
+func Diff(inCluster, inGraph []string) (missingInGraph, missingInCluster []string) {
+	// Build sets once; keys are external_ids which are short strings, so
+	// the map overhead is trivial on cluster sizes the operator targets
+	// (10k Pods → ~1MiB transient).
+	cluster := make(map[string]struct{}, len(inCluster))
+	for _, id := range inCluster {
+		if id == "" {
+			// Defensive: reject empty external_ids so a publisher bug
+			// upstream cannot poison the diff. Empty would round-trip
+			// as "everything missing" which is spectacularly wrong.
+			continue
+		}
+		cluster[id] = struct{}{}
+	}
+
+	graph := make(map[string]struct{}, len(inGraph))
+	for _, id := range inGraph {
+		if id == "" {
+			continue
+		}
+		graph[id] = struct{}{}
+	}
+
+	for id := range cluster {
+		if _, ok := graph[id]; !ok {
+			missingInGraph = append(missingInGraph, id)
+		}
+	}
+	for id := range graph {
+		if _, ok := cluster[id]; !ok {
+			missingInCluster = append(missingInCluster, id)
+		}
+	}
+
+	sort.Strings(missingInGraph)
+	sort.Strings(missingInCluster)
+	return missingInGraph, missingInCluster
+}

--- a/operator/internal/reconciler/diff_test.go
+++ b/operator/internal/reconciler/diff_test.go
@@ -1,0 +1,154 @@
+// Tests for the pure Diff function. The matrix below is the one called
+// out as required in issue #163 acceptance.
+package reconciler_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/100rd/omniscience/operator/internal/reconciler"
+)
+
+func TestDiff_BothEmpty(t *testing.T) {
+	mig, mic := reconciler.Diff(nil, nil)
+	if len(mig) != 0 || len(mic) != 0 {
+		t.Fatalf("expected zero-zero diff, got mig=%v mic=%v", mig, mic)
+	}
+}
+
+func TestDiff_Identical(t *testing.T) {
+	in := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+	}
+	mig, mic := reconciler.Diff(in, in)
+	if len(mig) != 0 || len(mic) != 0 {
+		t.Fatalf("expected zero-zero diff for identical sets, got mig=%v mic=%v", mig, mic)
+	}
+}
+
+func TestDiff_MissingInGraph_OneSide(t *testing.T) {
+	cluster := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+	}
+	graph := []string{
+		"k8s_resource/cid/Pod/ns/a",
+	}
+	mig, mic := reconciler.Diff(cluster, graph)
+	if !reflect.DeepEqual(mig, []string{"k8s_resource/cid/Pod/ns/b"}) {
+		t.Fatalf("missing-in-graph mismatch: %v", mig)
+	}
+	if len(mic) != 0 {
+		t.Fatalf("expected empty missing-in-cluster, got %v", mic)
+	}
+}
+
+func TestDiff_MissingInCluster_OneSide(t *testing.T) {
+	cluster := []string{
+		"k8s_resource/cid/Pod/ns/a",
+	}
+	graph := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+	}
+	mig, mic := reconciler.Diff(cluster, graph)
+	if len(mig) != 0 {
+		t.Fatalf("expected empty missing-in-graph, got %v", mig)
+	}
+	if !reflect.DeepEqual(mic, []string{"k8s_resource/cid/Pod/ns/b"}) {
+		t.Fatalf("missing-in-cluster mismatch: %v", mic)
+	}
+}
+
+func TestDiff_BothDirections_MassDrift(t *testing.T) {
+	cluster := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+		"k8s_resource/cid/Pod/ns/c",
+		"k8s_resource/cid/Pod/ns/d",
+	}
+	graph := []string{
+		"k8s_resource/cid/Pod/ns/c",
+		"k8s_resource/cid/Pod/ns/d",
+		"k8s_resource/cid/Pod/ns/e",
+		"k8s_resource/cid/Pod/ns/f",
+	}
+	mig, mic := reconciler.Diff(cluster, graph)
+	wantMig := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+	}
+	wantMic := []string{
+		"k8s_resource/cid/Pod/ns/e",
+		"k8s_resource/cid/Pod/ns/f",
+	}
+	if !reflect.DeepEqual(mig, wantMig) {
+		t.Fatalf("missing-in-graph mismatch: got=%v want=%v", mig, wantMig)
+	}
+	if !reflect.DeepEqual(mic, wantMic) {
+		t.Fatalf("missing-in-cluster mismatch: got=%v want=%v", mic, wantMic)
+	}
+}
+
+func TestDiff_EmptyClusterDeletesEverything(t *testing.T) {
+	graph := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+	}
+	mig, mic := reconciler.Diff(nil, graph)
+	if len(mig) != 0 {
+		t.Fatalf("expected empty missing-in-graph, got %v", mig)
+	}
+	if len(mic) != 2 {
+		t.Fatalf("expected 2 deletions, got %v", mic)
+	}
+}
+
+func TestDiff_EmptyGraphCreatesEverything(t *testing.T) {
+	cluster := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+	}
+	mig, mic := reconciler.Diff(cluster, nil)
+	if len(mig) != 2 {
+		t.Fatalf("expected 2 creations, got %v", mig)
+	}
+	if len(mic) != 0 {
+		t.Fatalf("expected empty missing-in-cluster, got %v", mic)
+	}
+}
+
+func TestDiff_IgnoresEmptyStrings(t *testing.T) {
+	// Defensive: an upstream bug that produces an empty external_id MUST
+	// NOT cause "everything looks missing" because empty would map to a
+	// distinct set element on one side only.
+	cluster := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"",
+	}
+	graph := []string{
+		"k8s_resource/cid/Pod/ns/a",
+	}
+	mig, mic := reconciler.Diff(cluster, graph)
+	if len(mig) != 0 || len(mic) != 0 {
+		t.Fatalf("expected zero diff with empty filtered, got mig=%v mic=%v", mig, mic)
+	}
+}
+
+func TestDiff_DeterministicOrder(t *testing.T) {
+	cluster := []string{
+		"k8s_resource/cid/Pod/ns/c",
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+	}
+	mig, _ := reconciler.Diff(cluster, nil)
+	want := []string{
+		"k8s_resource/cid/Pod/ns/a",
+		"k8s_resource/cid/Pod/ns/b",
+		"k8s_resource/cid/Pod/ns/c",
+	}
+	if !reflect.DeepEqual(mig, want) {
+		t.Fatalf("expected sorted output: got=%v want=%v", mig, want)
+	}
+}

--- a/operator/internal/reconciler/kinds.go
+++ b/operator/internal/reconciler/kinds.go
@@ -1,0 +1,682 @@
+// Per-kind metadata and dispatch for the reconciliation worker.
+//
+// The reconciler iterates over a deterministic list of kinds. For each
+// kind it needs three operations packaged in a KindHandler:
+//
+//  1. ListInCluster — read the cluster, return a map keyed on external_id
+//     whose value is a *closure* that emits the corresponding "created"
+//     event (closing over the live K8s object). Keys feed the diff; values
+//     drive the missing-in-graph emit path. The keys-as-strings list is
+//     handed to Diff() which only cares about set membership; storing the
+//     full object behind the key lets us emit without a second Get round
+//     trip and keeps the reconciler's transient memory footprint at one
+//     copy of the cluster's objects per kind per cycle.
+//
+//  2. EmitDeleted — produce a "deleted" event for an external_id present
+//     in the graph but missing from the cluster. The external_id format
+//     ("k8s_resource/{cluster_id}/{Kind}/{namespace}/{name}" or
+//     "k8s_resource/{cluster_id}/{Kind}/{name}" for cluster-scoped) is
+//     reversed into (Kind, namespace, name). A stub object with only
+//     namespace+name is fed to the mapper, mirroring how the existing
+//     watch controllers handle NotFound deletions (see
+//     deployment_controller.go's stub path).
+//
+// We deliberately reuse the live mappers (operator/internal/entity/*) so
+// the reconciler and watch path produce byte-identical external_ids —
+// that is the symmetric-difference invariant Diff depends on.
+//
+// The kind list intentionally subsets the watcher coverage. Optional CRDs
+// (ArgoCD, Argo Rollouts, DRA) are listed only when the API server has
+// them — discovery-gated registration mirrors the watcher startup path
+// (see cmd/manager/main.go ── #161 / #160 / #190 ──). v0.2 ships without
+// optional-CRD reconciliation; coverage parity will be a follow-up.
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// EventBuilder is a closure that emits an Event on demand. The reconciler
+// keeps one of these per in-cluster object so it can emit a synthetic
+// "created" event for items missing from the graph without re-Get'ing.
+type EventBuilder func(workspaceID, clusterID uuid.UUID, clusterName string, now time.Time) *entity.Event
+
+// KindHandler bundles the operations the reconciler performs per kind.
+type KindHandler struct {
+	// Name is the K8s API Kind string (e.g. "Pod", "Deployment"). Used as
+	// the metric `kind` label and as the request to the read API.
+	Name string
+
+	// ListInCluster reads the cluster and returns a map external_id →
+	// EventBuilder for every in-cluster object of this kind. The keys
+	// feed the diff; the closures drive missing-in-graph emit.
+	ListInCluster func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error)
+
+	// EmitDeleted constructs a deletion event for an external_id present in
+	// the graph but missing from the cluster. The external_id is parsed
+	// back to (namespace, name) and a stub object fed to the mapper.
+	EmitDeleted func(externalID string, workspaceID, clusterID uuid.UUID, clusterName string, now time.Time) (*entity.Event, error)
+}
+
+// kindRegistry returns every KindHandler the reconciler covers in v0.2.
+// Order is fixed and deterministic so reconcile cycles are diff-stable
+// across operator restarts (helps when grepping logs).
+//
+// The list mirrors the watcher set in cmd/manager/main.go for the kinds
+// that the operator reliably watches without optional-CRD discovery.
+func kindRegistry() []KindHandler {
+	return []KindHandler{
+		// Workload kinds — the highest-volume drift candidates.
+		newPodHandler(),
+		newDeploymentHandler(),
+		newReplicaSetHandler(),
+		newStatefulSetHandler(),
+		newDaemonSetHandler(),
+		newJobHandler(),
+		// Networking + config kinds (#158).
+		newServiceHandler(),
+		newEndpointsHandler(),
+		newIngressHandler(),
+		newNetworkPolicyHandler(),
+		newConfigMapHandler(),
+		newSecretHandler(),
+		// Cluster-scoped kinds (#159).
+		newNodeHandler(),
+		newNamespaceHandler(),
+		newPersistentVolumeHandler(),
+		newStorageClassHandler(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-kind handler constructors. Each is a small named function rather than
+// an inline literal so a stack trace points at the right kind.
+// ---------------------------------------------------------------------------
+
+func newPodHandler() KindHandler {
+	return KindHandler{
+		Name: "Pod",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.PodList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "Pod", obj.Namespace, obj.Name)
+				// In Go 1.22+, loop variables are per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.PodToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("Pod", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.Pod{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.PodToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newDeploymentHandler() KindHandler {
+	return KindHandler{
+		Name: "Deployment",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list appsv1.DeploymentList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "Deployment", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.DeploymentToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("Deployment", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &appsv1.Deployment{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.DeploymentToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newReplicaSetHandler() KindHandler {
+	return KindHandler{
+		Name: "ReplicaSet",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list appsv1.ReplicaSetList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "ReplicaSet", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.ReplicaSetToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("ReplicaSet", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &appsv1.ReplicaSet{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.ReplicaSetToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newStatefulSetHandler() KindHandler {
+	return KindHandler{
+		Name: "StatefulSet",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list appsv1.StatefulSetList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "StatefulSet", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.StatefulSetToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("StatefulSet", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &appsv1.StatefulSet{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.StatefulSetToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newDaemonSetHandler() KindHandler {
+	return KindHandler{
+		Name: "DaemonSet",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list appsv1.DaemonSetList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "DaemonSet", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.DaemonSetToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("DaemonSet", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &appsv1.DaemonSet{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.DaemonSetToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newJobHandler() KindHandler {
+	return KindHandler{
+		Name: "Job",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list batchv1.JobList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "Job", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.JobToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("Job", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &batchv1.Job{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.JobToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newServiceHandler() KindHandler {
+	return KindHandler{
+		Name: "Service",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.ServiceList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "Service", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.ServiceToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("Service", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.Service{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.ServiceToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newEndpointsHandler() KindHandler {
+	return KindHandler{
+		Name: "Endpoints",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.EndpointsList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "Endpoints", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.EndpointsToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("Endpoints", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.Endpoints{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.EndpointsToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newIngressHandler() KindHandler {
+	return KindHandler{
+		Name: "Ingress",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list networkingv1.IngressList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "Ingress", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.IngressToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("Ingress", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &networkingv1.Ingress{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.IngressToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newNetworkPolicyHandler() KindHandler {
+	return KindHandler{
+		Name: "NetworkPolicy",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list networkingv1.NetworkPolicyList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "NetworkPolicy", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.NetworkPolicyToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("NetworkPolicy", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &networkingv1.NetworkPolicy{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.NetworkPolicyToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newConfigMapHandler() KindHandler {
+	return KindHandler{
+		Name: "ConfigMap",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.ConfigMapList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "ConfigMap", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.ConfigMapToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("ConfigMap", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.ConfigMap{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.ConfigMapToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newSecretHandler() KindHandler {
+	return KindHandler{
+		Name: "Secret",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.SecretList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := namespacedExternalID(clusterID, "Secret", obj.Namespace, obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.SecretToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: namespacedDeleter("Secret", func(ns, name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.Secret{}
+				stub.Namespace = ns
+				stub.Name = name
+				return entity.SecretToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newNodeHandler() KindHandler {
+	return KindHandler{
+		Name: "Node",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.NodeList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := clusterScopedExternalID(clusterID, "Node", obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.NodeToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: clusterScopedDeleter("Node", func(name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+				return entity.NodeToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newNamespaceHandler() KindHandler {
+	return KindHandler{
+		Name: "Namespace",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.NamespaceList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := clusterScopedExternalID(clusterID, "Namespace", obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.NamespaceToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: clusterScopedDeleter("Namespace", func(name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+				return entity.NamespaceToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newPersistentVolumeHandler() KindHandler {
+	return KindHandler{
+		Name: "PersistentVolume",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list corev1.PersistentVolumeList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := clusterScopedExternalID(clusterID, "PersistentVolume", obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.PersistentVolumeToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: clusterScopedDeleter("PersistentVolume", func(name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: name}}
+				return entity.PersistentVolumeToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+func newStorageClassHandler() KindHandler {
+	return KindHandler{
+		Name: "StorageClass",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]EventBuilder, error) {
+			var list storagev1.StorageClassList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]EventBuilder, len(list.Items))
+			for i := range list.Items {
+				obj := &list.Items[i]
+				ext := clusterScopedExternalID(clusterID, "StorageClass", obj.Name)
+				// Go 1.22 loop var is per-iteration; capture is implicit.
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.StorageClassToEvent(obj, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: clusterScopedDeleter("StorageClass", func(name string) entityFromStub {
+			return func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+				stub := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: name}}
+				return entity.StorageClassToEvent(stub, entity.ActionDeleted, ws, cid, cname, now)
+			}
+		}),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// External-id format helpers (production and parse).
+//
+// These mirror operator/internal/entity/common.go::externalIDFor and
+// externalIDForClusterScoped exactly, so the reconciler's strings line up
+// byte-for-byte with what the watch path emits.
+//
+// We do NOT call into the entity package's externalIDFor (it is exported but
+// keeping the format duplicated here is a deliberate pact with one rule:
+// any change to one MUST land with a matching change to the other,
+// enforced by integration tests that compare watch-emitted external_ids
+// against reconciler-emitted ones for the same cluster object).
+// ---------------------------------------------------------------------------
+
+// namespacedExternalID returns "k8s_resource/{cluster_id}/{Kind}/{namespace}/{name}".
+func namespacedExternalID(clusterID uuid.UUID, kind, namespace, name string) string {
+	if namespace == "" {
+		namespace = "default"
+	}
+	return entity.EntityKindPrefix + "/" + clusterID.String() + "/" + kind + "/" + namespace + "/" + name
+}
+
+// clusterScopedExternalID returns "k8s_resource/{cluster_id}/{Kind}/{name}".
+func clusterScopedExternalID(clusterID uuid.UUID, kind, name string) string {
+	return entity.EntityKindPrefix + "/" + clusterID.String() + "/" + kind + "/" + name
+}
+
+// parseNamespacedExternalID reverses namespacedExternalID: returns
+// (namespace, name) or an error when the prefix or shape is wrong.
+func parseNamespacedExternalID(externalID, expectedKind string) (namespace, name string, err error) {
+	parts := strings.Split(externalID, "/")
+	// Expected: ["k8s_resource", "{cid}", "{Kind}", "{ns}", "{name}"]
+	if len(parts) != 5 {
+		return "", "", fmt.Errorf("reconciler: malformed namespaced external_id %q", externalID)
+	}
+	if parts[0] != entity.EntityKindPrefix {
+		return "", "", fmt.Errorf("reconciler: external_id has unexpected prefix %q", parts[0])
+	}
+	if parts[2] != expectedKind {
+		return "", "", fmt.Errorf("reconciler: external_id kind %q does not match expected %q", parts[2], expectedKind)
+	}
+	if parts[3] == "" || parts[4] == "" {
+		return "", "", fmt.Errorf("reconciler: external_id missing namespace or name: %q", externalID)
+	}
+	return parts[3], parts[4], nil
+}
+
+// parseClusterScopedExternalID reverses clusterScopedExternalID.
+func parseClusterScopedExternalID(externalID, expectedKind string) (name string, err error) {
+	parts := strings.Split(externalID, "/")
+	// Expected: ["k8s_resource", "{cid}", "{Kind}", "{name}"]
+	if len(parts) != 4 {
+		return "", fmt.Errorf("reconciler: malformed cluster-scoped external_id %q", externalID)
+	}
+	if parts[0] != entity.EntityKindPrefix {
+		return "", fmt.Errorf("reconciler: external_id has unexpected prefix %q", parts[0])
+	}
+	if parts[2] != expectedKind {
+		return "", fmt.Errorf("reconciler: external_id kind %q does not match expected %q", parts[2], expectedKind)
+	}
+	if parts[3] == "" {
+		return "", fmt.Errorf("reconciler: external_id missing name: %q", externalID)
+	}
+	return parts[3], nil
+}
+
+// entityFromStub binds (ns, name) at dispatch and accepts (workspace, cluster, ts) at emit.
+type entityFromStub func(workspaceID, clusterID uuid.UUID, clusterName string, now time.Time) *entity.Event
+
+// namespacedDeleter wraps a stub-builder closure into the EmitDeleted shape.
+func namespacedDeleter(kind string, stubBuilder func(ns, name string) entityFromStub) func(string, uuid.UUID, uuid.UUID, string, time.Time) (*entity.Event, error) {
+	return func(externalID string, ws, cid uuid.UUID, cname string, now time.Time) (*entity.Event, error) {
+		ns, name, err := parseNamespacedExternalID(externalID, kind)
+		if err != nil {
+			return nil, err
+		}
+		fn := stubBuilder(ns, name)
+		ev := fn(ws, cid, cname, now)
+		if ev == nil {
+			return nil, errors.New("reconciler: stub mapper returned nil event")
+		}
+		return ev, nil
+	}
+}
+
+// clusterScopedDeleter is the cluster-scoped counterpart of namespacedDeleter.
+func clusterScopedDeleter(kind string, stubBuilder func(name string) entityFromStub) func(string, uuid.UUID, uuid.UUID, string, time.Time) (*entity.Event, error) {
+	return func(externalID string, ws, cid uuid.UUID, cname string, now time.Time) (*entity.Event, error) {
+		name, err := parseClusterScopedExternalID(externalID, kind)
+		if err != nil {
+			return nil, err
+		}
+		fn := stubBuilder(name)
+		ev := fn(ws, cid, cname, now)
+		if ev == nil {
+			return nil, errors.New("reconciler: stub mapper returned nil event")
+		}
+		return ev, nil
+	}
+}

--- a/operator/internal/reconciler/metrics.go
+++ b/operator/internal/reconciler/metrics.go
@@ -1,0 +1,102 @@
+// Prometheus metrics for the reconciliation worker.
+//
+// The five metrics below match issue #163 §Metrics exactly. Every metric
+// is registered with controller-runtime's metrics registry so they appear
+// on the existing /metrics endpoint (OMNISCIENCE_METRICS_ADDR).
+//
+// ACL invariant: labels include `kind` and (for drift) `direction`, but
+// NEVER `workspace_id`. Tagging with workspace_id would expose tenancy in
+// the metrics endpoint — multi-tenant operators in the same Prometheus
+// scrape target would leak each other's existence. See issue #163 §ACL
+// invariant #4. Labels are append-only with respect to the issue spec; we
+// add no others.
+package reconciler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Drift directions used by the drift counter's `direction` label. Closed
+// vocabulary — defined as constants so dashboards can match without a
+// free-form-string surface.
+const (
+	DriftDirectionMissingInGraph   = "missing_in_graph"
+	DriftDirectionMissingInCluster = "missing_in_cluster"
+)
+
+// Result values used by the runs counter's `result` label.
+const (
+	RunResultSuccess = "success"
+	RunResultError   = "error"
+)
+
+var (
+	// reconcileRunsTotal counts reconcile cycles per kind, partitioned by
+	// outcome. Operators page on this metric — a sustained `error` rate
+	// is the primary "reconciler stuck" signal.
+	reconcileRunsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "omniscience_operator_reconcile_runs_total",
+			Help: "Total number of reconcile runs by kind and outcome.",
+		},
+		[]string{"kind", "result"},
+	)
+
+	// reconcileDurationSeconds tracks per-kind reconcile cycle latency.
+	// Buckets cover the expected range from <1s (small clusters) to
+	// minutes (10k-pod clusters with paginated reads).
+	reconcileDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "omniscience_operator_reconcile_duration_seconds",
+			Help:    "Wall-clock duration of a reconcile cycle, by kind.",
+			Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300},
+		},
+		[]string{"kind"},
+	)
+
+	// reconcileDriftTotal counts drift events found per kind and direction.
+	// Dashboards graph the rolling sum to catch deletes-only or
+	// creates-only patterns indicative of a stuck consumer.
+	reconcileDriftTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "omniscience_operator_reconcile_drift_total",
+			Help: "Total drift events found by kind and direction.",
+		},
+		[]string{"kind", "direction"},
+	)
+
+	// reconcileInGraphCount is a gauge of the most recent in-graph entity
+	// count per kind. Useful for both validation (matches expected
+	// cluster size?) and capacity planning.
+	reconcileInGraphCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "omniscience_operator_reconcile_in_graph_count",
+			Help: "Most recent in-graph entity count by kind.",
+		},
+		[]string{"kind"},
+	)
+
+	// reconcileInClusterCount is the cluster-side counterpart.
+	reconcileInClusterCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "omniscience_operator_reconcile_in_cluster_count",
+			Help: "Most recent in-cluster entity count by kind.",
+		},
+		[]string{"kind"},
+	)
+)
+
+// init registers every metric with controller-runtime's registry once at
+// package import. controller-runtime exposes them at the same /metrics
+// endpoint as every other operator metric, so adding a scrape config here
+// is unnecessary — the existing one already covers it.
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		reconcileRunsTotal,
+		reconcileDurationSeconds,
+		reconcileDriftTotal,
+		reconcileInGraphCount,
+		reconcileInClusterCount,
+	)
+}

--- a/operator/internal/reconciler/reconciler.go
+++ b/operator/internal/reconciler/reconciler.go
@@ -1,0 +1,340 @@
+// The Worker type and its run loop. The worker:
+//
+//   - Implements sigs.k8s.io/controller-runtime/pkg/manager.Runnable so the
+//     manager can start it as a managed goroutine.
+//   - Implements manager.LeaderElectionRunnable returning true so it
+//     participates in the existing controller-runtime leader-election lease
+//     (#101). Two operator replicas with leader-elect enabled will see only
+//     the leader's worker tick — the second never holds the lease.
+//   - Wakes on a configurable ticker (OMNISCIENCE_RECONCILE_INTERVAL).
+//   - For each kind: lists in-cluster, lists in-graph (HTTP), diffs, and
+//     either emits corrective events or, when dry-run is enabled, only
+//     records the metrics.
+//
+// ACL invariant restated:
+//   - The HTTP client carries a Secret-mounted bearer token. The server
+//     decides whether the token's workspace matches the requested
+//     workspace_id query parameter and 403s on mismatch.
+//   - Diff is a pure set operation. The reconciler MUST NEVER cross-
+//     reference data outside the queried (workspace_id, cluster_id) slice.
+//   - Logs and metrics include `kind` but never `workspace_id`. Dry-run
+//     log lines name only the in-cluster resource (already tenanted by
+//     the operator's own watch coverage); the in-graph payload is NEVER
+//     logged in the missing-in-cluster direction — only the count.
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// Worker is the reconciliation worker singleton. One per operator process.
+// Construction is via New; the zero value is invalid.
+type Worker struct {
+	// k8sClient lists in-cluster resources. The controller-runtime cached
+	// client is reused — it shares the manager's informer cache, so the
+	// reconciler does not pay an extra API-server List on every cycle for
+	// kinds the watcher already informers (Pod, Deployment, ...).
+	k8sClient client.Client
+
+	// apiClient queries the Omniscience read API for in-graph entities.
+	apiClient EntitiesAPIClient
+
+	// pub re-enters the existing publisher path; the reconciler does not
+	// know or care that publishes go to NATS — it just calls Publish.
+	pub publisher.Publisher
+
+	// workspaceID, clusterID, clusterName are the identity tuple stamped
+	// on every emitted event. Sourced from operator config (Secret-
+	// mounted) per ADR-0007 §ACL — never from cluster state.
+	workspaceID uuid.UUID
+	clusterID   uuid.UUID
+	clusterName string
+
+	// interval is the ticker period between reconcile cycles. Default 15m
+	// per issue #163; tunable via OMNISCIENCE_RECONCILE_INTERVAL.
+	interval time.Duration
+
+	// dryRun toggles emission. When true, the worker logs and increments
+	// metrics but emits zero events. Used for first-time-on-customer-
+	// cluster validation before flipping to live.
+	dryRun bool
+
+	// kinds is the per-kind handler list. Defaults to kindRegistry();
+	// tests inject a narrowed slice for kind-specific assertions.
+	kinds []KindHandler
+
+	// now is injected for deterministic test timestamps. Production uses
+	// time.Now.
+	now func() time.Time
+}
+
+// Options is the constructor input. All fields except Kinds are required.
+type Options struct {
+	K8sClient   client.Client
+	APIClient   EntitiesAPIClient
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Interval    time.Duration
+	DryRun      bool
+	// Kinds, when non-nil, overrides the default kindRegistry. Production
+	// callers leave this nil; tests narrow to one or two kinds.
+	Kinds []KindHandler
+	// Now overrides the clock. Production callers leave this nil.
+	Now func() time.Time
+}
+
+// New validates inputs and returns a configured Worker. The validation
+// surface mirrors the existing controller constructors (NewPodReconciler
+// etc.) so misconfiguration fails the same way at the same layer.
+func New(o Options) (*Worker, error) {
+	if o.K8sClient == nil {
+		return nil, errors.New("reconciler: k8s client must not be nil")
+	}
+	if o.APIClient == nil {
+		return nil, errors.New("reconciler: api client must not be nil")
+	}
+	if o.Publisher == nil {
+		return nil, errors.New("reconciler: publisher must not be nil")
+	}
+	if o.WorkspaceID == uuid.Nil {
+		return nil, errors.New("reconciler: workspace id must not be the zero UUID")
+	}
+	if o.ClusterID == uuid.Nil {
+		return nil, errors.New("reconciler: cluster id must not be the zero UUID")
+	}
+	if o.ClusterName == "" {
+		return nil, errors.New("reconciler: cluster name is required")
+	}
+	if o.Interval <= 0 {
+		return nil, errors.New("reconciler: interval must be positive")
+	}
+	kinds := o.Kinds
+	if kinds == nil {
+		kinds = kindRegistry()
+	}
+	now := o.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Worker{
+		k8sClient:   o.K8sClient,
+		apiClient:   o.APIClient,
+		pub:         o.Publisher,
+		workspaceID: o.WorkspaceID,
+		clusterID:   o.ClusterID,
+		clusterName: o.ClusterName,
+		interval:    o.Interval,
+		dryRun:      o.DryRun,
+		kinds:       kinds,
+		now:         now,
+	}, nil
+}
+
+// NeedLeaderElection makes Worker a manager.LeaderElectionRunnable so the
+// controller-runtime manager only ticks the worker on the leader replica.
+// Returning true means: "I should run only when this replica holds the
+// leader-election lease" — the standard pattern for singleton background
+// workers in a controller.
+func (w *Worker) NeedLeaderElection() bool {
+	return true
+}
+
+// Start runs the reconcile loop until ctx is cancelled. Implements
+// manager.Runnable so the manager can mgr.Add(worker).
+//
+// The loop performs an immediate first cycle, then waits one interval
+// between subsequent cycles. The immediate first cycle keeps acceptance
+// tests reasonable (no need to wait 15 minutes after operator startup) and
+// matches the watcher path's "publish on initial sync" behaviour.
+//
+// Errors during a cycle are logged and counted but do NOT abort the loop —
+// a transient API-server or NATS hiccup must not wedge reconciliation
+// indefinitely. A pathological persistent error surface is observed via
+// the runs_total{result="error"} metric, which dashboards page on.
+func (w *Worker) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("reconciler")
+	logger.Info(
+		"reconciler.start",
+		"interval", w.interval.String(),
+		"dry_run", w.dryRun,
+		"kinds", len(w.kinds),
+		"cluster", w.clusterName,
+		// Deliberately do NOT log workspace_id at INFO — see ACL invariant
+		// #4. It is available in operator config logs at startup; logging
+		// here on every Start would put it on every line of the worker.
+	)
+
+	// Run one cycle immediately. If ctx is cancelled before the cycle
+	// completes, the per-cycle context propagates the cancel and the
+	// cycle exits naturally.
+	w.runCycle(ctx, logger)
+
+	t := time.NewTicker(w.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("reconciler.stop", "reason", ctx.Err().Error())
+			return nil
+		case <-t.C:
+			w.runCycle(ctx, logger)
+		}
+	}
+}
+
+// RunOnce executes a single reconcile cycle synchronously. Exposed for
+// integration tests that need deterministic per-cycle assertions without
+// racing the ticker. Production code goes through Start.
+func (w *Worker) RunOnce(ctx context.Context) {
+	w.runCycle(ctx, log.FromContext(ctx).WithName("reconciler"))
+}
+
+// runCycle reconciles every kind once. Errors per kind are logged and the
+// metric error counter increments; the loop continues to the next kind.
+func (w *Worker) runCycle(ctx context.Context, logger logr.Logger) {
+	for _, h := range w.kinds {
+		if ctx.Err() != nil {
+			return
+		}
+		w.runKind(ctx, logger, h)
+	}
+}
+
+// runKind reconciles a single kind. The function is small and named so
+// stack traces in production point at the right kind on panic.
+func (w *Worker) runKind(ctx context.Context, logger logr.Logger, h KindHandler) {
+	kindLogger := logger.WithValues("kind", h.Name)
+	start := w.now()
+	defer func() {
+		reconcileDurationSeconds.WithLabelValues(h.Name).Observe(time.Since(start).Seconds())
+	}()
+
+	// 1. List in-cluster.
+	inCluster, err := h.ListInCluster(ctx, w.k8sClient, w.clusterID)
+	if err != nil {
+		reconcileRunsTotal.WithLabelValues(h.Name, RunResultError).Inc()
+		kindLogger.Error(err, "reconcile.list_cluster_failed")
+		return
+	}
+	clusterIDs := keysOf(inCluster)
+	reconcileInClusterCount.WithLabelValues(h.Name).Set(float64(len(clusterIDs)))
+
+	// 2. List in-graph.
+	graphIDs, err := w.apiClient.ListExternalIDs(ctx, w.workspaceID, w.clusterID, h.Name)
+	if err != nil {
+		reconcileRunsTotal.WithLabelValues(h.Name, RunResultError).Inc()
+		kindLogger.Error(err, "reconcile.list_graph_failed")
+		return
+	}
+	reconcileInGraphCount.WithLabelValues(h.Name).Set(float64(len(graphIDs)))
+
+	// 3. Diff.
+	missingInGraph, missingInCluster := Diff(clusterIDs, graphIDs)
+	reconcileDriftTotal.WithLabelValues(h.Name, DriftDirectionMissingInGraph).Add(float64(len(missingInGraph)))
+	reconcileDriftTotal.WithLabelValues(h.Name, DriftDirectionMissingInCluster).Add(float64(len(missingInCluster)))
+
+	// 4. Emit corrective events. Dry-run skips Publish entirely — metrics
+	// and logs still record the diff.
+	if w.dryRun {
+		// Log only counts in the missing-in-cluster direction (per ACL
+		// invariant #5: do NOT log payload from the read API). Names are
+		// safe in the missing-in-graph direction because they come from
+		// our own watch coverage.
+		kindLogger.Info(
+			"reconcile.dry_run.diff",
+			"in_cluster", len(clusterIDs),
+			"in_graph", len(graphIDs),
+			"missing_in_graph", len(missingInGraph),
+			"missing_in_cluster", len(missingInCluster),
+		)
+		reconcileRunsTotal.WithLabelValues(h.Name, RunResultSuccess).Inc()
+		return
+	}
+
+	failed := 0
+	now := w.now()
+	for _, ext := range missingInGraph {
+		build := inCluster[ext]
+		if build == nil {
+			// Defensive: should never happen — the key was just produced
+			// by ListInCluster — but log + count rather than panic.
+			kindLogger.Error(errors.New("missing builder for in-cluster id"), "reconcile.emit.create",
+				"external_id", ext,
+			)
+			failed++
+			continue
+		}
+		ev := build(w.workspaceID, w.clusterID, w.clusterName, now)
+		if perr := w.publishOne(ctx, ev); perr != nil {
+			failed++
+			kindLogger.Error(perr, "reconcile.emit.create.publish_failed", "external_id", ext)
+		}
+	}
+	for _, ext := range missingInCluster {
+		ev, err := h.EmitDeleted(ext, w.workspaceID, w.clusterID, w.clusterName, now)
+		if err != nil {
+			failed++
+			// Do NOT log the external_id contents at INFO if the path is
+			// malformed — only the parse error itself, with the kind.
+			kindLogger.Error(err, "reconcile.emit.delete.parse_failed")
+			continue
+		}
+		if perr := w.publishOne(ctx, ev); perr != nil {
+			failed++
+			// Deletion log line carries only the kind, not the in-graph
+			// payload, per ACL invariant #5.
+			kindLogger.Error(perr, "reconcile.emit.delete.publish_failed")
+		}
+	}
+
+	if failed > 0 {
+		reconcileRunsTotal.WithLabelValues(h.Name, RunResultError).Inc()
+	} else {
+		reconcileRunsTotal.WithLabelValues(h.Name, RunResultSuccess).Inc()
+	}
+	kindLogger.Info(
+		"reconcile.cycle",
+		"in_cluster", len(clusterIDs),
+		"in_graph", len(graphIDs),
+		"missing_in_graph", len(missingInGraph),
+		"missing_in_cluster", len(missingInCluster),
+		"failed_emits", failed,
+	)
+}
+
+// publishOne wraps publisher.Publish with a defence-in-depth workspace
+// guard. The publisher itself rejects zero-workspace events; this is a
+// second check so any future code path that constructs an event without
+// going through the entity helpers cannot leak.
+func (w *Worker) publishOne(ctx context.Context, ev *entity.Event) error {
+	if ev == nil {
+		return errors.New("reconciler: nil event")
+	}
+	if ev.WorkspaceID != w.workspaceID {
+		return fmt.Errorf("reconciler: refusing to publish event with workspace mismatch: ev=%s want=%s", ev.WorkspaceID, w.workspaceID)
+	}
+	return w.pub.Publish(ctx, ev)
+}
+
+// keysOf returns the keys of m in unspecified order. Diff sorts internally
+// so we don't pre-sort here.
+func keysOf(m map[string]EventBuilder) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/operator/internal/reconciler/reconciler_test.go
+++ b/operator/internal/reconciler/reconciler_test.go
@@ -1,0 +1,384 @@
+// Integration-grade tests for the reconciliation worker.
+//
+// These tests exercise the worker against the controller-runtime fake
+// client (in lieu of envtest, which is not yet wired in this repo — the
+// fake client is sufficient because the worker's code path boils down to:
+// List → diff → Publish, with no Reconcile loop semantics to exercise) and
+// a stubbed Omniscience read API server (httptest).
+//
+// Coverage:
+//   - happy path: cluster has 2, graph has 0 → 2 created events emitted
+//   - inverse:    cluster has 0, graph has 2 → 2 deleted events emitted
+//   - dry-run:    flag set, diff observed, ZERO events emitted
+//   - cross-workspace isolation: two operators, two stubbed servers; each
+//     reconciler in workspace A queries only A's graph, never touches B
+//   - leader election: NeedLeaderElection returns true so the manager
+//     gates the worker on the leader-elect lease (the actual single-leader
+//     guarantee is provided by controller-runtime's manager and is tested
+//     by controller-runtime upstream — we only need to assert the wiring)
+package reconciler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	"github.com/100rd/omniscience/operator/internal/reconciler"
+)
+
+// fakePublisher captures published events so tests assert on the corrective
+// emissions. Mirrors the workload_controllers_test.go fixture for parity.
+type fakePublisher struct {
+	mu     sync.Mutex
+	events []*entity.Event
+}
+
+func (f *fakePublisher) Publish(_ context.Context, ev *entity.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, ev)
+	return nil
+}
+
+func (f *fakePublisher) Close() error { return nil }
+
+func (f *fakePublisher) snapshot() []*entity.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]*entity.Event, len(f.events))
+	copy(out, f.events)
+	return out
+}
+
+// stubServer returns a tiny http.Handler that returns the given external_ids
+// for ANY workspace_id query (used for non-cross-workspace tests). The
+// cross-workspace test uses a separate per-workspace handler.
+func stubServer(t *testing.T, externalIDs []string) (*httptest.Server, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		rec.record(req)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"external_ids": externalIDs,
+			"next_cursor":  "",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func newFakeClient(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func TestWorker_RunCycle_EmitsCreatedForMissingInGraph(t *testing.T) {
+	wsID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	cidID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "a"}}
+	c := newFakeClient(pod)
+	srv, _ := stubServer(t, nil) // graph is empty → all in-cluster pods are missing-in-graph
+
+	apiClient, err := reconciler.NewHTTPEntitiesClient(srv.URL, "tok", reconciler.WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("api client: %v", err)
+	}
+	pub := &fakePublisher{}
+	worker, err := reconciler.New(reconciler.Options{
+		K8sClient:   c,
+		APIClient:   apiClient,
+		Publisher:   pub,
+		WorkspaceID: wsID,
+		ClusterID:   cidID,
+		ClusterName: "test-cluster",
+		Interval:    1 * time.Hour, // long; only run-once tested
+		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
+		Now:         func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("worker: %v", err)
+	}
+
+	worker.RunOnce(context.Background())
+
+	events := pub.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 created event, got %d: %+v", len(events), events)
+	}
+	ev := events[0]
+	if ev.Action != entity.ActionCreated {
+		t.Errorf("action = %q, want created", ev.Action)
+	}
+	if ev.WorkspaceID != wsID {
+		t.Errorf("workspace_id = %s, want %s", ev.WorkspaceID, wsID)
+	}
+	if ev.Metadata["emitter"] != entity.EmitterLabel {
+		t.Errorf("emitter = %q, want %q", ev.Metadata["emitter"], entity.EmitterLabel)
+	}
+	if ev.Metadata["cluster_id"] != cidID.String() {
+		t.Errorf("cluster_id = %s, want %s", ev.Metadata["cluster_id"], cidID)
+	}
+}
+
+func TestWorker_RunCycle_EmitsDeletedForMissingInCluster(t *testing.T) {
+	wsID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	cidID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+
+	c := newFakeClient() // empty cluster
+	graphID := "k8s_resource/" + cidID.String() + "/Pod/ns/ghost"
+	srv, _ := stubServer(t, []string{graphID})
+
+	apiClient, err := reconciler.NewHTTPEntitiesClient(srv.URL, "tok", reconciler.WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("api client: %v", err)
+	}
+	pub := &fakePublisher{}
+	worker, err := reconciler.New(reconciler.Options{
+		K8sClient:   c,
+		APIClient:   apiClient,
+		Publisher:   pub,
+		WorkspaceID: wsID,
+		ClusterID:   cidID,
+		ClusterName: "test-cluster",
+		Interval:    1 * time.Hour,
+		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
+		Now:         func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("worker: %v", err)
+	}
+
+	worker.RunOnce(context.Background())
+
+	events := pub.snapshot()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 deletion event, got %d: %+v", len(events), events)
+	}
+	ev := events[0]
+	if ev.Action != entity.ActionDeleted {
+		t.Errorf("action = %q, want deleted", ev.Action)
+	}
+	if ev.ExternalID != graphID {
+		t.Errorf("external_id = %q, want %q", ev.ExternalID, graphID)
+	}
+	if ev.WorkspaceID != wsID {
+		t.Errorf("workspace_id mismatch: %s vs %s", ev.WorkspaceID, wsID)
+	}
+}
+
+func TestWorker_DryRun_EmitsZeroEventsButObservesDiff(t *testing.T) {
+	wsID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	cidID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "live"}}
+	c := newFakeClient(pod)
+	graphID := "k8s_resource/" + cidID.String() + "/Pod/ns/ghost"
+	srv, _ := stubServer(t, []string{graphID})
+
+	apiClient, err := reconciler.NewHTTPEntitiesClient(srv.URL, "tok", reconciler.WithHTTPClient(srv.Client()))
+	if err != nil {
+		t.Fatalf("api client: %v", err)
+	}
+	pub := &fakePublisher{}
+	worker, err := reconciler.New(reconciler.Options{
+		K8sClient:   c,
+		APIClient:   apiClient,
+		Publisher:   pub,
+		WorkspaceID: wsID,
+		ClusterID:   cidID,
+		ClusterName: "test-cluster",
+		Interval:    1 * time.Hour,
+		DryRun:      true,
+		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
+		Now:         func() time.Time { return time.Now() },
+	})
+	if err != nil {
+		t.Fatalf("worker: %v", err)
+	}
+
+	worker.RunOnce(context.Background())
+
+	if n := len(pub.snapshot()); n != 0 {
+		t.Fatalf("expected ZERO events in dry-run, got %d", n)
+	}
+}
+
+func TestWorker_NeedLeaderElection_ReturnsTrue(t *testing.T) {
+	// The worker MUST run only on the leader replica when leader-elect is
+	// enabled. controller-runtime's manager keys this off NeedLeaderElection.
+	wsID := uuid.New()
+	cidID := uuid.New()
+	srv, _ := stubServer(t, nil)
+	apiClient, _ := reconciler.NewHTTPEntitiesClient(srv.URL, "tok", reconciler.WithHTTPClient(srv.Client()))
+	worker, err := reconciler.New(reconciler.Options{
+		K8sClient:   newFakeClient(),
+		APIClient:   apiClient,
+		Publisher:   &fakePublisher{},
+		WorkspaceID: wsID,
+		ClusterID:   cidID,
+		ClusterName: "x",
+		Interval:    1 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("worker: %v", err)
+	}
+	if !worker.NeedLeaderElection() {
+		t.Fatalf("NeedLeaderElection must return true so multi-replica deployments do not double-reconcile")
+	}
+}
+
+func TestWorker_Start_RunsOneCycleThenStopsOnContextCancel(t *testing.T) {
+	// Smoke-test the Start() loop. Verifies the loop performs the immediate
+	// first cycle, then exits cleanly on context cancellation.
+	wsID := uuid.New()
+	cidID := uuid.New()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "smoke"}}
+	c := newFakeClient(pod)
+	srv, _ := stubServer(t, nil)
+	apiClient, _ := reconciler.NewHTTPEntitiesClient(srv.URL, "tok", reconciler.WithHTTPClient(srv.Client()))
+	pub := &fakePublisher{}
+	worker, err := reconciler.New(reconciler.Options{
+		K8sClient:   c,
+		APIClient:   apiClient,
+		Publisher:   pub,
+		WorkspaceID: wsID,
+		ClusterID:   cidID,
+		ClusterName: "x",
+		// Short interval so a follow-up tick fires within the test window —
+		// proves the ticker loop is live, not that we just ran the immediate
+		// first cycle.
+		Interval: 50 * time.Millisecond,
+		Kinds:    []reconciler.KindHandler{podOnlyKind(t)},
+	})
+	if err != nil {
+		t.Fatalf("worker: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	startErr := worker.Start(ctx)
+	if startErr != nil {
+		t.Fatalf("Start returned error: %v", startErr)
+	}
+
+	if n := len(pub.snapshot()); n < 1 {
+		t.Fatalf("expected at least 1 event from Start loop, got %d", n)
+	}
+}
+
+func TestNew_RejectsBadOptions(t *testing.T) {
+	srv, _ := stubServer(t, nil)
+	apiClient, _ := reconciler.NewHTTPEntitiesClient(srv.URL, "tok", reconciler.WithHTTPClient(srv.Client()))
+	good := reconciler.Options{
+		K8sClient:   newFakeClient(),
+		APIClient:   apiClient,
+		Publisher:   &fakePublisher{},
+		WorkspaceID: uuid.New(),
+		ClusterID:   uuid.New(),
+		ClusterName: "x",
+		Interval:    1 * time.Hour,
+	}
+
+	cases := map[string]func(o *reconciler.Options){
+		"nil k8s":         func(o *reconciler.Options) { o.K8sClient = nil },
+		"nil api":         func(o *reconciler.Options) { o.APIClient = nil },
+		"nil publisher":   func(o *reconciler.Options) { o.Publisher = nil },
+		"zero workspace":  func(o *reconciler.Options) { o.WorkspaceID = uuid.Nil },
+		"zero cluster":    func(o *reconciler.Options) { o.ClusterID = uuid.Nil },
+		"empty cluster":   func(o *reconciler.Options) { o.ClusterName = "" },
+		"non-positive iv": func(o *reconciler.Options) { o.Interval = 0 },
+	}
+	for name, mut := range cases {
+		t.Run(name, func(t *testing.T) {
+			o := good
+			mut(&o)
+			if _, err := reconciler.New(o); err == nil {
+				t.Fatalf("expected error for case %q", name)
+			}
+		})
+	}
+}
+
+// podOnlyKind returns a KindHandler restricted to Pod for narrow assertions.
+// Reuses the entity mappers via the public reconciler API by exporting via
+// kindRegistry and filtering — but that registry is package-private, so this
+// fixture builds a Pod-only handler inline. The handler's behaviour mirrors
+// kinds.go's newPodHandler exactly; the duplication is the price of keeping
+// kindRegistry unexported.
+func podOnlyKind(t *testing.T) reconciler.KindHandler {
+	t.Helper()
+	return reconciler.KindHandler{
+		Name: "Pod",
+		ListInCluster: func(ctx context.Context, c client.Client, clusterID uuid.UUID) (map[string]reconciler.EventBuilder, error) {
+			var list corev1.PodList
+			if err := c.List(ctx, &list); err != nil {
+				return nil, err
+			}
+			out := make(map[string]reconciler.EventBuilder, len(list.Items))
+			for i := range list.Items {
+				p := &list.Items[i]
+				ns := p.Namespace
+				if ns == "" {
+					ns = "default"
+				}
+				ext := entity.EntityKindPrefix + "/" + clusterID.String() + "/Pod/" + ns + "/" + p.Name
+				out[ext] = func(ws, cid uuid.UUID, cname string, now time.Time) *entity.Event {
+					return entity.PodToEvent(p, entity.ActionCreated, ws, cid, cname, now)
+				}
+			}
+			return out, nil
+		},
+		EmitDeleted: func(ext string, ws, cid uuid.UUID, cname string, now time.Time) (*entity.Event, error) {
+			// Reuse the package-private parser via a one-shot Pod stub. Because
+			// the parser lives behind the package boundary we duplicate the
+			// minimal logic here; the integration test is small enough that
+			// keeping it self-contained is preferable to exporting helpers.
+			parts := splitN(ext, '/', 5)
+			if len(parts) != 5 || parts[0] != entity.EntityKindPrefix || parts[2] != "Pod" {
+				t.Fatalf("malformed external_id: %q", ext)
+			}
+			stub := &corev1.Pod{}
+			stub.Namespace = parts[3]
+			stub.Name = parts[4]
+			return entity.PodToEvent(stub, entity.ActionDeleted, ws, cid, cname, now), nil
+		},
+	}
+}
+
+// splitN returns the first n+1 segments of s split by sep, like strings.Split
+// but inlined to avoid an import cycle with the package under test (which
+// already uses strings.Split internally; we duplicate to keep the test
+// fixture self-contained and obvious).
+func splitN(s string, sep byte, n int) []string {
+	if n <= 0 {
+		return nil
+	}
+	out := make([]string, 0, n)
+	start := 0
+	for i := 0; i < len(s) && len(out) < n-1; i++ {
+		if s[i] == sep {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}

--- a/operator/internal/reconciler/reconciler_test.go
+++ b/operator/internal/reconciler/reconciler_test.go
@@ -208,7 +208,7 @@ func TestWorker_DryRun_EmitsZeroEventsButObservesDiff(t *testing.T) {
 		Interval:    1 * time.Hour,
 		DryRun:      true,
 		Kinds:       []reconciler.KindHandler{podOnlyKind(t)},
-		Now:         func() time.Time { return time.Now() },
+		Now:         time.Now,
 	})
 	if err != nil {
 		t.Fatalf("worker: %v", err)

--- a/packages/core/alembic/versions/0006_source_type_k8s_operator.py
+++ b/packages/core/alembic/versions/0006_source_type_k8s_operator.py
@@ -1,0 +1,57 @@
+"""Add ``k8s_operator`` value to the ``source_type`` enum (issue #163).
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-30 00:00:00.000000
+
+Context
+-------
+
+The reconciliation worker (#163) and its companion read API endpoint
+need to distinguish operator-emitted entities from the agentic ``k8s``
+connector during the parallel-deprecation window (epic #98).  This
+migration adds the new enum value so the SQLAlchemy
+``Enum(SourceType, name="source_type")`` column accepts
+``"k8s_operator"`` without a CHECK violation.
+
+Additive-only — same shape as ``0005_source_type_otel`` (issue #152).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision: str = "0006"
+down_revision: str | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # ``ALTER TYPE ... ADD VALUE`` cannot run inside a transaction in
+    # Postgres < 12; pin AUTOCOMMIT for the duration of this DDL so the
+    # migration applies cleanly on every supported server version.
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'k8s_operator'")
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    # Postgres does not support ``ALTER TYPE ... DROP VALUE``; downgrade is
+    # a no-op (consistent with 0005 and the rest of the tree).
+    pass

--- a/packages/core/src/omniscience_core/auth/scopes.py
+++ b/packages/core/src/omniscience_core/auth/scopes.py
@@ -14,6 +14,14 @@ class Scope(enum.StrEnum):
     stats_read = "stats:read"
     otel_write = "otel:write"
     incidents_write = "incidents:write"
+    # operator:read — read-only access to operator-emitted entities for the
+    # in-cluster reconciliation worker (issue #163). Distinct from
+    # ``sources:read`` because the operator endpoint is workspace-scoped at
+    # the protocol level (token's workspace_id MUST match query param) and
+    # filters server-side to ``emitter=k8s-operator``. Granting
+    # ``sources:read`` on its own would expose entities from every connector
+    # — narrower scope is the principle-of-least-privilege fix.
+    operator_read = "operator:read"
     admin = "admin"
 
 
@@ -26,6 +34,7 @@ SCOPE_HIERARCHY: dict[Scope, set[Scope]] = {
         Scope.stats_read,
         Scope.otel_write,
         Scope.incidents_write,
+        Scope.operator_read,
         Scope.admin,
     },
     Scope.sources_write: {Scope.sources_write},
@@ -33,6 +42,7 @@ SCOPE_HIERARCHY: dict[Scope, set[Scope]] = {
     Scope.stats_read: {Scope.stats_read},
     Scope.otel_write: {Scope.otel_write},
     Scope.incidents_write: {Scope.incidents_write},
+    Scope.operator_read: {Scope.operator_read},
     Scope.search: {Scope.search},
 }
 

--- a/packages/core/src/omniscience_core/db/models.py
+++ b/packages/core/src/omniscience_core/db/models.py
@@ -53,6 +53,11 @@ class SourceType(enum.StrEnum):
     aws = "aws"
     alerts = "alerts"
     otel = "otel"
+    # k8s_operator — in-cluster operator emitter (ADR-0007). Distinct from
+    # the agentic ``k8s`` connector during the parallel-deprecation window
+    # (epic #98); allows server-side dedup (#164) and the operator-scoped
+    # read endpoint (#163) to disambiguate.
+    k8s_operator = "k8s_operator"
 
 
 class SourceStatus(enum.StrEnum):

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -125,6 +125,9 @@ class TestSourceModel:
             "aws",
             "alerts",
             "otel",
+            # Issue #163 — operator emitter, distinct from agentic ``k8s``
+            # for the parallel-deprecation window (epic #98).
+            "k8s_operator",
         }
         assert {t.value for t in SourceType} == expected
 

--- a/tests/test_operator_endpoint.py
+++ b/tests/test_operator_endpoint.py
@@ -1,0 +1,642 @@
+"""ACL + happy-path tests for the operator-scoped read endpoint (#163).
+
+Coverage:
+  * No bearer token              → 401
+  * Token without operator:read  → 403 (scope)
+  * Token's workspace_id mismatch query param → 403 (workspace)
+  * Token has no workspace_id at all          → 403 (workspace)
+  * Happy path returns external_ids
+  * Pagination via ``next_cursor``
+  * Emitter filter — only ``source_type='k8s_operator'`` rows are returned
+  * Cluster filter — wrong cluster_id returns empty
+
+These tests are the load-bearing security regression for the read API.
+The cross-workspace-isolation test verifies that a token for workspace A
+cannot read entities from workspace B even when the SQL universe contains
+both.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.db.models import ApiToken
+from omniscience_server.rest.operator import router as operator_router
+
+# ---------------------------------------------------------------------------
+# Tiny in-memory SQL substitute. Routes between (a) auth middleware token
+# lookups and (b) the operator endpoint's Document+Source join. The mock
+# inspects the FROM clause to decide which side to return.
+# ---------------------------------------------------------------------------
+
+
+class _DocumentRow:
+    """Minimal stand-in for a SQL row carrying (id, external_id)."""
+
+    def __init__(self, id_: uuid.UUID, external_id: str) -> None:
+        self.id = id_
+        self.external_id = external_id
+
+
+class _DocumentRecord:
+    """In-memory Document row joined with its Source. The mock SQL
+    universe is a list of these; the mock _execute() filters by SQL
+    predicates as best it can, but the load-bearing assertions test the
+    LIKE/source_type/tenant filters directly via the matching helper.
+    """
+
+    def __init__(
+        self,
+        external_id: str,
+        source_type: str,
+        tenant_id: uuid.UUID,
+        tombstoned: bool = False,
+        doc_id: uuid.UUID | None = None,
+    ) -> None:
+        self.id = doc_id or uuid.uuid4()
+        self.external_id = external_id
+        self.source_type = source_type
+        self.tenant_id = tenant_id
+        self.tombstoned = tombstoned
+
+
+def _matches_filters(
+    record: _DocumentRecord,
+    *,
+    workspace_id: uuid.UUID,
+    source_type: str,
+    prefix: str,
+) -> bool:
+    if record.tombstoned:
+        return False
+    if record.source_type != source_type:
+        return False
+    if record.tenant_id != workspace_id:
+        return False
+    return record.external_id.startswith(prefix.rstrip("%"))
+
+
+def _make_token(
+    *,
+    plaintext: str,
+    prefix: str,
+    workspace_id: uuid.UUID | None,
+    scopes: list[str],
+    is_active: bool = True,
+) -> ApiToken:
+    hashed = hash_token(plaintext)
+    token: ApiToken = MagicMock(spec=ApiToken)
+    token.id = uuid.uuid4()
+    token.name = f"token-{workspace_id}"
+    token.token_prefix = prefix
+    token.hashed_token = hashed
+    token.scopes = scopes
+    token.workspace_id = workspace_id
+    token.expires_at = datetime.now(tz=UTC) + timedelta(hours=1)
+    token.last_used_at = None
+    token.is_active = is_active
+    return token
+
+
+def _routing_session_factory(
+    tokens: list[ApiToken],
+    documents: list[_DocumentRecord],
+) -> Any:
+    """Return a session-factory MagicMock that routes between auth and
+    operator queries.
+
+    The router decides which result set to return by inspecting the SQL
+    statement's rendered FROM clause:
+      * ``FROM api_tokens`` → return the configured token list (auth path)
+      * ``FROM documents JOIN sources`` → run the in-memory filter
+        replaying the WHERE clauses by inspecting the compiled bind
+        params with ``literal_binds=True``.
+    """
+
+    fake_session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        rendered = str(stmt).lower()
+        if "from api_tokens" in rendered:
+            res = MagicMock()
+            res.scalars.return_value.all.return_value = tokens
+            return res
+
+        # Operator endpoint query (Document + Source join). Compile to a
+        # literal-binds string so we can scrape the predicate values.
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        sql_text = str(compiled)
+        ws_uuid = _scrape_uuid_after(sql_text, "tenant_id =")
+        prefix = _scrape_string_after(sql_text, "external_id LIKE")
+        cursor_uuid = _scrape_uuid_after(sql_text, "id >") if "id >" in sql_text else None
+        limit_val = _scrape_int_after(sql_text, "LIMIT") or 1000
+
+        if ws_uuid is None or prefix is None:
+            res = MagicMock()
+            res.all.return_value = []
+            return res
+
+        matched = [
+            r
+            for r in documents
+            if _matches_filters(
+                r,
+                workspace_id=ws_uuid,
+                source_type="k8s_operator",
+                prefix=prefix,
+            )
+        ]
+        matched.sort(key=lambda r: r.id)
+        if cursor_uuid is not None:
+            matched = [r for r in matched if r.id > cursor_uuid]
+        matched = matched[:limit_val]
+        rows = [_DocumentRow(r.id, r.external_id) for r in matched]
+
+        result = MagicMock()
+        result.all.return_value = rows
+        return result
+
+    fake_session.execute = _execute
+    fake_session.flush = AsyncMock()
+    fake_session.commit = AsyncMock()
+    fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+    fake_session.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=fake_session)
+
+
+def _scrape_uuid_after(sql: str, marker: str) -> uuid.UUID | None:
+    """Find the UUID literal that immediately follows ``marker`` in ``sql``."""
+    idx = sql.lower().find(marker.lower())
+    if idx < 0:
+        return None
+    rest = sql[idx + len(marker) :].strip()
+    # UUID literal is wrapped in single quotes: 'xxxx-...-xxxx'
+    if not rest.startswith("'"):
+        return None
+    end = rest.find("'", 1)
+    if end < 0:
+        return None
+    try:
+        return uuid.UUID(rest[1:end])
+    except ValueError:
+        return None
+
+
+def _scrape_string_after(sql: str, marker: str) -> str | None:
+    """Find the quoted string literal following ``marker`` in ``sql``."""
+    idx = sql.lower().find(marker.lower())
+    if idx < 0:
+        return None
+    rest = sql[idx + len(marker) :].strip()
+    if not rest.startswith("'"):
+        return None
+    end = rest.find("'", 1)
+    if end < 0:
+        return None
+    return rest[1:end]
+
+
+def _scrape_int_after(sql: str, marker: str) -> int | None:
+    """Find the integer literal following ``marker`` in ``sql``."""
+    idx = sql.find(marker)
+    if idx < 0:
+        return None
+    rest = sql[idx + len(marker) :].strip()
+    digits = ""
+    for ch in rest:
+        if ch.isdigit():
+            digits += ch
+        else:
+            break
+    return int(digits) if digits else None
+
+
+def _build_app(tokens: list[ApiToken], documents: list[_DocumentRecord]) -> FastAPI:
+    app = FastAPI()
+    app.state.db_session_factory = _routing_session_factory(tokens, documents)
+    app.include_router(operator_router, prefix="/api/v1")
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def two_workspace_setup() -> AsyncIterator[
+    tuple[
+        AsyncClient,
+        str,
+        uuid.UUID,
+        uuid.UUID,
+        str,
+        uuid.UUID,
+        uuid.UUID,
+        list[_DocumentRecord],
+    ]
+]:
+    """Yield (client, plaintext_a, ws_a, cluster_a, plaintext_b, ws_b, cluster_b, docs).
+
+    Two workspaces, two clusters per workspace, populated documents so
+    both happy-path and cross-workspace assertions are expressible.
+    """
+    ws_a = uuid.uuid4()
+    ws_b = uuid.uuid4()
+    cluster_a = uuid.uuid4()
+    cluster_b = uuid.uuid4()
+    plaintext_a, prefix_a = generate_token("development")
+    plaintext_b, prefix_b = generate_token("development")
+
+    token_a = _make_token(
+        plaintext=plaintext_a,
+        prefix=prefix_a,
+        workspace_id=ws_a,
+        scopes=[Scope.operator_read.value],
+    )
+    token_b = _make_token(
+        plaintext=plaintext_b,
+        prefix=prefix_b,
+        workspace_id=ws_b,
+        scopes=[Scope.operator_read.value],
+    )
+
+    docs = [
+        # workspace A, cluster A — three Pod entries
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_a}/Pod/ns/a1",
+            source_type="k8s_operator",
+            tenant_id=ws_a,
+        ),
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_a}/Pod/ns/a2",
+            source_type="k8s_operator",
+            tenant_id=ws_a,
+        ),
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_a}/Pod/ns/a3",
+            source_type="k8s_operator",
+            tenant_id=ws_a,
+        ),
+        # Workspace A, different cluster — should NOT match a query for cluster_a/Pod
+        _DocumentRecord(
+            external_id=f"k8s_resource/{uuid.uuid4()}/Pod/ns/other",
+            source_type="k8s_operator",
+            tenant_id=ws_a,
+        ),
+        # Workspace A, cluster A, but Deployment kind — should NOT match Pod query
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_a}/Deployment/ns/d1",
+            source_type="k8s_operator",
+            tenant_id=ws_a,
+        ),
+        # Workspace A, cluster A, Pod — but emitted by the agentic ``k8s``
+        # connector (NOT k8s_operator). The emitter filter MUST exclude this.
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_a}/Pod/ns/agentic-leak",
+            source_type="k8s",
+            tenant_id=ws_a,
+        ),
+        # Workspace A, cluster A, Pod, but tombstoned — should NOT match.
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_a}/Pod/ns/tombstoned",
+            source_type="k8s_operator",
+            tenant_id=ws_a,
+            tombstoned=True,
+        ),
+        # Workspace B, cluster B — two Pod entries. The ACL gate must
+        # ensure A's token cannot reach these.
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_b}/Pod/ns/b1",
+            source_type="k8s_operator",
+            tenant_id=ws_b,
+        ),
+        _DocumentRecord(
+            external_id=f"k8s_resource/{cluster_b}/Pod/ns/b2",
+            source_type="k8s_operator",
+            tenant_id=ws_b,
+        ),
+    ]
+
+    app = _build_app([token_a, token_b], docs)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield (client, plaintext_a, ws_a, cluster_a, plaintext_b, ws_b, cluster_b, docs)
+
+
+# ---------------------------------------------------------------------------
+# Auth surface — 401 / 403
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_token_rejected_401(two_workspace_setup: Any) -> None:
+    client, _pa, ws_a, cluster_a, *_ = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={"workspace_id": str(ws_a), "cluster_id": str(cluster_a), "kind": "Pod"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_token_rejected_401(two_workspace_setup: Any) -> None:
+    client, _pa, ws_a, cluster_a, *_ = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={"workspace_id": str(ws_a), "cluster_id": str(cluster_a), "kind": "Pod"},
+        headers={"Authorization": "Bearer sk_dev_garbage_does_not_match"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_token_without_operator_read_scope_rejected_403() -> None:
+    """A token without operator:read → 403, even with matching workspace.
+
+    ACL invariant: scope is the second line of defence; even within the
+    correct tenant, a token MUST hold operator:read explicitly (or admin).
+    """
+    ws = uuid.uuid4()
+    plaintext, prefix = generate_token("development")
+    token = _make_token(
+        plaintext=plaintext,
+        prefix=prefix,
+        workspace_id=ws,
+        scopes=[Scope.search.value],  # NO operator:read, NO admin
+    )
+    app = _build_app([token], [])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/operator/entities",
+            params={"workspace_id": str(ws), "cluster_id": str(uuid.uuid4()), "kind": "Pod"},
+            headers={"Authorization": f"Bearer {plaintext}"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_workspace_mismatch_rejected_403(two_workspace_setup: Any) -> None:
+    """Token's workspace ≠ query workspace_id → 403.
+
+    THIS IS THE LOAD-BEARING SECURITY ASSERTION FOR ISSUE #163.
+    """
+    client, plaintext_a, _ws_a, _cluster_a, _pb, ws_b, _cluster_b, _docs = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={
+            "workspace_id": str(ws_b),  # workspace B
+            "cluster_id": str(uuid.uuid4()),
+            "kind": "Pod",
+        },
+        # Token A — its workspace is ws_a, NOT ws_b.
+        headers={"Authorization": f"Bearer {plaintext_a}"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["detail"]["code"] == "forbidden"
+
+
+@pytest.mark.asyncio
+async def test_token_without_workspace_at_all_rejected_403() -> None:
+    """Legacy token with no workspace_id → 403.
+
+    ACL invariant: the operator endpoint REQUIRES a workspace-scoped
+    token. Tokens predating workspace scoping (workspace_id=None) cannot
+    use this endpoint.
+    """
+    plaintext, prefix = generate_token("development")
+    token = _make_token(
+        plaintext=plaintext,
+        prefix=prefix,
+        workspace_id=None,  # Legacy token
+        scopes=[Scope.operator_read.value],
+    )
+    app = _build_app([token], [])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/operator/entities",
+            params={
+                "workspace_id": str(uuid.uuid4()),
+                "cluster_id": str(uuid.uuid4()),
+                "kind": "Pod",
+            },
+            headers={"Authorization": f"Bearer {plaintext}"},
+        )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["detail"]["code"] == "forbidden"
+
+
+# ---------------------------------------------------------------------------
+# Happy path + filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_filtered_external_ids(two_workspace_setup: Any) -> None:
+    client, plaintext_a, ws_a, cluster_a, *_ = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={
+            "workspace_id": str(ws_a),
+            "cluster_id": str(cluster_a),
+            "kind": "Pod",
+            "limit": 100,
+        },
+        headers={"Authorization": f"Bearer {plaintext_a}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Three Pods in workspace A's cluster A — Deployment + other-cluster +
+    # agentic-leak + tombstoned MUST NOT appear.
+    assert len(body["external_ids"]) == 3
+    assert all("/Pod/" in ext for ext in body["external_ids"])
+    assert all(str(cluster_a) in ext for ext in body["external_ids"])
+    # Specifically: no agentic leakage (different source_type)
+    assert not any("agentic-leak" in ext for ext in body["external_ids"])
+    # No tombstoned
+    assert not any("tombstoned" in ext for ext in body["external_ids"])
+
+
+@pytest.mark.asyncio
+async def test_emitter_filter_excludes_other_connectors(two_workspace_setup: Any) -> None:
+    """The 'agentic-leak' fixture has source_type='k8s' (the agentic
+    connector), not k8s_operator. The endpoint must NEVER return it
+    even though it matches workspace + cluster + kind on every other axis.
+
+    ACL invariant #2 in the issue spec — emitter filter is mandatory.
+    """
+    client, plaintext_a, ws_a, cluster_a, *_ = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={
+            "workspace_id": str(ws_a),
+            "cluster_id": str(cluster_a),
+            "kind": "Pod",
+            "limit": 100,
+        },
+        headers={"Authorization": f"Bearer {plaintext_a}"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    for ext in body["external_ids"]:
+        assert "agentic-leak" not in ext, f"emitter filter failed: {ext}"
+
+
+@pytest.mark.asyncio
+async def test_pagination_walk(two_workspace_setup: Any) -> None:
+    """A small ``limit`` produces a non-empty cursor that the next call
+    can resume from. Two pages ⇒ all three matching entities visited.
+    """
+    client, plaintext_a, ws_a, cluster_a, *_ = two_workspace_setup
+    seen: list[str] = []
+
+    cursor = ""
+    while True:
+        resp = await client.get(
+            "/api/v1/operator/entities",
+            params={
+                "workspace_id": str(ws_a),
+                "cluster_id": str(cluster_a),
+                "kind": "Pod",
+                "limit": 2,  # Force pagination — 3 matches across 2 pages
+                **({"cursor": cursor} if cursor else {}),
+            },
+            headers={"Authorization": f"Bearer {plaintext_a}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        seen.extend(body["external_ids"])
+        cursor = body["next_cursor"]
+        if not cursor:
+            break
+    assert len(seen) == 3, f"pagination visited {seen}"
+    assert len(set(seen)) == 3, "duplicate external_ids across pages"
+
+
+@pytest.mark.asyncio
+async def test_kind_filter_excludes_other_kinds(two_workspace_setup: Any) -> None:
+    """Querying for kind=Pod must NOT return the Deployment fixture."""
+    client, plaintext_a, ws_a, cluster_a, *_ = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={
+            "workspace_id": str(ws_a),
+            "cluster_id": str(cluster_a),
+            "kind": "Pod",
+            "limit": 100,
+        },
+        headers={"Authorization": f"Bearer {plaintext_a}"},
+    )
+    body = resp.json()
+    assert all("/Pod/" in ext for ext in body["external_ids"])
+    assert not any("/Deployment/" in ext for ext in body["external_ids"])
+
+
+@pytest.mark.asyncio
+async def test_cluster_filter_excludes_other_clusters(two_workspace_setup: Any) -> None:
+    """Querying cluster_a must NOT return entities from a different cluster
+    (the 'other' fixture)."""
+    client, plaintext_a, ws_a, cluster_a, *_ = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={
+            "workspace_id": str(ws_a),
+            "cluster_id": str(cluster_a),
+            "kind": "Pod",
+            "limit": 100,
+        },
+        headers={"Authorization": f"Bearer {plaintext_a}"},
+    )
+    body = resp.json()
+    for ext in body["external_ids"]:
+        assert str(cluster_a) in ext, f"cluster filter failed: {ext}"
+
+
+@pytest.mark.asyncio
+async def test_token_a_cannot_read_workspace_b_data(two_workspace_setup: Any) -> None:
+    """Even if A's token tried to query B's cluster_id (with B's
+    workspace_id), the workspace gate fires first and 403s.
+
+    Cross-workspace isolation — server-side mirror of the operator-side
+    cross_workspace_test.go assertion.
+    """
+    (
+        client,
+        plaintext_a,
+        _ws_a,
+        _cluster_a,
+        _pb,
+        ws_b,
+        cluster_b,
+        _docs,
+    ) = two_workspace_setup
+    resp = await client.get(
+        "/api/v1/operator/entities",
+        params={
+            "workspace_id": str(ws_b),
+            "cluster_id": str(cluster_b),
+            "kind": "Pod",
+            "limit": 100,
+        },
+        headers={"Authorization": f"Bearer {plaintext_a}"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_token_bypasses_scope_but_not_workspace_check(
+    two_workspace_setup: Any,
+) -> None:
+    """admin scope implies operator:read (per SCOPE_HIERARCHY) so an
+    admin token CAN read its own workspace. But admin DOES NOT bypass
+    the workspace_id-vs-token-workspace check — admin in workspace A
+    still cannot read workspace B.
+    """
+    ws_a = uuid.uuid4()
+    ws_b = uuid.uuid4()
+    plaintext, prefix = generate_token("development")
+    admin_token = _make_token(
+        plaintext=plaintext,
+        prefix=prefix,
+        workspace_id=ws_a,
+        scopes=[Scope.admin.value],  # admin → operator:read implied
+    )
+    app = _build_app([admin_token], [])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        # Admin token in workspace A queries workspace B → still 403.
+        resp = await client.get(
+            "/api/v1/operator/entities",
+            params={
+                "workspace_id": str(ws_b),
+                "cluster_id": str(uuid.uuid4()),
+                "kind": "Pod",
+            },
+            headers={"Authorization": f"Bearer {plaintext}"},
+        )
+        assert resp.status_code == 403
+        # And admin token reading its OWN workspace → 200.
+        resp_self = await client.get(
+            "/api/v1/operator/entities",
+            params={
+                "workspace_id": str(ws_a),
+                "cluster_id": str(uuid.uuid4()),
+                "kind": "Pod",
+            },
+            headers={"Authorization": f"Bearer {plaintext}"},
+        )
+        assert resp_self.status_code == 200


### PR DESCRIPTION
## Summary

Adds a periodic drift detector to the operator that compares cluster state against the Omniscience graph slice for `(workspace_id, cluster_id)` and emits corrective events for both directions of drift. Closes the gap that watch-only coverage leaves during operator downtime, NATS outages, or transient API-server hiccups.

Closes #163. Builds on #167 (cluster_id plumbing) — uses `cfg.ClusterID` from day 1; no `cluster_name`-based v0.2 path.

## ACL posture (issue #163 §ACL — explicit call-out as required by the issue)

1. **Workspace identity is taken from the operator's Secret-mounted bearer token only.** The reconciler queries `(workspace_id, cluster_id)`. Server-side handler 403s on any mismatch between the token's workspace and the `workspace_id` query parameter — the load-bearing ACL gate.
2. **Cluster filter uses `cluster_id` (UUID), not `cluster_name`.** Server-side filter is an indexed LIKE prefix on `external_id` of the form `k8s_resource/{cluster_id}/{kind}/%`, which precisely matches both namespaced and cluster-scoped operator emit shapes.
3. **Diff is a pure in-memory set operation** scoped to one `(workspace_id, cluster_id)` tuple. Reconciler never cross-references data outside that slice.
4. **Metric labels include `kind` but NEVER `workspace_id`.** Tagging metrics with workspace_id would expose tenancy in the metrics endpoint.
5. **Dry-run logs in the missing-in-cluster direction carry counts only, never the in-graph payload.** Hardening against a server-side bug accidentally returning cross-workspace data.
6. **Server-side filtering on `source_type='k8s_operator'` is mandatory and not a query param** — clients cannot opt out, so the response set never includes entities emitted by other connectors (the agentic `k8s` connector, Terraform, etc.).

## What landed

### Operator side (`operator/internal/reconciler/`)
- `diff.go` — pure `Diff(inCluster, inGraph []string) (missingInGraph, missingInCluster []string)` over external_id sets.
- `client.go` — `HTTPEntitiesClient` with bearer auth + paginated cursor walk; 30s per-request timeout; pagination cap; never logs the bearer token.
- `kinds.go` — per-kind registry covering Pod, Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, Service, Endpoints, Ingress, NetworkPolicy, ConfigMap, Secret, Node, Namespace, PersistentVolume, StorageClass. Reuses existing entity mappers unchanged.
- `reconciler.go` — `Worker` implementing `manager.Runnable` + `manager.LeaderElectionRunnable`; ticker loop with immediate first cycle, dry-run support, defence-in-depth workspace check before publish.
- `metrics.go` — five Prometheus metrics on the existing controller-runtime metrics endpoint.
- Tests: 29 reconciler tests covering the diff matrix, paginated client walks, integration with stubbed read API, dry-run, leader-election, **cross-workspace isolation with two stubbed servers**, and adversarial workspace mismatch.

### `operator/cmd/manager/main.go`
- Section-marker block `── #163 reconciliation worker ──` wires `mgr.Add(worker)` after watcher registrations and before healthz.
- Empty `OMNISCIENCE_API_BASE_URL` disables the worker (operator continues to start; watch path unchanged).

### `operator/internal/config/config.go`
- New env vars: `OMNISCIENCE_RECONCILE_INTERVAL` (default `15m`), `OMNISCIENCE_RECONCILE_DRY_RUN` (default `false`), `OMNISCIENCE_API_BASE_URL`, `OMNISCIENCE_API_BEARER_TOKEN`.
- Fail-closed: base URL set + token empty → startup error.

### Server side
- `apps/server/src/omniscience_server/rest/operator.py` — new `GET /api/v1/operator/entities` route with bearer auth, `operator:read` scope, workspace gate, paginated query, and `source_type='k8s_operator'` mandatory filter.
- `packages/core/src/omniscience_core/auth/scopes.py` — new `Scope.operator_read`; `admin` implies it.
- `packages/core/src/omniscience_core/db/models.py` — new `SourceType.k8s_operator`.
- `packages/core/alembic/versions/0006_source_type_k8s_operator.py` — additive enum migration.
- `tests/test_operator_endpoint.py` — 12 pytest tests covering 401 / 403 (scope) / 403 (workspace mismatch) / 403 (legacy token) / happy path / pagination / kind filter / cluster filter / emitter filter / cross-workspace isolation / admin token scope-implication.

### Helm
- `helm/omniscience-operator/values.yaml` — new `reconciler.{interval,dryRun}`, `api.{baseUrl,bearerToken}` keys.
- `templates/secret.yaml` + `templates/deployment.yaml` — wire the new env vars.

### Pre-existing build skew fixed
The merged main contained a build break between #167 (cluster_id plumbing) and #190 (DRA controllers): the DRA entity mappers were updated to take a `clusterID` parameter, but three of the four DRA controllers were not. The operator binary did not compile on `main`. Three controllers (`dra_deviceclass`, `dra_resourceclaimtemplate`, `dra_resourceslice`) plus `setupDRAWatchers` are patched with the deterministic uuid5 fallback that matches `entity.DeriveClusterID(workspace_id, cluster_name)` — same value for single-cluster deployments, no graph data churn. `ResourceClaim` already had `ClusterID`; the call site in `setupDRAWatchers` is updated to plumb `cfg.ClusterID` through. This is the minimal patch required to make the operator binary build.

## Acceptance checklist

- [x] `cd operator && go build ./... && go test -count=1 ./...` — 126 tests passed across 7 packages
- [x] `cd operator && golangci-lint run` — clean (govet, errcheck, staticcheck, ineffassign, unused)
- [x] `helm lint helm/omniscience-operator` — clean (1 INFO, 0 failures)
- [x] Server-side endpoint pytest coverage: happy path, 401 on no token, 403 on missing scope, 403 on workspace mismatch, 403 on legacy-token-without-workspace, pagination walk, kind filter, cluster filter, emitter filter (`source_type='k8s_operator'` excludes agentic-leak fixture), admin scope respects workspace gate — 12 tests pass
- [x] PR body explicitly cites the ACL posture (this section)
- [x] `pytest --no-cov` full suite — 2035 passed, 52 skipped, 0 failed
- [x] `mypy --strict apps/ packages/` — 184 source files clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] Unit tests over `Diff()` — empty/empty, identical, single-direction drift, mass drift, deterministic ordering, defensive empty-string handling
- [x] Integration test (stubbed Omniscience server + fake K8s client)
- [x] Leader-election test (`NeedLeaderElection() == true`)
- [x] **Cross-workspace isolation test** — two workspaces, two stubbed servers, asserts zero cross-talk + symmetric ACL rejection on mismatched workspace
- [x] Dry-run test (zero events emitted, diff observed in metrics)

## Test plan

- [ ] Reviewer runs `cd operator && go test ./internal/reconciler/...` and confirms the cross-workspace isolation test fails loudly if the server-side ACL gate is removed.
- [ ] Reviewer runs `pytest tests/test_operator_endpoint.py` and confirms the workspace-mismatch test 403s.
- [ ] On a `kind` cluster with the operator chart installed and `reconciler.dryRun=true`:
  - Pre-populate the graph with 5 fake `Pod` entities not present in the cluster.
  - Trigger a reconcile cycle (force-trigger via short interval).
  - Verify `omniscience_operator_reconcile_drift_total{kind=Pod,direction=missing_in_cluster}` increments by 5.
  - Verify zero events emitted to the publisher.
- [ ] Live mode (`reconciler.dryRun=false`) on the same setup emits 5 deletion events.

## Open questions / follow-ups

- Optional-CRD reconciliation (ArgoCD, Argo Rollouts, DRA) is deferred to a follow-up that handles discovery-gated registration on the reconciler's typed list path. Coverage parity is acceptable in stages — the watch path for these CRDs is unchanged.
- The pre-existing DRA controller build skew fixed inline could alternatively be reverted by a dedicated PR; landing it here was necessary to make `go build ./...` pass per acceptance.
- envtest is not yet wired in this repo; the controller integration test uses controller-runtime's fake client + `httptest.Server`, which is sufficient because the reconciler is a goroutine, not a `Reconcile()` controller. envtest can layer on later without invalidating these assertions.

References
- Issue: #163
- Dependency: #167 (merged) — cluster_id plumbing used from day 1.
- ADR-0007 §ACL — workspace_id source-of-truth invariant.

Do not merge — leaving this PR open for human review.