### PR TITLE
feat: operator LimitRange watcher (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] — v0.3 line
 
+### Added
+
+- **Operator: `LimitRange` watcher (issue #202).** The operator now watches
+  `core/v1 LimitRange` cluster-wide and emits a deterministic-JSON
+  representation of `spec.limits[]` (defaults / min / max /
+  maxLimitRequestRatio for Container, Pod, PersistentVolumeClaim, and
+  similar object types). Closes one of the v0.4 default-flip parity gaps
+  tracked under epic #199. RBAC adds `get`/`list`/`watch` on
+  `limitranges`; no other verbs.
+
 ### Deprecated
 
 - **`k8s-agentic` connector deprecation announced (issue #168, ADR-0011).**

--- a/docs/connectors/k8s-agentic-vs-operator-parity.md
+++ b/docs/connectors/k8s-agentic-vs-operator-parity.md
@@ -58,7 +58,7 @@ migration described in the
 | `ConfigMap` | yes | yes (`configmap_controller.go`, `configmap.go`) | **COVERED** | Operator emits via watch; agentic via list. Operator data is fresher. |
 | `Endpoints` | yes | yes (`endpoints_controller.go`, `endpoints.go`) | **COVERED** | Agentic includes `Endpoints` in `_KIND_CORE` despite `_DEFAULT_EXCLUDE_KINDS` listing it (the LLM can re-include it). Operator covers explicitly. |
 | `Event` | **no** (`_ALWAYS_EXCLUDE`) | no | NEITHER | Both paths exclude; not relevant to deprecation. |
-| `LimitRange` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Operator has neither a controller nor an entity mapper for `LimitRange`. Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+| `LimitRange` | yes | yes (`limitrange_controller.go`, `limitrange_mapper.go`) | **COVERED** | Operator emits via watch (issue #202). Mapper renders `spec.limits` as deterministic JSON in metadata; namespace appears only in `external_id` and base metadata, never as a metric label. |
 | `Namespace` | yes | yes (`namespace_controller.go`, `namespace.go`) | **COVERED** | Operator additionally emits a synthetic `Cluster` anchor (issue #159) — strict superset. |
 | `Node` | yes | yes (`node_controller.go`, `node.go`) | **COVERED** | |
 | `PersistentVolume` | yes | yes (`persistentvolume_controller.go`, `persistentvolume.go`) | **COVERED** | |
@@ -156,22 +156,22 @@ migration described in the
 
 | Status | Count | Kinds |
 |---|---|---|
-| **COVERED** | 14 | ConfigMap, Endpoints, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy |
+| **COVERED** | 15 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy |
 | **PARTIAL** | 7 | Argo Rollouts (Rollout), ArgoCD (Application, ApplicationSet), DRA (DeviceClass, ResourceClaim, ResourceClaimTemplate, ResourceSlice) — all gated on customer cluster CRD installation |
-| **NOT-COVERED** | 11 | LimitRange, PersistentVolumeClaim, ReplicationController (low priority), ResourceQuota, ServiceAccount, CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
+| **NOT-COVERED** | 10 | PersistentVolumeClaim, ReplicationController (low priority), ResourceQuota, ServiceAccount, CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
 | **OPERATOR-ONLY** | 3 | Secret (redacted), StorageClass, Cluster (synthetic) |
 | **NEITHER** | 1 | Event |
 
-Total: 14 + 7 + 11 + 3 + 1 = **36 rows**.
+Total: 15 + 7 + 10 + 3 + 1 = **36 rows**.
 
 ### Release-blocker summary for v0.4 default-disable
 
-The following 10 kinds are **NOT-COVERED** by the operator and emit
+The following 9 kinds are **NOT-COVERED** by the operator and emit
 from the agentic connector's `_DEFAULT_INCLUDE_KINDS`. Each must be
 addressed before the v0.4 release flips
 `OMNISCIENCE_K8S_AGENTIC_ALLOWED` to `false` by default:
 
-1. `LimitRange` — namespace resource caps
+1. ~~`LimitRange`~~ — **DONE** in issue #202 (namespace resource caps).
 2. `PersistentVolumeClaim` — persistent storage requests
 3. `ResourceQuota` — namespace quota enforcement
 4. `ServiceAccount` — workload identity

--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -36,6 +36,14 @@ rules:
     resources: ["ingresses", "networkpolicies"]
     verbs: ["get", "list", "watch"]
   # ── end #158 ──────────────────────────────────────────────────────────
+  # ── #202 LimitRange watcher (epic #199 v0.4 parity) ───────────────────
+  # Read-only verbs only. LimitRange is namespaced under core/v1; the
+  # ClusterRole binding above grants the watch cluster-wide so the
+  # informer sees LimitRanges in every namespace.
+  - apiGroups: [""]
+    resources: ["limitranges"]
+    verbs: ["get", "list", "watch"]
+  # ── end #202 ──────────────────────────────────────────────────────────
   # --- BEGIN issue #159: cluster-scoped watcher RBAC ---
   # Node, Namespace, PersistentVolume — all cluster-scoped under the core
   # API group. ClusterRole + ClusterRoleBinding above already grants the

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -448,6 +448,12 @@ func setupNetworkingAndConfigWatchers(
 	} else if err := sec.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("secret reconciler setup: %w", err)
 	}
+	// ── #202 LimitRange watcher (epic #199 v0.4 parity) ────────────────────
+	if lr, err := controller.NewLimitRangeReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("limitrange reconciler init: %w", err)
+	} else if err := lr.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("limitrange reconciler setup: %w", err)
+	}
 	return nil
 }
 

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -650,6 +650,8 @@ func buildCacheSizeKinds(mgr ctrl.Manager, argoPresent bool, logger interface {
 		{kind: "NetworkPolicy", listFactory: func() client.ObjectList { return &networkingv1.NetworkPolicyList{} }},
 		{kind: "ConfigMap", listFactory: func() client.ObjectList { return &corev1.ConfigMapList{} }},
 		{kind: "Secret", listFactory: func() client.ObjectList { return &corev1.SecretList{} }},
+		// Resource governance (#202)
+		{kind: "LimitRange", listFactory: func() client.ObjectList { return &corev1.LimitRangeList{} }},
 		// Cluster-scoped (#159)
 		{kind: "Node", listFactory: func() client.ObjectList { return &corev1.NodeList{} }},
 		{kind: "Namespace", listFactory: func() client.ObjectList { return &corev1.NamespaceList{} }},

--- a/operator/internal/controller/limitrange_controller.go
+++ b/operator/internal/controller/limitrange_controller.go
@@ -1,0 +1,119 @@
+// limitrange_controller.go: controller for corev1.LimitRange (issue #202).
+//
+// LimitRange is part of the v0.4 default-flip parity push (epic #199). The
+// controller mirrors configmap_controller.go shape exactly — only the kind,
+// the mapper, and the metric label change.
+//
+// RecordEmit placement matches the pattern wired in #201 across the other
+// 23 controllers: the freshness probe is recorded BEFORE Publish, on the
+// upsert (err == nil) branch only. Deletions do not emit a freshness
+// observation because there is no resource state to be "fresh" against.
+//
+// Build dependency note (intentional, per #202 plan): this file imports the
+// freshness helper from internal/metrics. That symbol lands in #201 (PR
+// #201 → branch feat/operator-event-lag-wiring). If #201 has not merged at
+// the time this branch is built from main, the package will not compile —
+// that is the desired ordering signal for the human reviewer (merge #201
+// first, then rebase this PR).
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// LimitRangeReconciler watches LimitRanges and publishes change events.
+type LimitRangeReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewLimitRangeReconciler returns a reconciler with sane defaults. Same
+// precondition checks as every other controller — fail closed on any nil/
+// zero input rather than silently emitting events with the zero workspace.
+func NewLimitRangeReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*LimitRangeReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &LimitRangeReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every LimitRange add /
+// update / delete.
+func (r *LimitRangeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"limitrange", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var lr corev1.LimitRange
+	err := r.Client.Get(ctx, req.NamespacedName, &lr)
+	switch {
+	case err == nil:
+		ev := entity.LimitRangeToEvent(&lr, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("LimitRange", &lr) // #198/#201 freshness probe
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish limitrange event: %w", perr)
+		}
+		logger.V(1).Info("published limitrange upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.LimitRange{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.LimitRangeToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish limitrange deletion: %w", perr)
+		}
+		logger.V(1).Info("published limitrange deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get limitrange failed")
+		return ctrl.Result{}, fmt.Errorf("get limitrange %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *LimitRangeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.LimitRange{}).
+		Named("limitrange-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/limitrange_controller_test.go
+++ b/operator/internal/controller/limitrange_controller_test.go
@@ -1,0 +1,272 @@
+// limitrange_controller_test.go: tests for LimitRangeReconciler (#202).
+//
+// envtest is not wired in this controller package (workload_controllers_test
+// .go uses controller-runtime's fake client + an in-memory publisher). We
+// follow the same pattern here. Lifecycle coverage:
+//
+//   - Create: object present in client → publisher sees Updated event with
+//     correct external_id and workspace stamp.
+//   - Update: object updated in client between reconciles → publisher sees
+//     a second Updated event with the new spec reflected in metadata
+//     (limits_count change).
+//   - Delete: client returns IsNotFound → publisher sees a Deleted event
+//     for a stub LimitRange (no RecordEmit on this branch).
+//
+// The fakePublisher and shared test fixtures (tcWorkspace, fixedClusterID,
+// tcClusterName, tcFixedTime, fixedNowFunc, req, newScheme) are defined in
+// workload_controllers_test.go and reused here.
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/100rd/omniscience/operator/internal/controller"
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func lrQty(s string) resource.Quantity { return resource.MustParse(s) }
+
+// ─── Constructor preconditions ─────────────────────────────────────────────
+
+func TestNewLimitRangeReconciler_RejectsZeroWorkspace(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewLimitRangeReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+}
+
+func TestNewLimitRangeReconciler_RejectsNilPublisher(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewLimitRangeReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+}
+
+func TestNewLimitRangeReconciler_RejectsEmptyClusterName(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewLimitRangeReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+}
+
+func TestNewLimitRangeReconciler_RejectsNilClient(t *testing.T) {
+	if _, err := controller.NewLimitRangeReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+// ─── Lifecycle: create / update / delete ───────────────────────────────────
+
+// containerFixture builds a Container-typed LimitRange with default+min+max.
+func containerFixture(ns, name string) *corev1.LimitRange {
+	return &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+			Type:    corev1.LimitTypeContainer,
+			Default: corev1.ResourceList{corev1.ResourceCPU: lrQty("500m")},
+			Min:     corev1.ResourceList{corev1.ResourceCPU: lrQty("50m")},
+			Max:     corev1.ResourceList{corev1.ResourceCPU: lrQty("2")},
+		}}},
+	}
+}
+
+func TestLimitRangeReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	lr := containerFixture("team-a", "container-limits")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(lr).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewLimitRangeReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "container-limits")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	ev := got[0]
+	if ev.WorkspaceID != tcWorkspace {
+		t.Fatalf("workspace_id = %s, want %s", ev.WorkspaceID, tcWorkspace)
+	}
+	if ev.Action != entity.ActionUpdated {
+		t.Fatalf("action = %q, want %q", ev.Action, entity.ActionUpdated)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/LimitRange/team-a/container-limits" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["limits_count"] != "1" {
+		t.Fatalf("limits_count = %q", ev.Metadata["limits_count"])
+	}
+	if !ev.EmittedAt.Equal(tcFixedTime) {
+		t.Fatalf("emitted_at = %s, want %s", ev.EmittedAt, tcFixedTime)
+	}
+}
+
+// Update path: reconcile twice with a spec change in between; both events
+// land and reflect the current spec at reconcile time.
+func TestLimitRangeReconciler_UpdateEmitsSecondUpdated(t *testing.T) {
+	s := newScheme(t)
+	lr := containerFixture("team-a", "container-limits")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(lr).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewLimitRangeReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, req("team-a", "container-limits")); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	// Mutate: add a Pod-type limit so limits_count flips 1 → 2.
+	var live corev1.LimitRange
+	if err := c.Get(ctx, req("team-a", "container-limits").NamespacedName, &live); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	live.Spec.Limits = append(live.Spec.Limits, corev1.LimitRangeItem{
+		Type: corev1.LimitTypePod,
+		Max:  corev1.ResourceList{corev1.ResourceCPU: lrQty("4")},
+	})
+	if err := c.Update(ctx, &live); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if _, err := r.Reconcile(ctx, req("team-a", "container-limits")); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("publisher saw %d events, want 2", len(got))
+	}
+	if got[0].Metadata["limits_count"] != "1" {
+		t.Fatalf("first event limits_count = %q, want 1", got[0].Metadata["limits_count"])
+	}
+	if got[1].Metadata["limits_count"] != "2" {
+		t.Fatalf("second event limits_count = %q, want 2 (update should reflect new spec)", got[1].Metadata["limits_count"])
+	}
+	for _, ev := range got {
+		if ev.Action != entity.ActionUpdated {
+			t.Fatalf("action = %q, want %q", ev.Action, entity.ActionUpdated)
+		}
+	}
+}
+
+// Delete path: reconcile against an empty client → IsNotFound branch fires
+// and a Deleted event is emitted with a stub LimitRange identity.
+func TestLimitRangeReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build() // no objects
+	pub := &fakePublisher{}
+
+	r, err := controller.NewLimitRangeReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "container-limits")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	if got[0].Action != entity.ActionDeleted {
+		t.Fatalf("action = %q, want %q", got[0].Action, entity.ActionDeleted)
+	}
+	if got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/LimitRange/team-a/container-limits" {
+		t.Fatalf("external_id = %q", got[0].ExternalID)
+	}
+	if got[0].Metadata["limits_count"] != "0" {
+		t.Fatalf("stub deletion should have empty spec; limits_count = %q", got[0].Metadata["limits_count"])
+	}
+}
+
+// All four spec.limits[].type fixture shapes (Container / Pod / PVC / ratio)
+// round-trip through the controller without altering envelope identity.
+func TestLimitRangeReconciler_AllFixtureShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		lr   *corev1.LimitRange
+	}{
+		{
+			name: "Container",
+			lr:   containerFixture("team-a", "container-limits"),
+		},
+		{
+			name: "Pod",
+			lr: &corev1.LimitRange{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "pod-limits"},
+				Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+					Type: corev1.LimitTypePod,
+					Min:  corev1.ResourceList{corev1.ResourceCPU: lrQty("100m")},
+					Max:  corev1.ResourceList{corev1.ResourceCPU: lrQty("4")},
+				}}},
+			},
+		},
+		{
+			name: "PersistentVolumeClaim",
+			lr: &corev1.LimitRange{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "pvc-limits"},
+				Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+					Type: corev1.LimitTypePersistentVolumeClaim,
+					Min:  corev1.ResourceList{corev1.ResourceStorage: lrQty("1Gi")},
+					Max:  corev1.ResourceList{corev1.ResourceStorage: lrQty("100Gi")},
+				}}},
+			},
+		},
+		{
+			name: "MaxLimitRequestRatio",
+			lr: &corev1.LimitRange{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "ratio-limits"},
+				Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+					Type:                 corev1.LimitTypeContainer,
+					MaxLimitRequestRatio: corev1.ResourceList{corev1.ResourceCPU: lrQty("4")},
+				}}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newScheme(t)
+			c := fake.NewClientBuilder().WithScheme(s).WithObjects(tc.lr).Build()
+			pub := &fakePublisher{}
+			r, err := controller.NewLimitRangeReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+			if err != nil {
+				t.Fatalf("new reconciler: %v", err)
+			}
+			r.Now = fixedNowFunc()
+			if _, err := r.Reconcile(context.Background(), req(tc.lr.Namespace, tc.lr.Name)); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+			got := pub.snapshot()
+			if len(got) != 1 {
+				t.Fatalf("events = %d, want 1", len(got))
+			}
+			if got[0].Metadata["kind"] != "LimitRange" {
+				t.Fatalf("kind = %q", got[0].Metadata["kind"])
+			}
+			if got[0].Metadata["limits_count"] != "1" {
+				t.Fatalf("limits_count = %q", got[0].Metadata["limits_count"])
+			}
+		})
+	}
+}

