### PR TITLE
docs: k8s-agentic deprecation plan + migration guide (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to Omniscience are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v0.3 line
+
+### Deprecated
+
+- **`k8s-agentic` connector deprecation announced (issue #168, ADR-0011).**
+  The legacy LLM-driven Kubernetes connector at
+  `packages/connectors/src/omniscience_connectors/agentic/k8s.py` is
+  superseded by the in-cluster `omniscience-operator` Go controller at
+  `operator/`.  Importing
+  `omniscience_connectors.agentic.k8s` now emits a `DeprecationWarning`
+  carrying the removal version (`v0.5.0`), the migration target name
+  (`omniscience-operator`), and a URL to the migration guide.
+
+  - Migration guide: [`docs/connectors/k8s-agentic-deprecation.md`](docs/connectors/k8s-agentic-deprecation.md)
+  - Parity matrix: [`docs/connectors/k8s-agentic-vs-operator-parity.md`](docs/connectors/k8s-agentic-vs-operator-parity.md)
+  - Schedule (ADR-0011): v0.3 announce → v0.4 default-disabled →
+    v0.5 remove.
+  - During the cutover window, server-side dedup
+    ([ADR-0010](docs/decisions/0010-server-side-emitter-dedup.md))
+    silently drops agentic events for any
+    `(workspace_id, external_id)` the operator is authoritative on.
+    Watch
+    `omniscience_ingestion_dedup_drop_total{authority_emitter="k8s-operator"}`
+    rise as the operator takes over.
+
+  The connector remains **fully functional** in v0.3.  No customer
+  code change is required to upgrade to v0.3; the deprecation warning
+  is informational.
+
 ## [0.2.0] — 2026-04-25
 
 Cutover release for Epic #96. Vector and graph storage move out of Postgres

--- a/docs/connectors/k8s-agentic-deprecation.md
+++ b/docs/connectors/k8s-agentic-deprecation.md
@@ -1,0 +1,415 @@
+# Migrating from `k8s-agentic` to `omniscience-operator`
+
+> **Status**: deprecation announced in **v0.3**.  Default-disabled in **v0.4**.
+> Connector code removed in **v0.5**.  See
+> [ADR-0011](../decisions/0011-k8s-agentic-deprecation-schedule.md) for the
+> schedule and [issue #168](https://github.com/100rd/Omniscience/issues/168)
+> for the tracking issue.
+
+This guide walks operators from the legacy `k8s-agentic` connector
+(`packages/connectors/src/omniscience_connectors/agentic/k8s.py`) to the
+in-cluster `omniscience-operator` Go controller at `operator/`.  The
+operator is the path forward for every Kubernetes-shaped signal in
+Omniscience — see [ADR-0007](../decisions/0007-k8s-operator-architecture.md)
+for the architectural rationale.
+
+**Read this if you have:** a deployed Omniscience server with a
+`k8s-agentic` connector configured, and you want to switch to the
+operator before the v0.5 removal.
+
+**Reference parity matrix:** every kind the agentic connector emits is
+catalogued against the operator's coverage at
+[`k8s-agentic-vs-operator-parity.md`](k8s-agentic-vs-operator-parity.md).
+**Read it before starting** — there are kinds that the agentic connector
+emits which the operator does *not* yet cover; if your deployment relies
+on them, the migration is gated on the gap-closure issues listed there.
+
+---
+
+## TL;DR
+
+1. Install the operator chart in your cluster
+   (`helm install omniscience-operator ./helm/omniscience-operator …`).
+2. Set the operator's `workspaceId` and `clusterName` to match the
+   workspace your existing `k8s-agentic` connector publishes into.
+3. Run both paths in parallel for **1–2 weeks**.  The server-side dedup
+   gate ([ADR-0010](../decisions/0010-server-side-emitter-dedup.md))
+   silently drops the agentic events for any kind the operator has
+   started emitting.
+4. Watch the
+   `omniscience_ingestion_dedup_drop_total{authority_emitter="k8s-operator"}`
+   counter rise.  When the drop rate plateaus (i.e. the operator is
+   emitting for every kind the agentic connector was previously
+   emitting), disable the agentic connector entirely.
+5. Keep the agentic connector available as a **rollback path** for the
+   first 24 hours after disabling it.  See [Rollback](#rollback).
+
+---
+
+## Why migrate
+
+The agentic connector was the bridge between v0.1's REST-poll model and
+v0.2's streaming-ingest model.  It served well as a bootstrap.  It is
+not the right substrate for the Living Semantic Core direction:
+
+- **Freshness budget.**  Agentic polls on a configurable interval; the
+  operator watches the API server and emits events with sub-second
+  latency.  The vision §6 freshness SLO is unreachable from the
+  poll path.
+- **Causal-edge fidelity.**  The agentic path observes steady-state
+  snapshots and infers transitions; the operator sees every
+  `ADDED`/`MODIFIED`/`DELETED` directly, including short-lived ones
+  that matter during incident timelines.
+- **Network and credential surface.**  The agentic path needs a
+  kubeconfig with cluster-wide read on the Omniscience server side; the
+  operator runs in-cluster with a narrowly-scoped `ServiceAccount` and
+  emits outbound to NATS only.
+- **Multi-cluster reach.**  The operator establishes a stable
+  per-cluster `cluster_id` (issue #167) so the same workload across
+  clusters does not collide on `external_id`; the agentic path's
+  `cluster_name` is a free-form string and offers no equivalent guarantee.
+- **Workspace tenancy.**  The operator reads `workspace_id` from a
+  Secret mounted at chart install time and stamps it on every event;
+  no cluster-side state can forge it.  The agentic path resolves the
+  workspace from `Source.tenant_id` server-side — correct, but one
+  server-side hop further from the emit point.
+
+---
+
+## Side-by-side comparison
+
+| Dimension | `k8s-agentic` (legacy) | `omniscience-operator` (replacement) |
+|---|---|---|
+| **Deployment shape** | Runs on the Omniscience server; one Source row per cluster, one kubeconfig per Source. | Runs **inside** the customer cluster as a `Deployment` in its own namespace. |
+| **Control-plane reach** | Outbound from Omniscience server to each cluster's API server (typically the public endpoint). | Inbound from operator to NATS only. No path *into* the cluster from outside. |
+| **Authentication** | Bearer token or kubeconfig stored as a Source secret in Omniscience. | In-cluster `ServiceAccount`; token rotation handled by Kubernetes. |
+| **RBAC** | Cluster-wide read on whatever the kubeconfig grants (typically `cluster-admin`-equivalent for discovery). | `ClusterRole` listing the exact kinds the operator watches; no wildcards. |
+| **Network surface** | One outbound TLS connection from Omniscience server to each cluster's API server (port 6443). Cluster must accept the connection. | One outbound NATS connection from each operator to the Omniscience NATS endpoint (port 4222 default; mTLS-wrappable). No inbound to the cluster. |
+| **Event freshness** | Poll-based; freshness floor = poll interval (default hourly).  Bursts of churn produce list races and missed transitions. | Watch-based; sub-second freshness in steady state. Reconciliation worker (issue #163) closes the gap on operator restarts on a 15-minute cycle. |
+| **Schema fidelity** | Stores raw `application/json` payloads from the API server; downstream pipeline must re-parse. | Per-kind structured entity mappers (`operator/internal/entity/*.go`) emit pre-shaped graph entities with named edges. |
+| **CRD support** | Only kinds the LLM picks plus a hard-coded core/apps set; no CRD-aware enumeration. | First-class CRD support for ArgoCD, Argo Rollouts, and DRA, gated by API-server discovery. |
+| **Multi-cluster identity** | `cluster_name` free-form; collisions across clusters silently merge entities. | `cluster_id` UUID Secret-mounted (issue #167); collisions impossible across clusters. |
+| **Server-side authority** | None; both paths emit independently into the graph store. | Operator-wins dedup (ADR-0010) — the operator is authoritative for kinds it covers. |
+| **Resource cost** | One Omniscience-server-side worker per cluster; CPU/memory scales with cluster size on the server. | One in-cluster pod per cluster; idle ~10 MB RAM, single-digit-MB image (distroless Go). |
+| **Restart durability** | Loses any events that fired during an Omniscience-server-side restart of the connector worker. | Watch reconnect on operator restart; reconciliation worker (issue #163) closes the gap. |
+
+---
+
+## Step-by-step migration
+
+### Step 0 — Read the parity matrix
+
+Open
+[`k8s-agentic-vs-operator-parity.md`](k8s-agentic-vs-operator-parity.md)
+and confirm the operator covers every kind your existing pipelines
+consume.  If a kind shows **NOT-COVERED** or **PARTIAL** and you depend
+on it, **stop here** and follow that row's gap-closure issue.
+
+### Step 1 — Install the operator chart
+
+Per-cluster prerequisites:
+
+- Kubernetes 1.27+ (informer reflector dependencies).
+- A `Secret`-grade source for the workspace UUID (the same UUID your
+  existing `k8s-agentic` Source publishes into; query it from your
+  Omniscience admin if you don't have it handy).
+- Outbound network egress to the Omniscience NATS endpoint
+  (port 4222 default; configurable via `nats.url`).
+
+```bash
+# In the cluster being observed:
+kubectl create namespace omniscience-operator
+
+# Workspace UUID is the load-bearing tenancy identifier; fetch it from
+# your Omniscience admin and pass it in via --set or a values file.
+helm install omniscience-operator ./helm/omniscience-operator \
+  --namespace omniscience-operator \
+  --set workspaceId="00000000-0000-0000-0000-000000000000" \
+  --set clusterName="prod-eu-west-1" \
+  --set nats.url="nats://omniscience-nats.example.com:4222" \
+  --set nats.credentials="$(cat ./nats.creds)"
+```
+
+The chart's `values.yaml` lists every override; the **required**
+values are `workspaceId`, `clusterName`, and `nats.url`.
+
+### Step 2 — Verify the operator is publishing
+
+In the operator pod:
+
+```bash
+kubectl -n omniscience-operator logs -f deploy/omniscience-operator | grep "publish.success"
+```
+
+On the Omniscience server side:
+
+```bash
+# Operator emit rate, by kind
+curl -s http://omniscience-server/metrics | grep '^omniscience_operator_events_emitted_total'
+```
+
+If the operator emit rate is non-zero, the path is alive.
+
+### Step 3 — Watch the dedup metric
+
+The server-side dedup gate (issue #164, ADR-0010) is the during-cutover
+health signal.  As the operator starts emitting for kinds the agentic
+connector was previously emitting, the gate transitions authority to
+the operator and silently drops the agentic events:
+
+```promql
+# Headline: agentic events being dropped because operator now authoritative.
+sum by (kind) (
+  rate(omniscience_ingestion_dedup_drop_total{
+    dropped_emitter="k8s-agentic",
+    authority_emitter="k8s-operator"
+  }[5m])
+)
+```
+
+```promql
+# Authority transitions (per-kind cutover progress).
+sum by (kind) (
+  increase(omniscience_ingestion_dedup_authority_transitions_total{
+    from_emitter="k8s-agentic",
+    to_emitter="k8s-operator"
+  }[1h])
+)
+```
+
+A **non-zero drop rate is expected and healthy** — it is the visible
+signal that the operator has taken authority.  A **zero drop rate
+during the parallel window** is a misconfiguration symptom; check that
+both paths are actually emitting and that `OMNISCIENCE_DEDUP_ENABLED`
+is not unset to `false`.
+
+### Step 4 — Run both paths in parallel for 1–2 weeks
+
+This is the recommended bake-in window.  During this window:
+
+- Both paths emit; the dedup gate ensures exactly one wins per
+  `(workspace_id, external_id)`.
+- The operator is authoritative for the kinds it covers
+  (per the parity matrix).
+- The agentic connector remains authoritative for any kind the
+  operator does not cover (see the parity matrix's NOT-COVERED rows).
+
+Watch for:
+
+- Operator emit-rate match against the agentic baseline.  The two are
+  not strictly equal — the operator emits per-event whereas the agentic
+  path emits per-poll — but the *unique-entity* counts should converge.
+- Reconcile loop health
+  (`omniscience_operator_reconciler_runs_total{result="success"}`)
+  rising steadily.
+- Zero unexpected error spikes on
+  `omniscience_operator_publisher_errors_total`.
+
+### Step 5 — Disable the agentic connector
+
+When you are confident the operator is covering every kind your
+pipelines need:
+
+1. Update the agentic Source in your Omniscience admin:
+   - **Set `enabled: false`** on the Source row, OR
+   - **Remove the Source entirely** if you don't intend to keep it as a
+     rollback option.
+
+2. Confirm the dedup-drop metric trails off to zero — once the agentic
+   connector stops emitting, there are no events for the gate to drop.
+
+3. **Do not** uninstall the agentic connector module (the module is
+   still shipped in v0.3 — its removal is scheduled for v0.5).
+
+### Step 6 — (v0.4 only) Set the server-side feature flag
+
+In v0.4 the server gains the `OMNISCIENCE_K8S_AGENTIC_ALLOWED` env var.
+Default is `false` in v0.4; setting it to `true` re-enables agentic
+ingestion as the rollback path.  In v0.3 this flag does not yet exist
+— use the Source-level `enabled` flag instead.
+
+---
+
+## Troubleshooting
+
+### NATS connectivity
+
+```text
+operator startup logs:
+  publisher.connect.error: dial tcp: i/o timeout
+```
+
+- Confirm `nats.url` resolves from inside the cluster
+  (`kubectl run debug --rm -it --image=alpine -- nslookup
+  omniscience-nats.example.com`).
+- Confirm outbound port (4222 default) is allowed by your
+  `NetworkPolicy` and any cluster-egress firewall.
+- If using mTLS, confirm `nats.credentials` is a non-empty string and
+  the corresponding NATS user has `publish` permission on
+  `ingest.changes.k8s.>`.
+- The chart enables a `NetworkPolicy` by default; if your cluster's
+  CNI is missing or your egress rules are stricter, set
+  `networkPolicy.enabled=false` and rely on cluster-level egress
+  controls.
+
+### RBAC denied
+
+```text
+operator startup logs:
+  reflector.go: Failed to watch *v1.Pod: forbidden
+```
+
+- The chart provisions a `ClusterRole` and `ClusterRoleBinding`
+  scoped to the kinds the operator watches.  If you set `rbac.create=false`
+  to use a pre-provisioned RBAC, confirm the role grants
+  `get`, `list`, `watch` on every kind in the
+  [parity matrix](k8s-agentic-vs-operator-parity.md) row marked
+  `operator.emits=yes`.
+- For ArgoCD/Argo Rollouts/DRA CRDs, the operator's discovery probe
+  fails-soft: it logs `argocd.crd.absent` (or equivalent) and
+  continues; you do not need to grant permissions on CRDs that aren't
+  installed.
+
+### Pod Security Admission (PSA) violations
+
+```text
+admission webhook denied the pod:
+  ... violates PodSecurity "restricted:v1.27" ...
+```
+
+The operator chart's `podSecurityContext` and `securityContext`
+defaults satisfy the `restricted` PSA profile (issue #166).  If your
+namespace's PSA label is `restricted` and the chart still fails:
+
+- Confirm `image.repository` is the published `ghcr.io/100rd/omniscience-operator`
+  image.  Custom images that don't run as non-root will fail.
+- Confirm `seccompProfile.type=RuntimeDefault` is not overridden in
+  your values.
+
+### NetworkPolicy egress blocking
+
+If you've enabled the chart's `NetworkPolicy` and the operator's
+publisher times out, check the egress rule allows traffic to the
+NATS endpoint.  The chart's default policy whitelists port 4222 to the
+NATS service; for a non-default port or external NATS, override
+`networkPolicy.egress`.
+
+### Kubernetes API version skew
+
+The operator targets Kubernetes 1.27+.  On older clusters:
+
+- `informers/v1beta1` types are unavailable; the operator fails-fast
+  at startup with `unable to construct informer: no kind ... in version`.
+- DRA CRDs (`resource.k8s.io/v1beta1`) are 1.30+; the operator's
+  discovery gate logs `dra.crd.absent` and skips them on older
+  clusters.
+
+If you're stuck on a pre-1.27 cluster, the agentic connector remains
+the supported path — the deprecation timeline assumes you will upgrade
+*or* migrate before v0.5.
+
+### Operator pod crashlooping on `workspace_id`
+
+```text
+operator startup logs:
+  config: workspaceId is required and must be a valid UUID
+```
+
+The `workspaceId` Helm value is required and must parse as a UUID.
+A blank string or a non-UUID value triggers fail-fast
+(per [ADR-0007 §ACL](../decisions/0007-k8s-operator-architecture.md#5-acl-invariant--workspace-from-mounted-token-never-from-cluster)
+fail-closed posture).
+
+### Dedup gate not dropping agentic events
+
+```promql
+# Should be non-zero during the parallel window:
+rate(omniscience_ingestion_dedup_drop_total[5m])
+```
+
+If this is zero while both paths are running:
+
+- Confirm `OMNISCIENCE_DEDUP_ENABLED` is not set to `false` on the
+  Omniscience server.
+- Confirm `OMNISCIENCE_INGEST_DEDUP_TTL_HOURS` is not set to `-1`
+  (which is the disable sentinel).
+- Confirm the operator and the agentic connector are publishing into
+  the **same** `workspace_id`.  The dedup table is keyed on
+  `(workspace_id, external_id)`; cross-workspace events are not
+  deduped (and should not be — that would be a tenant-isolation
+  violation).
+- Confirm `external_id` shapes match.  The operator's
+  `external_id = "k8s_resource/<cluster_id>/<Kind>/<namespace>/<name>"`;
+  the agentic connector's
+  `external_id = "k8s:<cluster_name>:kind:<Kind>"` (a coarser shape).
+  **They will not collide on `external_id` alone** — the dedup table's
+  authority pointers are established per `external_id`, so the two
+  paths' events for the same Kubernetes object end up in different
+  rows.  This is documented as a known v0.3 gap; the v0.4 release line
+  pins the `OMNISCIENCE_K8S_AGENTIC_ALLOWED=false` server-side flag as
+  the primary cutover mechanism, not dedup-only deduplication.
+
+---
+
+## Rollback
+
+The dedup TTL is the rollback budget.  The default
+`OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=24` means: if the operator stops
+emitting for **more than 24 hours**, the agentic connector's events
+re-take authority for any `(workspace_id, external_id)` pair the
+operator was authoritative on.
+
+**Within the TTL window** (the first 24 h after the operator stops
+emitting):
+
+- Re-enable the agentic Source in your Omniscience admin
+  (`enabled: true`).
+- The agentic connector resumes polling on its configured cadence.
+- The dedup gate continues to drop agentic events for kinds where the
+  operator's `last_emit_at` is still within the TTL — but the operator
+  isn't emitting anymore, so on the next agentic poll **after** the TTL
+  expires, authority flips back to agentic.  This is the
+  `ttl_reassign_to_agentic` action in the dedup metrics.
+
+**After the TTL window**, the agentic path is the authority again;
+re-installing the operator at this point is a fresh cutover, not a
+rollback.
+
+**To rollback faster than the TTL allows** (operational urgency,
+e.g. operator emit produces incorrect entities):
+
+1. Set `OMNISCIENCE_DEDUP_ENABLED=false` on the Omniscience server
+   and restart the worker.  Both paths now emit in parallel into the
+   graph store.  This is the v0.2 fallback posture.
+2. Disable the operator chart (`helm uninstall omniscience-operator`).
+3. Investigate and fix.
+4. Re-enable dedup once the issue is resolved.  The dedup table's
+   authority pointers persist; you may want to manually clear stale
+   pointers for affected `(workspace_id, external_id)` pairs.
+
+**Do not** mix this rollback with a workspace_id rotation.  The
+`workspace_id` is the tenancy boundary; rotating it during a rollback
+would mean the previously-emitted entities are unreachable from the
+new `workspace_id`'s read scope.
+
+---
+
+## Future versions
+
+| Version | What changes | Customer action |
+|---|---|---|
+| **v0.3** (current) | Deprecation announced.  Both paths run in parallel.  `DeprecationWarning` on import. | Optional: start migrating now. |
+| **v0.4** | Agentic moves to opt-in extra (`omniscience-connectors[k8s-agentic]`).  `OMNISCIENCE_K8S_AGENTIC_ALLOWED=false` default — server drops agentic events server-side. | **Required**: complete migration before upgrade. |
+| **v0.5** | Agentic module deleted.  Helm chart references removed.  Importing `omniscience_connectors.agentic.k8s` raises `ImportError`. | **Required**: be on the operator path. |
+
+---
+
+## References
+
+- [Issue #168](https://github.com/100rd/Omniscience/issues/168) — this deprecation plan
+- [ADR-0007](../decisions/0007-k8s-operator-architecture.md) — operator architecture (the destination)
+- [ADR-0007 §6](../decisions/0007-k8s-operator-architecture.md#6-cross-document-consequences) — original commitment to set deprecation date once parity reached
+- [ADR-0010](../decisions/0010-server-side-emitter-dedup.md) — server-side dedup (the during-cutover gate)
+- [ADR-0011](../decisions/0011-k8s-agentic-deprecation-schedule.md) — this deprecation schedule
+- [Parity matrix](k8s-agentic-vs-operator-parity.md) — kind-by-kind coverage status
+- [Operator chart README](../../helm/omniscience-operator/README.md) — installation reference

--- a/docs/connectors/k8s-agentic-vs-operator-parity.md
+++ b/docs/connectors/k8s-agentic-vs-operator-parity.md
@@ -1,0 +1,218 @@
+# Parity matrix — `k8s-agentic` connector vs `omniscience-operator`
+
+> Reference document for [issue #168](https://github.com/100rd/Omniscience/issues/168)
+> (deprecation schedule).  Every kind the legacy `k8s-agentic` connector
+> can emit has a row here, paired with the operator's coverage status.
+
+This matrix is the parity reference for the v0.3 → v0.4 → v0.5
+migration described in the
+[migration guide](k8s-agentic-deprecation.md) and pinned in
+[ADR-0011](../decisions/0011-k8s-agentic-deprecation-schedule.md).
+
+## How the columns are derived
+
+- **`agentic.emits`** — derived by inspection of
+  `packages/connectors/src/omniscience_connectors/agentic/k8s.py`:
+  - `_KIND_CORE`, `_KIND_APPS`, `_KIND_BATCH`, `_KIND_NETWORKING`,
+    `_KIND_RBAC`, `_KIND_AUTOSCALING` are the explicit REST-path mappers
+    the connector knows about — every kind in those tables is reachable
+    by the connector's `fetch()`.
+  - Subtract `_ALWAYS_EXCLUDE = {Secret, Event, TokenReview,
+    SubjectAccessReview, SelfSubjectAccessReview, SelfSubjectRulesReview,
+    LocalSubjectAccessReview}` — the connector enforces these as never-emit.
+  - The LLM discovery loop can in principle pick *any* kind from
+    `/api`+`/apis`, but the `fetch()` mapper has a fallback to a
+    lowercase-plural REST path under `/apis/` — undeclared kinds will
+    be attempted with best-effort.  We do **not** treat best-effort
+    fallback as guaranteed coverage; this matrix only lists kinds
+    with explicit `_KIND_*` mapping plus the always-excluded set
+    flagged.
+
+- **`operator.emits`** — derived by inspection of
+  `operator/internal/entity/*.go` (the entity mappers) cross-checked
+  against `operator/internal/controller/*.go` (the wired controllers
+  registered in `operator/cmd/manager/main.go`).  A kind is `yes` only
+  if there is **both** an entity mapper *and* a wired controller (or,
+  for ArgoCD/DRA CRDs, a discovery-gated wiring through
+  `argocd_setup.go` / `dra_setup.go`).
+
+- **`status`** —
+  - `COVERED` — agentic emits *and* operator emits.  Migration is
+    seamless for this kind.
+  - `PARTIAL` — operator emits but with caveats (e.g. CRD discovery
+    gated; agentic field-level fidelity differs).
+  - `NOT-COVERED` — agentic emits but operator does not.  **Release-blocker
+    for v0.4 default-disable.** A new operator controller is required.
+  - `OPERATOR-ONLY` — operator emits but agentic does not.  Listed
+    here for completeness; not a parity concern for the deprecation.
+  - `NEITHER` — agentic's `_ALWAYS_EXCLUDE` blocks emission; operator
+    has its own posture.  Documented for transparency, not a migration
+    concern.
+
+---
+
+## Core API group (`/api/v1`)
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `ConfigMap` | yes | yes (`configmap_controller.go`, `configmap.go`) | **COVERED** | Operator emits via watch; agentic via list. Operator data is fresher. |
+| `Endpoints` | yes | yes (`endpoints_controller.go`, `endpoints.go`) | **COVERED** | Agentic includes `Endpoints` in `_KIND_CORE` despite `_DEFAULT_EXCLUDE_KINDS` listing it (the LLM can re-include it). Operator covers explicitly. |
+| `Event` | **no** (`_ALWAYS_EXCLUDE`) | no | NEITHER | Both paths exclude; not relevant to deprecation. |
+| `LimitRange` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Operator has neither a controller nor an entity mapper for `LimitRange`. Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+| `Namespace` | yes | yes (`namespace_controller.go`, `namespace.go`) | **COVERED** | Operator additionally emits a synthetic `Cluster` anchor (issue #159) — strict superset. |
+| `Node` | yes | yes (`node_controller.go`, `node.go`) | **COVERED** | |
+| `PersistentVolume` | yes | yes (`persistentvolume_controller.go`, `persistentvolume.go`) | **COVERED** | |
+| `PersistentVolumeClaim` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Operator covers `PersistentVolume` but not `PersistentVolumeClaim`. Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+| `Pod` | yes | yes (`pod_controller.go`, `entity.go::PodToEvent`) | **COVERED** | Note: agentic's `_DEFAULT_EXCLUDE_KINDS` lists Pod, but the LLM is allowed to override and the explicit `_KIND_CORE` mapping is present. Operator covers Pod as a first-class kind. |
+| `ReplicationController` | yes (`_KIND_CORE`) | **no** | **NOT-COVERED** (low priority) | Legacy kind; superseded by `ReplicaSet` upstream. Most clusters have zero `ReplicationController` resources. **Acceptable v0.5 gap** if customer telemetry confirms zero usage; flagged for explicit confirmation before v0.4 cut. |
+| `ResourceQuota` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. Customers using namespace-quota enforcement rely on this kind being indexed. |
+| `Secret` | **no** (`_ALWAYS_EXCLUDE`) | yes (`secret_controller.go`, `secret.go`, **redacted-by-default per issue #166**) | OPERATOR-ONLY | Agentic refuses to emit Secret on security grounds. Operator emits a redacted-by-default mapping (issue #166); strictly safer. Not a deprecation concern. |
+| `Service` | yes | yes (`service_controller.go`, `service.go`) | **COVERED** | |
+| `ServiceAccount` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+
+---
+
+## apps/v1
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `Deployment` | yes | yes (`deployment_controller.go`, `deployment.go`) | **COVERED** | |
+| `DaemonSet` | yes | yes (`daemonset_controller.go`, `daemonset.go`) | **COVERED** | |
+| `ReplicaSet` | yes | yes (`replicaset_controller.go`, `replicaset.go`) | **COVERED** | Agentic's `_DEFAULT_EXCLUDE_KINDS` lists ReplicaSet; LLM can re-include. Operator covers as first-class. |
+| `StatefulSet` | yes | yes (`statefulset_controller.go`, `statefulset.go`) | **COVERED** | |
+
+---
+
+## batch/v1
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `Job` | yes | yes (`job_controller.go`, `job.go`) | **COVERED** | |
+| `CronJob` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Operator covers `Job` but not `CronJob`. Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+
+---
+
+## networking.k8s.io/v1
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `Ingress` | yes | yes (`ingress_controller.go`, `ingress.go`) | **COVERED** | |
+| `NetworkPolicy` | yes | yes (`networkpolicy_controller.go`, `networkpolicy.go`) | **COVERED** | |
+
+---
+
+## rbac.authorization.k8s.io/v1
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `Role` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. RBAC indexing is a security-posture-relevant capability. |
+| `RoleBinding` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Same as Role. |
+| `ClusterRole` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Same as Role. |
+| `ClusterRoleBinding` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Same as Role. |
+
+---
+
+## autoscaling/v2
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `HorizontalPodAutoscaler` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. Customers using autoscaling rely on HPA indexing for capacity-investigation MCP queries. |
+
+---
+
+## storage.k8s.io/v1
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `StorageClass` | best-effort fallback (no explicit `_KIND_*` mapping; LLM can pick) | yes (`storageclass_controller.go`, `storageclass.go`) | OPERATOR-ONLY | Agentic has no explicit mapper; operator covers first-class. Strict superset for storage indexing. |
+
+---
+
+## CRDs (discovery-gated on the operator)
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `argoproj.io/Rollout` (Argo Rollouts) | best-effort fallback | yes (`argo_rollout_controller.go`, `argo_rollout.go`) — gated on CRD presence (issue #161) | **PARTIAL** (operator authoritative when CRD installed) | Agentic has no explicit mapper; if the LLM picks it, the fallback REST path may or may not work. Operator's coverage is gated on cluster CRD presence. |
+| `argoproj.io/Application` (ArgoCD) | best-effort fallback | yes (`argocd_application_controller.go`, `argocd_application.go`) — gated on CRD presence (issue #160) | **PARTIAL** (operator authoritative when CRD installed) | Same caveat. |
+| `argoproj.io/ApplicationSet` (ArgoCD) | best-effort fallback | yes (`argocd_applicationset_controller.go`, `argocd_applicationset.go`) — gated on CRD presence | **PARTIAL** (operator authoritative when CRD installed) | Same caveat. |
+| `resource.k8s.io/DeviceClass` (DRA) | best-effort fallback | yes (`dra_deviceclass_controller.go`, `dra_deviceclass.go`) — gated on CRD presence (issue #190) | **PARTIAL** (operator authoritative when CRD installed) | DRA is K8s 1.30+. |
+| `resource.k8s.io/ResourceClaim` (DRA) | best-effort fallback | yes (`dra_resourceclaim_controller.go`, `dra_resourceclaim.go`) — gated on CRD presence (issue #162) | **PARTIAL** (operator authoritative when CRD installed) | |
+| `resource.k8s.io/ResourceClaimTemplate` (DRA) | best-effort fallback | yes (`dra_resourceclaimtemplate_controller.go`, `dra_resourceclaimtemplate.go`) | **PARTIAL** (operator authoritative when CRD installed) | |
+| `resource.k8s.io/ResourceSlice` (DRA) | best-effort fallback | yes (`dra_resourceslice_controller.go`, `dra_resourceslice.go`) | **PARTIAL** (operator authoritative when CRD installed) | |
+
+---
+
+## Synthetic kinds (operator-only)
+
+| Kind | agentic.emits | operator.emits | Status | Notes |
+|---|---|---|---|---|
+| `Cluster` (synthetic anchor) | no | yes (`cluster.go`, anchor publisher in `cluster_anchor.go`, issue #159) | OPERATOR-ONLY | The operator emits a `Cluster` anchor that ties every other entity to a cluster identity — there is no agentic equivalent. |
+
+---
+
+## Summary
+
+**Total kinds catalogued**: 36
+
+| Status | Count | Kinds |
+|---|---|---|
+| **COVERED** | 14 | ConfigMap, Endpoints, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy |
+| **PARTIAL** | 7 | Argo Rollouts (Rollout), ArgoCD (Application, ApplicationSet), DRA (DeviceClass, ResourceClaim, ResourceClaimTemplate, ResourceSlice) — all gated on customer cluster CRD installation |
+| **NOT-COVERED** | 11 | LimitRange, PersistentVolumeClaim, ReplicationController (low priority), ResourceQuota, ServiceAccount, CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
+| **OPERATOR-ONLY** | 3 | Secret (redacted), StorageClass, Cluster (synthetic) |
+| **NEITHER** | 1 | Event |
+
+Total: 14 + 7 + 11 + 3 + 1 = **36 rows**.
+
+### Release-blocker summary for v0.4 default-disable
+
+The following 10 kinds are **NOT-COVERED** by the operator and emit
+from the agentic connector's `_DEFAULT_INCLUDE_KINDS`. Each must be
+addressed before the v0.4 release flips
+`OMNISCIENCE_K8S_AGENTIC_ALLOWED` to `false` by default:
+
+1. `LimitRange` — namespace resource caps
+2. `PersistentVolumeClaim` — persistent storage requests
+3. `ResourceQuota` — namespace quota enforcement
+4. `ServiceAccount` — workload identity
+5. `CronJob` — scheduled batch workloads
+6. `Role` — namespaced RBAC
+7. `RoleBinding` — namespaced RBAC binding
+8. `ClusterRole` — cluster-scoped RBAC
+9. `ClusterRoleBinding` — cluster-scoped RBAC binding
+10. `HorizontalPodAutoscaler` — workload autoscaling
+
+`ReplicationController` is also NOT-COVERED but acceptable as a v0.5
+gap pending customer-telemetry confirmation that no production cluster
+relies on it.
+
+**Each item above must become an issue under epic #98** (or a new
+gap-closure epic for v0.4) and ship before the v0.4 default-flip.
+The deprecation announcement landed by issue #168 is **independent**
+of these gaps — the announcement, ADR-0011, and the migration guide
+all stand even with the gaps documented; what they *gate* is the v0.4
+release-time flip of the server-side feature flag.
+
+---
+
+## Verification methodology
+
+This matrix was built by:
+
+1. Enumerating every kind in the agentic connector's
+   `_KIND_*` REST-path tables (file:
+   `packages/connectors/src/omniscience_connectors/agentic/k8s.py`).
+2. Subtracting `_ALWAYS_EXCLUDE` (the never-emit set).
+3. Cross-referencing against the operator's entity mappers
+   (`operator/internal/entity/*.go`, count: 24 mapper functions of
+   shape `XxxToEvent`).
+4. Cross-referencing against the operator's wired controllers
+   (`operator/cmd/manager/main.go`, count: 21
+   `controller.NewXxxReconciler` call sites plus discovery-gated
+   `SetupArgoCDWatchers` and `SetupDRAWatchers`).
+5. Checking the discovery-gated CRD coverage in
+   `operator/internal/controller/argocd_setup.go` and
+   `operator/internal/controller/dra_setup.go`.
+
+Re-run this audit before the v0.4 cut to confirm the gap list is
+unchanged or has been closed.

--- a/docs/decisions/0011-k8s-agentic-deprecation-schedule.md
+++ b/docs/decisions/0011-k8s-agentic-deprecation-schedule.md
@@ -1,0 +1,308 @@
+# ADR-0011 — Deprecation schedule for the `k8s-agentic` connector
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Deciders**: dev-team Lead, Architect, Security Engineer, QA Engineer
+- **Issue**: [#168](https://github.com/100rd/Omniscience/issues/168)
+- **Implements**: the commitment in
+  [ADR-0007 §6](0007-k8s-operator-architecture.md#6-cross-document-consequences)
+  to set the deprecation date once operator parity is reached.
+- **Builds on**: [ADR-0010](0010-server-side-emitter-dedup.md) (server-side
+  emitter dedup; the during-cutover gate that makes parallel running safe).
+- **Closes** epic [#98](https://github.com/100rd/Omniscience/issues/98) — K8s
+  operator GA.
+
+## Context
+
+The legacy agentic Kubernetes connector at
+`packages/connectors/src/omniscience_connectors/agentic/k8s.py` was the v0.1
+bridge between Omniscience and customer Kubernetes clusters.  It uses an
+LLM agent to decide which `kind`s to index and a polling REST loop to
+fetch them.
+
+[ADR-0007](0007-k8s-operator-architecture.md) committed to replacing
+this with an in-cluster Go operator
+(`omniscience-operator`, `operator/`) for three structural reasons:
+freshness budget, causal-edge fidelity, and per-cluster reach.
+ADR-0007 §6 explicitly deferred the deprecation date:
+
+> `packages/connectors/src/omniscience_connectors/agentic/k8s.py` is
+> **not deprecated by this ADR**.  The operator runs in parallel through
+> GA.  A follow-up issue in epic #98 will set the deprecation date once
+> the operator's coverage matches the connector's.
+
+This ADR is that follow-up.  By the time issue #168 is picked up, the
+operator stack is in place:
+
+| Capability | Issue | Status |
+|---|---|---|
+| Operator scaffold + Pod watcher | #101 | merged |
+| Workload watchers (Deployment, RS, SS, DS, Job) | #157 | merged |
+| Network + Config watchers (Service, Endpoints, Ingress, NetworkPolicy, ConfigMap, Secret) | #158 | merged |
+| Cluster-scoped watchers (Namespace, Node, PV, StorageClass, Cluster anchor) | #159 | merged |
+| ArgoCD CRD coverage (Application, ApplicationSet) | #160 | merged |
+| Argo Rollouts CRD coverage | #161 | merged |
+| DRA CRD coverage | #162, #190 | merged |
+| Reconciliation worker (drift correction) | #163 | merged |
+| Server-side dedup (operator-wins) | #164 / ADR-0010 | merged (#195) |
+| Operator metrics + Grafana + alerts | #165 | merged (#194) |
+| Helm chart hardening (PSA, NetworkPolicy, image scanning) | #166 | merged |
+| Multi-cluster identity (`cluster_id` UUID) | #167 | merged |
+
+The remaining open work for full v0.4 default-disable parity is the
+**NOT-COVERED** rows in
+[`docs/connectors/k8s-agentic-vs-operator-parity.md`](../connectors/k8s-agentic-vs-operator-parity.md).
+Those gaps are **out of scope for issue #168** — this issue announces
+the deprecation and pins the schedule; the gaps gate the v0.4 cut, not
+the v0.3 announcement.
+
+## Decision
+
+We pin a three-version deprecation schedule for the `k8s-agentic`
+connector:
+
+### v0.3 — deprecation announcement (this issue)
+
+- The agentic connector remains **fully shipped and functional**.  No
+  removal, no behaviour change, no extras flip.
+- Importing
+  `omniscience_connectors.agentic.k8s` raises a single
+  `DeprecationWarning` at module-import time.  The warning carries:
+  - the removal version string `v0.5.0`
+  - the migration target name `omniscience-operator`
+  - a URL to the migration guide
+    (`docs/connectors/k8s-agentic-deprecation.md`)
+- The migration guide and the parity matrix ship in
+  `docs/connectors/`.
+- The CHANGELOG's **`[0.3.0] → Deprecated`** section announces the
+  schedule and links to the guide.
+- The `pyproject.toml` extras for the connector are documented but
+  **not yet flipped** — `omniscience-connectors[k8s-agentic]` resolves
+  to the same module set as the base install.
+- The Helm chart README for the operator
+  (`helm/omniscience-operator/README.md`) gets a "Migrating from
+  k8s-agentic?" pointer to the migration guide.
+- **Server-side dedup** ([ADR-0010](0010-server-side-emitter-dedup.md))
+  is the during-cutover gate.  It already lives on `main` from #164/#195
+  and silently drops agentic events for any pair the operator is
+  authoritative on.  A non-zero rate on
+  `omniscience_ingestion_dedup_drop_total{authority_emitter="k8s-operator"}`
+  is the visible "operator is taking over" signal customers watch
+  during the parallel window.
+
+### v0.4 — opt-in default-disabled
+
+- The agentic module **moves out** of the base install.  Customers who
+  want to keep using it must explicitly install
+  `omniscience-connectors[k8s-agentic]`.
+- A new server-side feature flag
+  `OMNISCIENCE_K8S_AGENTIC_ALLOWED` is wired in the ingestion worker.
+  Default: **`false`** in v0.4.  When `false`, ingestion drops every
+  event with `source_type="k8s-agentic"` at the gate (before dedup);
+  `omniscience_ingest_emitter_disallowed_total` increments per drop.
+- Customers still on the agentic path at v0.4 have a single Helm /
+  env-var change to roll back: `OMNISCIENCE_K8S_AGENTIC_ALLOWED=true`.
+  This is the **rollback switch**.
+- **The v0.4 cut is gated on closing every NOT-COVERED row in the
+  parity matrix.**  See the [Verification gates](#verification-gates)
+  section.
+- A v0.4 changelog entry announces the opt-in default-disable and
+  re-cites the migration guide.
+
+### v0.5 — removal
+
+- `packages/connectors/src/omniscience_connectors/agentic/k8s.py` and
+  its tests, fixtures, Helm references, and CHANGELOG dedup-during-deprecation
+  test are deleted.
+- The `[k8s-agentic]` extra is removed from `pyproject.toml`.
+- The connector registry entry is removed from
+  `omniscience_connectors/__init__.py`.
+- A v0.5 changelog entry under **Removed** announces the deletion.
+- A one-final-warning is logged on Omniscience server start if any
+  Source row in the database still has `connector_type="k8s-agentic"`
+  — pointing at the migration guide URL with the explicit "this Source
+  is now non-functional" wording.
+
+## Why operator-wins dedup is the right gate (cross-link to ADR-0010)
+
+The deprecation schedule depends on **server-side dedup** being the
+"both paths can run safely" mechanism during the v0.3 → v0.4 window.
+ADR-0010 details the persistent-state operator-wins state machine; the
+load-bearing properties for *this* schedule are:
+
+- **No undefined ordering.**  When both paths emit for the same
+  `(workspace_id, external_id)`, exactly one wins.  No graph-store
+  corruption.
+- **Operator is authoritative for its covered kinds.**  ADR-0010's
+  state machine pins the operator as the winner once it emits, so
+  customers can safely run both paths during cutover without worrying
+  about agentic clobbering operator state.
+- **24-hour TTL for rollback.**  The `OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`
+  default of 24 means the agentic path can re-take authority within
+  24 h of an operator outage — this is the rollback budget customers
+  rely on if the operator misbehaves during the cutover window.
+- **Sticky mode for paranoid customers.**  Setting
+  `OMNISCIENCE_INGEST_DEDUP_TTL_HOURS=0` makes operator authority
+  permanent; useful when the operator is the only K8s emitter and a
+  misconfigured agentic instance must never reclaim a row.
+
+The v0.3 → v0.4 transition reuses this gate; v0.4 adds the
+`OMNISCIENCE_K8S_AGENTIC_ALLOWED=false` posture which short-circuits
+even before dedup runs.
+
+## Why we don't shorten the v0.3-to-v0.5 timeline
+
+A faster timeline (e.g. v0.4 = removal) would be operationally
+hostile:
+
+- Customers on the v0.3 line need at least one minor-version cycle to
+  observe the deprecation warning, plan migration, and execute it.
+  Skipping straight from "announcement" to "removal" violates the
+  contract that deprecation warnings provide a *grace period*.
+- The opt-in extra in v0.4 is the customer-facing rollback path.
+  Removing the connector entirely without that step would leave
+  customers with stuck pipelines and no in-version remediation.
+- The v0.4 server-side feature flag is the "default-disabled" surface;
+  it is the cheapest possible enforcement mechanism (one env var, no
+  module deletion).  Shipping it before the removal lets us gather
+  a release of telemetry on customer flag-flips before pulling the
+  module.
+
+A slower timeline (e.g. v0.6 = removal) is acceptable in principle;
+we pin v0.5 as the **earliest** removal release.  The actual timing
+will be confirmed at v0.4 cut against customer telemetry.
+
+## Verification gates
+
+Each release-line transition is gated on:
+
+### v0.3 (this issue)
+
+- [x] `DeprecationWarning` emitted on import; tested in
+      `tests/test_agentic_deprecation.py`.
+- [x] Migration guide at
+      `docs/connectors/k8s-agentic-deprecation.md`.
+- [x] Parity matrix at
+      `docs/connectors/k8s-agentic-vs-operator-parity.md`.
+- [x] CHANGELOG `[0.3.0] → Deprecated` entry citing the guide.
+- [x] Connector code unchanged except the warning.
+- [x] All existing pytest, mypy, ruff gates green.
+
+### v0.4 default-disable (future, not part of this issue)
+
+- [ ] **All NOT-COVERED kinds in the parity matrix have closed gap
+      issues.**  Specifically: LimitRange, PersistentVolumeClaim,
+      ResourceQuota, ServiceAccount, CronJob, Role, RoleBinding,
+      ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler.
+      `ReplicationController` is acceptable as a v0.5 gap pending
+      telemetry confirmation.
+- [ ] Customer telemetry confirms operator emit-rate match against the
+      agentic baseline for at least 30 days on at least 3 distinct
+      production clusters.
+- [ ] Server-side feature flag
+      `OMNISCIENCE_K8S_AGENTIC_ALLOWED` wired with closed-posture
+      default (`false`) and emitter-disallowed metric.
+- [ ] Helm chart `values.yaml` documents the v0.3 → v0.4 upgrade
+      flow with a config snippet.
+
+### v0.5 removal (future, separate issue)
+
+- [ ] No production customer reports agentic-as-only-source.
+- [ ] All v0.4 customers have either migrated or explicitly opted into
+      `omniscience-connectors[k8s-agentic]`.
+- [ ] Removal PR deletes the module, its tests, fixtures, registry
+      entry, and Helm references in a single change with a clear
+      rollback path (revert the PR).
+
+## Alternatives considered
+
+### Alternative A — single-release removal (v0.3 = remove)
+
+Rejected.  Removes the grace period customers rely on; violates the
+implicit contract of a deprecation warning ("you have at least one
+minor-version cycle to migrate").
+
+### Alternative B — five-release removal (v0.3 announce, v0.7 remove)
+
+Rejected as too long.  The agentic path costs operational and security
+complexity to keep alive (kubeconfig handling on the server, broad
+RBAC, polling load).  Three minor versions is the right balance
+between customer migration time and platform-side maintenance.
+
+### Alternative C — keep agentic indefinitely as a fallback for clusters where the operator can't run
+
+Rejected per ADR-0007's commitment to the operator as **the** K8s
+pathway.  Maintaining a second pathway forever doubles the
+ongoing cost and re-creates the very dual-write problem ADR-0010
+exists to fix.  Customers stuck on pre-1.27 K8s can stay on v0.3 / v0.4
+until they upgrade; this is documented in the migration guide's
+"Kubernetes API version skew" troubleshooting section.
+
+### Alternative D — back-compat shim that proxies agentic output through operator-shaped emit semantics
+
+Rejected.  A shim hides the cutover instead of forcing it; customers
+would never feel pressure to actually move.  The shim's existence
+would also block future operator-side schema evolution because the
+shim has to remain semantically faithful to the agentic shape.
+
+## Consequences
+
+### Positive
+
+- A clear, dated migration timeline customers can plan against.
+- A working dedup gate (ADR-0010) means the parallel-running window is
+  safe; customers can run both paths during cutover without graph
+  corruption.
+- The v0.4 server-side feature flag is the rollback switch — operational
+  remediation in a single env-var change, no code rollback needed.
+- The parity matrix is a forcing function for closing the operator's
+  remaining coverage gaps before v0.4.
+
+### Negative
+
+- The 10 NOT-COVERED kinds are real gaps that block the v0.4 cut.
+  They are individually small but collectively non-trivial; closing
+  them is at least 10 issues' worth of work in epic #98 (or its
+  successor).
+- Customer migration is operational work for them: install operator
+  chart, configure NATS, run parallel, monitor, disable agentic.  We
+  cannot automate this server-side because the operator runs in the
+  customer's cluster.
+
+### Risks
+
+- **A customer skips v0.4 and upgrades v0.3 → v0.5 directly.**  At v0.5,
+  their agentic Source becomes non-functional with no in-version
+  remediation.  Mitigation: the v0.5 changelog under **Breaking
+  changes** will be loud, and the v0.5 server start-up logs a
+  prominent warning when an agentic Source row is found in the DB.
+- **A customer's cluster runs a kind we mis-identified as covered.**
+  Mitigation: the parity matrix lists every kind explicitly with a
+  cross-reference to the operator's mapper file; the matrix is
+  re-audited at v0.4 cut, and customers can challenge it via issue
+  before the cut.
+- **The dedup gate misbehaves during the parallel window.**  Mitigation:
+  ADR-0010's `OMNISCIENCE_DEDUP_ENABLED=false` kill switch reverts to
+  v0.2 dual-write posture; the migration guide's "Rollback faster than
+  the TTL allows" section documents the runbook.
+
+## Revisit triggers
+
+- Customer telemetry at v0.4 cut shows fewer than expected migrations
+  → extend v0.4 by one minor (v0.5 stays announce-only, v0.6 = removal).
+- A NOT-COVERED kind closure is delayed past the v0.4 release schedule
+  → drop the v0.4 default-flip until the gap closes; deprecation
+  warning continues to fire.
+- A new operator-only feature creates a customer-visible quality gap
+  in the agentic path (e.g. an MCP query that needs operator-side data)
+  → the v0.4 cut becomes more urgent; customers feel the pressure
+  organically.
+
+## References
+
+- [Issue #168](https://github.com/100rd/Omniscience/issues/168) — this issue
+- [ADR-0007](0007-k8s-operator-architecture.md) — operator architecture
+- [ADR-0007 §6](0007-k8s-operator-architecture.md#6-cross-document-consequences) — original deprecation-date commitment
+- [ADR-0010](0010-server-side-emitter-dedup.md) — server-side dedup gate
+- [Migration guide](../connectors/k8s-agentic-deprecation.md)
+- [Parity matrix](../connectors/k8s-agentic-vs-operator-parity.md)

--- a/helm/omniscience-operator/README.md
+++ b/helm/omniscience-operator/README.md
@@ -1,0 +1,55 @@
+# omniscience-operator Helm chart
+
+In-cluster Kubernetes operator for Omniscience.  Watches K8s resources
+and publishes entity events to Omniscience over NATS JetStream.  See
+[ADR-0007](../../docs/decisions/0007-k8s-operator-architecture.md) for
+the architecture.
+
+## Quick start
+
+```bash
+helm install omniscience-operator ./helm/omniscience-operator \
+  --namespace omniscience-operator --create-namespace \
+  --set workspaceId="00000000-0000-0000-0000-000000000000" \
+  --set clusterName="prod-eu-west-1" \
+  --set nats.url="nats://omniscience-nats.example.com:4222" \
+  --set nats.credentials="$(cat ./nats.creds)"
+```
+
+`workspaceId`, `clusterName`, and `nats.url` are **required**.  The
+chart fail-fasts at install time if any are missing or invalid.  See
+`values.yaml` for every override.
+
+## Migrating from `k8s-agentic`?
+
+If you currently run the legacy `k8s-agentic` connector
+(`packages/connectors/src/omniscience_connectors/agentic/k8s.py`) on
+the Omniscience server side, this operator is the replacement.  The
+agentic connector is **deprecated as of v0.3** and scheduled for
+removal in **v0.5** — see
+[ADR-0011](../../docs/decisions/0011-k8s-agentic-deprecation-schedule.md).
+
+The detailed migration playbook — including the side-by-side
+comparison, the parallel-running window, the dedup metrics to watch
+during cutover, troubleshooting (NATS, RBAC, PSA, NetworkPolicy), and
+the rollback procedure — lives at:
+
+> [`docs/connectors/k8s-agentic-deprecation.md`](../../docs/connectors/k8s-agentic-deprecation.md)
+
+The kind-by-kind parity status (which K8s kinds the operator covers
+versus the agentic connector) lives at:
+
+> [`docs/connectors/k8s-agentic-vs-operator-parity.md`](../../docs/connectors/k8s-agentic-vs-operator-parity.md)
+
+**Read both before starting your migration.**  In particular, the
+parity matrix lists kinds where the operator does **not yet** cover
+what the agentic connector does — if your deployment relies on those
+kinds, the migration is gated on the gap-closure issues listed in the
+matrix.
+
+## Operational references
+
+- Architecture: [ADR-0007](../../docs/decisions/0007-k8s-operator-architecture.md)
+- Server-side dedup (during-cutover gate): [ADR-0010](../../docs/decisions/0010-server-side-emitter-dedup.md)
+- Deprecation schedule: [ADR-0011](../../docs/decisions/0011-k8s-agentic-deprecation-schedule.md)
+- Alerts runbook: [`docs/runbooks/operator-alerts.md`](../../docs/runbooks/operator-alerts.md)

--- a/packages/connectors/pyproject.toml
+++ b/packages/connectors/pyproject.toml
@@ -3,6 +3,26 @@ name = "omniscience-connectors"
 version = "0.2.0"
 description = "Source connector framework and built-in connectors for Omniscience"
 requires-python = ">=3.12"
+# ──────────────────────────────────────────────────────────────────────────────
+# Deprecation schedule — k8s-agentic connector (issue #168, ADR-0011)
+# ──────────────────────────────────────────────────────────────────────────────
+# v0.3  (current line):  k8s-agentic remains in-tree and shipped as part of
+#                        this package; importing it raises a DeprecationWarning.
+#                        Both the agentic connector and the in-cluster
+#                        omniscience-operator emit events; server-side dedup
+#                        (#164 / ADR-0010) makes the operator authoritative.
+# v0.4  (next minor):    k8s-agentic moves to an opt-in extra
+#                        ``omniscience-connectors[k8s-agentic]``.  The default
+#                        install no longer pulls the connector module surface;
+#                        existing customers must explicitly opt in.  A new
+#                        server-side feature flag
+#                        ``OMNISCIENCE_K8S_AGENTIC_ALLOWED`` (default ``true`` in
+#                        v0.3, default ``false`` in v0.4) enforces the
+#                        deprecation at ingest time.
+# v0.5  (removal):       agentic/k8s.py and its tests / fixtures / Helm
+#                        references are deleted.  Tracked as a separate
+#                        follow-up issue at the time of #168 close.
+# ──────────────────────────────────────────────────────────────────────────────
 dependencies = [
     "omniscience-core",
     "pydantic>=2.7.0",
@@ -15,6 +35,19 @@ dependencies = [
     # of opentelemetry-exporter-otlp pulled in via omniscience-core.
     "opentelemetry-proto>=1.20",
 ]
+
+[project.optional-dependencies]
+# ── DEPRECATED extra (issue #168, ADR-0011) ─────────────────────────────────
+# In v0.3 this extra is a no-op marker: the k8s-agentic module is included in
+# the base install for backward compatibility, and pip/uv install of
+# ``omniscience-connectors[k8s-agentic]`` resolves to the same module set.
+#
+# In v0.4 the agentic/k8s.py module will move OUT of the base package and
+# only be installed when this extra is requested explicitly.  The empty list
+# here is a v0.3-line stable slot — adding deps to it before v0.4 would
+# silently change the install closure for customers who haven't yet opted
+# in.  See docs/decisions/0011-k8s-agentic-deprecation-schedule.md.
+k8s-agentic = []
 
 [tool.uv.sources]
 omniscience-core = { workspace = true }

--- a/packages/connectors/src/omniscience_connectors/agentic/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/agentic/__init__.py
@@ -16,6 +16,14 @@ The ``AgenticConnector`` base class extends ``Connector`` with an LLM-driven
 Built-in agentic connectors:
 
 - ``k8s-agentic`` — discovers which Kubernetes resource kinds to index.
+
+  .. deprecated:: 0.3.0
+      The K8s agentic connector is superseded by ``omniscience-operator``.
+      Importing :mod:`omniscience_connectors.agentic.k8s` (or this package,
+      which re-exports it) emits a :class:`DeprecationWarning` carrying the
+      removal version (``v0.5.0``), the migration target
+      (``omniscience-operator``), and the migration-guide URL.  See
+      ``docs/connectors/k8s-agentic-deprecation.md`` and ADR-0011.
 """
 
 from omniscience_connectors.agentic.base import AgentConfig, AgenticConnector

--- a/packages/connectors/src/omniscience_connectors/agentic/k8s.py
+++ b/packages/connectors/src/omniscience_connectors/agentic/k8s.py
@@ -1,4 +1,19 @@
-"""Kubernetes agentic connector.
+"""Kubernetes agentic connector — DEPRECATED in v0.3, scheduled for removal in v0.5.
+
+.. deprecated:: 0.3.0
+    This connector is superseded by ``omniscience-operator`` — the in-cluster
+    Go operator at ``operator/`` of this repository.  Both paths run in
+    parallel through v0.3 with server-side dedup (issue #164, ADR-0010)
+    making the operator authoritative for kinds it covers.  The connector
+    becomes opt-in default-disabled in v0.4 and is removed in v0.5.
+
+    See the migration guide at
+    ``docs/connectors/k8s-agentic-deprecation.md`` and the parity matrix at
+    ``docs/connectors/k8s-agentic-vs-operator-parity.md``.
+
+    Importing this module raises a :class:`DeprecationWarning` on first
+    import.  The warning is informational only — the connector remains
+    fully functional in v0.3.
 
 Uses an LLM agent to decide which Kubernetes resource kinds to index.
 The LLM is given the list of available API resource kinds in the cluster and
@@ -35,8 +50,9 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 from collections.abc import AsyncIterator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Final
 
 import httpx
 from pydantic import BaseModel, Field
@@ -47,6 +63,45 @@ from omniscience_connectors.base import DocumentRef, FetchedDocument, WebhookHan
 __all__ = ["K8sAgenticConfig", "K8sAgenticConnector"]
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Deprecation announcement (issue #168, ADR-0011)
+# ---------------------------------------------------------------------------
+#
+# This connector is deprecated as of v0.3.  The replacement is the
+# ``omniscience-operator`` co-located at ``operator/`` of this repo.
+# Removal is scheduled for v0.5 per docs/decisions/0011-k8s-agentic-deprecation-schedule.md.
+#
+# We emit a single ``DeprecationWarning`` at module import time.  Exactly-once
+# semantics are achieved via Python's default warning filter
+# (``"default"`` action) plus the ``stacklevel=2`` argument so the warning
+# is attributed to the caller's import site, not to this module's own line.
+#
+# The warning's message is the load-bearing signal:
+#   * it carries the removal version string ``v0.5``
+#   * it carries the migration target name ``omniscience-operator``
+#   * it carries a relative URL to the migration guide
+# All three are asserted by ``tests/test_agentic_deprecation.py`` so a
+# wording change cannot regress the contract.
+_DEPRECATION_REMOVAL_VERSION: Final[str] = "v0.5.0"
+_DEPRECATION_MIGRATION_TARGET: Final[str] = "omniscience-operator"
+_DEPRECATION_MIGRATION_GUIDE_URL: Final[str] = (
+    "https://github.com/100rd/Omniscience/blob/main/docs/connectors/k8s-agentic-deprecation.md"
+)
+
+DEPRECATION_MESSAGE: Final[str] = (
+    "K8sAgenticConnector is deprecated as of Omniscience v0.3 and will be "
+    f"removed in {_DEPRECATION_REMOVAL_VERSION}.  "
+    f"Migrate to {_DEPRECATION_MIGRATION_TARGET} (the in-cluster Go operator "
+    "at operator/ of this repo).  "
+    f"Migration guide: {_DEPRECATION_MIGRATION_GUIDE_URL}"
+)
+
+warnings.warn(
+    DEPRECATION_MESSAGE,
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # Resource kinds that are almost always noise or contain secrets — always skip.
 _ALWAYS_EXCLUDE: frozenset[str] = frozenset(

--- a/tests/test_agentic_deprecation.py
+++ b/tests/test_agentic_deprecation.py
@@ -1,0 +1,108 @@
+"""Deprecation announcement tests for the legacy ``k8s-agentic`` connector.
+
+Issue #168 — deprecation plan + migration guide + removal schedule for
+``packages/connectors/src/omniscience_connectors/agentic/k8s.py``.
+
+These tests guard the *contract* of the deprecation announcement:
+
+1. Importing :mod:`omniscience_connectors.agentic.k8s` raises exactly one
+   :class:`DeprecationWarning`.
+2. The warning's message contains the removal version string ``"0.5"``,
+   the migration target ``"omniscience-operator"``, and a URL to the
+   migration guide.
+3. The connector remains *functionally* importable — the warning is
+   informational, not an error.
+
+These tests deliberately do NOT touch any other behaviour of the
+connector (factory registration, discovery, fetch).  Regression of the
+existing connector behaviour is covered by ``tests/test_agentic_connector.py``.
+
+Implementation note on warning isolation
+----------------------------------------
+
+The ``warnings.warn`` call lives at module-import time, so a previous
+test in the same process may have already imported the module and
+silenced the warning under the default ``"default"`` filter (which fires
+once per location).  Each test below uses
+:func:`importlib.reload` inside a ``warnings.catch_warnings`` block with
+``simplefilter("always")`` to guarantee the warning is observable
+regardless of import ordering.
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+
+def test_importing_k8s_agentic_emits_deprecation_warning() -> None:
+    """Importing the module raises exactly one DeprecationWarning.
+
+    The warning's message must be the load-bearing payload — the rest of
+    this test asserts the contents.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # Reload to force re-execution of module-level code regardless of
+        # whether a prior test (or pytest's collection) already imported it.
+        module = importlib.import_module("omniscience_connectors.agentic.k8s")
+        importlib.reload(module)
+
+    deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecation_warnings) == 1, (
+        f"Expected exactly one DeprecationWarning on import; got {len(deprecation_warnings)}: "
+        f"{[str(w.message) for w in deprecation_warnings]}"
+    )
+
+    message = str(deprecation_warnings[0].message)
+    # Removal version is the load-bearing schedule pin (ADR-0011).
+    assert "0.5" in message, f"DeprecationWarning must mention removal version 0.5; got: {message}"
+    # Migration target name is what customers grep their docs for.
+    assert "omniscience-operator" in message, (
+        f"DeprecationWarning must name the migration target 'omniscience-operator'; got: {message}"
+    )
+    # Migration-guide URL is what the warning text steers them to.
+    # The URL points at docs/connectors/k8s-agentic-deprecation.md so it
+    # round-trips through GitHub Markdown rendering.
+    assert "docs/connectors/k8s-agentic-deprecation.md" in message, (
+        "DeprecationWarning must include the migration-guide URL "
+        f"(docs/connectors/k8s-agentic-deprecation.md); got: {message}"
+    )
+
+
+def test_connector_class_is_still_importable_after_deprecation() -> None:
+    """The connector class continues to import successfully in v0.3.
+
+    Deprecation is an *announcement*, not an enforcement.  Customers'
+    existing pipelines must continue to work without code changes through
+    the v0.3 line.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from omniscience_connectors.agentic.k8s import (
+            K8sAgenticConfig,
+            K8sAgenticConnector,
+        )
+
+    # The class object resolves and is the expected type.
+    assert K8sAgenticConnector.connector_type == "k8s-agentic"
+    # The Pydantic config schema is intact.
+    cfg = K8sAgenticConfig()
+    assert cfg.cluster_name == "default"
+    assert cfg.api_server == "https://kubernetes.default.svc"
+
+
+def test_deprecation_message_constant_exposes_removal_version() -> None:
+    """The exported ``DEPRECATION_MESSAGE`` constant is asserted as the
+    canonical wording.
+
+    The migration guide and the ADR both quote this constant by reference;
+    a wording change must be a deliberate edit visible in code review.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from omniscience_connectors.agentic.k8s import DEPRECATION_MESSAGE
+
+    assert "v0.5" in DEPRECATION_MESSAGE
+    assert "omniscience-operator" in DEPRECATION_MESSAGE
+    assert "docs/connectors/k8s-agentic-deprecation.md" in DEPRECATION_MESSAGE

--- a/uv.lock
+++ b/uv.lock
@@ -1356,6 +1356,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "watchfiles", specifier = ">=0.21.0" },
 ]
+provides-extras = ["k8s-agentic"]
 
 [[package]]
 name = "omniscience-core"


### PR DESCRIPTION
Closes #168 (do not merge — author-requested hold).

## Summary

Announces the deprecation of the legacy `k8s-agentic` connector and pins
the **v0.3 announce → v0.4 default-disabled → v0.5 remove** schedule.
Implements ADR-0007 §6's commitment to set the deprecation date once
operator parity is reached. Builds on ADR-0010 (server-side dedup) as the
during-cutover gate.

## Acceptance criteria checklist

- [x] `DeprecationWarning` on import of `omniscience_connectors.agentic.k8s`
      (warning text carries removal version `v0.5.0`, migration target
      `omniscience-operator`, and migration-guide URL).
- [x] Tested in `tests/test_agentic_deprecation.py` — 3/3 passing.
- [x] Full pytest suite green (2075 passed, 52 skipped).
- [x] `mypy --strict apps/ packages/` clean (186 source files).
- [x] `ruff check` and `ruff format --check` clean (288 files).
- [x] Migration guide at `docs/connectors/k8s-agentic-deprecation.md`
      includes: parity matrix link, dedup metric reference, rollback plan,
      NATS/RBAC/PSA/NetworkPolicy/API-skew troubleshooting.
- [x] Parity matrix at `docs/connectors/k8s-agentic-vs-operator-parity.md`
      enumerates every kind the agentic connector emits, reconciled
      against `operator/internal/entity/*.go` mappers and
      `operator/cmd/manager/main.go` wired controllers.
- [x] ADR-0011 references ADR-0007 §6 and ADR-0010 explicitly.
- [x] CHANGELOG `[Unreleased] → Deprecated` entry citing the migration
      guide and removal schedule.
- [x] `pyproject.toml` extras documented (no-op in v0.3, will gate the
      install closure in v0.4).
- [x] Helm chart README pointer to migration guide.
- [x] Connector code unchanged except the deprecation warning — existing
      functionality preserved.

## Parity matrix completeness check

Total kinds catalogued: **36**

| Status | Count | Notes |
|---|---|---|
| COVERED | 14 | Operator covers in full |
| PARTIAL | 7 | Operator covers, gated on customer-cluster CRD presence (ArgoCD x2, Argo Rollouts, DRA x4) |
| **NOT-COVERED** | **11** | **Release-blockers for v0.4 default-flip, surfaced explicitly** |
| OPERATOR-ONLY | 3 | Operator strict superset (Secret/redacted, StorageClass, synthetic Cluster) |
| NEITHER | 1 | Event (excluded by both) |

### NOT-COVERED kinds (release-blockers for v0.4)

These are kinds the agentic connector emits but the operator does not
cover today. **Per the prompt's invariant, surfaced explicitly rather
than papered over.** Each must close before the v0.4 release flips
`OMNISCIENCE_K8S_AGENTIC_ALLOWED` to `false` by default — they are NOT
release-blockers for v0.3 (this PR's announcement).

1. `LimitRange`
2. `PersistentVolumeClaim`
3. `ResourceQuota`
4. `ServiceAccount`
5. `CronJob`
6. `Role`
7. `RoleBinding`
8. `ClusterRole`
9. `ClusterRoleBinding`
10. `HorizontalPodAutoscaler`
11. `ReplicationController` (low-priority — legacy, deprecated upstream; acceptable as a v0.5 gap pending customer-telemetry confirmation)

Each warrants its own follow-up issue under epic #98 (or successor).
The deprecation announcement, ADR-0011, and the migration guide all
stand even with these gaps; what they gate is the v0.4 server-side
flag flip, not the v0.3 announcement.

## Removal schedule (ADR-0011)

- **v0.3** (this PR): deprecation announced; both paths run in parallel;
  `DeprecationWarning` on import; server-side dedup (ADR-0010) is the
  during-cutover gate.
- **v0.4**: `omniscience-connectors[k8s-agentic]` becomes opt-in;
  `OMNISCIENCE_K8S_AGENTIC_ALLOWED=false` server-side default — drops
  agentic events at ingest. Gated on closure of the 11 NOT-COVERED kinds.
- **v0.5**: connector module + tests + Helm references deleted.

## Migration guide URL

`docs/connectors/k8s-agentic-deprecation.md` (in this PR).

## Parity preconditions referenced

This PR is the closing issue for the operator-coverage chain. The parity
matrix verifies coverage from:

- #157 (workload watchers) — Deployment/RS/SS/DS/Job: COVERED
- #158 (network + config watchers) — Service/Endpoints/Ingress/NetworkPolicy/ConfigMap/Secret: COVERED
- #159 (cluster-scoped watchers + Cluster anchor) — Namespace/Node/PV/StorageClass: COVERED + synthetic Cluster
- #160 (ArgoCD CRDs) — Application/ApplicationSet: PARTIAL (CRD-gated)
- #161 (Argo Rollouts CRD) — Rollout: PARTIAL (CRD-gated)
- #162 + #190 (DRA CRDs) — DeviceClass/ResourceClaim/ResourceClaimTemplate/ResourceSlice: PARTIAL (CRD-gated)
- #163 (reconciliation worker) — makes operator authoritative; precondition for ADR-0010
- #164 (server-side dedup) / ADR-0010 — the during-cutover gate
- #165 (operator metrics) — provides the dedup-during-cutover health signal customers monitor
- #166 (Helm chart hardening) — production-ready chart; precondition for the migration guide's `helm install` step
- #167 (multi-cluster identity) — `cluster_id` UUID; precondition for stable `external_id` across clusters

## Test plan

- [x] `pytest -x tests/test_agentic_deprecation.py` (3 tests, all green)
- [x] `pytest -x tests/test_agentic_connector.py` (regression, 51 tests, all green)
- [x] Full `pytest --no-cov` (2075 passed, 52 skipped)
- [x] `mypy --strict apps/ packages/` (clean, 186 files)
- [x] `ruff check .` (clean, 288 files)
- [x] `ruff format --check .` (clean)
- [x] Manual: `python -W default -c "import omniscience_connectors.agentic.k8s"` shows the warning with all three contract pieces
- [ ] Reviewer verifies parity matrix against operator entity-mapper inventory
- [ ] Reviewer confirms ADR-0011 schedule is acceptable (or proposes alternative timeline)

## Notes

- Per directive: do **not** merge.
- The connector code is **not deleted**. Removal is a separate v0.5
  follow-up.
- The `OMNISCIENCE_K8S_AGENTIC_ALLOWED` server-side feature flag is
  documented but **not wired** in this PR — it is a v0.4 mechanism.
- The migration guide includes one acknowledged v0.3 gap: the agentic
  connector's `external_id` shape (`k8s:<cluster_name>:kind:<Kind>`)
  does not collide on dedup with the operator's
  `external_id` shape (`k8s_resource/<cluster_id>/<Kind>/<ns>/<name>`),
  so dedup-only deduplication is not the primary cutover mechanism.
  Customers cut over via Source-level disable in v0.3 and via the
  v0.4 server-side flag thereafter — this is documented in the guide's
  "Dedup gate not dropping agentic events" troubleshooting section.