### PR TITLE
feat: operator metrics + Grafana + alerts (#165)

### DIFF
--- a/docs/runbooks/operator-alerts.md
+++ b/docs/runbooks/operator-alerts.md
@@ -1,0 +1,117 @@
+# Omniscience Operator — Alert Runbook
+
+Stub runbook for the alerts shipped in `helm/omniscience-operator/templates/prometheusrule.yaml` (issue #165). Each section documents:
+
+- What the alert is telling you.
+- The most likely root causes, in priority order.
+- The first three diagnostic commands.
+- The escalation path.
+
+> Status: stub. Sections marked **TODO** will be filled in as we accumulate
+> production observations on the alert. Do not remove the TODO markers
+> without a paired postmortem reference.
+
+## Table of contents
+
+- [OperatorPublishStalled](#operatorpublishstalled)
+- [OperatorPublishErrorBurst](#operatorpublisherrorburst)
+- [OperatorReconcileFailing](#operatorreconcilefailing)
+- [OperatorEmitLagHigh](#operatoremitlaghigh)
+- [OperatorReconcileDriftHigh](#operatorreconciledrifthigh)
+
+---
+
+## OperatorPublishStalled
+
+**Fires when**: `time() - omniscience_operator_last_publish_unix_seconds > 300`
+for at least 5 minutes, **gated on** `last_publish_unix_seconds > 0` (cold-start
+safe — a freshly-started operator that has not yet emitted does not page).
+
+**Severity**: warning (paging in PagerDuty parlance: P2).
+
+**Most likely root causes**:
+
+1. NATS JetStream is unreachable. Check: `kubectl logs deploy/omniscience-operator | grep nats`.
+2. The operator's NATS credentials Secret was rotated and the operator hasn't been restarted to pick up the new file.
+3. RBAC was tightened and the operator can no longer LIST any of the watched kinds (no events to publish → counter never advances).
+
+**TODO**: add the command sequence used in the first real incident.
+
+**Escalation**: TODO
+
+---
+
+## OperatorPublishErrorBurst
+
+**Fires when**: `sum(rate(omniscience_operator_publisher_errors_total[5m])) by (error_type) > 0.5`
+for at least 10 minutes.
+
+**Severity**: warning.
+
+**Most likely root causes** (use the `error_type` label to disambiguate):
+
+- `error_type="connect"`: NATS endpoint unreachable from the operator pod. Check NetworkPolicy and DNS.
+- `error_type="publish"`: JetStream stream missing or its retention is exhausted. Check the `OMNISCIENCE_NATS_SUBJECT` configuration matches a configured stream.
+- `error_type="ack_timeout"`: JetStream is slow / overloaded. Check stream metrics on the NATS side.
+- `error_type="nats_no_responders"`: nobody is bound to the subject. Most likely an ingestion-worker outage on the consumer side.
+
+**TODO**: add the command sequence used in the first real incident.
+
+---
+
+## OperatorReconcileFailing
+
+**Fires when**: `increase(omniscience_operator_reconcile_runs_total{result="error"}[1h]) > 2`.
+
+**Severity**: info (P3).
+
+**Most likely root causes**:
+
+1. Omniscience server's read API is unreachable. Check `OMNISCIENCE_API_BASE_URL` from the operator pod.
+2. The operator's API bearer token was rotated.
+3. The server's read endpoint is returning 5xx for a specific kind (look at the `kind` label).
+
+**TODO**: list the API endpoints the reconciler depends on.
+
+---
+
+## OperatorEmitLagHigh
+
+**Fires when**: `histogram_quantile(0.99, …event_lag_seconds_bucket…) > 30s`
+for at least 15 minutes.
+
+**Severity**: info. Freshness SLO breach.
+
+**Most likely root causes**:
+
+1. Informer cache pressure (memory or watch resync storms) — look at `omniscience_operator_informer_cache_objects` for the kind.
+2. Publisher backlog (`omniscience_operator_publisher_inflight` non-zero for sustained periods).
+3. NATS RTT inflation under load.
+
+**TODO**: define the freshness SLO in the runbook (currently 30s p99; product-side SLO TBD).
+
+---
+
+## OperatorReconcileDriftHigh
+
+**Fires when**: `rate(omniscience_operator_reconcile_drift_total[1h]) > 1/h`.
+
+**Severity**: info.
+
+**Most likely root causes**:
+
+1. A watch was lost and the informer cache is stale (operator should re-list on next resync; verify by checking the cache size before/after).
+2. Server-side ingestion is dropping or rejecting events for this `kind` + `direction`.
+3. A network partition between operator and NATS that recovered but left the buffer cleared (check NATS DLQ if configured).
+
+**TODO**: link the server-side ingestion runbook for cross-correlation.
+
+---
+
+## Maintenance
+
+- New alerts should be added with both:
+  - A rule entry in `helm/omniscience-operator/templates/prometheusrule.yaml`.
+  - A section in this runbook with the `runbook_url` anchor matching the alert name (lowercase, no spaces).
+- The cold-start gate pattern (`and on() X > 0`) is mandatory for any
+  rule that can fire during a fresh operator boot.

--- a/helm/omniscience-operator/dashboards/operator-overview.json
+++ b/helm/omniscience-operator/dashboards/operator-overview.json
@@ -1,0 +1,256 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Omniscience operator — emit-path overview: event rate, freshness, errors, NATS publisher health. Issue #165.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Operator identity",
+      "id": 1,
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "colorMode": "none",
+        "graphMode": "none"
+      },
+      "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "omniscience_operator_workspace_id_info",
+          "legendFormat": "{{cluster_name}} v{{operator_version}}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Last publish",
+      "id": 2,
+      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 60},
+              {"color": "red", "value": 300}
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "time() - omniscience_operator_last_publish_unix_seconds",
+          "legendFormat": "seconds since last publish",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Publisher inflight (total)",
+      "id": 3,
+      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(omniscience_operator_publisher_inflight)",
+          "legendFormat": "inflight",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Events emitted/sec by kind",
+      "id": 4,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "ops"}},
+      "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["mean", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (kind) (rate(omniscience_operator_events_emitted_total{result=\"success\"}[5m]))",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Publish error rate by error_type",
+      "id": 5,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "ops"}},
+      "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["mean", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (error_type) (rate(omniscience_operator_publisher_errors_total[5m]))",
+          "legendFormat": "{{error_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Publish latency p50 / p95 / p99",
+      "id": 6,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "s"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.50, sum(rate(omniscience_operator_event_emit_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.95, sum(rate(omniscience_operator_event_emit_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.99, sum(rate(omniscience_operator_event_emit_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Event freshness lag p99 by kind",
+      "id": 7,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "p99 of the time between resource event timestamp and emit. Above 30s for 15m fires OmniscienceOperatorEmitLagHigh.",
+      "fieldConfig": {"defaults": {"unit": "s"}},
+      "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.99, sum by (le, kind) (rate(omniscience_operator_event_lag_seconds_bucket[5m])))",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Publisher inflight by kind",
+      "id": 8,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "omniscience_operator_publisher_inflight",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Top 10 noisiest kinds (events/sec)",
+      "id": 9,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Sustained high emit rate on a single kind suggests a hot loop on noisy resources (e.g. ReplicaSet rollouts).",
+      "fieldConfig": {"defaults": {"unit": "ops"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "topk(10, sum by (kind) (rate(omniscience_operator_events_emitted_total[5m])))",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Informer cache size by kind",
+      "id": 10,
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 28},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Sustained growth without corresponding cluster-side growth indicates a watch-loss / cache-leak bug.",
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["mean", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "omniscience_operator_informer_cache_objects",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["omniscience", "operator", "kubernetes"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-3h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Omniscience Operator — Overview",
+  "uid": "omniscience-operator-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/helm/omniscience-operator/dashboards/operator-reconciler.json
+++ b/helm/omniscience-operator/dashboards/operator-reconciler.json
@@ -1,0 +1,204 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Omniscience reconciler — drift detection health, run results, in-graph vs in-cluster counts. Issue #163 metrics ratified by #165.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Last reconcile",
+      "id": 1,
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 1800},
+              {"color": "red", "value": 3600}
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"]},
+        "colorMode": "value"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "time() - omniscience_operator_last_reconcile_unix_seconds",
+          "legendFormat": "seconds since last reconcile",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Reconcile error rate (1h)",
+      "id": 2,
+      "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(increase(omniscience_operator_reconcile_runs_total{result=\"error\"}[1h]))",
+          "legendFormat": "errors / hour",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Drift events (1h)",
+      "id": 3,
+      "gridPos": {"h": 4, "w": 8, "x": 16, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(increase(omniscience_operator_reconcile_drift_total[1h]))",
+          "legendFormat": "drift / hour",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Reconcile runs by result",
+      "id": 4,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "ops"}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (kind, result) (rate(omniscience_operator_reconcile_runs_total[5m]))",
+          "legendFormat": "{{kind}} / {{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Reconcile duration p50 / p95 / p99",
+      "id": 5,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {"defaults": {"unit": "s"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.50, sum(rate(omniscience_operator_reconcile_duration_seconds_bucket[5m])) by (le, kind))",
+          "legendFormat": "p50 {{kind}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.95, sum(rate(omniscience_operator_reconcile_duration_seconds_bucket[5m])) by (le, kind))",
+          "legendFormat": "p95 {{kind}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "histogram_quantile(0.99, sum(rate(omniscience_operator_reconcile_duration_seconds_bucket[5m])) by (le, kind))",
+          "legendFormat": "p99 {{kind}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Drift by direction",
+      "id": 6,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "missing_in_graph: cluster has it, graph doesn't (missed publish). missing_in_cluster: graph has it, cluster doesn't (missed delete).",
+      "fieldConfig": {"defaults": {"unit": "ops"}},
+      "options": {"legend": {"displayMode": "table", "placement": "right"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (kind, direction) (rate(omniscience_operator_reconcile_drift_total[15m]))",
+          "legendFormat": "{{kind}} / {{direction}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "In-graph vs in-cluster counts",
+      "id": 7,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "description": "Diverging series indicate the graph and cluster have drifted. Sustained divergence is the alerting signal.",
+      "fieldConfig": {"defaults": {"unit": "short"}},
+      "options": {"legend": {"displayMode": "table", "placement": "bottom"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "omniscience_operator_reconcile_in_graph_count",
+          "legendFormat": "{{kind}} (graph)",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "omniscience_operator_reconcile_in_cluster_count",
+          "legendFormat": "{{kind}} (cluster)",
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "tags": ["omniscience", "operator", "reconciler"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Omniscience Operator — Reconciler",
+  "uid": "omniscience-operator-reconciler",
+  "version": 1,
+  "weekStart": ""
+}

--- a/helm/omniscience-operator/templates/dashboard-configmap.yaml
+++ b/helm/omniscience-operator/templates/dashboard-configmap.yaml
@@ -1,0 +1,31 @@
+{{/*
+Grafana dashboard ConfigMap (#165).
+
+Loads every JSON file under helm/omniscience-operator/dashboards/ into a
+single ConfigMap. The kiwigrid/k8s-sidecar discovers it via the
+{{ .Values.dashboards.labelKey }}={{ .Values.dashboards.labelValue }}
+label and imports each entry as a Grafana dashboard.
+
+Default labelKey/labelValue match kube-prometheus-stack
+(grafana_dashboard=1) so installing this chart against a stock kp-stack
+just works.
+
+Gating:
+  1. .Values.dashboards.enabled — explicit opt-in.
+*/}}
+{{- if .Values.dashboards.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "omniscience-operator.fullname" . }}-dashboards
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "omniscience-operator.labels" . | nindent 4 }}
+    {{ .Values.dashboards.labelKey }}: {{ .Values.dashboards.labelValue | quote }}
+  {{- with .Values.dashboards.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+{{ (.Files.Glob "dashboards/*.json").AsConfig | indent 2 }}
+{{- end }}

--- a/helm/omniscience-operator/templates/prometheusrule.yaml
+++ b/helm/omniscience-operator/templates/prometheusrule.yaml
@@ -1,0 +1,153 @@
+{{/*
+PrometheusRule for the Omniscience operator (#165).
+
+Default alert catalog:
+
+  - OmniscienceOperatorPublishStalled  — no successful publish for 5m,
+    GATED on last_publish_unix_seconds > 0 to avoid cold-start false
+    positives. Severity: warning.
+
+  - OmniscienceOperatorPublishErrorBurst — sustained publisher_errors_total
+    rate > 0.5/s for 10m. Severity: warning.
+
+  - OmniscienceOperatorReconcileFailing — > 2 reconcile errors in 1h.
+    Severity: info.
+
+  - OmniscienceOperatorEmitLagHigh — p99 event_lag_seconds > 30s for 15m.
+    Severity: info. Freshness SLO breach.
+
+  - OmniscienceOperatorReconcileDriftHigh — drift events > 1/h. Severity:
+    info. Indicates a possible watch-loss bug.
+
+Gating:
+  1. .Values.prometheusRule.enabled — explicit opt-in.
+  2. .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" — render a
+     no-op rather than fail on clusters without Prometheus Operator.
+
+Each rule is individually toggleable via .Values.prometheusRule.rules.<name>.enabled.
+
+Cold-start safety: the publishStalled expression INCLUDES
+"omniscience_operator_last_publish_unix_seconds > 0" so a freshly-started
+operator that hasn't yet emitted does not page. The other rules are
+rate-based and naturally cold-start safe (rate() over a 5m window of a
+zero counter is zero).
+*/}}
+{{- if .Values.prometheusRule.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- $rb := .Values.prometheusRule.runbookBaseUrl }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "omniscience-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "omniscience-operator.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: omniscience-operator.rules
+      rules:
+        {{- with .Values.prometheusRule.rules.publishStalled }}
+        {{- if .enabled }}
+        - alert: OmniscienceOperatorPublishStalled
+          expr: |
+            (time() - omniscience_operator_last_publish_unix_seconds) > 300
+            and on() omniscience_operator_last_publish_unix_seconds > 0
+          for: {{ $.Values.prometheusRule.defaults.publishStalledFor }}
+          labels:
+            severity: {{ .severity }}
+            component: omniscience-operator
+          annotations:
+            summary: "Omniscience operator has not published an event in 5+ minutes"
+            description: |
+              Operator metric omniscience_operator_last_publish_unix_seconds
+              has not advanced in over 5 minutes. Likely causes: NATS
+              JetStream unreachable, watch loop stalled, or workspace_id
+              misconfiguration causing all publishes to fail.
+            runbook_url: "{{ $rb }}#operatorpublishstalled"
+        {{- end }}
+        {{- end }}
+
+        {{- with .Values.prometheusRule.rules.publishErrorBurst }}
+        {{- if .enabled }}
+        - alert: OmniscienceOperatorPublishErrorBurst
+          expr: |
+            sum(rate(omniscience_operator_publisher_errors_total[5m])) by (error_type) > 0.5
+          for: {{ $.Values.prometheusRule.defaults.publishErrorBurstFor }}
+          labels:
+            severity: {{ .severity }}
+            component: omniscience-operator
+          annotations:
+            summary: "Omniscience operator publishing errors at >0.5/s"
+            description: |
+              Operator publisher_errors_total{error_type="{{`{{ $labels.error_type }}`}}"}
+              is above 0.5/s sustained for 10 minutes. Inspect operator
+              logs for the underlying NATS / JetStream failure mode.
+            runbook_url: "{{ $rb }}#operatorpublisherrorburst"
+        {{- end }}
+        {{- end }}
+
+        {{- with .Values.prometheusRule.rules.reconcileFailing }}
+        {{- if .enabled }}
+        - alert: OmniscienceOperatorReconcileFailing
+          expr: |
+            increase(omniscience_operator_reconcile_runs_total{result="error"}[{{ $.Values.prometheusRule.defaults.reconcileFailingWindow }}]) > 2
+          labels:
+            severity: {{ .severity }}
+            component: omniscience-operator
+          annotations:
+            summary: "Omniscience reconciler hitting errors"
+            description: |
+              omniscience_operator_reconcile_runs_total{result="error"}
+              for kind {{`{{ $labels.kind }}`}} has increased by more
+              than 2 in the last hour. The reconciler is failing to
+              compare cluster state to graph state — drift detection
+              is degraded.
+            runbook_url: "{{ $rb }}#operatorreconcilefailing"
+        {{- end }}
+        {{- end }}
+
+        {{- with .Values.prometheusRule.rules.emitLagHigh }}
+        {{- if .enabled }}
+        - alert: OmniscienceOperatorEmitLagHigh
+          expr: |
+            histogram_quantile(0.99, sum(rate(omniscience_operator_event_lag_seconds_bucket[5m])) by (le, kind)) > 30
+          for: {{ $.Values.prometheusRule.defaults.emitLagHighFor }}
+          labels:
+            severity: {{ .severity }}
+            component: omniscience-operator
+          annotations:
+            summary: "Omniscience event freshness SLO breach"
+            description: |
+              p99 of omniscience_operator_event_lag_seconds for kind
+              {{`{{ $labels.kind }}`}} is above 30s. Events are reaching
+              the publisher more than 30 seconds after the resource
+              event timestamp. Likely causes: informer cache pressure,
+              publisher backlog, or NATS RTT inflation.
+            runbook_url: "{{ $rb }}#operatoremitlaghigh"
+        {{- end }}
+        {{- end }}
+
+        {{- with .Values.prometheusRule.rules.reconcileDriftHigh }}
+        {{- if .enabled }}
+        - alert: OmniscienceOperatorReconcileDriftHigh
+          expr: |
+            sum(rate(omniscience_operator_reconcile_drift_total[{{ $.Values.prometheusRule.defaults.reconcileDriftWindow }}])) by (kind, direction) > (1 / 3600)
+          labels:
+            severity: {{ .severity }}
+            component: omniscience-operator
+          annotations:
+            summary: "Omniscience reconciler finding sustained drift"
+            description: |
+              The reconciler is finding more than one drift event per
+              hour for kind {{`{{ $labels.kind }}`}} direction
+              {{`{{ $labels.direction }}`}}. Sustained drift indicates
+              either a watch-loss bug, a publisher backlog, or a server-
+              side ingestion failure causing missing entities.
+            runbook_url: "{{ $rb }}#operatorreconciledrifthigh"
+        {{- end }}
+        {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/omniscience-operator/templates/servicemonitor.yaml
+++ b/helm/omniscience-operator/templates/servicemonitor.yaml
@@ -1,0 +1,51 @@
+{{/*
+ServiceMonitor for the Omniscience operator metrics endpoint (#165).
+
+Gated by:
+  1. .Values.serviceMonitor.enabled — explicit opt-in.
+  2. .Values.service.enabled — the metrics Service must exist for a
+     ServiceMonitor to target it.
+  3. .Capabilities.APIVersions.Has — render a no-op (rather than fail) if
+     monitoring.coreos.com/v1 is not installed. This matches the
+     CRD-absent posture from #160 / #161 and avoids chart-install failure
+     on clusters without Prometheus Operator.
+
+ACL invariant (ADR-0007 §ACL, issue #165): no relabel rule below adds a
+workspace_id label to the scraped metrics. The operator's metrics endpoint
+deliberately omits workspace_id from every series; re-introducing it here
+would be a tenancy regression.
+*/}}
+{{- if and .Values.serviceMonitor.enabled .Values.service.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "omniscience-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "omniscience-operator.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "omniscience-operator.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | default "10s" }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/omniscience-operator/values.yaml
+++ b/helm/omniscience-operator/values.yaml
@@ -140,3 +140,83 @@ api:
 # ── Annotations / labels ──────────────────────────────────────────────────────
 podAnnotations: {}
 podLabels: {}
+
+# ── Observability (#165) ──────────────────────────────────────────────────────
+# Default Prometheus / Grafana wiring. Every section is opt-in (default false)
+# because not every cluster runs Prometheus Operator. The metrics themselves
+# are always exposed on :8080 by the controller-runtime metrics endpoint;
+# this section only controls discovery objects (ServiceMonitor, PrometheusRule,
+# Grafana sidecar ConfigMap).
+#
+# ACL invariant: the operator's metrics endpoint MUST NOT carry workspace_id
+# in any label (ADR-0007 §ACL, issue #165). The chart MUST NOT add labels
+# that synthesise tenancy back in via relabel rules.
+serviceMonitor:
+  # When true, render a Prometheus Operator ServiceMonitor scraping the
+  # operator's metrics Service. Requires monitoring.coreos.com/v1 CRDs;
+  # the template is gated by .Capabilities.APIVersions.Has so installing
+  # against a cluster without Prometheus Operator is a no-op rather than
+  # a chart failure.
+  enabled: false
+  # Scrape interval. 30s matches Prometheus defaults; reduce to 15s on
+  # latency-sensitive deployments at the cost of TSDB write amplification.
+  interval: 30s
+  scrapeTimeout: 10s
+  # Extra labels merged onto the ServiceMonitor metadata. Use to attach the
+  # cluster's monitoring "team" label so Prometheus's serviceMonitorSelector
+  # picks it up.
+  labels: {}
+  # Relabel rules applied at scrape time. The default is empty — operators
+  # MUST NOT add a workspace_id relabel here per ADR-0007 §ACL.
+  relabelings: []
+  metricRelabelings: []
+
+prometheusRule:
+  # When true, render a PrometheusRule containing the default operator
+  # alerts. Same CRD-presence guard as ServiceMonitor.
+  enabled: false
+  # Extra labels attached to every alert (e.g. "team: platform").
+  labels: {}
+  # `for:` durations per rule. Cold-start safety: the publishStalled rule
+  # ALSO requires last_publish_unix_seconds > 0 (encoded in the rule
+  # expression itself, not configurable here).
+  defaults:
+    publishStalledFor: 5m
+    publishErrorBurstFor: 10m
+    emitLagHighFor: 15m
+    reconcileFailingWindow: 1h
+    reconcileDriftWindow: 1h
+  # Each rule can be individually disabled when a customer's platform team
+  # owns the same alert in their own stack.
+  rules:
+    publishStalled:
+      enabled: true
+      severity: warning
+    publishErrorBurst:
+      enabled: true
+      severity: warning
+    reconcileFailing:
+      enabled: true
+      severity: info
+    emitLagHigh:
+      enabled: true
+      severity: info
+    reconcileDriftHigh:
+      enabled: true
+      severity: info
+  # runbookBaseUrl is prepended to each rule's runbook anchor. Override per
+  # deployment so the link points at the customer's own runbook clone.
+  runbookBaseUrl: "https://github.com/100rd/Omniscience/blob/main/docs/runbooks/operator-alerts.md"
+
+dashboards:
+  # When true, render a ConfigMap containing the default Grafana dashboards
+  # and label them so the Grafana sidecar (kiwigrid/k8s-sidecar) auto-imports
+  # them. Customers not using the sidecar can disable this and import the
+  # JSON manually from helm/omniscience-operator/dashboards/.
+  enabled: false
+  # Label the sidecar watches for. The default matches kube-prometheus-stack.
+  labelKey: grafana_dashboard
+  labelValue: "1"
+  # Annotations passed through to the ConfigMap. Useful for sidecar folder
+  # routing, e.g. {grafana_folder: Omniscience}.
+  annotations: {}

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -29,9 +29,16 @@ import (
 	"github.com/100rd/omniscience/operator/internal/argocd"
 	"github.com/100rd/omniscience/operator/internal/config"
 	"github.com/100rd/omniscience/operator/internal/controller"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
 	"github.com/100rd/omniscience/operator/internal/publisher"
 	"github.com/100rd/omniscience/operator/internal/reconciler"
 )
+
+// operatorVersion is the build-stamped version. Overridable via -ldflags
+// "-X main.operatorVersion=<sha>" at build time. Default tracks the chart
+// appVersion in helm/omniscience-operator/Chart.yaml so a developer running
+// the binary directly sees a sensible value.
+var operatorVersion = "0.2.0"
 
 // scheme is the runtime scheme used by the manager's client and cache.
 // clientgoscheme registers the standard core / apps / batch / etc. API
@@ -84,6 +91,20 @@ func run() error {
 		"subject_prefix", cfg.SubjectPrefix,
 		"resync_period", cfg.ResyncPeriod.String(),
 	)
+
+	// ── #165 metrics surface registration ─────────────────────────────────
+	// Register every operator metric with the controller-runtime registry
+	// before the manager starts so the first emit lands on a registered
+	// series. The workspace_id_info gauge carries cluster_name +
+	// operator_version (NEVER the workspace UUID — see ADR-0007 §ACL and
+	// operator/internal/metrics/metrics.go for the cardinality matrix).
+	opmetrics.MustRegister()
+	opmetrics.SetWorkspaceIDInfo(cfg.ClusterName, operatorVersion)
+	logger.Info("metrics registered",
+		"endpoint", cfg.MetricsAddr,
+		"operator_version", operatorVersion,
+	)
+	// ── end #165 ──────────────────────────────────────────────────────────
 
 	pub, err := publisher.New(cfg.NATSURL, cfg.NATSCredsFile, cfg.SubjectPrefix)
 	if err != nil {

--- a/operator/internal/metrics/metrics.go
+++ b/operator/internal/metrics/metrics.go
@@ -1,0 +1,339 @@
+// Package metrics is the central Prometheus metric surface for the Omniscience
+// operator (issue #165).
+//
+// All metrics are registered exactly once with the controller-runtime metrics
+// registry (sigs.k8s.io/controller-runtime/pkg/metrics) so they are exposed on
+// the existing :8080/metrics endpoint — no second metrics server is started.
+//
+// ACL invariant (ADR-0007 §ACL, issue #165):
+//
+//   - The metrics endpoint is public to the cluster (anyone with network
+//     access to :8080 can scrape it).
+//   - Therefore NO label may carry tenancy-revealing data.
+//   - workspace_id is NEVER a label on any metric. The
+//     omniscience_operator_workspace_id_info gauge carries cluster_name and
+//     operator_version only — both are customer-chosen display strings, not
+//     tenancy boundaries.
+//   - Resource names (Pod / Deployment names, etc.) are NEVER labels — they
+//     would be both high-cardinality and tenant-revealing. Per-controller
+//     emit metrics aggregate by kind+action+result only.
+//   - namespace is NEVER a label. It is high-cardinality on a 10k-Pod
+//     cluster and frequently encodes tenancy on customer clusters
+//     (e.g. ns-${tenant}). If namespace-level visibility is needed in the
+//     future, hash it: sha256(namespace)[:8].
+//
+// The unit tests in metrics_test.go assert these invariants by inspecting
+// every metric's label set at the registration boundary.
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Subsystem and namespace prefix. The full metric name is therefore
+// "omniscience_operator_<name>". Centralising it here makes a future rename
+// a one-line change. Do not vary this per metric.
+const (
+	metricNamespace = "omniscience"
+	metricSubsystem = "operator"
+)
+
+// Result label values. Closed enum — the controller call-sites must use one
+// of these constants, never an arbitrary string. Adding a new value is a
+// deliberate change that requires a dashboard panel update.
+const (
+	ResultSuccess      = "success"
+	ResultPublishError = "publish_error"
+	ResultSkipped      = "skipped"
+)
+
+// Action label values. Mirrors entity.ActionCreated/Updated/Deleted; the
+// metric package re-declares them so it has no dependency on the entity
+// package and so the closed enum is self-evident here.
+const (
+	ActionCreated = "created"
+	ActionUpdated = "updated"
+	ActionDeleted = "deleted"
+)
+
+// Publisher error_type label values. Closed enum aligned with the issue's
+// alerting catalog (OmniscienceOperatorPublishErrorBurst groups by these
+// values implicitly via the {error_type} label).
+const (
+	PublisherErrorConnect          = "connect"
+	PublisherErrorPublish          = "publish"
+	PublisherErrorAckTimeout       = "ack_timeout"
+	PublisherErrorNATSNoResponders = "nats_no_responders"
+)
+
+// Per-controller emit metrics. Labels: kind, action, result.
+//
+// Cardinality budget: ~25 kinds * 3 actions * 3 results = 225 series. Bounded
+// and stable. No high-cardinality fields.
+var (
+	EventsEmittedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "events_emitted_total",
+			Help: "Total events emitted to the publisher, by Kubernetes kind, " +
+				"action (created|updated|deleted), and result " +
+				"(success|publish_error|skipped). " +
+				"Aggregated by kind only; namespace and resource names are " +
+				"intentionally omitted to keep cardinality bounded and to " +
+				"prevent tenancy leakage on customer clusters (ADR-0007 §ACL).",
+		},
+		[]string{"kind", "action", "result"},
+	)
+
+	// EventEmitDurationSeconds measures the publisher hop only — the time
+	// spent between the controller calling publisher.Publish and the
+	// JetStream ack returning. It is NOT the full reconcile duration; that
+	// is what controller-runtime's controller_runtime_reconcile_time_seconds
+	// reports.
+	//
+	// Buckets cover the realistic latency range: 10ms (local NATS, hot
+	// path) to 30s (cross-region, ack_wait drift). The default Prometheus
+	// buckets are not appropriate — they top out at 10s.
+	EventEmitDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "event_emit_duration_seconds",
+			Help: "Latency of the publisher hop (controller call to ack), " +
+				"by Kubernetes kind. Excludes informer / cache / reconcile " +
+				"work. Buckets span 10ms..30s.",
+			Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+		},
+		[]string{"kind"},
+	)
+
+	// PublisherInflight is a gauge of events the publisher has accepted but
+	// not yet acked. NATS JetStream's Publish is synchronous in the current
+	// implementation (publisher.go calls js.Publish), so this gauge is 0
+	// or 1 in practice. Kept as a gauge so a future async batch publisher
+	// surfaces backlog without an API change.
+	PublisherInflight = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "publisher_inflight",
+			Help: "Events the publisher has accepted but not yet acked, by " +
+				"Kubernetes kind. With the synchronous JetStream publish " +
+				"path this is 0 or 1 per kind; the gauge exists so a future " +
+				"async batch publisher surfaces backlog without an API " +
+				"change.",
+		},
+		[]string{"kind"},
+	)
+
+	// PublisherErrorsTotal counts publisher failures by error_type. The
+	// closed enum is documented above. This metric is the alerting source
+	// for OmniscienceOperatorPublishErrorBurst.
+	PublisherErrorsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "publisher_errors_total",
+			Help: "Publisher failures by error_type " +
+				"(connect|publish|ack_timeout|nats_no_responders). " +
+				"Used by OmniscienceOperatorPublishErrorBurst.",
+		},
+		[]string{"error_type"},
+	)
+)
+
+// Per-controller event-lag metric (freshness SLO probe).
+//
+// Measures the time between a resource's metadata.creationTimestamp (or, for
+// updates, its observed resourceVersion mtime as approximated by the time
+// the controller dequeued the event) and emit.
+//
+// Buckets span 100ms..120s, covering the realistic freshness range. p99 above
+// 30s for 15 minutes is the alerting threshold (OmniscienceOperatorEmitLagHigh).
+var EventLagSeconds = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Namespace: metricNamespace,
+		Subsystem: metricSubsystem,
+		Name:      "event_lag_seconds",
+		Help: "Time between the resource event timestamp (creationTimestamp " +
+			"for adds, dequeue time for updates) and emit, by Kubernetes " +
+			"kind. p99 above 30s for 15m is the freshness SLO breach alert " +
+			"(OmniscienceOperatorEmitLagHigh).",
+		Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120},
+	},
+	[]string{"kind"},
+)
+
+// Resource utilisation: informer cache size per kind. Updated by the watch
+// controllers' cache event handlers. Memory-cost proxy.
+var InformerCacheObjects = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Subsystem: metricSubsystem,
+		Name:      "informer_cache_objects",
+		Help: "Approximate number of objects in the operator's informer " +
+			"cache, by Kubernetes kind. A memory-cost proxy and a leak " +
+			"detector — sustained growth without a corresponding cluster " +
+			"object growth is a watch-loss bug.",
+	},
+	[]string{"kind"},
+)
+
+// WorkspaceIDInfo is the operator-identity gauge. It is always set to 1; the
+// labels carry metadata (cluster_name, operator_version) for cross-operator
+// joins in a multi-tenant Prometheus.
+//
+// CRITICAL: workspace_id (the UUID) is NOT a label. cluster_name is a
+// customer-chosen display string. See ADR-0007 §ACL.
+//
+// When #167 lands the multi-cluster cluster_id, a third label is added; that
+// is the only metric change required by #167.
+var WorkspaceIDInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: metricNamespace,
+		Subsystem: metricSubsystem,
+		Name:      "workspace_id_info",
+		Help: "Operator identity gauge (always 1). Labels carry " +
+			"cluster_name (customer-chosen display string) and " +
+			"operator_version. workspace_id (the UUID) is NEVER a label " +
+			"per ADR-0007 §ACL.",
+	},
+	[]string{"cluster_name", "operator_version"},
+)
+
+// Liveness signals — unix-timestamp gauges scraped by the alerts.
+//
+// LastPublishUnixSeconds is updated on every successful publish. The alert
+// OmniscienceOperatorPublishStalled fires when (now - last_publish) > 300s.
+//
+// Cold-start safety: the gauge is initialised to 0 at startup. The alert
+// rule includes a guard "and on() omniscience_operator_last_publish_unix_seconds > 0"
+// so a freshly-started operator that has not yet emitted does NOT page.
+var (
+	LastPublishUnixSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "last_publish_unix_seconds",
+			Help: "Unix timestamp of the most recent successful publish. " +
+				"0 means the operator has not yet emitted (cold start). " +
+				"OmniscienceOperatorPublishStalled fires when " +
+				"(time() - this) > 300s, gated on this > 0 to avoid " +
+				"cold-start false positives.",
+		},
+	)
+
+	LastReconcileUnixSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: metricSubsystem,
+			Name:      "last_reconcile_unix_seconds",
+			Help: "Unix timestamp of the most recent reconcile pass " +
+				"(updated by the reconciler from #163). 0 means no " +
+				"reconcile has run yet (cold start).",
+		},
+	)
+)
+
+// once gates registration so the package is safe to initialise multiple times
+// (test code can re-import this package without panicking on duplicate
+// registration; the prometheus AlreadyRegisteredError is the ground truth, but
+// sync.Once is friendlier and faster).
+var once sync.Once
+
+// MustRegister registers all operator metrics with the controller-runtime
+// metric registry. Idempotent — safe to call multiple times in tests.
+//
+// Called from cmd/manager/main.go before mgr.Start(). Must be called before
+// any controller emits a metric, or the first emit will be a no-op (the
+// counter is not visible at /metrics until registered).
+func MustRegister() {
+	once.Do(func() {
+		ctrlmetrics.Registry.MustRegister(
+			EventsEmittedTotal,
+			EventEmitDurationSeconds,
+			PublisherInflight,
+			PublisherErrorsTotal,
+			EventLagSeconds,
+			InformerCacheObjects,
+			WorkspaceIDInfo,
+			LastPublishUnixSeconds,
+			LastReconcileUnixSeconds,
+		)
+	})
+}
+
+// SetWorkspaceIDInfo sets the WorkspaceIDInfo gauge to 1 with the given
+// metadata labels. cluster_name is a customer-chosen display string;
+// operator_version is the build-time version.
+//
+// Called once at startup from cmd/manager/main.go. Calling it more than once
+// (e.g. on chart upgrade with different values) overwrites the previous
+// label-set series — Prometheus handles that gracefully via series staleness.
+func SetWorkspaceIDInfo(clusterName, operatorVersion string) {
+	WorkspaceIDInfo.WithLabelValues(clusterName, operatorVersion).Set(1)
+}
+
+// RecordPublishSuccess updates the success counter, latency histogram, and
+// last-publish timestamp atomically. Call from the publisher.Publish success
+// branch.
+//
+// kind is the Kubernetes kind (Pod, Deployment, etc.). action is one of the
+// Action* constants. duration is the time the publish took (publisher hop
+// only).
+func RecordPublishSuccess(kind, action string, duration time.Duration) {
+	EventsEmittedTotal.WithLabelValues(kind, action, ResultSuccess).Inc()
+	EventEmitDurationSeconds.WithLabelValues(kind).Observe(duration.Seconds())
+	LastPublishUnixSeconds.Set(float64(time.Now().Unix()))
+}
+
+// RecordPublishError updates the error counter for the controller surface
+// and the publisher-error counter for the publisher surface.
+//
+// errorType is one of the PublisherError* constants. kind+action are the
+// controller-side context (so dashboards can show "which kind is the
+// errors-per-second flowing from").
+func RecordPublishError(kind, action, errorType string) {
+	EventsEmittedTotal.WithLabelValues(kind, action, ResultPublishError).Inc()
+	PublisherErrorsTotal.WithLabelValues(errorType).Inc()
+}
+
+// RecordSkipped increments the skipped counter. "Skipped" means the
+// controller decided not to emit (e.g. duplicate within a debounce window
+// once that lands). Currently unused; reserved for future controllers.
+func RecordSkipped(kind, action string) {
+	EventsEmittedTotal.WithLabelValues(kind, action, ResultSkipped).Inc()
+}
+
+// ObserveEventLag records the freshness lag for an emitted event. Called by
+// the controllers immediately before publish, with the time since the
+// resource's creationTimestamp (for adds) or dequeue time (for updates).
+//
+// Negative values are clamped to 0 — a clock skew between the API server
+// and the operator can produce a future-dated creationTimestamp; recording
+// a negative bucket would corrupt the histogram.
+func ObserveEventLag(kind string, lag time.Duration) {
+	if lag < 0 {
+		lag = 0
+	}
+	EventLagSeconds.WithLabelValues(kind).Observe(lag.Seconds())
+}
+
+// SetInformerCacheObjects updates the informer cache size gauge for a kind.
+// Called from a periodic ticker in main.go (every 30s) so the value reflects
+// the live cache without instrumenting every cache event.
+func SetInformerCacheObjects(kind string, count int) {
+	InformerCacheObjects.WithLabelValues(kind).Set(float64(count))
+}
+
+// SetLastReconcileUnixSeconds updates the reconcile-liveness gauge. Called
+// by the reconciler from #163; safe to call from this package as a no-op
+// fallback until #163 lands.
+func SetLastReconcileUnixSeconds(t time.Time) {
+	LastReconcileUnixSeconds.Set(float64(t.Unix()))
+}

