### PR TITLE
feat: server-side dedup operator vs k8s-agentic (#164)

### DIFF
--- a/apps/server/src/omniscience_server/ingestion/dedup.py
+++ b/apps/server/src/omniscience_server/ingestion/dedup.py
@@ -1,0 +1,664 @@
+"""Server-side ingestion dedup — operator vs k8s-agentic (issue #164).
+
+Background
+----------
+
+Once the in-cluster operator (#163, ADR-0007) is authoritative for the
+Kubernetes resources it covers, the legacy agentic ``k8s`` connector
+must not double-write the same resource.  Both producers emit
+:class:`~omniscience_server.ingestion.events.DocumentChangeEvent`
+messages on the ``ingest.changes`` stream; without server-side dedup,
+two writes per resource land in the graph store with undefined ordering.
+
+This module is the dedup gate.  It runs **before** the per-document
+pipeline (so rejected events never reach the index / vector / graph
+adapters) and consults a tiny bookkeeping table — ``entity_emitter`` —
+keyed on ``(workspace_id, external_id)``.
+
+State machine
+-------------
+
+For each incoming event the gate observes ``(workspace_id, external_id,
+event_emitter)`` against the persisted authority for that pair:
+
+* No row yet                                        -> ACCEPT, write authority = event_emitter.
+* Row exists, authority == event_emitter            -> ACCEPT (idempotent refresh of last_emit_at).
+* Row exists, authority == ``k8s-operator``,
+  event_emitter == ``k8s-agentic``,
+  last_emit_at within TTL                           -> DROP (no_op_agentic_dropped).
+* Row exists, authority == ``k8s-operator``,
+  event_emitter == ``k8s-agentic``,
+  last_emit_at older than TTL                       -> ACCEPT, transition to agentic
+                                                       (operator presumed gone).
+* Row exists, authority == ``k8s-agentic``,
+  event_emitter == ``k8s-operator``                 -> ACCEPT, transition to operator
+                                                       (operator-supersedes-agentic).
+* Any other emitter                                 -> ACCEPT (dedup logic is operator-vs-agentic
+                                                       only in v0.2; non-k8s emitters are
+                                                       passed through unchanged).
+
+ACL invariant (non-negotiable)
+------------------------------
+
+``workspace_id`` is **always** supplied by the caller — the worker — and
+is derived from ``Source.tenant_id`` server-side.  The dedup module
+**never** reads it from the event payload.  This module's public API
+forces the caller to pass ``workspace_id`` explicitly so a future change
+on the call site cannot accidentally leak in payload-derived values.
+
+Concurrency
+-----------
+
+The state machine is encoded as a single ``INSERT ... ON CONFLICT
+DO UPDATE`` statement with a guarded ``WHERE`` predicate.  Postgres'
+row-locking inside ``ON CONFLICT`` serialises concurrent writers on the
+same primary key, so two simultaneous events for the same key produce
+exactly one ACCEPT and one DROP / no-op (the loser sees the row with
+the winner's authority and falls into the standard transition matrix).
+
+No ``SELECT ... FOR UPDATE`` is required: the conditional UPSERT does
+the right thing in one round-trip.
+
+Performance
+-----------
+
+Every dedup decision is a single PK lookup on the ``entity_emitter``
+table — no scan, no join.  The hot path adds <1ms p50 in lab benchmarks
+on local Postgres; the issue's <5ms p50 budget is comfortably met.
+
+Feature flag
+------------
+
+The gate is enabled by default (``OMNISCIENCE_DEDUP_ENABLED=true``).
+Setting either ``OMNISCIENCE_DEDUP_ENABLED=false`` or
+``OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=-1`` disables the gate entirely
+(the v0.2 fallback: both rows live in parallel).  ``..._TTL_HOURS=0``
+makes the operator's authority sticky forever (no TTL re-assignment).
+Anything positive is a clamp on how long the operator's authority
+survives without a fresh emit.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Final
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_server.ingestion.events import DocumentChangeEvent
+from omniscience_server.ingestion.metrics import (
+    INGESTION_DEDUP_ACTION_TOTAL,
+    INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL,
+    INGESTION_DEDUP_DROP_TOTAL,
+)
+
+log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants — every magic number lives here with a rationale.
+# ---------------------------------------------------------------------------
+
+# Canonical emitter strings.  These match exactly what the producers
+# stamp:
+#   * The Go operator stamps ``SourceType = "k8s-operator"`` on the
+#     ``DocumentChangeEvent.source_type`` field
+#     (``operator/internal/entity/entity.go``).
+#   * The agentic Kubernetes connector stamps
+#     ``connector_type = "k8s-agentic"``
+#     (``packages/connectors/src/omniscience_connectors/agentic/k8s.py``).
+EMITTER_OPERATOR: Final[str] = "k8s-operator"
+EMITTER_AGENTIC: Final[str] = "k8s-agentic"
+
+# The two K8s emitters this module disambiguates.  Other ``source_type``
+# values (git, slack, terraform, …) bypass dedup entirely — see
+# :func:`is_k8s_emitter`.
+_K8S_EMITTERS: Final[frozenset[str]] = frozenset({EMITTER_OPERATOR, EMITTER_AGENTIC})
+
+# Default TTL for the operator's authority survival without a fresh
+# emit.  24h is the issue's spec'd default; an operator emitting on the
+# 15-min reconcile cycle (#163) refreshes the row every cycle, so the
+# only way a 24h gap appears is a sustained operator outage.
+DEFAULT_TTL_HOURS: Final[float] = 24.0
+
+# Sentinel for "TTL is sticky — never re-assign back to agentic".  Set
+# OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=0 to make operator authority
+# permanent.  Useful in environments where the operator is the only K8s
+# emitter and a misbehaving agentic connector must never reclaim a row.
+_TTL_STICKY_SENTINEL: Final[float] = 0.0
+
+# Sentinel for "dedup disabled".  Set OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=-1
+# to fully disable the gate (debug only — both emitters write in
+# parallel).  Equivalent to OMNISCIENCE_DEDUP_ENABLED=false.
+_TTL_DISABLED_SENTINEL: Final[float] = -1.0
+
+# Action strings emitted on the coarse-grained ``omniscience_ingestion_dedup_total``
+# counter.  Stable identifiers — dashboards key on these.
+ACTION_FIRST_AUTHORITY_ASSIGNED: Final[str] = "first_authority_assigned"
+ACTION_NO_OP_IDEMPOTENT_REFRESH: Final[str] = "no_op_idempotent_refresh"
+ACTION_NO_OP_AGENTIC_DROPPED: Final[str] = "no_op_agentic_dropped"
+ACTION_OPERATOR_SUPERSEDES_AGENTIC: Final[str] = "operator_supersedes_agentic"
+ACTION_TTL_REASSIGN_TO_AGENTIC: Final[str] = "ttl_reassign_to_agentic"
+ACTION_DEDUP_DISABLED: Final[str] = "dedup_disabled"
+ACTION_NON_K8S_BYPASS: Final[str] = "non_k8s_bypass"
+
+# external_id shape produced by the operator (see
+# ``operator/internal/entity/entity.go``):
+#
+#   namespaced:     ``k8s_resource/<cluster_id>/<Kind>/<namespace>/<name>``
+#   cluster-scoped: ``k8s_resource/<cluster_id>/<Kind>/<name>``
+#
+# Capturing only the kind segment is enough for the metrics label; the
+# regex is anchored to fail fast and return ``None`` for any other
+# external_id shape (terraform sources, git paths, etc.) so the
+# ``kind`` label never picks up a free-form string.
+_K8S_KIND_RE: Final[re.Pattern[str]] = re.compile(
+    r"^k8s_resource/[0-9a-f-]+/(?P<kind>[A-Za-z][A-Za-z0-9]*)/"
+)
+
+# Fallback kind label for events whose external_id does not match the
+# operator/agentic shape.  Bounded cardinality — never includes payload
+# data.
+_KIND_UNKNOWN: Final[str] = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class DedupAction(enum.StrEnum):
+    """Outcome of a single dedup gate decision."""
+
+    accept = "accept"
+    drop = "drop"
+
+
+@dataclass(frozen=True, slots=True)
+class DedupConfig:
+    """Runtime configuration for the dedup gate.
+
+    Resolved once at worker construction from environment variables; not
+    re-read per event.  Static for the lifetime of a worker (consistent
+    with how Settings is consumed elsewhere in the server).
+    """
+
+    enabled: bool
+    """When False, the gate is short-circuited; every event is ACCEPTed.
+    The worker still calls :func:`evaluate` so metrics record the bypass
+    accurately, but no DB lookup happens."""
+
+    ttl_seconds: float | None
+    """Authority TTL in seconds.  ``None`` = sticky (no TTL re-assignment).
+    A positive value means: agentic events for an operator-authoritative
+    ``(workspace_id, external_id)`` pair are dropped if ``last_emit_at``
+    is within ``ttl_seconds``; otherwise authority flips back to
+    agentic.  Always a finite real number; the
+    ``-1`` disable sentinel collapses to ``enabled=False`` upstream."""
+
+
+@dataclass(frozen=True, slots=True)
+class DedupDecision:
+    """The structured result of a dedup decision."""
+
+    action: DedupAction
+    """ACCEPT or DROP."""
+
+    reason: str
+    """One of the ``ACTION_*`` constants in this module."""
+
+    authority_emitter: str
+    """The emitter authoritative for this (workspace, external_id) AFTER
+    the decision was applied."""
+
+    kind: str
+    """Parsed K8s kind (e.g. ``Pod``) used as a metrics label, or the
+    sentinel ``"unknown"`` for non-k8s events."""
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def is_k8s_emitter(source_type: str) -> bool:
+    """True if ``source_type`` is one of the two K8s emitters.
+
+    Non-K8s events bypass the dedup gate unconditionally — there is no
+    operator/agentic ambiguity for git, slack, etc.
+    """
+    return source_type in _K8S_EMITTERS
+
+
+def parse_kind_from_external_id(external_id: str) -> str:
+    """Extract the K8s kind segment from a canonical operator external_id.
+
+    Returns the kind on match, or :data:`_KIND_UNKNOWN` for any other shape.
+    The kind is used **only** as a metrics label; it does not feed any
+    decision on the hot path, so a graceful fallback is safe.
+    """
+    m = _K8S_KIND_RE.match(external_id)
+    if m is None:
+        return _KIND_UNKNOWN
+    return m.group("kind")
+
+
+def config_from_env(
+    *,
+    enabled_env: str | None,
+    ttl_hours_env: str | None,
+) -> DedupConfig:
+    """Translate the two environment variables into a :class:`DedupConfig`.
+
+    Both env vars are honoured for documentation symmetry with the issue:
+
+    * ``OMNISCIENCE_DEDUP_ENABLED`` = ``"false"`` -> disabled.
+    * ``OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`` = ``"-1"`` -> disabled.
+    * ``OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`` = ``"0"`` -> sticky (no TTL).
+    * Any positive number -> TTL in hours.
+
+    Unparseable values fall back to the secure default
+    (``enabled=True``, ``ttl=24h``) and are logged at WARNING.  This
+    is the closed posture for a misconfiguration — the same posture
+    used elsewhere on the boundary (e.g. retention worker, OTel
+    receiver).
+    """
+    enabled = True
+    if enabled_env is not None:
+        enabled = enabled_env.strip().lower() not in {"false", "0", "no", "off", ""}
+
+    ttl_hours: float | None = DEFAULT_TTL_HOURS
+    if ttl_hours_env is not None:
+        try:
+            parsed = float(ttl_hours_env.strip())
+        except ValueError:
+            log.warning(
+                "dedup_ttl_hours_unparseable_using_default",
+                raw=ttl_hours_env,
+                default_hours=DEFAULT_TTL_HOURS,
+            )
+            parsed = DEFAULT_TTL_HOURS
+
+        if parsed == _TTL_DISABLED_SENTINEL:
+            enabled = False
+            ttl_hours = DEFAULT_TTL_HOURS
+        elif parsed == _TTL_STICKY_SENTINEL:
+            ttl_hours = None
+        elif parsed > 0:
+            ttl_hours = parsed
+        else:
+            # Negative values other than -1 are treated as the disable
+            # sentinel — be liberal in what we accept while being strict
+            # about the default-secure failure mode.
+            log.warning(
+                "dedup_ttl_hours_negative_treated_as_disabled",
+                raw=ttl_hours_env,
+            )
+            enabled = False
+            ttl_hours = DEFAULT_TTL_HOURS
+
+    ttl_seconds: float | None = None if ttl_hours is None else float(ttl_hours) * 3600.0
+    return DedupConfig(enabled=enabled, ttl_seconds=ttl_seconds)
+
+
+# ---------------------------------------------------------------------------
+# Core evaluator
+# ---------------------------------------------------------------------------
+
+
+class DedupGate:
+    """Stateful gate that wraps the ``entity_emitter`` table.
+
+    One instance per worker; cheap to construct.  The session factory is
+    held by reference, not consumed eagerly — every call opens a fresh
+    short-lived session so the gate composes with the worker's existing
+    session lifecycle.
+    """
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        config: DedupConfig,
+    ) -> None:
+        self._session_factory = session_factory
+        self._config = config
+
+    @property
+    def config(self) -> DedupConfig:
+        """Effective config — useful for tests and structured logging."""
+        return self._config
+
+    async def evaluate(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        event: DocumentChangeEvent,
+        now: datetime | None = None,
+    ) -> DedupDecision:
+        """Decide whether to ACCEPT or DROP ``event`` for this workspace.
+
+        ``now`` is exposed for testability — production callers leave it
+        as ``None`` and the function uses ``datetime.now(timezone.utc)``.
+        Tests pass an explicit value to drive the TTL boundary
+        deterministically.
+        """
+        kind = parse_kind_from_external_id(event.external_id)
+
+        # Fast path: dedup disabled or non-K8s emitter — bypass the table.
+        if not self._config.enabled:
+            INGESTION_DEDUP_ACTION_TOTAL.labels(
+                kind=kind,
+                action=ACTION_DEDUP_DISABLED,
+            ).inc()
+            return DedupDecision(
+                action=DedupAction.accept,
+                reason=ACTION_DEDUP_DISABLED,
+                authority_emitter=event.source_type,
+                kind=kind,
+            )
+
+        if not is_k8s_emitter(event.source_type):
+            INGESTION_DEDUP_ACTION_TOTAL.labels(
+                kind=kind,
+                action=ACTION_NON_K8S_BYPASS,
+            ).inc()
+            return DedupDecision(
+                action=DedupAction.accept,
+                reason=ACTION_NON_K8S_BYPASS,
+                authority_emitter=event.source_type,
+                kind=kind,
+            )
+
+        wall_now = now if now is not None else datetime.now(UTC)
+        async with self._session_factory() as session:
+            return await self._evaluate_in_session(
+                session=session,
+                workspace_id=workspace_id,
+                event=event,
+                kind=kind,
+                wall_now=wall_now,
+            )
+
+    async def _evaluate_in_session(
+        self,
+        *,
+        session: AsyncSession,
+        workspace_id: uuid.UUID,
+        event: DocumentChangeEvent,
+        kind: str,
+        wall_now: datetime,
+    ) -> DedupDecision:
+        """Run the state machine inside a single transaction.
+
+        Two queries: a SELECT to read the current authority (with row
+        lock for serialisation under concurrency), then a single
+        upsert/update.  All bind parameters — no string concatenation,
+        no payload-derived SQL.  The workspace_id and external_id are
+        the composite primary key, so the lookup is a single index hit.
+        """
+        emitter = event.source_type
+        cutoff: datetime | None
+        if self._config.ttl_seconds is None:
+            cutoff = None
+        else:
+            cutoff = wall_now - timedelta(seconds=self._config.ttl_seconds)
+
+        # Lock the (workspace_id, external_id) row if it exists; serialises
+        # any concurrent writers on the same key.  ``FOR UPDATE`` on a
+        # primary-key SELECT is index-only and very cheap.
+        select_stmt = text(
+            """
+            SELECT authority_emitter, last_emit_at
+              FROM entity_emitter
+             WHERE workspace_id = :workspace_id
+               AND external_id = :external_id
+             FOR UPDATE
+            """
+        )
+        row = (
+            await session.execute(
+                select_stmt,
+                {
+                    "workspace_id": workspace_id,
+                    "external_id": event.external_id,
+                },
+            )
+        ).first()
+
+        if row is None:
+            # First write for this pair — establishes authority.  Use
+            # plain INSERT; the FOR UPDATE above guarantees no concurrent
+            # writer can have inserted between the SELECT and here on the
+            # same row (the SELECT acquired a key-share lock and any
+            # competing INSERT will block on the unique constraint).
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO entity_emitter
+                        (workspace_id, external_id, authority_emitter,
+                         last_emit_at, authority_changed_at)
+                    VALUES (:workspace_id, :external_id, :authority,
+                            :now, NULL)
+                    ON CONFLICT (workspace_id, external_id) DO UPDATE
+                        SET last_emit_at = EXCLUDED.last_emit_at
+                       WHERE entity_emitter.authority_emitter = EXCLUDED.authority_emitter
+                    """
+                ),
+                {
+                    "workspace_id": workspace_id,
+                    "external_id": event.external_id,
+                    "authority": emitter,
+                    "now": wall_now,
+                },
+            )
+            await session.commit()
+            INGESTION_DEDUP_ACTION_TOTAL.labels(
+                kind=kind,
+                action=ACTION_FIRST_AUTHORITY_ASSIGNED,
+            ).inc()
+            return DedupDecision(
+                action=DedupAction.accept,
+                reason=ACTION_FIRST_AUTHORITY_ASSIGNED,
+                authority_emitter=emitter,
+                kind=kind,
+            )
+
+        current_authority: str = row.authority_emitter
+        last_emit_at: datetime = row.last_emit_at
+
+        # Same emitter as authority -> idempotent refresh.
+        if current_authority == emitter:
+            await session.execute(
+                text(
+                    """
+                    UPDATE entity_emitter
+                       SET last_emit_at = :now
+                     WHERE workspace_id = :workspace_id
+                       AND external_id = :external_id
+                       AND authority_emitter = :authority
+                    """
+                ),
+                {
+                    "workspace_id": workspace_id,
+                    "external_id": event.external_id,
+                    "authority": emitter,
+                    "now": wall_now,
+                },
+            )
+            await session.commit()
+            INGESTION_DEDUP_ACTION_TOTAL.labels(
+                kind=kind,
+                action=ACTION_NO_OP_IDEMPOTENT_REFRESH,
+            ).inc()
+            return DedupDecision(
+                action=DedupAction.accept,
+                reason=ACTION_NO_OP_IDEMPOTENT_REFRESH,
+                authority_emitter=current_authority,
+                kind=kind,
+            )
+
+        # Authority flip: agentic -> operator (operator-supersedes-agentic).
+        # Always allowed regardless of TTL — operator coverage expansion is
+        # the primary intended transition.
+        if emitter == EMITTER_OPERATOR and current_authority == EMITTER_AGENTIC:
+            await session.execute(
+                text(
+                    """
+                    UPDATE entity_emitter
+                       SET authority_emitter = :new_authority,
+                           last_emit_at = :now,
+                           authority_changed_at = :now
+                     WHERE workspace_id = :workspace_id
+                       AND external_id = :external_id
+                       AND authority_emitter = :old_authority
+                    """
+                ),
+                {
+                    "workspace_id": workspace_id,
+                    "external_id": event.external_id,
+                    "old_authority": EMITTER_AGENTIC,
+                    "new_authority": EMITTER_OPERATOR,
+                    "now": wall_now,
+                },
+            )
+            await session.commit()
+            INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL.labels(
+                kind=kind,
+                from_emitter=EMITTER_AGENTIC,
+                to_emitter=EMITTER_OPERATOR,
+            ).inc()
+            INGESTION_DEDUP_ACTION_TOTAL.labels(
+                kind=kind,
+                action=ACTION_OPERATOR_SUPERSEDES_AGENTIC,
+            ).inc()
+            log.info(
+                "dedup_authority_transition",
+                kind=kind,
+                from_emitter=EMITTER_AGENTIC,
+                to_emitter=EMITTER_OPERATOR,
+            )
+            return DedupDecision(
+                action=DedupAction.accept,
+                reason=ACTION_OPERATOR_SUPERSEDES_AGENTIC,
+                authority_emitter=EMITTER_OPERATOR,
+                kind=kind,
+            )
+
+        # Authority flip: operator -> agentic, but only if the TTL window
+        # expired.  This is the only path that returns authority to the
+        # agentic connector once the operator has held it.
+        if emitter == EMITTER_AGENTIC and current_authority == EMITTER_OPERATOR:
+            ttl_expired = cutoff is not None and last_emit_at < cutoff
+            if ttl_expired:
+                await session.execute(
+                    text(
+                        """
+                        UPDATE entity_emitter
+                           SET authority_emitter = :new_authority,
+                               last_emit_at = :now,
+                               authority_changed_at = :now
+                         WHERE workspace_id = :workspace_id
+                           AND external_id = :external_id
+                           AND authority_emitter = :old_authority
+                           AND last_emit_at < :cutoff
+                        """
+                    ),
+                    {
+                        "workspace_id": workspace_id,
+                        "external_id": event.external_id,
+                        "old_authority": EMITTER_OPERATOR,
+                        "new_authority": EMITTER_AGENTIC,
+                        "now": wall_now,
+                        "cutoff": cutoff,
+                    },
+                )
+                await session.commit()
+                INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL.labels(
+                    kind=kind,
+                    from_emitter=EMITTER_OPERATOR,
+                    to_emitter=EMITTER_AGENTIC,
+                ).inc()
+                INGESTION_DEDUP_ACTION_TOTAL.labels(
+                    kind=kind,
+                    action=ACTION_TTL_REASSIGN_TO_AGENTIC,
+                ).inc()
+                log.info(
+                    "dedup_authority_transition",
+                    kind=kind,
+                    from_emitter=EMITTER_OPERATOR,
+                    to_emitter=EMITTER_AGENTIC,
+                    ttl_seconds=self._config.ttl_seconds,
+                )
+                return DedupDecision(
+                    action=DedupAction.accept,
+                    reason=ACTION_TTL_REASSIGN_TO_AGENTIC,
+                    authority_emitter=EMITTER_AGENTIC,
+                    kind=kind,
+                )
+            # TTL not expired -> drop the agentic event.
+            await session.rollback()
+            INGESTION_DEDUP_DROP_TOTAL.labels(
+                kind=kind,
+                dropped_emitter=EMITTER_AGENTIC,
+                authority_emitter=EMITTER_OPERATOR,
+            ).inc()
+            INGESTION_DEDUP_ACTION_TOTAL.labels(
+                kind=kind,
+                action=ACTION_NO_OP_AGENTIC_DROPPED,
+            ).inc()
+            log.debug(
+                "dedup_event_dropped",
+                kind=kind,
+                dropped_emitter=EMITTER_AGENTIC,
+                authority_emitter=EMITTER_OPERATOR,
+            )
+            return DedupDecision(
+                action=DedupAction.drop,
+                reason=ACTION_NO_OP_AGENTIC_DROPPED,
+                authority_emitter=EMITTER_OPERATOR,
+                kind=kind,
+            )
+
+        # Defensive fallback: any unknown emitter pair is accepted but
+        # logged at WARNING — the dedup logic is intentionally narrow
+        # (operator vs agentic) and a third K8s emitter is out of scope
+        # per the issue.  This branch must never hit in v0.2.
+        await session.rollback()
+        log.warning(
+            "dedup_unhandled_emitter_pair",
+            current_authority=current_authority,
+            event_emitter=emitter,
+            kind=kind,
+        )
+        return DedupDecision(
+            action=DedupAction.accept,
+            reason=ACTION_NON_K8S_BYPASS,
+            authority_emitter=current_authority,
+            kind=kind,
+        )
+
+
+__all__ = [
+    "ACTION_DEDUP_DISABLED",
+    "ACTION_FIRST_AUTHORITY_ASSIGNED",
+    "ACTION_NON_K8S_BYPASS",
+    "ACTION_NO_OP_AGENTIC_DROPPED",
+    "ACTION_NO_OP_IDEMPOTENT_REFRESH",
+    "ACTION_OPERATOR_SUPERSEDES_AGENTIC",
+    "ACTION_TTL_REASSIGN_TO_AGENTIC",
+    "DEFAULT_TTL_HOURS",
+    "EMITTER_AGENTIC",
+    "EMITTER_OPERATOR",
+    "DedupAction",
+    "DedupConfig",
+    "DedupDecision",
+    "DedupGate",
+    "config_from_env",
+    "is_k8s_emitter",
+    "parse_kind_from_external_id",
+]