--- a/operator/internal/entity/limitrange_mapper.go
+++ b/operator/internal/entity/limitrange_mapper.go
@@ -1,0 +1,133 @@
+// limitrange_mapper.go: corev1.LimitRange -> Event mapper (issue #202).
+//
+// LimitRange holds per-namespace defaults / min / max for CPU, memory,
+// storage, and ephemeral-storage on Container, Pod, PersistentVolumeClaim,
+// and similar object types. The mapper emits ONLY the closed allow-list of
+// fields from baseMetadata (cluster, cluster_id, namespace, name, kind,
+// emitter) plus a kind-specific limits payload.
+//
+// SECURITY POSTURE — same as every other operator mapper:
+//
+//   - User-supplied labels and annotations are NEVER copied through. The
+//     ACL invariant (ADR-0007 §ACL) is that workspace_id flows from operator
+//     config; nothing on the watched resource influences tenancy.
+//
+//   - `namespace` appears in baseMetadata + external_id ONLY. It is a graph-
+//     linking field and MUST NOT become a metric label dimension (high
+//     cardinality + tenancy leak). The corresponding metric (RecordEmit) is
+//     wired in the controller, not here, and uses kind only — see #198/#201.
+//
+//   - LimitRange spec contains operational quantities (CPU/memory/storage
+//     limits expressed as resource.Quantity strings). These are not secrets,
+//     but the mapper still does NOT touch annotations / labels.
+package entity
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EntityKindLimitRange is the K8s kind segment in LimitRange external_ids.
+const EntityKindLimitRange = "LimitRange"
+
+// LimitRangeToEvent maps a corev1.LimitRange plus an action into an Event.
+// Pure function — no I/O, no clients, no clock beyond `now`.
+//
+// The emitted metadata is:
+//
+//   - Base allow-list: cluster, cluster_id, namespace, name, kind, emitter
+//   - "limits_count": decimal string of len(spec.limits)
+//   - "limits_json":  deterministic JSON encoding of spec.limits (see
+//     marshalLimits below). Empty / absent when spec.limits is empty so the
+//     consumer can distinguish "no limits configured" from "marshal failed".
+//
+// The JSON encoding sorts limit entries by `type` and resource keys within
+// each map lexicographically; this keeps event payloads byte-identical
+// across operator restarts and Go's non-deterministic map iteration order.
+func LimitRangeToEvent(lr *corev1.LimitRange, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(lr.Namespace)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindLimitRange, lr.Name)
+
+	meta["limits_count"] = strconv.Itoa(len(lr.Spec.Limits))
+	if len(lr.Spec.Limits) > 0 {
+		raw, err := marshalLimits(lr.Spec.Limits)
+		if err != nil {
+			// resource.Quantity has a well-defined String() form and the
+			// shape we marshal is map[string]string — encoding/json cannot
+			// fail in practice. Emit empty marker rather than partial JSON
+			// so the consumer can tell something went wrong.
+			meta["limits_json"] = ""
+		} else {
+			meta["limits_json"] = raw
+		}
+	}
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindLimitRange, namespace, lr.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindLimitRange, lr.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// limitItemView is the deterministic JSON shape we emit for one
+// spec.limits[] entry. Resource maps are flattened to map[string]string with
+// the resource.Quantity rendered via its canonical .String() form (which is
+// what kubectl prints — e.g. "500m", "1Gi"). encoding/json sorts string-
+// keyed map keys since Go 1.12, so the output is byte-stable.
+type limitItemView struct {
+	Type                 string            `json:"type"`
+	Default              map[string]string `json:"default,omitempty"`
+	DefaultRequest       map[string]string `json:"defaultRequest,omitempty"`
+	Min                  map[string]string `json:"min,omitempty"`
+	Max                  map[string]string `json:"max,omitempty"`
+	MaxLimitRequestRatio map[string]string `json:"maxLimitRequestRatio,omitempty"`
+}
+
+// marshalLimits renders spec.limits as deterministic JSON. Entries are
+// sorted by .Type so two operators observing the same LimitRange emit the
+// same bytes regardless of map iteration order in the source object.
+func marshalLimits(items []corev1.LimitRangeItem) (string, error) {
+	views := make([]limitItemView, 0, len(items))
+	for _, it := range items {
+		views = append(views, limitItemView{
+			Type:                 string(it.Type),
+			Default:              quantityMap(it.Default),
+			DefaultRequest:       quantityMap(it.DefaultRequest),
+			Min:                  quantityMap(it.Min),
+			Max:                  quantityMap(it.Max),
+			MaxLimitRequestRatio: quantityMap(it.MaxLimitRequestRatio),
+		})
+	}
+	sort.Slice(views, func(i, j int) bool { return views[i].Type < views[j].Type })
+
+	b, err := json.Marshal(views)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// quantityMap converts a corev1.ResourceList (map[ResourceName]Quantity) into
+// a string-keyed map suitable for deterministic JSON. Returns nil for empty
+// inputs so the caller's omitempty tag suppresses the field — keeps the JSON
+// compact and the diff easy to read.
+func quantityMap(rl corev1.ResourceList) map[string]string {
+	if len(rl) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(rl))
+	for k, v := range rl {
+		out[string(k)] = v.String()
+	}
+	return out
+}