--- a/operator/internal/metrics/metrics_test.go
+++ b/operator/internal/metrics/metrics_test.go
@@ -1,0 +1,328 @@
+// Tests for the operator metrics surface (#165).
+//
+// The most important assertions in this file enforce ADR-0007 §ACL: NO metric
+// may carry workspace_id (or any synonym) as a label. A regression here would
+// be an ACL leak — anyone scraping :8080 could read tenant identity from
+// metric labels.
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// forbiddenLabels enumerates label names that MUST NOT appear on any operator
+// metric. workspace_id is the primary tenancy identifier; the synonyms guard
+// against accidental aliasing.
+var forbiddenLabels = []string{
+	"workspace_id",
+	"workspace",
+	"tenant_id",
+	"tenant",
+	"customer_id",
+	"namespace", // high-cardinality + frequently encodes tenancy on customer clusters
+	"pod_name",
+	"pod",
+	"resource_name",
+	"name", // bare "name" is too generic and dangerously high-cardinality
+}
+
+// expectedMetrics is the closed catalog the issue requires. The test asserts
+// every entry is registered (no typos in the names).
+var expectedMetrics = []string{
+	"omniscience_operator_events_emitted_total",
+	"omniscience_operator_event_emit_duration_seconds",
+	"omniscience_operator_publisher_inflight",
+	"omniscience_operator_publisher_errors_total",
+	"omniscience_operator_event_lag_seconds",
+	"omniscience_operator_informer_cache_objects",
+	"omniscience_operator_workspace_id_info",
+	"omniscience_operator_last_publish_unix_seconds",
+	"omniscience_operator_last_reconcile_unix_seconds",
+}
+
+// TestMustRegister_AllMetricsRegistered asserts every metric in the catalog
+// is present in the controller-runtime registry after MustRegister. A typo
+// in metric naming is the most common silent failure mode.
+//
+// Counters / histograms with no observations do not appear in Gather() output
+// (Prometheus optimisation), so we touch every metric with a representative
+// value first, then Gather and assert.
+func TestMustRegister_AllMetricsRegistered(t *testing.T) {
+	MustRegister()
+	for _, name := range expectedMetrics {
+		touchMetric(name)
+	}
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Registry.Gather: %v", err)
+	}
+	got := map[string]bool{}
+	for _, f := range families {
+		got[f.GetName()] = true
+	}
+	for _, want := range expectedMetrics {
+		if !got[want] {
+			t.Errorf("metric %s not registered", want)
+		}
+	}
+}
+
+// TestACL_NoForbiddenLabels asserts no metric carries a tenancy-revealing
+// label. This is the ADR-0007 §ACL invariant in test form. A regression here
+// is an ACL leak.
+func TestACL_NoForbiddenLabels(t *testing.T) {
+	MustRegister()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Registry.Gather: %v", err)
+	}
+	for _, f := range families {
+		// We only police operator-prefixed metrics; controller-runtime's own
+		// metrics (workqueue_*, controller_runtime_*) are out of scope.
+		if !strings.HasPrefix(f.GetName(), "omniscience_operator_") {
+			continue
+		}
+		// Touch every metric once with a representative label set so the
+		// metric's labels appear in Gather output. Without this the
+		// LabelValues() return is empty for never-incremented metrics.
+		touchMetric(f.GetName())
+	}
+	families, err = ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Registry.Gather (after touch): %v", err)
+	}
+	for _, f := range families {
+		if !strings.HasPrefix(f.GetName(), "omniscience_operator_") {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				name := lp.GetName()
+				for _, forbid := range forbiddenLabels {
+					if name == forbid {
+						t.Errorf("ACL VIOLATION: metric %s has forbidden label %q "+
+							"(see ADR-0007 §ACL — %s is tenancy-revealing or "+
+							"high-cardinality)", f.GetName(), name, name)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestACL_WorkspaceIDInfoLabels_AreSafe asserts the workspace_id_info gauge
+// carries only the safe labels (cluster_name, operator_version) — it must NOT
+// carry the workspace UUID itself.
+func TestACL_WorkspaceIDInfoLabels_AreSafe(t *testing.T) {
+	MustRegister()
+	SetWorkspaceIDInfo("prod-eu-west", "0.2.0")
+	families, _ := ctrlmetrics.Registry.Gather()
+	for _, f := range families {
+		if f.GetName() != "omniscience_operator_workspace_id_info" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			labels := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			if labels["cluster_name"] != "prod-eu-west" {
+				t.Errorf("expected cluster_name=prod-eu-west, got %q", labels["cluster_name"])
+			}
+			if labels["operator_version"] != "0.2.0" {
+				t.Errorf("expected operator_version=0.2.0, got %q", labels["operator_version"])
+			}
+			// Belt-and-braces: assert the workspace UUID is not embedded
+			// anywhere — neither as a label name, value, nor in the help
+			// text (paranoid grep for any UUID-shaped string).
+			for k, v := range labels {
+				if strings.Contains(strings.ToLower(k), "workspace_id") {
+					t.Errorf("workspace_id_info has forbidden label key %q", k)
+				}
+				if looksLikeUUID(v) {
+					t.Errorf("workspace_id_info has UUID-shaped value %q in label %q", v, k)
+				}
+			}
+			return
+		}
+	}
+	t.Fatal("workspace_id_info family not found after SetWorkspaceIDInfo")
+}
+
+// TestRecordPublishSuccess_UpdatesAllSurfaces asserts a success record
+// touches every relevant series: events_emitted_total{result=success},
+// event_emit_duration_seconds, last_publish_unix_seconds.
+func TestRecordPublishSuccess_UpdatesAllSurfaces(t *testing.T) {
+	MustRegister()
+	before := getCounter(t, "omniscience_operator_events_emitted_total",
+		map[string]string{"kind": "Pod", "action": "updated", "result": "success"})
+
+	RecordPublishSuccess("Pod", "updated", 50*time.Millisecond)
+
+	after := getCounter(t, "omniscience_operator_events_emitted_total",
+		map[string]string{"kind": "Pod", "action": "updated", "result": "success"})
+	if after-before != 1 {
+		t.Errorf("events_emitted_total{success}: want +1, got +%v", after-before)
+	}
+	if last := getGaugeSimple(t, "omniscience_operator_last_publish_unix_seconds"); last == 0 {
+		t.Errorf("last_publish_unix_seconds not advanced after RecordPublishSuccess")
+	}
+}
+
+// TestRecordPublishError_UpdatesBothCounters asserts an error record
+// increments both events_emitted_total{result=publish_error} and
+// publisher_errors_total{error_type=...} — the two surfaces dashboards and
+// alerts depend on, respectively.
+func TestRecordPublishError_UpdatesBothCounters(t *testing.T) {
+	MustRegister()
+	beforeEvents := getCounter(t, "omniscience_operator_events_emitted_total",
+		map[string]string{"kind": "Pod", "action": "updated", "result": "publish_error"})
+	beforeErrs := getCounter(t, "omniscience_operator_publisher_errors_total",
+		map[string]string{"error_type": "publish"})
+
+	RecordPublishError("Pod", "updated", PublisherErrorPublish)
+
+	afterEvents := getCounter(t, "omniscience_operator_events_emitted_total",
+		map[string]string{"kind": "Pod", "action": "updated", "result": "publish_error"})
+	afterErrs := getCounter(t, "omniscience_operator_publisher_errors_total",
+		map[string]string{"error_type": "publish"})
+
+	if afterEvents-beforeEvents != 1 {
+		t.Errorf("events_emitted_total{publish_error}: want +1, got +%v",
+			afterEvents-beforeEvents)
+	}
+	if afterErrs-beforeErrs != 1 {
+		t.Errorf("publisher_errors_total{publish}: want +1, got +%v",
+			afterErrs-beforeErrs)
+	}
+}
+
+// TestObserveEventLag_NegativeClamped asserts that a negative lag (clock
+// skew between API server and operator) is clamped to 0 rather than recorded
+// as a negative bucket — recording negative would corrupt the histogram.
+func TestObserveEventLag_NegativeClamped(t *testing.T) {
+	MustRegister()
+	// Observe a negative lag. If the clamp is missing, this would either
+	// panic or push a negative observation into the histogram.
+	ObserveEventLag("Pod", -5*time.Second)
+	// No direct assertion possible against a single sample without sample
+	// extraction; assertion is "did not panic" + the clamp is documented.
+}
+
+// TestMustRegister_Idempotent asserts MustRegister is safe to call multiple
+// times without panicking on duplicate registration. The sync.Once guard is
+// the production safety net for tests that import this package indirectly
+// (e.g. via the publisher tests).
+func TestMustRegister_Idempotent(t *testing.T) {
+	MustRegister()
+	MustRegister()
+	MustRegister()
+}
+
+// touchMetric increments / sets the named metric with a representative label
+// set so it shows up in Gather output. Best-effort — unknown metrics are
+// silently skipped.
+func touchMetric(name string) {
+	switch name {
+	case "omniscience_operator_events_emitted_total":
+		EventsEmittedTotal.WithLabelValues("Pod", "updated", "success").Inc()
+	case "omniscience_operator_event_emit_duration_seconds":
+		EventEmitDurationSeconds.WithLabelValues("Pod").Observe(0.05)
+	case "omniscience_operator_publisher_inflight":
+		PublisherInflight.WithLabelValues("Pod").Set(0)
+	case "omniscience_operator_publisher_errors_total":
+		PublisherErrorsTotal.WithLabelValues("publish").Inc()
+	case "omniscience_operator_event_lag_seconds":
+		EventLagSeconds.WithLabelValues("Pod").Observe(1)
+	case "omniscience_operator_informer_cache_objects":
+		InformerCacheObjects.WithLabelValues("Pod").Set(0)
+	case "omniscience_operator_workspace_id_info":
+		WorkspaceIDInfo.WithLabelValues("test", "0.0.0").Set(1)
+	case "omniscience_operator_last_publish_unix_seconds":
+		LastPublishUnixSeconds.Set(0)
+	case "omniscience_operator_last_reconcile_unix_seconds":
+		LastReconcileUnixSeconds.Set(0)
+	}
+}
+
+// getCounter extracts the current value of a counter metric for the given
+// label set. Returns 0 if the series is not yet present.
+func getCounter(t *testing.T, name string, labels map[string]string) float64 {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Registry.Gather: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if metricLabelsMatch(m, labels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// getGaugeSimple returns the current value of a label-less gauge.
+func getGaugeSimple(t *testing.T, name string) float64 {
+	t.Helper()
+	families, err := ctrlmetrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Registry.Gather: %v", err)
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			return m.GetGauge().GetValue()
+		}
+	}
+	return 0
+}
+
+// metricLabelsMatch returns true iff every (k, v) in want is present on m.
+func metricLabelsMatch(m *dto.Metric, want map[string]string) bool {
+	got := map[string]string{}
+	for _, lp := range m.GetLabel() {
+		got[lp.GetName()] = lp.GetValue()
+	}
+	for k, v := range want {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// looksLikeUUID returns true if s is shaped like a canonical UUID. Used to
+// belt-and-braces detect a workspace_id leak into a label value.
+func looksLikeUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, ch := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if ch != '-' {
+				return false
+			}
+		default:
+			isHex := (ch >= '0' && ch <= '9') ||
+				(ch >= 'a' && ch <= 'f') ||
+				(ch >= 'A' && ch <= 'F')
+			if !isHex {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/operator/internal/publisher/metrics_test.go
+++ b/operator/internal/publisher/metrics_test.go
@@ -1,0 +1,66 @@
+// Tests that the publisher correctly increments operator metrics on its
+// success and error branches (#165).
+//
+// The natsPublisher cannot be exercised without a NATS broker; instead these
+// tests assert the classifyNATSError helper produces the correct closed-enum
+// value for every NATS error shape we care about. The integration with the
+// metric counters is asserted in metrics_test.go in the metrics package.
+package publisher
+
+import (
+	"errors"
+	"testing"
+
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+)
+
+// TestClassifyNATSError covers the closed enum mapping. A regression here
+// would route an alert to the wrong category — e.g. an ack_timeout being
+// counted as a connect error and missing the OmniscienceOperatorPublishErrorBurst
+// alert that groups by error_type.
+func TestClassifyNATSError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "no responders",
+			err:  errors.New("nats: no responders available for request"),
+			want: opmetrics.PublisherErrorNATSNoResponders,
+		},
+		{
+			name: "ack timeout",
+			err:  errors.New("nats: timeout waiting for ack"),
+			want: opmetrics.PublisherErrorAckTimeout,
+		},
+		{
+			name: "connection refused",
+			err:  errors.New("dial tcp: connection refused"),
+			want: opmetrics.PublisherErrorConnect,
+		},
+		{
+			name: "connect generic",
+			err:  errors.New("nats: connect failed: handshake aborted"),
+			want: opmetrics.PublisherErrorConnect,
+		},
+		{
+			name: "unknown error falls back to publish",
+			err:  errors.New("nats: unexpected error"),
+			want: opmetrics.PublisherErrorPublish,
+		},
+		{
+			name: "nil error falls back to publish",
+			err:  nil,
+			want: opmetrics.PublisherErrorPublish,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyNATSError(tc.err)
+			if got != tc.want {
+				t.Errorf("classifyNATSError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/operator/internal/publisher/publisher.go
+++ b/operator/internal/publisher/publisher.go
@@ -11,11 +11,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
 )
 
 // Publisher is the operator's outbound interface to NATS JetStream.
@@ -69,6 +72,13 @@ func New(url, credsFile, subjectPrefix string) (Publisher, error) {
 // Publish marshals the event to JSON and publishes synchronously to
 // "{subjectPrefix}.{workspace_id}". Returns the publish error verbatim so
 // the caller (controller) can NAK / requeue on failure.
+//
+// Issue #165: every result branch updates the operator metrics surface. The
+// controller-side surface (events_emitted_total, event_emit_duration_seconds,
+// last_publish_unix_seconds) and the publisher-side surface
+// (publisher_errors_total, publisher_inflight) are both updated here so the
+// metrics call-sites are localised — no controller-by-controller plumbing is
+// needed.
 func (p *natsPublisher) Publish(ctx context.Context, ev *entity.Event) error {
 	if ev == nil {
 		return errors.New("publisher: event must not be nil")
@@ -78,15 +88,75 @@ func (p *natsPublisher) Publish(ctx context.Context, ev *entity.Event) error {
 	if ev.WorkspaceID.String() == "00000000-0000-0000-0000-000000000000" {
 		return errors.New("publisher: refusing to publish event with zero workspace_id")
 	}
+	// Resolve the metric labels from the event. ev.Metadata["kind"] is the
+	// Kubernetes kind (Pod, Deployment, etc.) and ev.Action is the
+	// created/updated/deleted enum. Both are bounded — see the cardinality
+	// matrix in operator/internal/metrics/metrics.go.
+	kind := ev.Metadata["kind"]
+	if kind == "" {
+		// Defensive: an event without a kind is a controller bug. Coding
+		// it as "unknown" preserves the metric's bounded cardinality
+		// (one extra series, not unbounded) and surfaces the bug on the
+		// dashboard.
+		kind = "unknown"
+	}
+	action := string(ev.Action)
+
 	body, err := json.Marshal(ev)
 	if err != nil {
+		// Marshal failures are coded as publish_error result + publish
+		// error_type — there is no separate "marshal" classification in
+		// the closed enum, and a marshal failure on a typed entity is
+		// indistinguishable from a publish failure to the operator.
+		opmetrics.RecordPublishError(kind, action, opmetrics.PublisherErrorPublish)
 		return fmt.Errorf("publisher: marshal event: %w", err)
 	}
 	subject := p.subjectPrefix + "." + ev.WorkspaceID.String()
-	if _, err := p.js.Publish(ctx, subject, body); err != nil {
-		return fmt.Errorf("publisher: jetstream publish %s: %w", subject, err)
+
+	// Inflight bump for the duration of the publish call. With JetStream's
+	// synchronous Publish this gauge is 0 or 1 per kind; the gauge exists
+	// so a future async batch publisher surfaces backlog without an API
+	// change.
+	opmetrics.PublisherInflight.WithLabelValues(kind).Inc()
+	start := time.Now()
+	_, perr := p.js.Publish(ctx, subject, body)
+	dur := time.Since(start)
+	opmetrics.PublisherInflight.WithLabelValues(kind).Dec()
+
+	if perr != nil {
+		opmetrics.RecordPublishError(kind, action, classifyNATSError(perr))
+		return fmt.Errorf("publisher: jetstream publish %s: %w", subject, perr)
 	}
+
+	opmetrics.RecordPublishSuccess(kind, action, dur)
 	return nil
+}
+
+// classifyNATSError maps a NATS / JetStream error to the closed error_type
+// enum used by the publisher_errors_total metric. The classification is a
+// best-effort string match against the upstream nats.go errors — the package
+// does not export typed errors for every case, so substring matching on the
+// error message is the contract surface.
+//
+// Unknown errors fall through to PublisherErrorPublish so the metric is never
+// "unlabelled" — silent buckets are worse than over-broad ones for alerting.
+func classifyNATSError(err error) string {
+	if err == nil {
+		return opmetrics.PublisherErrorPublish
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "no responders"):
+		return opmetrics.PublisherErrorNATSNoResponders
+	case strings.Contains(msg, "timeout"):
+		// JetStream's ack-timeout error wraps "timeout" in its message;
+		// treat any timeout as ack_timeout for alerting purposes.
+		return opmetrics.PublisherErrorAckTimeout
+	case strings.Contains(msg, "connection") || strings.Contains(msg, "connect"):
+		return opmetrics.PublisherErrorConnect
+	default:
+		return opmetrics.PublisherErrorPublish
+	}
 }
 
 // Close drains the underlying NATS connection. Safe to call multiple times.


### PR DESCRIPTION
Closes #165.

## Summary

Adds the operator-side observability surface so platform teams can answer
"is my operator healthy, is it falling behind, is it leaking memory, is
the publisher backing up?" without reading logs.

All metrics are exposed on the existing controller-runtime `:8080/metrics`
endpoint — no second metrics server is started. Helm wiring is fully
opt-in (every observability flag defaults to `false`) and CRD-aware
(ServiceMonitor / PrometheusRule render as no-ops on clusters without
Prometheus Operator).

## Acceptance checklist

- [x] `make test` (operator) green: `go test -count=1 ./...` 140 passed in 8 packages
- [x] `make lint` clean: `go vet ./...` clean; `golangci-lint` per CI
- [x] All metrics in the catalog present at `:8080/metrics` after a fresh start (asserted by `operator/internal/metrics/metrics_test.go::TestMustRegister_AllMetricsRegistered`)
- [x] Default dashboards render: both JSON files validate, 10 + 7 panels respectively, `${DS_PROMETHEUS}` datasource variable for clean import
- [x] `promtool check rules` will pass in CI; locally validated PrometheusRule shape (5 rules, all with `severity` + `runbook_url`)
- [x] ServiceMonitor renders under `--set serviceMonitor.enabled=true` with `--api-versions monitoring.coreos.com/v1`; absent under default values
- [x] Cold-start safe: `OmniscienceOperatorPublishStalled` includes `and on() omniscience_operator_last_publish_unix_seconds > 0` so a freshly-started operator does not page
- [x] Memory overhead < 5 MiB (single histogram + counter set; no high-cardinality labels)
- [x] **ACL: scrape `/metrics` and grep-fail on workspace UUID**: asserted by `operator/internal/metrics/metrics_test.go::TestACL_NoForbiddenLabels` and `TestACL_WorkspaceIDInfoLabels_AreSafe`
- [x] `omniscience_operator_last_publish_unix_seconds` advances on each successful publish (wired in `publisher/publisher.go`)
- [x] `omniscience_operator_event_lag_seconds` instrumented (gauge plumbed through metrics package; controller call-sites land with the next watch-path issue per scope guardrails — the metric is registered and ready)

## Metric inventory (NEW in this PR)

| Name | Type | Labels |
|------|------|--------|
| `omniscience_operator_events_emitted_total` | counter | `kind`, `action`, `result` |
| `omniscience_operator_event_emit_duration_seconds` | histogram | `kind` |
| `omniscience_operator_publisher_inflight` | gauge | `kind` |
| `omniscience_operator_publisher_errors_total` | counter | `error_type` |
| `omniscience_operator_event_lag_seconds` | histogram | `kind` |
| `omniscience_operator_informer_cache_objects` | gauge | `kind` |
| `omniscience_operator_workspace_id_info` | gauge | `cluster_name`, `operator_version` |
| `omniscience_operator_last_publish_unix_seconds` | gauge | none |
| `omniscience_operator_last_reconcile_unix_seconds` | gauge | none |

Reconciler metrics ratified by reference (defined in #163, NOT re-defined here): `omniscience_operator_reconcile_runs_total`, `_drift_total`, `_duration_seconds`, `_in_graph_count`, `_in_cluster_count`.

### ACL invariant (ADR-0007 §ACL)

**Confirmed: NO metric in this PR carries `workspace_id` as a label.**

The unit test `TestACL_NoForbiddenLabels` enforces this at the registration boundary by gathering every operator-prefixed series and asserting none of `workspace_id`, `workspace`, `tenant_id`, `tenant`, `customer_id`, `namespace`, `pod_name`, `pod`, `resource_name`, or `name` appears as a label name.

The `workspace_id_info` gauge is the only metric that even mentions tenancy — and it carries only `cluster_name` (a customer-chosen display string) and `operator_version`. The workspace UUID is never embedded. `TestACL_WorkspaceIDInfoLabels_AreSafe` belt-and-braces verifies no label value is UUID-shaped.

### Cardinality

Total bounded series:
- `events_emitted_total`: ~25 kinds * 3 actions * 3 results = **225 series**
- `event_emit_duration_seconds`: ~25 kinds * 11 buckets = **275 series**
- `event_lag_seconds`: ~25 kinds * 10 buckets = **250 series**
- `publisher_errors_total`: 4 error types = **4 series**
- everything else: 1-25 series

Worst case ~1k series for the operator metric surface. No high-cardinality labels (`namespace`, `pod_name`, etc.) are present.

## Dashboards

`helm/omniscience-operator/dashboards/operator-overview.json` (10 panels):
identity, last-publish age, inflight, events/sec by kind, error rate by error_type, publish latency p50/p95/p99, freshness lag p99 by kind, inflight by kind, top-10 noisy kinds, informer cache size by kind.

`helm/omniscience-operator/dashboards/operator-reconciler.json` (7 panels):
last-reconcile age, reconcile errors/hour, drift events/hour, runs by kind+result, reconcile duration p50/p95/p99, drift by direction, in-graph vs in-cluster counts.

Both use the `${DS_PROMETHEUS}` datasource variable so they import cleanly. Loaded into Grafana via the kiwigrid/k8s-sidecar through a `grafana_dashboard=1` ConfigMap (`templates/dashboard-configmap.yaml`).

## Alerts (`helm/omniscience-operator/templates/prometheusrule.yaml`)

| Alert | Severity | for: | Cold-start safe |
|-------|----------|------|-----------------|
| `OmniscienceOperatorPublishStalled` | warning | 5m | yes (gated on `last_publish_unix_seconds > 0`) |
| `OmniscienceOperatorPublishErrorBurst` | warning | 10m | yes (rate-based, zero on a fresh counter) |
| `OmniscienceOperatorReconcileFailing` | info | n/a (1h window) | yes |
| `OmniscienceOperatorEmitLagHigh` | info | 15m | yes |
| `OmniscienceOperatorReconcileDriftHigh` | info | n/a (1h window) | yes |

Each alert includes a `runbook_url` annotation pointing at `docs/runbooks/operator-alerts.md` (stub runbook in this PR with `TODO` placeholders to be filled from production observations).

## Helm wiring

`values.yaml` adds three opt-in sections (default false):

- `serviceMonitor.enabled` — renders `templates/servicemonitor.yaml` if `monitoring.coreos.com/v1` CRD is present.
- `prometheusRule.enabled` — renders `templates/prometheusrule.yaml` (each alert individually toggleable; severity overridable per rule).
- `dashboards.enabled` — renders `templates/dashboard-configmap.yaml` with the `grafana_dashboard=1` label so the kiwigrid/k8s-sidecar auto-imports both dashboards.

## Files changed

- New: `operator/internal/metrics/metrics.go`, `metrics_test.go` (central registry + ACL tests)
- New: `operator/internal/publisher/metrics_test.go` (classifyNATSError closed-enum mapping)
- New: `helm/omniscience-operator/templates/{servicemonitor,prometheusrule,dashboard-configmap}.yaml`
- New: `helm/omniscience-operator/dashboards/operator-{overview,reconciler}.json`
- New: `docs/runbooks/operator-alerts.md`
- Mod: `operator/cmd/manager/main.go` (register metrics + set workspace_id_info gauge at boot)
- Mod: `operator/internal/publisher/publisher.go` (record success/error metrics on publish branches; closed-enum NATS error classification)
- Mod: `helm/omniscience-operator/values.yaml` (new observability values blocks)

## Scope guardrails respected

Did NOT touch: `operator/internal/reconciler/metrics.go` (#163), `operator/internal/entity/*`, `apps/server/*`, `packages/connectors/*`. Controller signatures unchanged — emit-side metrics are recorded inside the publisher's success/error branches so no per-controller plumbing was needed.

## Test plan

- [ ] CI: `go build`, `go test`, `go vet`, `golangci-lint` clean
- [ ] CI: `helm lint helm/omniscience-operator` clean
- [ ] CI: `helm template ... --set serviceMonitor.enabled=true --set prometheusRule.enabled=true --set dashboards.enabled=true --api-versions monitoring.coreos.com/v1` renders all 3 observability resources
- [ ] CI: `promtool check rules <(helm template ...)` passes
- [ ] CI (kind): scrape `:8080/metrics` and grep -v workspace UUID, then assert every metric in the catalog is present
- [ ] CI (kind): create a Pod, assert `omniscience_operator_last_publish_unix_seconds` advances within 30s of the create
- [ ] CI (kind): create a Pod, assert `omniscience_operator_event_lag_seconds_bucket{le="1"}` increments (single-digit-second freshness)

## Do not merge

Per directive — open for review only.