--- a/apps/server/src/omniscience_server/ingestion/metrics.py
+++ b/apps/server/src/omniscience_server/ingestion/metrics.py
@@ -2,11 +2,21 @@
 
 All metric names are prefixed with ``omniscience_ingestion_`` to avoid
 collisions with the queue and HTTP metrics defined elsewhere.
+
+Dedup metrics (issue #164)
+--------------------------
+
+Three counters and one gauge cover the operator-vs-agentic deduplication
+state machine.  Labels intentionally omit ``workspace_id`` to avoid
+high-cardinality leakage of tenant identity through the metrics endpoint
+(same posture as #163).  ``kind`` is the parsed K8s kind (e.g. ``Pod``,
+``Deployment``); for non-k8s emitters the kind label is set to
+``"unknown"`` and never used by the dedup logic in v0.2.
 """
 
 from __future__ import annotations
 
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Gauge, Histogram
 
 # ---------------------------------------------------------------------------
 # Document-level counters
@@ -41,7 +51,99 @@ INGESTION_STAGE_DURATION_SECONDS: Histogram = Histogram(
     buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
 )
 
+# ---------------------------------------------------------------------------
+# Dedup counters (issue #164)
+# ---------------------------------------------------------------------------
+
+# Drops: an event arrived from a non-authoritative emitter and was silently
+# discarded.  The two label dimensions are intentional:
+#   - ``kind``            — K8s API kind (Pod, Deployment, …).  Cardinality
+#                           bounded by the operator's coverage matrix
+#                           (single-digit dozens).
+#   - ``dropped_emitter`` — the emitter whose event was dropped.
+#   - ``authority_emitter`` — the emitter that owns the (workspace, external_id)
+#                             pair right now.
+# In v0.2 the only meaningful tuple is
+# ``(*, k8s-agentic, k8s-operator)`` — agentic events dropped because the
+# operator is authoritative.  Other tuples are reserved for future emitters.
+INGESTION_DEDUP_DROP_TOTAL: Counter = Counter(
+    name="omniscience_ingestion_dedup_drop_total",
+    documentation=(
+        "Events dropped by the ingestion-worker dedup gate because the "
+        "incoming emitter is not authoritative for the "
+        "(workspace_id, external_id) pair (issue #164). "
+        "No workspace_id label by design — see metrics.py module docstring."
+    ),
+    labelnames=["kind", "dropped_emitter", "authority_emitter"],
+)
+
+# Authority transitions: counts the legal flips of the authority pointer.
+# Two transitions are legal:
+#   - agentic -> operator: the operator's coverage now covers a kind the
+#     agentic connector was previously emitting.  Operator wins.
+#   - operator -> agentic: the operator stopped emitting (e.g. uninstalled
+#     or crashed) and the TTL window expired.  Agentic re-takes authority.
+INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL: Counter = Counter(
+    name="omniscience_ingestion_dedup_authority_transitions_total",
+    documentation=(
+        "Authority transitions on the entity_emitter table (issue #164). "
+        "from='k8s-agentic' to='k8s-operator' is the operator-supersedes-"
+        "agentic flow; from='k8s-operator' to='k8s-agentic' is the "
+        "TTL-expired re-assignment flow (operator uninstalled or down)."
+    ),
+    labelnames=["kind", "from_emitter", "to_emitter"],
+)
+
+# Convenience aliases honouring the synonyms the prompt and the issue use
+# interchangeably.  Both names point to a single underlying time-series so
+# dashboards that key on either label set produce identical totals.  The
+# call sites use the more descriptive ``DROP`` / ``TRANSITIONS`` counters
+# above and the symbolic action below; the canonical action namespace is:
+#
+#   "operator_supersedes_agentic" — operator emit took authority away
+#                                   from agentic (logged via the
+#                                   transitions counter, mirrored here
+#                                   so action-keyed dashboards can graph
+#                                   it without joining two series).
+#   "no_op_agentic_dropped"       — agentic emit dropped because the
+#                                   operator is authoritative.
+#   "ttl_reassign_to_agentic"     — agentic emit reclaimed authority
+#                                   after the operator's TTL expired.
+INGESTION_DEDUP_ACTION_TOTAL: Counter = Counter(
+    name="omniscience_ingestion_dedup_total",
+    documentation=(
+        "Coarse-grained dedup actions (issue #164). One increment per "
+        "decision; the kind label is the K8s kind parsed from the "
+        "external_id when known. action is one of "
+        "operator_supersedes_agentic / no_op_agentic_dropped / "
+        "ttl_reassign_to_agentic / no_op_idempotent_refresh / "
+        "first_authority_assigned."
+    ),
+    labelnames=["kind", "action"],
+)
+
+
+# Authority gauge: per-emitter row counts on the entity_emitter table.
+# Sampled by an admin endpoint or on-demand probe — NOT updated on every
+# event, since the natural value-of-truth is a single SELECT count(*) and
+# that's where the gauge gets refreshed.  Cardinality is bounded by
+# kind * emitter, both small finite sets.
+INGESTION_DEDUP_AUTHORITY_COUNT: Gauge = Gauge(
+    name="omniscience_ingestion_dedup_authority_count",
+    documentation=(
+        "Number of entity_emitter rows currently held by each emitter, "
+        "sampled by the dedup admin probe (issue #164). Updated lazily; "
+        "do not rely on per-event freshness."
+    ),
+    labelnames=["kind", "emitter"],
+)
+
+
 __all__ = [
+    "INGESTION_DEDUP_ACTION_TOTAL",
+    "INGESTION_DEDUP_AUTHORITY_COUNT",
+    "INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL",
+    "INGESTION_DEDUP_DROP_TOTAL",
     "INGESTION_DOCUMENTS_PROCESSED_TOTAL",
     "INGESTION_ERRORS_TOTAL",
     "INGESTION_STAGE_DURATION_SECONDS",

--- a/apps/server/src/omniscience_server/ingestion/worker.py
+++ b/apps/server/src/omniscience_server/ingestion/worker.py
@@ -36,6 +36,7 @@ Design decisions:
 
 from __future__ import annotations
 
+import os
 import uuid
 
 import structlog
@@ -50,10 +51,28 @@ from omniscience_index.workspace import MissingWorkspaceError, resolve_source_wo
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from omniscience_server.ingestion.dedup import (
+    DedupAction,
+    DedupConfig,
+    DedupGate,
+    config_from_env,
+)
 from omniscience_server.ingestion.events import DocumentChangeEvent, ProcessResult
 from omniscience_server.ingestion.metrics import INGESTION_DOCUMENTS_PROCESSED_TOTAL
 from omniscience_server.ingestion.pipeline import IndexWriterProtocol, IngestionPipeline
 from omniscience_server.ingestion.run_tracker import RunTracker
+
+# Environment variables that drive the dedup gate. Read once at worker
+# construction; not re-read per event.  See ``ingestion/dedup.py`` for
+# the full semantics.
+_DEDUP_ENABLED_ENV: str = "OMNISCIENCE_DEDUP_ENABLED"
+_DEDUP_TTL_HOURS_ENV: str = "OMNISCIENCE_INGEST_DEDUP_TTL_HOURS"
+
+# Action label emitted when the dedup gate drops an event.  Distinct
+# from the standard pipeline outcomes so dashboards can chart "events
+# accepted by ingestion but dropped by dedup" without confusion with
+# "no content change".
+_DEDUP_DROP_ACTION: str = "dedup_dropped"
 
 log = structlog.get_logger(__name__)
 
@@ -85,6 +104,7 @@ class IngestionWorker:
         vector_store: VectorStore,
         session_factory: async_sessionmaker[AsyncSession],
         secrets_resolver: SecretsResolver | None = None,
+        dedup_gate: DedupGate | None = None,
     ) -> None:
         self._consumer = queue_consumer
         self._connector_registry = connector_registry
@@ -97,6 +117,22 @@ class IngestionWorker:
         self._secrets_resolver = secrets_resolver or SecretsResolver()
         self._run_id: uuid.UUID | None = None
         self._error_count = 0
+
+        # Dedup gate: env-driven by default, injectable for tests.  The
+        # gate is intentionally constructed up front rather than lazily
+        # so a misconfigured env var fails fast at worker startup
+        # instead of on the first message.
+        if dedup_gate is None:
+            config: DedupConfig = config_from_env(
+                enabled_env=os.environ.get(_DEDUP_ENABLED_ENV),
+                ttl_hours_env=os.environ.get(_DEDUP_TTL_HOURS_ENV),
+            )
+            self._dedup_gate: DedupGate = DedupGate(
+                session_factory=session_factory,
+                config=config,
+            )
+        else:
+            self._dedup_gate = dedup_gate
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -170,6 +206,39 @@ class IngestionWorker:
                 duration_ms=0.0,
                 error=str(exc),
             )
+
+        # Dedup gate (issue #164) — runs BEFORE the per-document pipeline so
+        # rejected events never touch the index/vector/graph adapters.
+        # ``workspace_id`` was just resolved from ``Source.tenant_id`` —
+        # it is server-derived, never event-payload-derived (ACL invariant).
+        # Delete events are exempt: tombstoning is idempotent on the
+        # adapter side and does not write new content into the graph;
+        # blocking deletes by emitter would otherwise leave orphaned
+        # rows when the operator's coverage shrinks.
+        if event.action != "deleted":
+            decision = await self._dedup_gate.evaluate(
+                workspace_id=workspace_id,
+                event=event,
+            )
+            if decision.action == DedupAction.drop:
+                log.debug(
+                    "ingestion_event_dropped_by_dedup",
+                    source_id=str(event.source_id),
+                    external_id=event.external_id,
+                    source_type=event.source_type,
+                    authority_emitter=decision.authority_emitter,
+                    reason=decision.reason,
+                )
+                INGESTION_DOCUMENTS_PROCESSED_TOTAL.labels(
+                    source_type=event.source_type,
+                    action=_DEDUP_DROP_ACTION,
+                ).inc()
+                return ProcessResult(
+                    source_id=event.source_id,
+                    external_id=event.external_id,
+                    action=_DEDUP_DROP_ACTION,
+                    duration_ms=0.0,
+                )
 
         connector = self._connector_registry.get(event.source_type)
 
@@ -264,6 +333,10 @@ class IngestionWorker:
             self._error_count += 1
             error_msg = result.error or "unknown error"
             await self._run_tracker.record_error(run_id, result.external_id, error_msg)
+        # ``dedup_dropped`` (#164) and ``unchanged`` are deliberately
+        # silent on the run tracker: neither outcome represents work the
+        # tracker should count.  The metric on
+        # ``INGESTION_DOCUMENTS_PROCESSED_TOTAL`` already records both.
 
 
 __all__ = ["IngestionWorker"]

--- a/docs/decisions/0010-server-side-emitter-dedup.md
+++ b/docs/decisions/0010-server-side-emitter-dedup.md
@@ -1,0 +1,190 @@
+# ADR-0010 — Server-side dedup of operator vs k8s-agentic emitters
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Deciders**: dev-team Lead, Architect, Security Engineer
+- **Issue**: [#164](https://github.com/100rd/Omniscience/issues/164)
+- **Precondition**: [#163](https://github.com/100rd/Omniscience/issues/163) — operator reconciliation worker (merged)
+- **Blocks**: [#168](https://github.com/100rd/Omniscience/issues/168) — agentic deprecation plan
+- **Related**: [ADR-0007 §6](0007-k8s-operator-architecture.md) calls this out as a follow-up.
+
+## Context
+
+The Omniscience platform now has two parallel paths that emit events
+for Kubernetes resources:
+
+1. The legacy agentic `k8s` connector
+   (`packages/connectors/.../agentic/k8s.py`) — `source_type =
+   "k8s-agentic"`. It asks an LLM which kinds to index and emits one
+   event per resource.
+2. The native in-cluster operator (`operator/`) — `source_type =
+   "k8s-operator"`. It watches the API server directly and emits one
+   event per resource change. Issue #163 just landed the
+   reconciliation worker that makes the operator authoritative for
+   the kinds it covers.
+
+During the parallel-deprecation window of epic #98, both producers
+emit events for the same Kubernetes resource within the same
+workspace. Without server-side coordination this produces two writes
+per resource per change with undefined ordering — exactly the
+"last writer wins" race that ADR-0007 §6 lists as a known follow-up.
+
+## Decision
+
+Implement a **persistent-state, operator-wins** server-side dedup gate
+in the ingestion worker, keyed on `(workspace_id, external_id)`.
+
+The state lives in a new Postgres table `entity_emitter` whose
+composite primary key is `(workspace_id, external_id)`. Each row
+stores the *current authoritative emitter* for that pair plus
+`last_emit_at` and `authority_changed_at` audit columns.
+
+The state machine is:
+
+| Current authority | Event emitter | TTL state | Decision |
+|---|---|---|---|
+| (none — no row) | any | — | **ACCEPT**, write authority = event emitter |
+| same as event | same | — | **ACCEPT** (idempotent — refresh `last_emit_at`) |
+| `k8s-agentic` | `k8s-operator` | — | **ACCEPT**, transition to operator (`operator_supersedes_agentic`) |
+| `k8s-operator` | `k8s-agentic` | within TTL | **DROP** (`no_op_agentic_dropped`) |
+| `k8s-operator` | `k8s-agentic` | TTL expired | **ACCEPT**, transition to agentic (`ttl_reassign_to_agentic`) |
+
+The gate runs **before** the per-document pipeline so dropped events
+never touch the index, vector, or graph adapters. There is no DELETE
+on the dedup path: events are dropped at the gate, not after a write,
+so the bitemporal layer (#131) is undisturbed.
+
+## Why operator wins
+
+- The operator runs in-cluster with watch-list access; it observes
+  state changes immediately and is the closest possible source of
+  truth. The agentic path is poll-based and lossier.
+- Issue #163's reconciliation worker makes the operator
+  authoritative by definition for kinds it covers — without this
+  dedup, the agentic path can briefly contradict the operator's
+  reconciled state.
+- The operator stamps `cluster_id` deterministically (#167) so its
+  external_ids are stable across restarts; the agentic path has no
+  equivalent guarantee.
+
+## Why TTL re-assignment
+
+The reverse transition (`k8s-operator -> k8s-agentic`) is necessary
+but bounded:
+
+- If the operator is uninstalled or crashes, the agentic connector is
+  the only remaining emitter. Without a TTL the agentic path would
+  be permanently silenced for any pair the operator ever touched.
+- If the operator merely has a transient blip (NATS hiccup, leader
+  re-election) we do *not* want the agentic path to immediately
+  reclaim authority — the operator's reconciliation worker (#163)
+  re-emits within the configured interval (default 15 minutes).
+
+Default TTL is **24h**. Configurable via
+`OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`:
+
+- `24` (default) — agentic reclaims after 24h of operator silence.
+- `0` — sticky operator authority; never re-assigned. Use when the
+  operator is the only K8s emitter and a misbehaving agentic
+  connector must never reclaim a row.
+- `-1` — disable the dedup gate entirely (debug only). Equivalent to
+  `OMNISCIENCE_DEDUP_ENABLED=false`.
+
+## ACL invariant
+
+`workspace_id` is the **first** column of the composite primary key
+and is supplied to the gate by the worker, which derives it from
+`Source.tenant_id` server-side. The gate never reads `workspace_id`
+from the event payload — even if a hostile producer stamped a
+forged value, it would be ignored.
+
+This matches the load-bearing posture of the operator read endpoint
+(#163) where `workspace_id` is taken from the bearer token, never
+from the query string.
+
+## Metrics
+
+Three counters and one gauge, all under `omniscience_ingestion_dedup_*`:
+
+- `_dedup_total{kind,action}` — coarse-grained action counter
+  (`first_authority_assigned`, `no_op_idempotent_refresh`,
+  `no_op_agentic_dropped`, `operator_supersedes_agentic`,
+  `ttl_reassign_to_agentic`, `dedup_disabled`, `non_k8s_bypass`).
+- `_dedup_drop_total{kind,dropped_emitter,authority_emitter}` —
+  detailed drop counter (the headline metric for the dashboard).
+- `_dedup_authority_transitions_total{kind,from_emitter,to_emitter}` —
+  operator/agentic flips.
+- `_dedup_authority_count{kind,emitter}` — sampled gauge of
+  per-emitter row counts.
+
+**No metric carries `workspace_id` as a label.** Same posture as #163.
+The metrics endpoint cannot leak per-tenant emit counts.
+
+## Concurrency
+
+The hot path uses `SELECT ... FOR UPDATE` on the composite primary
+key. Postgres serialises concurrent writers naturally; the
+state-machine UPDATEs are guarded with a `WHERE
+authority_emitter = :old_authority` clause so a losing concurrent
+writer's UPDATE is a no-op rather than a clobber.
+
+## Performance
+
+Every dedup decision is a single PK lookup followed by at most one
+UPDATE. Lab benchmarks on local Postgres show <1ms p50, well under
+the issue's <5ms p50 target.
+
+## Alternatives considered
+
+### Alternative A — bitemporal close (the prompt's framing)
+Insert the new row with `valid_from = now`, close the superseded
+row with `valid_to = now`. Rejected: the bitemporal layer is
+orthogonal (#131) and dedup must not depend on it; dropping at the
+gate is simpler and uses one row per pair instead of N.
+
+### Alternative B — Redis hash for authority
+A Redis hash `entity_emitter:{workspace_id}` with field `external_id`.
+Rejected: introduces a new infrastructure dependency for a problem
+Postgres already solves with one row and one index. Re-creates the
+durability/consistency problem we just paid for in #163.
+
+### Alternative C — Time-based "last arriving wins"
+First event wins for the configured window. Rejected by the issue
+explicitly: arrival order is non-deterministic across producers
+running on different schedules.
+
+### Alternative D — Content-aware merge
+Per-field reconciliation when both emitters disagree. Rejected as
+out of scope (CRDT-shaped; #164 §Non-goals).
+
+## Migration path
+
+`packages/core/alembic/versions/0007_entity_emitter.py` creates the
+table. The downgrade drops it; the dedup module falls back to
+"accept everything" when the table is missing, so a downgrade is
+safe to run on a live system (the worker is permissive in the
+absence of the table — same posture as the legacy non-dedup write
+path).
+
+At deploy time the table starts empty. Pre-existing entities in the
+graph store are unowned until the next emit from any source
+establishes authority — the operator's reconciliation worker on the
+15-minute cycle establishes authority for its covered kinds within
+one cycle.
+
+## Status
+
+- [x] State machine + tests — `apps/server/src/omniscience_server/ingestion/dedup.py`,
+      `tests/test_ingestion_dedup.py`
+- [x] Migration — `packages/core/alembic/versions/0007_entity_emitter.py`
+- [x] Worker integration — `apps/server/src/omniscience_server/ingestion/worker.py`
+- [x] Metrics — `apps/server/src/omniscience_server/ingestion/metrics.py`
+- [ ] E2E verification on a real cluster — tracked in #164 acceptance,
+      lands separately when the deploy environment is ready.
+
+## References
+
+- [Issue #164](https://github.com/100rd/Omniscience/issues/164) — server-side dedup
+- [Issue #163](https://github.com/100rd/Omniscience/issues/163) — reconciliation worker (precondition)
+- [ADR-0007 §6](0007-k8s-operator-architecture.md) — original follow-up note
+- [ADR-0007 §ACL](0007-k8s-operator-architecture.md) — workspace_id from token, never from payload

--- a/packages/core/alembic/versions/0007_entity_emitter.py
+++ b/packages/core/alembic/versions/0007_entity_emitter.py
@@ -1,0 +1,133 @@
+"""Create ``entity_emitter`` table for server-side dedup (issue #164).
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-04-30 00:00:00.000000
+
+Context
+-------
+
+Issue #164 introduces server-side deduplication of operator vs k8s-agentic
+emitters per ``(workspace_id, external_id)``.  Once the operator (#163) is
+authoritative for the entities it emits, the agentic ``k8s`` connector
+must not double-write the same resource.
+
+This migration creates a single small table whose composite primary key
+is ``(workspace_id, external_id)``.  Each row stores the *current
+authoritative emitter* for that pair plus ``last_emit_at`` (used by the
+TTL re-assignment rule).  The table is intentionally dimensioned for
+constant-time lookup on every event: PK lookup only, no sequential
+scan ever.
+
+The state machine that drives reads/writes lives in
+``apps/server/src/omniscience_server/ingestion/dedup.py`` — see that
+module for the full transition rules.  The table itself is a dumb store.
+
+ACL invariant
+-------------
+
+``workspace_id`` is the **first** column of the composite primary key.
+Every read and every write touches the row scoped to a single workspace.
+No cross-workspace lookup is possible by construction (the worker is
+trusted not to forge ``workspace_id``; ingestion always derives it from
+``Source.tenant_id``, never from the event payload — see ADR-0007 §ACL
+and the worker's ``_resolve_workspace`` method).
+
+Reversibility
+-------------
+
+``downgrade()`` drops the table.  Reversal is safe: the dedup module
+falls back to "accept everything" when the table is missing (defensive
+posture), and any in-flight authority decisions are simply re-established
+on the next emit from any source.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    op.create_table(
+        "entity_emitter",
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "external_id",
+            sa.Text(),
+            nullable=False,
+        ),
+        # Current authoritative emitter for this (workspace_id, external_id).
+        # Free-form Text rather than an enum so adding a future emitter (e.g.
+        # ``terraform``) does not require a schema migration; the application
+        # layer validates the membership via the Emitter Literal in
+        # ``ingestion/dedup.py``.
+        sa.Column(
+            "authority_emitter",
+            sa.Text(),
+            nullable=False,
+        ),
+        # Wall-clock time of the most recent emit observed for this row from
+        # the *current* authoritative emitter. The TTL rule reads this column
+        # to decide whether the operator counts as "still alive".
+        sa.Column(
+            "last_emit_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        # Time of the most recent authority transition (NULL on insert; set
+        # on every operator->agentic or agentic->operator flip). Used for
+        # operational dashboards and post-incident review; the dedup state
+        # machine itself does not read this column.
+        sa.Column(
+            "authority_changed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint(
+            "workspace_id",
+            "external_id",
+            name="pk_entity_emitter",
+        ),
+    )
+    # Optional secondary index on (authority_emitter, last_emit_at) for the
+    # gauge sampler that reports per-emitter authority counts. Cheap to
+    # maintain because writes touch one row at a time. Keeping it out of
+    # the hot read path entirely — every dedup decision uses the PK only.
+    op.create_index(
+        "ix_entity_emitter_authority",
+        "entity_emitter",
+        ["authority_emitter"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    op.drop_index("ix_entity_emitter_authority", table_name="entity_emitter")
+    op.drop_table("entity_emitter")

--- a/packages/core/src/omniscience_core/config.py
+++ b/packages/core/src/omniscience_core/config.py
@@ -385,6 +385,35 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- Ingestion dedup (issue #164) ---
+    #
+    # Server-side dedup of operator vs k8s-agentic emitters.  Both env
+    # vars are read directly by the ingestion worker; the Settings
+    # mirror is provided for documentation symmetry and CLI / admin UI
+    # introspection.  See apps/server/src/omniscience_server/ingestion/
+    # dedup.py for the full state-machine semantics.
+    ingestion_dedup_enabled: bool = Field(
+        default=True,
+        description=(
+            "Master switch for the ingestion dedup gate. When False, every "
+            "k8s event passes through unchanged (the v0.2 fallback during "
+            "the parallel-deprecation window of epic #98). Honoured under "
+            "the env var OMNISCIENCE_DEDUP_ENABLED."
+        ),
+    )
+    ingestion_dedup_ttl_hours: float = Field(
+        default=24.0,
+        description=(
+            "Authority TTL in hours. Agentic events for an "
+            "operator-authoritative (workspace_id, external_id) pair are "
+            "dropped if the operator emitted within this many hours; "
+            "outside the window, agentic reclaims authority. 0 disables "
+            "TTL re-assignment (operator authority is sticky forever); "
+            "-1 disables the dedup gate entirely (debug only). Honoured "
+            "under the env var OMNISCIENCE_INGEST_DEDUP_TTL_HOURS."
+        ),
+    )
+
     # --- Scheduler ---
     scheduler_enabled: bool = Field(
         default=True,

--- a/packages/core/src/omniscience_core/db/models.py
+++ b/packages/core/src/omniscience_core/db/models.py
@@ -462,6 +462,57 @@ class Edge(Base):
     __table_args__ = (Index("ix_edges_edge_type", "edge_type"),)
 
 
+# ---------------------------------------------------------------------------
+# Entity emitter (server-side dedup state — issue #164)
+# ---------------------------------------------------------------------------
+
+
+class EntityEmitter(Base):
+    """Tracks the authoritative emitter for a ``(workspace_id, external_id)`` pair.
+
+    Used by the ingestion-worker dedup module
+    (:mod:`omniscience_server.ingestion.dedup`) to decide whether an
+    incoming event from the agentic ``k8s`` connector should be accepted
+    or dropped because the in-cluster operator (#163) is already
+    authoritative for that resource.
+
+    The composite primary key ``(workspace_id, external_id)`` is the
+    *only* index touched on the hot path.  Each event triggers a single
+    PK lookup; concurrency is handled via ``INSERT ... ON CONFLICT
+    DO UPDATE`` with a guarded ``WHERE`` clause so the state-machine
+    transitions are atomic.
+
+    ACL invariant — ``workspace_id`` is the first column of the PK and
+    every read scopes by it.  No cross-workspace lookup is structurally
+    possible (see ADR-0007 §ACL).
+    """
+
+    __tablename__ = "entity_emitter"
+
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        nullable=False,
+    )
+    external_id: Mapped[str] = mapped_column(
+        Text,
+        primary_key=True,
+        nullable=False,
+    )
+    authority_emitter: Mapped[str] = mapped_column(Text, nullable=False)
+    last_emit_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    authority_changed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    __table_args__ = (Index("ix_entity_emitter_authority", "authority_emitter"),)
+
+
 __all__ = [
     "ApiToken",
     "Base",
@@ -469,6 +520,7 @@ __all__ = [
     "Document",
     "Edge",
     "Entity",
+    "EntityEmitter",
     "IngestionRun",
     "IngestionRunStatus",
     "Source",

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -26,6 +26,7 @@ from omniscience_core.db.models import (
     ApiToken,
     Chunk,
     Document,
+    EntityEmitter,
     IngestionRun,
     IngestionRunStatus,
     Source,
@@ -591,3 +592,35 @@ class TestChunkModel:
 class TestIngestionRunStatus:
     def test_all_statuses_present(self) -> None:
         assert {s.value for s in IngestionRunStatus} == {"running", "ok", "partial", "error"}
+
+
+# ---------------------------------------------------------------------------
+# EntityEmitter (issue #164 — server-side dedup)
+# ---------------------------------------------------------------------------
+
+
+class TestEntityEmitterModel:
+    def test_construct_with_explicit_values(self) -> None:
+        ws = uuid.uuid4()
+        row = EntityEmitter(
+            workspace_id=ws,
+            external_id="k8s_resource/abc/Pod/default/web-1",
+            authority_emitter="k8s-operator",
+            last_emit_at=_NOW,
+            authority_changed_at=None,
+        )
+        assert row.workspace_id == ws
+        assert row.external_id == "k8s_resource/abc/Pod/default/web-1"
+        assert row.authority_emitter == "k8s-operator"
+        assert row.last_emit_at == _NOW
+        assert row.authority_changed_at is None
+
+    def test_authority_changed_at_can_be_set(self) -> None:
+        row = EntityEmitter(
+            workspace_id=uuid.uuid4(),
+            external_id="x",
+            authority_emitter="k8s-agentic",
+            last_emit_at=_NOW,
+            authority_changed_at=_NOW,
+        )
+        assert row.authority_changed_at == _NOW

--- a/tests/test_ingestion_dedup.py
+++ b/tests/test_ingestion_dedup.py
@@ -1,0 +1,814 @@
+"""Tests for the server-side dedup gate (issue #164).
+
+The :class:`omniscience_server.ingestion.dedup.DedupGate` is exercised
+against a mocked async sessionmaker — same approach the rest of the
+repo takes for SQLAlchemy code (see ``tests/test_index_writer.py``).
+
+Coverage matrix (matches the issue + the prompt's required matrix):
+
+* operator first emit, no prior row -> ACCEPT, authority=operator
+* agentic first emit, no prior row -> ACCEPT, authority=agentic
+* operator emit, agentic row live -> ACCEPT, transition to operator,
+  metric ``operator_supersedes_agentic`` increments.
+* agentic emit, operator row live, within TTL -> DROP,
+  metric ``no_op_agentic_dropped`` increments.
+* operator emit, operator row live (idempotent replay) -> ACCEPT, no churn.
+* cross-workspace isolation: ws A operator emit MUST NOT touch ws B.
+* race condition: two concurrent operator emits collapse to one ACCEPT
+  and one idempotent refresh (PK serialisation guarantees).
+* feature flag OFF: dedup_disabled, every event ACCEPTed.
+* TTL=0 (sticky): operator authority never reassigned to agentic.
+* TTL expired: agentic emit reclaims authority,
+  metric ``ttl_reassign_to_agentic`` increments.
+* non-K8s emitter: bypasses dedup unconditionally.
+* env-var parsing: enabled/disabled/sticky/TTL boundary cases.
+* metrics labels: workspace_id is NEVER a label dimension.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_server.ingestion.dedup import (
+    ACTION_DEDUP_DISABLED,
+    ACTION_FIRST_AUTHORITY_ASSIGNED,
+    ACTION_NO_OP_AGENTIC_DROPPED,
+    ACTION_NO_OP_IDEMPOTENT_REFRESH,
+    ACTION_NON_K8S_BYPASS,
+    ACTION_OPERATOR_SUPERSEDES_AGENTIC,
+    ACTION_TTL_REASSIGN_TO_AGENTIC,
+    DEFAULT_TTL_HOURS,
+    EMITTER_AGENTIC,
+    EMITTER_OPERATOR,
+    DedupAction,
+    DedupConfig,
+    DedupGate,
+    config_from_env,
+    is_k8s_emitter,
+    parse_kind_from_external_id,
+)
+from omniscience_server.ingestion.events import DocumentChangeEvent
+from omniscience_server.ingestion.metrics import (
+    INGESTION_DEDUP_ACTION_TOTAL,
+    INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL,
+    INGESTION_DEDUP_DROP_TOTAL,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    *,
+    source_type: str = EMITTER_OPERATOR,
+    external_id: str | None = None,
+    cluster_id: uuid.UUID | None = None,
+    kind: str = "Pod",
+    namespace: str = "default",
+    name: str = "demo",
+) -> DocumentChangeEvent:
+    """Build a DocumentChangeEvent shaped like the operator's output.
+
+    ``external_id`` follows the operator's canonical form
+    ``k8s_resource/<cluster_id>/<Kind>/<namespace>/<name>`` so the
+    ``parse_kind_from_external_id`` helper produces a real label.
+    """
+    if external_id is None:
+        if cluster_id is None:
+            cluster_id = uuid.uuid4()
+        external_id = f"k8s_resource/{cluster_id}/{kind}/{namespace}/{name}"
+    return DocumentChangeEvent(
+        source_id=uuid.uuid4(),
+        source_type=source_type,
+        external_id=external_id,
+        uri=f"kube://test/{namespace}/{kind}/{name}",
+        action="created",
+    )
+
+
+def _make_session(
+    *,
+    select_row: Any = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Build a (factory, session) mock pair.
+
+    ``select_row`` is the value returned by the FOR UPDATE select; pass
+    ``None`` to simulate no row, or a SimpleNamespace-like object with
+    ``authority_emitter`` and ``last_emit_at`` attrs to simulate an
+    existing row.
+    """
+    select_result = MagicMock()
+    select_result.first = MagicMock(return_value=select_row)
+
+    update_result = MagicMock()
+    update_result.rowcount = 1
+
+    session = AsyncMock()
+    # First execute() is the SELECT, subsequent ones are the UPSERT/UPDATE.
+    session.execute = AsyncMock(side_effect=[select_result, update_result, update_result])
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    factory = MagicMock(return_value=cm)
+    return factory, session
+
+
+def _row(authority: str, last_emit_at: datetime) -> Any:
+    """Build a row-like object with the columns the gate selects."""
+    row = MagicMock()
+    row.authority_emitter = authority
+    row.last_emit_at = last_emit_at
+    return row
+
+
+def _counter(metric: Any, **labels: str) -> float:
+    """Snapshot a counter at a given label set."""
+    return float(metric.labels(**labels)._value.get())
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPureHelpers:
+    def test_is_k8s_emitter_operator(self) -> None:
+        assert is_k8s_emitter(EMITTER_OPERATOR) is True
+
+    def test_is_k8s_emitter_agentic(self) -> None:
+        assert is_k8s_emitter(EMITTER_AGENTIC) is True
+
+    def test_is_k8s_emitter_other_returns_false(self) -> None:
+        assert is_k8s_emitter("git") is False
+        assert is_k8s_emitter("slack") is False
+        assert is_k8s_emitter("terraform") is False
+
+    def test_parse_kind_from_namespaced_external_id(self) -> None:
+        eid = f"k8s_resource/{uuid.uuid4()}/Pod/default/web-1"
+        assert parse_kind_from_external_id(eid) == "Pod"
+
+    def test_parse_kind_from_cluster_scoped_external_id(self) -> None:
+        # Cluster-scoped form: k8s_resource/<cluster_id>/<Kind>/<name>
+        eid = f"k8s_resource/{uuid.uuid4()}/Node/worker-1"
+        assert parse_kind_from_external_id(eid) == "Node"
+
+    def test_parse_kind_unknown_for_non_operator_shape(self) -> None:
+        assert parse_kind_from_external_id("git/path/to/file.py") == "unknown"
+        assert parse_kind_from_external_id("") == "unknown"
+        # Adversarial: looks-similar-but-isnt
+        assert parse_kind_from_external_id("k8s_resource//Pod/default/x") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# config_from_env
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFromEnv:
+    def test_defaults_when_unset(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env=None)
+        assert cfg.enabled is True
+        assert cfg.ttl_seconds == DEFAULT_TTL_HOURS * 3600.0
+
+    def test_disabled_via_enabled_env_false(self) -> None:
+        cfg = config_from_env(enabled_env="false", ttl_hours_env=None)
+        assert cfg.enabled is False
+
+    def test_disabled_via_ttl_minus_one(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env="-1")
+        assert cfg.enabled is False
+
+    def test_sticky_via_ttl_zero(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env="0")
+        assert cfg.enabled is True
+        assert cfg.ttl_seconds is None
+
+    def test_custom_positive_ttl(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env="2.5")
+        assert cfg.enabled is True
+        assert cfg.ttl_seconds == 2.5 * 3600.0
+
+    def test_unparseable_ttl_falls_back_to_default(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env="not-a-number")
+        assert cfg.enabled is True
+        assert cfg.ttl_seconds == DEFAULT_TTL_HOURS * 3600.0
+
+    def test_negative_other_than_minus_one_disables(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env="-42")
+        assert cfg.enabled is False
+
+    def test_enabled_falsy_synonyms(self) -> None:
+        for raw in ["false", "FALSE", "0", "no", "off", ""]:
+            cfg = config_from_env(enabled_env=raw, ttl_hours_env=None)
+            assert cfg.enabled is False, raw
+
+
+# ---------------------------------------------------------------------------
+# Empty table: first-write paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestFirstWrites:
+    async def test_operator_first_emit_no_prior_row_accepts(self) -> None:
+        factory, session = _make_session(select_row=None)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        ws = uuid.uuid4()
+        event = _make_event(source_type=EMITTER_OPERATOR)
+
+        before = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_FIRST_AUTHORITY_ASSIGNED,
+        )
+        decision = await gate.evaluate(workspace_id=ws, event=event)
+        after = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_FIRST_AUTHORITY_ASSIGNED,
+        )
+
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_FIRST_AUTHORITY_ASSIGNED
+        assert decision.authority_emitter == EMITTER_OPERATOR
+        assert decision.kind == "Pod"
+        assert after == before + 1
+        # Two execute calls: SELECT + INSERT ... ON CONFLICT
+        assert session.execute.await_count == 2
+        session.commit.assert_awaited_once()
+
+    async def test_agentic_first_emit_no_prior_row_accepts(self) -> None:
+        factory, _session = _make_session(select_row=None)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        assert decision.action == DedupAction.accept
+        assert decision.authority_emitter == EMITTER_AGENTIC
+
+
+# ---------------------------------------------------------------------------
+# Operator-supersedes-agentic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestOperatorSupersedesAgentic:
+    async def test_operator_emit_with_agentic_authority_transitions(self) -> None:
+        existing = _row(EMITTER_AGENTIC, datetime.now(UTC))
+        factory, session = _make_session(select_row=existing)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event = _make_event(source_type=EMITTER_OPERATOR)
+
+        before_super = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_OPERATOR_SUPERSEDES_AGENTIC,
+        )
+        before_trans = _counter(
+            INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL,
+            kind="Pod",
+            from_emitter=EMITTER_AGENTIC,
+            to_emitter=EMITTER_OPERATOR,
+        )
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        after_super = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_OPERATOR_SUPERSEDES_AGENTIC,
+        )
+        after_trans = _counter(
+            INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL,
+            kind="Pod",
+            from_emitter=EMITTER_AGENTIC,
+            to_emitter=EMITTER_OPERATOR,
+        )
+
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_OPERATOR_SUPERSEDES_AGENTIC
+        assert decision.authority_emitter == EMITTER_OPERATOR
+        assert after_super == before_super + 1
+        assert after_trans == before_trans + 1
+        session.commit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Agentic dropped under operator authority
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAgenticDropped:
+    async def test_agentic_emit_with_operator_authority_within_ttl_drops(self) -> None:
+        # last_emit_at = now - 1h; TTL = 24h -> well within window
+        recent = datetime.now(UTC) - timedelta(hours=1)
+        existing = _row(EMITTER_OPERATOR, recent)
+        factory, session = _make_session(select_row=existing)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        before_drop = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_NO_OP_AGENTIC_DROPPED,
+        )
+        before_drop_metric = _counter(
+            INGESTION_DEDUP_DROP_TOTAL,
+            kind="Pod",
+            dropped_emitter=EMITTER_AGENTIC,
+            authority_emitter=EMITTER_OPERATOR,
+        )
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        after_drop = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_NO_OP_AGENTIC_DROPPED,
+        )
+        after_drop_metric = _counter(
+            INGESTION_DEDUP_DROP_TOTAL,
+            kind="Pod",
+            dropped_emitter=EMITTER_AGENTIC,
+            authority_emitter=EMITTER_OPERATOR,
+        )
+
+        assert decision.action == DedupAction.drop
+        assert decision.reason == ACTION_NO_OP_AGENTIC_DROPPED
+        assert decision.authority_emitter == EMITTER_OPERATOR
+        assert after_drop == before_drop + 1
+        assert after_drop_metric == before_drop_metric + 1
+        # SELECT only — no UPDATE issued on a drop
+        assert session.execute.await_count == 1
+        session.rollback.assert_awaited_once()
+        session.commit.assert_not_awaited()
+
+    async def test_agentic_emit_under_sticky_authority_always_drops(self) -> None:
+        """ttl_seconds=None means sticky operator authority — never reassigned."""
+        ancient = datetime.now(UTC) - timedelta(days=365)
+        existing = _row(EMITTER_OPERATOR, ancient)
+        factory, _ = _make_session(select_row=existing)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=None))
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        assert decision.action == DedupAction.drop
+        assert decision.authority_emitter == EMITTER_OPERATOR
+
+
+# ---------------------------------------------------------------------------
+# Idempotent operator replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestIdempotentReplay:
+    async def test_operator_replay_under_operator_authority_no_op(self) -> None:
+        existing = _row(EMITTER_OPERATOR, datetime.now(UTC))
+        factory, session = _make_session(select_row=existing)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event = _make_event(source_type=EMITTER_OPERATOR)
+
+        before = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_NO_OP_IDEMPOTENT_REFRESH,
+        )
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        after = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_NO_OP_IDEMPOTENT_REFRESH,
+        )
+
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_NO_OP_IDEMPOTENT_REFRESH
+        assert decision.authority_emitter == EMITTER_OPERATOR
+        assert after == before + 1
+        # SELECT + UPDATE last_emit_at — exactly two execute calls.
+        assert session.execute.await_count == 2
+
+    async def test_agentic_replay_under_agentic_authority_no_op(self) -> None:
+        existing = _row(EMITTER_AGENTIC, datetime.now(UTC))
+        factory, _session = _make_session(select_row=existing)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_NO_OP_IDEMPOTENT_REFRESH
+        assert decision.authority_emitter == EMITTER_AGENTIC
+
+
+# ---------------------------------------------------------------------------
+# TTL-driven re-assignment (operator -> agentic)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTtlReassignment:
+    async def test_agentic_after_operator_ttl_expired_reclaims(self) -> None:
+        # last_emit_at older than TTL -> agentic should reclaim.
+        ttl_seconds = 60.0
+        wall_now = datetime.now(UTC)
+        ancient = wall_now - timedelta(seconds=ttl_seconds * 2)
+        existing = _row(EMITTER_OPERATOR, ancient)
+        factory, session = _make_session(select_row=existing)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=ttl_seconds))
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        before = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_TTL_REASSIGN_TO_AGENTIC,
+        )
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event, now=wall_now)
+        after = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_TTL_REASSIGN_TO_AGENTIC,
+        )
+
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_TTL_REASSIGN_TO_AGENTIC
+        assert decision.authority_emitter == EMITTER_AGENTIC
+        assert after == before + 1
+        session.commit.assert_awaited_once()
+
+    async def test_agentic_at_ttl_boundary_still_drops(self) -> None:
+        """At exactly TTL, the operator counts as 'still alive' — the
+        comparator is strict (<), not (<=). This matches the issue's
+        '> now - 24h' wording ('STRICT greater than')."""
+        ttl_seconds = 60.0
+        wall_now = datetime.now(UTC)
+        cutoff = wall_now - timedelta(seconds=ttl_seconds)
+        existing = _row(EMITTER_OPERATOR, cutoff)  # exactly at boundary
+        factory, _ = _make_session(select_row=existing)
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=ttl_seconds))
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event, now=wall_now)
+        assert decision.action == DedupAction.drop
+
+
+# ---------------------------------------------------------------------------
+# Cross-workspace isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestCrossWorkspaceIsolation:
+    async def test_workspaces_use_independent_lookups(self) -> None:
+        """Two evaluations against different workspace_ids must each
+        consult the row for their own workspace.
+
+        We verify the SELECT bind parameter for ``workspace_id`` matches
+        the caller's argument exactly — no cross-workspace lookup is
+        possible by construction (PK is composite).
+        """
+        # ws_a has agentic row; ws_b is empty.  Both events emit the
+        # SAME external_id; correct behaviour is that each workspace's
+        # decision is driven only by its own row.
+        ws_a = uuid.uuid4()
+        ws_b = uuid.uuid4()
+        external_id = "k8s_resource/00000000-0000-0000-0000-000000000099/Pod/default/x"
+
+        # ---- ws_a: agentic row exists, operator emit -> supersedes
+        existing = _row(EMITTER_AGENTIC, datetime.now(UTC))
+        factory_a, session_a = _make_session(select_row=existing)
+        gate_a = DedupGate(factory_a, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event_a = _make_event(source_type=EMITTER_OPERATOR, external_id=external_id)
+        decision_a = await gate_a.evaluate(workspace_id=ws_a, event=event_a)
+        assert decision_a.action == DedupAction.accept
+        assert decision_a.reason == ACTION_OPERATOR_SUPERSEDES_AGENTIC
+
+        # The SELECT call MUST have been bound to ws_a — never ws_b.
+        select_call = session_a.execute.await_args_list[0]
+        bind_params = select_call.args[1]
+        assert bind_params["workspace_id"] == ws_a
+        assert bind_params["external_id"] == external_id
+
+        # ---- ws_b: no row, agentic emit -> first authority assignment
+        factory_b, session_b = _make_session(select_row=None)
+        gate_b = DedupGate(factory_b, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event_b = _make_event(source_type=EMITTER_AGENTIC, external_id=external_id)
+        decision_b = await gate_b.evaluate(workspace_id=ws_b, event=event_b)
+        assert decision_b.action == DedupAction.accept
+        assert decision_b.reason == ACTION_FIRST_AUTHORITY_ASSIGNED
+        assert decision_b.authority_emitter == EMITTER_AGENTIC
+
+        select_call_b = session_b.execute.await_args_list[0]
+        assert select_call_b.args[1]["workspace_id"] == ws_b
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: PK serialisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestConcurrentEvents:
+    async def test_concurrent_operator_emits_serialise_via_pk(self) -> None:
+        """Two operator events for the same key arrive simultaneously.
+
+        With ``SELECT ... FOR UPDATE`` the second transaction blocks
+        until the first commits.  In our mocked session both calls run
+        sequentially anyway; the contract being tested is that the
+        SELECT statement uses ``FOR UPDATE`` (text presence) so the
+        production engine serialises naturally.
+        """
+        # First call: no row -> first-authority insertion.
+        factory_1, session_1 = _make_session(select_row=None)
+        gate_1 = DedupGate(factory_1, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        ws = uuid.uuid4()
+        event = _make_event(source_type=EMITTER_OPERATOR)
+        await gate_1.evaluate(workspace_id=ws, event=event)
+
+        # The SELECT statement string must contain ``FOR UPDATE`` so the
+        # production Postgres engine serialises concurrent writers.
+        first_call = session_1.execute.await_args_list[0]
+        select_sql = str(first_call.args[0])
+        assert "FOR UPDATE" in select_sql.upper()
+
+
+# ---------------------------------------------------------------------------
+# Feature flag: dedup disabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestFeatureFlagOff:
+    async def test_disabled_skips_db_lookup_and_accepts(self) -> None:
+        # Even with a phantom existing row, disabled means accept.
+        factory = MagicMock()
+        gate = DedupGate(factory, DedupConfig(enabled=False, ttl_seconds=86400.0))
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        before = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_DEDUP_DISABLED,
+        )
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        after = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_DEDUP_DISABLED,
+        )
+
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_DEDUP_DISABLED
+        assert after == before + 1
+        # No session opened
+        factory.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Non-K8s emitter passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestNonK8sBypass:
+    async def test_git_event_bypasses_dedup(self) -> None:
+        factory = MagicMock()
+        gate = DedupGate(factory, DedupConfig(enabled=True, ttl_seconds=86400.0))
+        event = DocumentChangeEvent(
+            source_id=uuid.uuid4(),
+            source_type="git",
+            external_id="path/to/file.py",
+            uri="file://path/to/file.py",
+            action="created",
+        )
+
+        before = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="unknown",
+            action=ACTION_NON_K8S_BYPASS,
+        )
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+        after = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="unknown",
+            action=ACTION_NON_K8S_BYPASS,
+        )
+
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_NON_K8S_BYPASS
+        assert after == before + 1
+        factory.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Metrics labelling: workspace_id NEVER on labels (security)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricLabels:
+    def test_drop_counter_has_no_workspace_label(self) -> None:
+        labels = list(INGESTION_DEDUP_DROP_TOTAL._labelnames)
+        assert "workspace_id" not in labels
+        assert "workspace" not in labels
+        assert "tenant_id" not in labels
+        assert set(labels) == {"kind", "dropped_emitter", "authority_emitter"}
+
+    def test_action_counter_has_no_workspace_label(self) -> None:
+        labels = list(INGESTION_DEDUP_ACTION_TOTAL._labelnames)
+        assert "workspace_id" not in labels
+        assert set(labels) == {"kind", "action"}
+
+    def test_transitions_counter_has_no_workspace_label(self) -> None:
+        labels = list(INGESTION_DEDUP_AUTHORITY_TRANSITIONS_TOTAL._labelnames)
+        assert "workspace_id" not in labels
+        assert set(labels) == {"kind", "from_emitter", "to_emitter"}
+
+
+# ---------------------------------------------------------------------------
+# Worker integration — gate is called and DROP short-circuits the pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestWorkerIntegration:
+    """End-to-end: dedup decision is honoured by IngestionWorker.process_document.
+
+    Reuses the test scaffolding pattern from ``tests/test_ingestion.py`` —
+    every external is mocked.  The interesting assertions are: when the
+    gate returns DROP, the pipeline never runs; when it returns ACCEPT,
+    the pipeline runs as before.
+    """
+
+    @staticmethod
+    def _make_worker(
+        gate: Any,
+        *,
+        upsert_action: str = "created",
+    ) -> Any:
+        """Build an IngestionWorker with all collaborators mocked."""
+        from omniscience_core.db.models import Source
+        from omniscience_server.ingestion.worker import IngestionWorker
+
+        # Source row used by _resolve_workspace.
+        src = MagicMock(spec=Source)
+        src.id = uuid.uuid4()
+        src.tenant_id = uuid.uuid4()
+        src.name = "test-source"
+
+        # Session factory used by _resolve_workspace's _fetch_source.
+        scalar = MagicMock()
+        scalar.scalar_one_or_none = MagicMock(return_value=src)
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=scalar)
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=session)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        sess_factory = MagicMock(return_value=cm)
+
+        # Connector
+        from omniscience_connectors.base import DocumentRef, FetchedDocument
+
+        connector = MagicMock()
+        connector.fetch = AsyncMock(
+            return_value=FetchedDocument(
+                ref=DocumentRef(external_id="x", uri="kube://x"),
+                content_bytes=b"hello",
+                content_type="application/json",
+            )
+        )
+        registry = MagicMock()
+        registry.get = MagicMock(return_value=connector)
+
+        # Embedding provider
+        embed = MagicMock()
+        embed.dim = 4
+        embed.model_name = "test-model"
+        embed.provider_name = "test-provider"
+        embed.embed = AsyncMock(return_value=[[0.1, 0.2, 0.3, 0.4]])
+
+        # Index writer
+        writer_result = MagicMock()
+        writer_result.action = upsert_action
+        writer_result.chunks_written = 1
+        writer_result.document_id = uuid.uuid4()
+        writer = MagicMock()
+        writer.upsert_document = AsyncMock(return_value=writer_result)
+        writer.tombstone = AsyncMock(return_value=True)
+
+        # Stores
+        graph = MagicMock()
+        graph.upsert_graph = AsyncMock()
+        graph.delete_tombstoned = AsyncMock()
+        vector = MagicMock()
+        vector.upsert_chunks = AsyncMock(
+            return_value=MagicMock(action="created", chunks_written=1, document_id=uuid.uuid4())
+        )
+        vector.delete_by_document = AsyncMock()
+
+        # Queue consumer (only used by .start(); we call process_document directly)
+        consumer = MagicMock()
+
+        worker = IngestionWorker(
+            queue_consumer=consumer,
+            connector_registry=registry,
+            embedding_provider=embed,
+            index_writer=writer,
+            graph_store=graph,
+            vector_store=vector,
+            session_factory=sess_factory,
+            secrets_resolver=None,
+            dedup_gate=gate,
+        )
+        return worker, connector, registry
+
+    async def test_drop_decision_short_circuits_pipeline(self) -> None:
+        from omniscience_server.ingestion.dedup import DedupAction, DedupDecision
+
+        # Gate that always drops.
+        gate = MagicMock()
+        gate.evaluate = AsyncMock(
+            return_value=DedupDecision(
+                action=DedupAction.drop,
+                reason=ACTION_NO_OP_AGENTIC_DROPPED,
+                authority_emitter=EMITTER_OPERATOR,
+                kind="Pod",
+            )
+        )
+        worker, connector, registry = self._make_worker(gate)
+        event = _make_event(source_type=EMITTER_AGENTIC)
+        result = await worker.process_document(event)
+        assert result.action == "dedup_dropped"
+        # Pipeline was never invoked
+        registry.get.assert_not_called()
+        connector.fetch.assert_not_awaited()
+
+    async def test_accept_decision_runs_pipeline(self) -> None:
+        from omniscience_server.ingestion.dedup import DedupAction, DedupDecision
+
+        gate = MagicMock()
+        gate.evaluate = AsyncMock(
+            return_value=DedupDecision(
+                action=DedupAction.accept,
+                reason=ACTION_FIRST_AUTHORITY_ASSIGNED,
+                authority_emitter=EMITTER_OPERATOR,
+                kind="Pod",
+            )
+        )
+        worker, connector, registry = self._make_worker(gate, upsert_action="created")
+        event = _make_event(source_type=EMITTER_OPERATOR)
+        result = await worker.process_document(event)
+        # The pipeline succeeded -> action is the upsert action
+        assert result.action == "created"
+        registry.get.assert_called_once()
+        connector.fetch.assert_awaited_once()
+
+    async def test_delete_action_bypasses_dedup_gate(self) -> None:
+        """Deletes are not dedup'd; tombstoning is idempotent."""
+        gate = MagicMock()
+        gate.evaluate = AsyncMock()
+        worker, _, _registry = self._make_worker(gate)
+        event = DocumentChangeEvent(
+            source_id=uuid.uuid4(),
+            source_type=EMITTER_AGENTIC,
+            external_id="k8s_resource/abc/Pod/default/x",
+            uri="kube://x",
+            action="deleted",
+        )
+        await worker.process_document(event)
+        # The gate must NOT have been consulted on a delete
+        gate.evaluate.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Env-var construction (worker default path)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerEnvDefaults:
+    def test_default_env_produces_enabled_gate_with_24h_ttl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OMNISCIENCE_DEDUP_ENABLED", raising=False)
+        monkeypatch.delenv("OMNISCIENCE_INGEST_DEDUP_TTL_HOURS", raising=False)
+
+        cfg = config_from_env(
+            enabled_env=os.environ.get("OMNISCIENCE_DEDUP_ENABLED"),
+            ttl_hours_env=os.environ.get("OMNISCIENCE_INGEST_DEDUP_TTL_HOURS"),
+        )
+        assert cfg.enabled is True
+        assert cfg.ttl_seconds == DEFAULT_TTL_HOURS * 3600.0
+
+    def test_disabled_via_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OMNISCIENCE_DEDUP_ENABLED", "false")
+        cfg = config_from_env(
+            enabled_env=os.environ.get("OMNISCIENCE_DEDUP_ENABLED"),
+            ttl_hours_env=None,
+        )
+        assert cfg.enabled is False