--- a/operator/internal/entity/limitrange_mapper_test.go
+++ b/operator/internal/entity/limitrange_mapper_test.go
@@ -1,0 +1,317 @@
+// limitrange_mapper_test.go: pure unit tests for LimitRangeToEvent (#202).
+//
+// The four fixture shapes mirror the spec.limits[].type values that show up
+// in real clusters: Container (defaults+min+max), Pod (min+max only),
+// PersistentVolumeClaim (min+max storage), and a maxLimitRequestRatio
+// shape. Each is exercised end-to-end through the mapper; we assert on
+// envelope (workspace_id stamp, external_id, source_id, URI) and on the
+// limits payload (count, deterministic JSON).
+package entity_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+var (
+	lrTestWorkspace   = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	lrTestClusterID   = uuid.MustParse("99999999-8888-7777-6666-555555555555")
+	lrTestClusterName = "prod-eu"
+	lrTestNow         = time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+)
+
+func qty(s string) resource.Quantity { return resource.MustParse(s) }
+
+// ─── Constructor / envelope ────────────────────────────────────────────────
+
+func TestLimitRangeToEvent_EnvelopeStampsWorkspaceFromConfig(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "default-limits",
+			// Adversarial labels — must NOT affect workspace stamp or
+			// metadata. The ACL invariant: tenancy comes from operator
+			// config, never from cluster state.
+			Labels: map[string]string{
+				"omniscience.io/workspace": "evil-ws",
+				"team":                     "platform",
+			},
+			Annotations: map[string]string{
+				"omniscience.io/index-data": "true", // not honoured here
+			},
+		},
+		Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{Type: corev1.LimitTypeContainer}}},
+	}
+	ev := entity.LimitRangeToEvent(lr, entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+
+	if ev.WorkspaceID != lrTestWorkspace {
+		t.Fatalf("workspace_id = %s, want %s — adversarial label honoured!", ev.WorkspaceID, lrTestWorkspace)
+	}
+	if ev.SourceType != entity.SourceType {
+		t.Fatalf("source_type = %q, want %q", ev.SourceType, entity.SourceType)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/LimitRange/team-a/default-limits" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.URI != "kube://prod-eu/team-a/LimitRange/default-limits" {
+		t.Fatalf("uri = %q", ev.URI)
+	}
+	if !ev.EmittedAt.Equal(lrTestNow) {
+		t.Fatalf("emitted_at = %s, want %s", ev.EmittedAt, lrTestNow)
+	}
+	if ev.Action != entity.ActionUpdated {
+		t.Fatalf("action = %q", ev.Action)
+	}
+}
+
+// ACL invariant: only the closed allow-list of metadata keys is emitted.
+// User labels and annotations must NOT leak through.
+func TestLimitRangeToEvent_ACL_NoUserLabelsOrAnnotationsLeak(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "default-limits",
+			Labels: map[string]string{
+				"team":          "platform",
+				"cost-center":   "eng-42",
+				"app.k8s.io/of": "checkout",
+			},
+			Annotations: map[string]string{
+				"description": "team-a default container limits",
+				"owner":       "alice@example.com",
+			},
+		},
+		Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{Type: corev1.LimitTypeContainer}}},
+	}
+	ev := entity.LimitRangeToEvent(lr, entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+
+	allowed := map[string]struct{}{
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"limits_count": {}, "limits_json": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("metadata leaked key %q (value=%q) — ACL allow-list violated", k, ev.Metadata[k])
+		}
+	}
+	for forbidden := range lr.Labels {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user label %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+	for forbidden := range lr.Annotations {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user annotation %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+}
+
+// ─── Fixture shape 1: Container with default + defaultRequest + min + max ──
+
+func TestLimitRangeToEvent_ContainerShape(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "container-limits"},
+		Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+			Type:           corev1.LimitTypeContainer,
+			Default:        corev1.ResourceList{corev1.ResourceCPU: qty("500m"), corev1.ResourceMemory: qty("256Mi")},
+			DefaultRequest: corev1.ResourceList{corev1.ResourceCPU: qty("100m"), corev1.ResourceMemory: qty("128Mi")},
+			Min:            corev1.ResourceList{corev1.ResourceCPU: qty("50m")},
+			Max:            corev1.ResourceList{corev1.ResourceCPU: qty("2"), corev1.ResourceMemory: qty("4Gi")},
+		}}},
+	}
+	ev := entity.LimitRangeToEvent(lr, entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+
+	if ev.Metadata["limits_count"] != "1" {
+		t.Fatalf("limits_count = %q, want 1", ev.Metadata["limits_count"])
+	}
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(ev.Metadata["limits_json"]), &got); err != nil {
+		t.Fatalf("limits_json not valid JSON: %v\n%s", err, ev.Metadata["limits_json"])
+	}
+	if len(got) != 1 || got[0]["type"] != "Container" {
+		t.Fatalf("got %#v", got)
+	}
+	def := got[0]["default"].(map[string]any)
+	if def["cpu"] != "500m" || def["memory"] != "256Mi" {
+		t.Fatalf("default = %#v", def)
+	}
+}
+
+// ─── Fixture shape 2: Pod with min + max only (no defaults) ────────────────
+
+func TestLimitRangeToEvent_PodShape(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "pod-limits"},
+		Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+			Type: corev1.LimitTypePod,
+			Min:  corev1.ResourceList{corev1.ResourceCPU: qty("100m"), corev1.ResourceMemory: qty("64Mi")},
+			Max:  corev1.ResourceList{corev1.ResourceCPU: qty("4"), corev1.ResourceMemory: qty("8Gi")},
+		}}},
+	}
+	ev := entity.LimitRangeToEvent(lr, entity.ActionCreated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+
+	var got []limitItemForTest
+	if err := json.Unmarshal([]byte(ev.Metadata["limits_json"]), &got); err != nil {
+		t.Fatalf("limits_json not valid JSON: %v", err)
+	}
+	if got[0].Type != "Pod" {
+		t.Fatalf("type = %q", got[0].Type)
+	}
+	if len(got[0].Default) != 0 || len(got[0].DefaultRequest) != 0 {
+		t.Fatalf("Pod limit must have empty default/defaultRequest; got default=%v defaultRequest=%v", got[0].Default, got[0].DefaultRequest)
+	}
+	if got[0].Min["cpu"] != "100m" || got[0].Max["memory"] != "8Gi" {
+		t.Fatalf("min=%v max=%v", got[0].Min, got[0].Max)
+	}
+}
+
+// ─── Fixture shape 3: PersistentVolumeClaim storage min/max ────────────────
+
+func TestLimitRangeToEvent_PVCShape(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "pvc-limits"},
+		Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+			Type: corev1.LimitTypePersistentVolumeClaim,
+			Min:  corev1.ResourceList{corev1.ResourceStorage: qty("1Gi")},
+			Max:  corev1.ResourceList{corev1.ResourceStorage: qty("100Gi")},
+		}}},
+	}
+	ev := entity.LimitRangeToEvent(lr, entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+
+	var got []limitItemForTest
+	if err := json.Unmarshal([]byte(ev.Metadata["limits_json"]), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got[0].Type != "PersistentVolumeClaim" {
+		t.Fatalf("type = %q", got[0].Type)
+	}
+	if got[0].Min["storage"] != "1Gi" || got[0].Max["storage"] != "100Gi" {
+		t.Fatalf("storage limits = min:%v max:%v", got[0].Min, got[0].Max)
+	}
+}
+
+// ─── Fixture shape 4: Container with maxLimitRequestRatio ──────────────────
+
+func TestLimitRangeToEvent_RatioShape(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "ratio-limits"},
+		Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{{
+			Type:                 corev1.LimitTypeContainer,
+			MaxLimitRequestRatio: corev1.ResourceList{corev1.ResourceCPU: qty("4"), corev1.ResourceMemory: qty("2")},
+		}}},
+	}
+	ev := entity.LimitRangeToEvent(lr, entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+
+	var got []limitItemForTest
+	if err := json.Unmarshal([]byte(ev.Metadata["limits_json"]), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got[0].MaxLimitRequestRatio["cpu"] != "4" || got[0].MaxLimitRequestRatio["memory"] != "2" {
+		t.Fatalf("ratio = %v", got[0].MaxLimitRequestRatio)
+	}
+}
+
+// ─── Determinism: two mappings of the same input produce identical bytes ──
+
+func TestLimitRangeToEvent_DeterministicJSON(t *testing.T) {
+	// Build the same LimitRange twice with maps that hash differently
+	// in Go (extra padding entries can change iteration order).
+	build := func() *corev1.LimitRange {
+		return &corev1.LimitRange{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+			Spec: corev1.LimitRangeSpec{Limits: []corev1.LimitRangeItem{
+				// Intentionally provide types in REVERSE alphabetical order.
+				// The mapper must sort the output by type.
+				{
+					Type: corev1.LimitTypePod,
+					Max:  corev1.ResourceList{corev1.ResourceMemory: qty("4Gi"), corev1.ResourceCPU: qty("2")},
+				},
+				{
+					Type: corev1.LimitTypeContainer,
+					Min:  corev1.ResourceList{corev1.ResourceMemory: qty("64Mi"), corev1.ResourceCPU: qty("100m")},
+				},
+			}},
+		}
+	}
+	a := entity.LimitRangeToEvent(build(), entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+	b := entity.LimitRangeToEvent(build(), entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+	if a.Metadata["limits_json"] != b.Metadata["limits_json"] {
+		t.Fatalf("non-deterministic JSON:\nA: %s\nB: %s", a.Metadata["limits_json"], b.Metadata["limits_json"])
+	}
+	// And it must be sorted: Container before Pod.
+	got := a.Metadata["limits_json"]
+	idxC := indexOfType(got, "Container")
+	idxP := indexOfType(got, "Pod")
+	if idxC < 0 || idxP < 0 || idxC > idxP {
+		t.Fatalf("expected Container before Pod in sorted JSON; got %s", got)
+	}
+}
+
+// ─── Empty Spec.Limits: no limits_json key, count is "0" ───────────────────
+
+func TestLimitRangeToEvent_EmptyLimits(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "empty"},
+		Spec:       corev1.LimitRangeSpec{Limits: nil},
+	}
+	ev := entity.LimitRangeToEvent(lr, entity.ActionDeleted, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+	if ev.Metadata["limits_count"] != "0" {
+		t.Fatalf("limits_count = %q, want 0", ev.Metadata["limits_count"])
+	}
+	if _, present := ev.Metadata["limits_json"]; present {
+		t.Fatalf("limits_json must be absent when spec.limits is empty; got %q", ev.Metadata["limits_json"])
+	}
+}
+
+// Default namespace fallback: empty namespace becomes "default" so the
+// external_id is still well-formed (defensive — LimitRange is namespaced
+// by definition, but be consistent with the rest of the entity package).
+
+func TestLimitRangeToEvent_EmptyNamespaceFallsBackToDefault(t *testing.T) {
+	lr := &corev1.LimitRange{
+		ObjectMeta: corev1.LimitRange{}.ObjectMeta,
+	}
+	lr.Name = "x"
+	ev := entity.LimitRangeToEvent(lr, entity.ActionUpdated, lrTestWorkspace, lrTestClusterID, lrTestClusterName, lrTestNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/LimitRange/default/x" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["namespace"] != "default" {
+		t.Fatalf("namespace = %q", ev.Metadata["namespace"])
+	}
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+// limitItemForTest mirrors the mapper's internal limitItemView so we can
+// decode in tests without exporting the production type. Field names match
+// the JSON tags.
+type limitItemForTest struct {
+	Type                 string            `json:"type"`
+	Default              map[string]string `json:"default,omitempty"`
+	DefaultRequest       map[string]string `json:"defaultRequest,omitempty"`
+	Min                  map[string]string `json:"min,omitempty"`
+	Max                  map[string]string `json:"max,omitempty"`
+	MaxLimitRequestRatio map[string]string `json:"maxLimitRequestRatio,omitempty"`
+}
+
+// indexOfType returns the byte index of the first occurrence of the given
+// limit type in `s`, or -1 if absent. Used to assert sort order without
+// regex overhead.
+func indexOfType(s, typ string) int {
+	needle := `"type":"` + typ + `"`
+	for i := 0; i+len(needle) <= len(s); i++ {
+		if s[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
Closes #202. Sub-task of epic #199 (v0.4 default-flip parity push).

## Summary

Adds a controller-runtime watcher for `core/v1 LimitRange`, following the pattern established by #157 (workload watchers, PR #181) and #158 (networking + config watchers, PR #182). LimitRange is one of the 10 NOT-COVERED operator gaps blocking the v0.4 default-flip per epic #199; this PR closes one of them.

### What landed

- `operator/internal/entity/limitrange_mapper.go` — pure `LimitRangeToEvent` mapper. Renders `spec.limits[]` as deterministic JSON (sorted by limit type, sorted within each resource map) so two operators emit byte-identical events.
- `operator/internal/controller/limitrange_controller.go` — `LimitRangeReconciler` in the same shape as `configmap_controller.go`. `RecordEmit(\"LimitRange\", &lr)` is recorded before `Publish` on the upsert branch only (matches the placement wired in PR #201; see ordering note below).
- `operator/internal/entity/limitrange_mapper_test.go` — pure unit tests for the four real-world fixture shapes (Container, Pod, PersistentVolumeClaim, MaxLimitRequestRatio), JSON determinism, ACL allow-list invariant, default-namespace fallback.
- `operator/internal/controller/limitrange_controller_test.go` — fake-client lifecycle tests (create / update / delete) + all four fixture shapes round-tripped through the reconciler. envtest is not wired in this controller package; we follow `workload_controllers_test.go`'s fake-client pattern.
- `operator/cmd/manager/main.go` — appends LimitRange registration to the existing #158 setup helper.
- `helm/omniscience-operator/templates/rbac.yaml` — adds `get`/`list`/`watch` on `limitranges` (no other verbs).
- `docs/connectors/k8s-agentic-vs-operator-parity.md` — flips the LimitRange row to COVERED, updates rollup counts, strikes LimitRange off the v0.4 release-blocker list.
- `CHANGELOG.md` — `[Unreleased] -> Added` entry.

### Ordering decision: based off `main`, depends on #201

The branch is rooted at `origin/main`. PR #201 (operator event-lag wiring) is still open and adds the `metrics.RecordEmit` helper this PR uses. Per the issue plan, I chose the option \"use `RecordEmit` anyway and accept the conflict\" rather than rebasing onto #201's branch. Effect: this PR will not compile (`undefined: opmetrics.RecordEmit`) until #201 merges. Reviewer should merge #201 first, then this PR will rebase cleanly onto main.

### Quality gates — actually run

| Gate | Result |
|---|---|
| `go build ./operator/...` | FAIL — `internal/controller/limitrange_controller.go:87:13: undefined: opmetrics.RecordEmit` (documented #201 dependency, intentional ordering signal) |
| `go vet ./internal/entity/...` | clean |
| `go test -race -count=1 ./internal/entity/...` | green (all mapper tests + existing) |
| `go test -race -count=1 -run \"TestACL_NoForbiddenLabels\\|TestACL_WorkspaceIDInfoLabels_AreSafe\" ./internal/metrics/...` | green |
| `go test -race -count=1 ./...` (full) | metrics / publisher / reconciler / entity green; controller + cmd/manager build-fail on #201 dep (expected) |
| `helm lint helm/omniscience-operator` | clean (1 INFO: chart icon recommended — pre-existing) |
| `helm template helm/omniscience-operator ...` | renders; new RBAC verbs visible at line 107-109 (`limitranges` with `get/list/watch`) |
| Grep audit `WithLabelValues` / `MustRegisterWith` on changed files | zero hits — no new metric label dimensions |
| `go mod tidy` | not committed — tidy wanted to promote `prometheus/client_golang` and `go-logr/logr` from indirect to direct because `internal/controller` now imports the metrics package transitively via `opmetrics`. Cosmetic only (no new module versions). Deferred so reviewer / CI regenerates after #201 lands and the package compiles cleanly. |
| CI v1.61 lint | deferred to CI (same as PR #201) |
| Kind smoke | deferred to reviewer (same as PR #201) |

### Security review — performed during implementation (solo, see disclosure)

- RBAC: only `get`/`list`/`watch` on `limitranges`. No mutating verbs.
- ACL invariant: mapper output asserted in `TestLimitRangeToEvent_ACL_NoUserLabelsOrAnnotationsLeak`. Only the closed allow-list of metadata keys is emitted; user labels / annotations never copied through.
- Cardinality: `namespace` appears in `external_id` and base metadata only. `RecordEmit(\"LimitRange\", obj)` uses kind-only as the metric label — no per-namespace cardinality explosion or tenancy leak via metrics.
- LimitRange spec is operational data (CPU/memory/storage `resource.Quantity` strings), not secrets, but the mapper still avoids touching `annotations` / `labels` entirely.
- Existing `TestACL_NoForbiddenLabels` and `TestACL_WorkspaceIDInfoLabels_AreSafe` still pass.
- No new module dependency added to `go.sum` (LimitRange is `core/v1`, already imported transitively).

### Solo execution disclosure

This PR was prepared by a single Claude Code session playing all four planned roles (architect / backend / security / QA). The configured agent-team flow could not spawn sub-agents — `TeamCreate`, `SendMessage`, and `Task*` tools are present in the session, but the underlying spawn primitive (`Agent`) does not register a callable schema, so the lead has no way to instantiate teammates. Same situation as PR #201 (issue #198). All review steps were executed in-session against the same checklist a multi-role team would follow; falling back to solo rather than fabricating a multi-role narrative.

### Hard scope guardrails — respected

This PR does NOT touch:
- `operator/internal/metrics/record_emit.go` (helper itself; lands in #201)
- `operator/cmd/manager/cache_size_ticker.go` (does not exist on this branch base; lands in #201)
- The other 9 NOT-COVERED gaps from epic #199 (PVC / ResourceQuota / ServiceAccount / CronJob / Role / RoleBinding / ClusterRole / ClusterRoleBinding / HPA — separate issues each)
- `OMNISCIENCE_K8S_AGENTIC_ALLOWED` server-side flag
- `apps/server/`, `packages/connectors/`

### Follow-ups

- Once #201 merges, rebase this PR; `go build ./operator/...`, `go vet`, full `go test -race`, and `go mod tidy` should all run clean. If `go mod tidy` produces any diff at that point, fold it into this PR before marking ready.
- Reviewer to run kind smoke on staging cluster before merge (same protocol as #201).