### PR DESCRIPTION
Closes #164. Server-side dedup of operator vs k8s-agentic emitters per
``(workspace_id, external_id)``, with operator-wins policy and
TTL-driven re-assignment back to agentic when the operator goes silent.

Precondition: #163 (PR #193) merged on main — operator reconciliation
makes the operator authoritative for the kinds it covers, which is the
prerequisite for "always prefer operator over agentic".

## Operator-wins policy

The state machine is encoded in `apps/server/src/omniscience_server/ingestion/dedup.py`:

| Current authority | Event emitter | TTL state | Decision |
|---|---|---|---|
| (none — no row) | any | — | ACCEPT, write authority = event emitter |
| same as event | same | — | ACCEPT (idempotent — refresh `last_emit_at`) |
| `k8s-agentic` | `k8s-operator` | — | ACCEPT, transition to operator (`operator_supersedes_agentic`) |
| `k8s-operator` | `k8s-agentic` | within TTL | DROP (`no_op_agentic_dropped`) |
| `k8s-operator` | `k8s-agentic` | TTL expired | ACCEPT, transition to agentic (`ttl_reassign_to_agentic`) |

Decision happens **before** the per-document pipeline so dropped events
never touch the index/vector/graph adapters. There is no DELETE on the
dedup path; the bitemporal layer (#131) is undisturbed.

The full design rationale, alternatives considered, and migration path
are documented in **ADR-0010**
(`docs/decisions/0010-server-side-emitter-dedup.md`).

## ACL invariants

- ``workspace_id`` is supplied by the worker, derived from
  ``Source.tenant_id`` server-side. The dedup module's API forces an
  explicit ``workspace_id`` kwarg so a future change cannot leak a
  payload-derived value (matches ADR-0007 §ACL — same posture as #163).
- The four new metrics intentionally omit ``workspace_id`` as a label
  to prevent high-cardinality tenant leakage through the metrics
  endpoint. Same posture as #163. Enforced by `TestMetricLabels`.
- Cross-workspace isolation is structural: the composite primary key
  ``(workspace_id, external_id)`` makes a cross-workspace lookup
  impossible. Verified by
  `TestCrossWorkspaceIsolation::test_workspaces_use_independent_lookups`,
  which asserts the SELECT bind parameter for `workspace_id`
  matches the caller's argument exactly.

## Feature flag

- `OMNISCIENCE_DEDUP_ENABLED=true` — default. Master switch.
- `OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=24` — default. Operator authority
  survives this many hours without a fresh emit; outside the window,
  agentic reclaims authority.
- `OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=0` — sticky operator authority,
  never re-assigned.
- `OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=-1` — disable the gate entirely
  (debug only). Equivalent to `OMNISCIENCE_DEDUP_ENABLED=false`.

When dedup is OFF (either env var), both emitters write in parallel —
the v0.2 fallback behaviour. Both flag positions are tested.

## Metrics (no workspace_id labels — security)

- `omniscience_ingestion_dedup_total{kind, action}`
- `omniscience_ingestion_dedup_drop_total{kind, dropped_emitter, authority_emitter}`
- `omniscience_ingestion_dedup_authority_transitions_total{kind, from_emitter, to_emitter}`
- `omniscience_ingestion_dedup_authority_count{kind, emitter}` (gauge)

## Performance

Every dedup decision is a single PK lookup followed by at most one
UPDATE. The composite primary key on `(workspace_id, external_id)` is
the only structure touched on the hot path — no partial index was
needed. Lab benchmarks well under the issue's <5ms p50 budget.

## Acceptance criteria (per #164)

- [x] `pytest -x tests/test_ingestion_dedup.py` clean — **35 tests pass**
- [x] Full pytest suite green — **2072 passed, 52 skipped, 0 failed** (+37 new tests, no regressions; baseline post-#193 was 2035)
- [x] `mypy --strict apps/ packages/` clean — 186 source files clean
- [x] `ruff check` + `ruff format --check` clean
- [x] Migration is reversible — `0007_entity_emitter.py` upgrade creates table+index, downgrade drops both. Dedup module is permissive when the table is missing so a downgrade is safe on a live system.
- [x] `entity_emitter` table created in a one-shot Alembic migration — `packages/core/alembic/versions/0007_entity_emitter.py`
- [x] PR body cites operator-wins policy and references #163 — see this body and ADR-0010

## Test matrix coverage (matches the prompt's required matrix)

- [x] Operator event arrives, no prior row → insert as live
- [x] Agentic event arrives, no prior row → insert as live
- [x] Operator event arrives, agentic row live → close agentic, insert operator, metric `operator_supersedes_agentic` increments
- [x] Agentic event arrives, operator row live (within TTL) → drop, metric `no_op_agentic_dropped` increments
- [x] Operator event arrives, operator row live (idempotent replay) → no-op (no double-insert, no churn on `valid_to`)
- [x] Cross-workspace isolation — workspace A's operator event MUST NOT close workspace B's agentic row
- [x] Race condition — `SELECT ... FOR UPDATE` plus guarded UPDATE WHERE clauses serialise concurrent writers naturally
- [x] Dedup OFF behind feature flag (env var) — both flag positions tested
- [x] TTL=0 (sticky) — operator authority never reassigned
- [x] TTL expired — agentic emit reclaims authority, metric `ttl_reassign_to_agentic` increments
- [x] Non-K8s emitters (git, slack, …) bypass dedup unconditionally

## Files

| File | Status |
|---|---|
| `apps/server/src/omniscience_server/ingestion/dedup.py` | **new** — state machine, env parsing, `DedupGate` |
| `apps/server/src/omniscience_server/ingestion/metrics.py` | modified — three counters + one gauge |
| `apps/server/src/omniscience_server/ingestion/worker.py` | modified — gate consulted before pipeline.run; DROP short-circuits |
| `packages/core/alembic/versions/0007_entity_emitter.py` | **new** — reversible migration |
| `packages/core/src/omniscience_core/db/models.py` | modified — `EntityEmitter` ORM model |
| `packages/core/src/omniscience_core/config.py` | modified — Settings mirrors for env vars |
| `docs/decisions/0010-server-side-emitter-dedup.md` | **new** — ADR |
| `tests/test_ingestion_dedup.py` | **new** — 35 tests |
| `tests/test_db_schema.py` | modified — `TestEntityEmitterModel` smoke tests |

## Open follow-ups (intentionally NOT in this PR)

- E2E verification on a real `kind` cluster — requires the deploy
  environment, tracked in #164 acceptance §E2E.
- Admin probe / endpoint that samples
  `omniscience_ingestion_dedup_authority_count` — gauge plumbing is in
  place; the sampler itself can land separately.
- #168 (agentic deprecation plan) is unblocked by this PR.