### PR TITLE
feat: operator ServiceAccount watcher (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracked under epic #199. RBAC adds `get`/`list`/`watch` on
   `resourcequotas`; no other verbs.
 
+- **Operator: `ServiceAccount` watcher (issue #206).** The operator now
+  watches `core/v1 ServiceAccount` cluster-wide and emits Secret
+  reference NAMES (no values), image pull Secret names, and the
+  automount setting. Closes one of the v0.4 default-flip parity gaps
+  tracked under epic #199. RBAC adds `get`/`list`/`watch` on
+  `serviceaccounts`; no other verbs.
+
 ### Deprecated
 
 - **`k8s-agentic` connector deprecation announced (issue #168, ADR-0011).**

--- a/docs/connectors/k8s-agentic-vs-operator-parity.md
+++ b/docs/connectors/k8s-agentic-vs-operator-parity.md
@@ -68,7 +68,7 @@ migration described in the
 | `ResourceQuota` | yes | yes (`resourcequota_controller.go`, `resourcequota_mapper.go`) | **COVERED** | Operator emits via watch (issue #204). Mapper renders `spec.hard`, `spec.scopes`, and `spec.scopeSelector` as deterministic JSON in metadata; namespace appears only in `external_id` and base metadata, never as a metric label. |
 | `Secret` | **no** (`_ALWAYS_EXCLUDE`) | yes (`secret_controller.go`, `secret.go`, **redacted-by-default per issue #166**) | OPERATOR-ONLY | Agentic refuses to emit Secret on security grounds. Operator emits a redacted-by-default mapping (issue #166); strictly safer. Not a deprecation concern. |
 | `Service` | yes | yes (`service_controller.go`, `service.go`) | **COVERED** | |
-| `ServiceAccount` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+| `ServiceAccount` | yes | yes (`serviceaccount_controller.go`, `serviceaccount_mapper.go`) | **COVERED** | Operator emits via watch (issue #206). Mapper emits Secret reference NAMES only (no values), image pull Secret names, and the automount setting. Namespace appears only in `external_id` and base metadata, never as a metric label. |
 
 ---
 
@@ -156,17 +156,17 @@ migration described in the
 
 | Status | Count | Kinds |
 |---|---|---|
-| **COVERED** | 16 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota |
+| **COVERED** | 17 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota, ServiceAccount |
 | **PARTIAL** | 7 | Argo Rollouts (Rollout), ArgoCD (Application, ApplicationSet), DRA (DeviceClass, ResourceClaim, ResourceClaimTemplate, ResourceSlice) — all gated on customer cluster CRD installation |
-| **NOT-COVERED** | 9 | PersistentVolumeClaim, ReplicationController (low priority), ServiceAccount, CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
+| **NOT-COVERED** | 8 | PersistentVolumeClaim, ReplicationController (low priority), CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
 | **OPERATOR-ONLY** | 3 | Secret (redacted), StorageClass, Cluster (synthetic) |
 | **NEITHER** | 1 | Event |
 
-Total: 16 + 7 + 9 + 3 + 1 = **36 rows**.
+Total: 17 + 7 + 8 + 3 + 1 = **36 rows**.
 
 ### Release-blocker summary for v0.4 default-disable
 
-The following 8 kinds are **NOT-COVERED** by the operator and emit
+The following 7 kinds are **NOT-COVERED** by the operator and emit
 from the agentic connector's `_DEFAULT_INCLUDE_KINDS`. Each must be
 addressed before the v0.4 release flips
 `OMNISCIENCE_K8S_AGENTIC_ALLOWED` to `false` by default:
@@ -174,7 +174,7 @@ addressed before the v0.4 release flips
 1. ~~`LimitRange`~~ — **DONE** in issue #202 (namespace resource caps).
 2. `PersistentVolumeClaim` — persistent storage requests
 3. ~~`ResourceQuota`~~ — **DONE** in issue #204 (namespace quota enforcement).
-4. `ServiceAccount` — workload identity
+4. ~~`ServiceAccount`~~ — **DONE** in issue #206 (workload identity).
 5. `CronJob` — scheduled batch workloads
 6. `Role` — namespaced RBAC
 7. `RoleBinding` — namespaced RBAC binding

--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -50,6 +50,14 @@ rules:
     resources: ["resourcequotas"]
     verbs: ["get", "list", "watch"]
   # ── end #204 ──────────────────────────────────────────────────────────
+  # ── #206 ServiceAccount watcher (epic #199 v0.4 parity) ───────────────
+  # Read-only verbs only. ServiceAccount is namespaced under core/v1.
+  # The mapper emits ONLY Secret reference NAMES — no values; the operator
+  # never reads Secret data via the SA references.
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  # ── end #206 ──────────────────────────────────────────────────────────
   # --- BEGIN issue #159: cluster-scoped watcher RBAC ---
   # Node, Namespace, PersistentVolume — all cluster-scoped under the core
   # API group. ClusterRole + ClusterRoleBinding above already grants the

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -460,6 +460,12 @@ func setupNetworkingAndConfigWatchers(
 	} else if err := rq.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("resourcequota reconciler setup: %w", err)
 	}
+	// ── #206 ServiceAccount watcher (epic #199 v0.4 parity) ────────────────
+	if sa, err := controller.NewServiceAccountReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("serviceaccount reconciler init: %w", err)
+	} else if err := sa.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("serviceaccount reconciler setup: %w", err)
+	}
 	return nil
 }
 
@@ -659,6 +665,8 @@ func buildCacheSizeKinds(mgr ctrl.Manager, argoPresent bool, logger interface {
 		// Resource governance (#202, #204)
 		{kind: "LimitRange", listFactory: func() client.ObjectList { return &corev1.LimitRangeList{} }},
 		{kind: "ResourceQuota", listFactory: func() client.ObjectList { return &corev1.ResourceQuotaList{} }},
+		// Identity (#206)
+		{kind: "ServiceAccount", listFactory: func() client.ObjectList { return &corev1.ServiceAccountList{} }},
 		// Cluster-scoped (#159)
 		{kind: "Node", listFactory: func() client.ObjectList { return &corev1.NodeList{} }},
 		{kind: "Namespace", listFactory: func() client.ObjectList { return &corev1.NamespaceList{} }},

--- a/operator/internal/controller/serviceaccount_controller.go
+++ b/operator/internal/controller/serviceaccount_controller.go
@@ -1,0 +1,106 @@
+// serviceaccount_controller.go: controller for corev1.ServiceAccount (issue #206).
+//
+// Sub-task of epic #199 (v0.4 default-flip parity push). Mirrors the
+// LimitRange (#202) / ResourceQuota (#204) shape exactly.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ServiceAccountReconciler watches ServiceAccounts and publishes change events.
+type ServiceAccountReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewServiceAccountReconciler returns a reconciler with sane defaults. Same
+// precondition checks as every other controller — fail closed on any nil/
+// zero input rather than silently emitting events with the zero workspace.
+func NewServiceAccountReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ServiceAccountReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ServiceAccountReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every ServiceAccount add /
+// update / delete.
+func (r *ServiceAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"serviceaccount", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var sa corev1.ServiceAccount
+	err := r.Client.Get(ctx, req.NamespacedName, &sa)
+	switch {
+	case err == nil:
+		ev := entity.ServiceAccountToEvent(&sa, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("ServiceAccount", &sa) // #198/#201 freshness probe
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish serviceaccount event: %w", perr)
+		}
+		logger.V(1).Info("published serviceaccount upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.ServiceAccount{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.ServiceAccountToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish serviceaccount deletion: %w", perr)
+		}
+		logger.V(1).Info("published serviceaccount deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get serviceaccount failed")
+		return ctrl.Result{}, fmt.Errorf("get serviceaccount %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *ServiceAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ServiceAccount{}).
+		Named("serviceaccount-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/serviceaccount_controller_test.go
+++ b/operator/internal/controller/serviceaccount_controller_test.go
@@ -1,0 +1,167 @@
+// serviceaccount_controller_test.go: tests for ServiceAccountReconciler (#206).
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/100rd/omniscience/operator/internal/controller"
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// ─── Constructor preconditions ─────────────────────────────────────────────
+
+func TestNewServiceAccountReconciler_RejectsZeroWorkspace(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewServiceAccountReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+}
+
+func TestNewServiceAccountReconciler_RejectsNilPublisher(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewServiceAccountReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+}
+
+func TestNewServiceAccountReconciler_RejectsEmptyClusterName(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewServiceAccountReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+}
+
+func TestNewServiceAccountReconciler_RejectsNilClient(t *testing.T) {
+	if _, err := controller.NewServiceAccountReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+// ─── Lifecycle: create / update / delete ───────────────────────────────────
+
+func saFixture(ns, name string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Secrets: []corev1.ObjectReference{
+			{Name: "build-bot-token-abc"},
+		},
+	}
+}
+
+func TestServiceAccountReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	sa := saFixture("team-a", "build-bot")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sa).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewServiceAccountReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "build-bot")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	ev := got[0]
+	if ev.WorkspaceID != tcWorkspace {
+		t.Fatalf("workspace_id = %s", ev.WorkspaceID)
+	}
+	if ev.Action != entity.ActionUpdated {
+		t.Fatalf("action = %q", ev.Action)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ServiceAccount/team-a/build-bot" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["secrets_count"] != "1" {
+		t.Fatalf("secrets_count = %q", ev.Metadata["secrets_count"])
+	}
+	if !ev.EmittedAt.Equal(tcFixedTime) {
+		t.Fatalf("emitted_at = %s", ev.EmittedAt)
+	}
+}
+
+// Update path: spec change between reconciles is reflected in the second event.
+func TestServiceAccountReconciler_UpdateEmitsSecondUpdated(t *testing.T) {
+	s := newScheme(t)
+	sa := saFixture("team-a", "build-bot")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sa).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewServiceAccountReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, req("team-a", "build-bot")); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	var live corev1.ServiceAccount
+	if err := c.Get(ctx, req("team-a", "build-bot").NamespacedName, &live); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	live.ImagePullSecrets = []corev1.LocalObjectReference{{Name: "ghcr-creds"}}
+	if err := c.Update(ctx, &live); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if _, err := r.Reconcile(ctx, req("team-a", "build-bot")); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("publisher saw %d events, want 2", len(got))
+	}
+	if got[0].Metadata["image_pull_secrets_count"] != "0" {
+		t.Fatalf("first image_pull_secrets_count = %q, want 0", got[0].Metadata["image_pull_secrets_count"])
+	}
+	if got[1].Metadata["image_pull_secrets_count"] != "1" {
+		t.Fatalf("second image_pull_secrets_count = %q, want 1", got[1].Metadata["image_pull_secrets_count"])
+	}
+}
+
+// Delete path: empty client → IsNotFound → Deleted event for stub.
+func TestServiceAccountReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewServiceAccountReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "build-bot")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	if got[0].Action != entity.ActionDeleted {
+		t.Fatalf("action = %q", got[0].Action)
+	}
+	if got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ServiceAccount/team-a/build-bot" {
+		t.Fatalf("external_id = %q", got[0].ExternalID)
+	}
+	if got[0].Metadata["secrets_count"] != "0" {
+		t.Fatalf("stub deletion should have empty secrets; secrets_count = %q", got[0].Metadata["secrets_count"])
+	}
+}

--- a/operator/internal/entity/serviceaccount_mapper.go
+++ b/operator/internal/entity/serviceaccount_mapper.go
@@ -1,0 +1,134 @@
+// serviceaccount_mapper.go: corev1.ServiceAccount -> Event mapper (issue #206).
+//
+// ServiceAccount represents a workload identity in a namespace. The mapper
+// emits ONLY the closed allow-list of fields from baseMetadata plus a small
+// shape describing which Secrets and image pull Secrets the SA references
+// (by NAME ONLY — no values, ever) and the automount setting.
+//
+// SECURITY POSTURE — same as every other operator mapper:
+//
+//   - User-supplied labels and annotations are NEVER copied through. The
+//     ACL invariant (ADR-0007 §ACL) is that workspace_id flows from operator
+//     config; nothing on the watched resource influences tenancy.
+//
+//   - `namespace` appears in baseMetadata + external_id ONLY. It is a graph-
+//     linking field and MUST NOT become a metric label dimension. The
+//     corresponding metric (RecordEmit) is wired in the controller and uses
+//     kind only — see #198/#201.
+//
+//   - Secret references are emitted as NAMES ONLY. Secret values are never
+//     touched here — the operator's Secret watcher (#158, redacted-by-default
+//     per #166) is the canonical Secret-content emitter and lives in
+//     secret_mapper.go.
+package entity
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EntityKindServiceAccount is the K8s kind segment in ServiceAccount external_ids.
+const EntityKindServiceAccount = "ServiceAccount"
+
+// ServiceAccountToEvent maps a corev1.ServiceAccount plus an action into an
+// Event. Pure function — no I/O, no clients, no clock beyond `now`.
+//
+// Emitted metadata:
+//
+//   - Base allow-list: cluster, cluster_id, namespace, name, kind, emitter
+//   - "secrets_count":                  decimal string of len(.Secrets)
+//   - "secrets_json":                   sorted JSON array of Secret NAMES.
+//                                       Absent when .Secrets is empty.
+//   - "image_pull_secrets_count":       decimal string of len(.ImagePullSecrets)
+//   - "image_pull_secrets_json":        sorted JSON array of Secret NAMES.
+//                                       Absent when .ImagePullSecrets is empty.
+//   - "automount_service_account_token": "true" / "false" / "" (when nil)
+func ServiceAccountToEvent(sa *corev1.ServiceAccount, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(sa.Namespace)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindServiceAccount, sa.Name)
+
+	meta["secrets_count"] = strconv.Itoa(len(sa.Secrets))
+	if len(sa.Secrets) > 0 {
+		raw, err := marshalObjectRefNames(sa.Secrets)
+		if err != nil {
+			meta["secrets_json"] = ""
+		} else {
+			meta["secrets_json"] = raw
+		}
+	}
+
+	meta["image_pull_secrets_count"] = strconv.Itoa(len(sa.ImagePullSecrets))
+	if len(sa.ImagePullSecrets) > 0 {
+		raw, err := marshalLocalObjectRefNames(sa.ImagePullSecrets)
+		if err != nil {
+			meta["image_pull_secrets_json"] = ""
+		} else {
+			meta["image_pull_secrets_json"] = raw
+		}
+	}
+
+	meta["automount_service_account_token"] = automountValue(sa.AutomountServiceAccountToken)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindServiceAccount, namespace, sa.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindServiceAccount, sa.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// marshalObjectRefNames renders []ObjectReference as a sorted JSON array of
+// the .Name fields only. Other fields (UID, ResourceVersion, etc.) are
+// intentionally dropped — they're high-cardinality and not graph-relevant.
+func marshalObjectRefNames(refs []corev1.ObjectReference) (string, error) {
+	names := make([]string, 0, len(refs))
+	for _, r := range refs {
+		names = append(names, r.Name)
+	}
+	sort.Strings(names)
+	b, err := json.Marshal(names)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// marshalLocalObjectRefNames is the LocalObjectReference variant.
+// LocalObjectReference has only a single Name field, but we keep the helper
+// separate so the caller's intent (image pull secrets vs other refs) is
+// type-checked at the call site.
+func marshalLocalObjectRefNames(refs []corev1.LocalObjectReference) (string, error) {
+	names := make([]string, 0, len(refs))
+	for _, r := range refs {
+		names = append(names, r.Name)
+	}
+	sort.Strings(names)
+	b, err := json.Marshal(names)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// automountValue renders *bool as "true" / "false" / "" (nil). String form
+// keeps the metadata schema flat (all values are strings); the empty string
+// distinguishes "explicitly nil — defer to namespace policy" from the two
+// concrete settings.
+func automountValue(b *bool) string {
+	if b == nil {
+		return ""
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
+}

--- a/operator/internal/entity/serviceaccount_mapper_test.go
+++ b/operator/internal/entity/serviceaccount_mapper_test.go
@@ -1,0 +1,271 @@
+// serviceaccount_mapper_test.go: pure unit tests for ServiceAccountToEvent (#206).
+package entity_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+var (
+	saTestWorkspace   = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	saTestClusterID   = uuid.MustParse("99999999-8888-7777-6666-555555555555")
+	saTestClusterName = "prod-eu"
+	saTestNow         = time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// ─── Envelope ─────────────────────────────────────────────────────────────
+
+func TestServiceAccountToEvent_EnvelopeStampsWorkspaceFromConfig(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "build-bot",
+			// Adversarial labels — ACL invariant: tenancy from operator
+			// config, not from cluster state.
+			Labels: map[string]string{
+				"omniscience.io/workspace": "evil-ws",
+				"team":                     "platform",
+			},
+			Annotations: map[string]string{
+				"omniscience.io/index-data": "true",
+			},
+		},
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+
+	if ev.WorkspaceID != saTestWorkspace {
+		t.Fatalf("workspace_id = %s, want %s — adversarial label honoured!", ev.WorkspaceID, saTestWorkspace)
+	}
+	if ev.SourceType != entity.SourceType {
+		t.Fatalf("source_type = %q", ev.SourceType)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ServiceAccount/team-a/build-bot" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.URI != "kube://prod-eu/team-a/ServiceAccount/build-bot" {
+		t.Fatalf("uri = %q", ev.URI)
+	}
+	if !ev.EmittedAt.Equal(saTestNow) {
+		t.Fatalf("emitted_at = %s", ev.EmittedAt)
+	}
+	if ev.Action != entity.ActionUpdated {
+		t.Fatalf("action = %q", ev.Action)
+	}
+}
+
+// ACL invariant: only the closed allow-list of metadata keys is emitted.
+func TestServiceAccountToEvent_ACL_NoUserLabelsOrAnnotationsLeak(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "build-bot",
+			Labels: map[string]string{
+				"team":          "platform",
+				"cost-center":   "eng-42",
+				"app.k8s.io/of": "checkout",
+			},
+			Annotations: map[string]string{
+				"description": "team-a build bot",
+				"owner":       "alice@example.com",
+			},
+		},
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+
+	allowed := map[string]struct{}{
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"secrets_count": {}, "secrets_json": {},
+		"image_pull_secrets_count": {}, "image_pull_secrets_json": {},
+		"automount_service_account_token": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("metadata leaked key %q (value=%q) — ACL allow-list violated", k, ev.Metadata[k])
+		}
+	}
+	for forbidden := range sa.Labels {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user label %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+	for forbidden := range sa.Annotations {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user annotation %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+}
+
+// ─── Fixture 1: default SA — no secrets, no image pull secrets, automount nil ──
+
+func TestServiceAccountToEvent_DefaultSA(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "default"},
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+
+	if ev.Metadata["secrets_count"] != "0" {
+		t.Fatalf("secrets_count = %q", ev.Metadata["secrets_count"])
+	}
+	if _, present := ev.Metadata["secrets_json"]; present {
+		t.Fatalf("secrets_json must be absent when .Secrets is empty")
+	}
+	if ev.Metadata["image_pull_secrets_count"] != "0" {
+		t.Fatalf("image_pull_secrets_count = %q", ev.Metadata["image_pull_secrets_count"])
+	}
+	if _, present := ev.Metadata["image_pull_secrets_json"]; present {
+		t.Fatalf("image_pull_secrets_json must be absent when .ImagePullSecrets is empty")
+	}
+	if ev.Metadata["automount_service_account_token"] != "" {
+		t.Fatalf("automount = %q, want empty for nil pointer", ev.Metadata["automount_service_account_token"])
+	}
+}
+
+// ─── Fixture 2: with secrets (sorted JSON) ────────────────────────────────
+
+func TestServiceAccountToEvent_WithSecrets(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "build-bot"},
+		Secrets: []corev1.ObjectReference{
+			// Intentionally reverse-alphabetical — mapper must sort.
+			{Name: "github-token", UID: "uid-1"},
+			{Name: "aws-creds", UID: "uid-2"},
+			{Name: "build-bot-token-abc", UID: "uid-3"},
+		},
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+
+	if ev.Metadata["secrets_count"] != "3" {
+		t.Fatalf("secrets_count = %q", ev.Metadata["secrets_count"])
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(ev.Metadata["secrets_json"]), &got); err != nil {
+		t.Fatalf("secrets_json not valid JSON: %v", err)
+	}
+	if len(got) != 3 || got[0] != "aws-creds" || got[1] != "build-bot-token-abc" || got[2] != "github-token" {
+		t.Fatalf("secrets_json = %#v (must be sorted by name only — no UID/ResourceVersion)", got)
+	}
+}
+
+// ─── Fixture 3: with image pull secrets ───────────────────────────────────
+
+func TestServiceAccountToEvent_WithImagePullSecrets(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "deploy-bot"},
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: "ghcr-creds"},
+			{Name: "dockerhub-creds"},
+		},
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionCreated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+
+	if ev.Metadata["image_pull_secrets_count"] != "2" {
+		t.Fatalf("image_pull_secrets_count = %q", ev.Metadata["image_pull_secrets_count"])
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(ev.Metadata["image_pull_secrets_json"]), &got); err != nil {
+		t.Fatalf("image_pull_secrets_json not valid JSON: %v", err)
+	}
+	if len(got) != 2 || got[0] != "dockerhub-creds" || got[1] != "ghcr-creds" {
+		t.Fatalf("image_pull_secrets_json = %#v (must be sorted)", got)
+	}
+}
+
+// ─── Fixture 4: automount true / false ────────────────────────────────────
+
+func TestServiceAccountToEvent_AutomountTrue(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta:                   metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+		AutomountServiceAccountToken: boolPtr(true),
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+	if ev.Metadata["automount_service_account_token"] != "true" {
+		t.Fatalf("automount = %q", ev.Metadata["automount_service_account_token"])
+	}
+}
+
+func TestServiceAccountToEvent_AutomountFalse(t *testing.T) {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta:                   metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+		AutomountServiceAccountToken: boolPtr(false),
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+	if ev.Metadata["automount_service_account_token"] != "false" {
+		t.Fatalf("automount = %q", ev.Metadata["automount_service_account_token"])
+	}
+}
+
+// ─── Determinism: two mappings of the same input produce identical bytes ──
+
+func TestServiceAccountToEvent_DeterministicJSON(t *testing.T) {
+	build := func() *corev1.ServiceAccount {
+		return &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+			Secrets: []corev1.ObjectReference{
+				{Name: "z-secret"}, {Name: "a-secret"}, {Name: "m-secret"},
+			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: "z-pull"}, {Name: "a-pull"},
+			},
+		}
+	}
+	a := entity.ServiceAccountToEvent(build(), entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+	b := entity.ServiceAccountToEvent(build(), entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+
+	if a.Metadata["secrets_json"] != b.Metadata["secrets_json"] {
+		t.Fatalf("non-deterministic secrets_json:\nA: %s\nB: %s", a.Metadata["secrets_json"], b.Metadata["secrets_json"])
+	}
+	if a.Metadata["image_pull_secrets_json"] != b.Metadata["image_pull_secrets_json"] {
+		t.Fatalf("non-deterministic image_pull_secrets_json:\nA: %s\nB: %s", a.Metadata["image_pull_secrets_json"], b.Metadata["image_pull_secrets_json"])
+	}
+	if a.Metadata["secrets_json"] != `["a-secret","m-secret","z-secret"]` {
+		t.Fatalf("secrets_json not in expected sorted form: %s", a.Metadata["secrets_json"])
+	}
+}
+
+// ─── Default namespace fallback ───────────────────────────────────────────
+
+func TestServiceAccountToEvent_EmptyNamespaceFallsBackToDefault(t *testing.T) {
+	sa := &corev1.ServiceAccount{}
+	sa.Name = "x"
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ServiceAccount/default/x" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["namespace"] != "default" {
+		t.Fatalf("namespace = %q", ev.Metadata["namespace"])
+	}
+}
+
+// ─── Critical security check: Secret VALUES must NEVER appear in metadata ──
+
+func TestServiceAccountToEvent_SecretValuesNeverLeak(t *testing.T) {
+	// ObjectReference doesn't carry data, but a future type-change could
+	// add fields. This belt-and-braces check encodes the invariant.
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "build-bot"},
+		Secrets: []corev1.ObjectReference{
+			{Name: "leaks-via-uid", UID: "secret-uid-do-not-leak"},
+			{Name: "leaks-via-rv", ResourceVersion: "secret-rv-do-not-leak"},
+		},
+	}
+	ev := entity.ServiceAccountToEvent(sa, entity.ActionUpdated, saTestWorkspace, saTestClusterID, saTestClusterName, saTestNow)
+	for _, v := range ev.Metadata {
+		if v == "secret-uid-do-not-leak" || v == "secret-rv-do-not-leak" {
+			t.Fatalf("Secret reference UID/ResourceVersion leaked into metadata; emit names only")
+		}
+	}
+	// Names are fine to emit.
+	got := ev.Metadata["secrets_json"]
+	if got == "" {
+		t.Fatalf("secrets_json missing; expected names")
+	}
+}


### PR DESCRIPTION
Closes #206. Sub-task of epic #199 (v0.4 default-flip parity push).

## Summary

Adds a `core/v1 ServiceAccount` watcher mirroring the LimitRange (#202, PR #203) / ResourceQuota (#204, PR #205) shape. Closes one of 8 remaining NOT-COVERED operator gaps blocking the v0.4 default-flip of `OMNISCIENCE_K8S_AGENTIC_ALLOWED=false`.

After this PR merges, **7 NOT-COVERED gaps remain**: PVC, CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HPA.

## What landed

1. **`entity.ServiceAccountToEvent` mapper** (`operator/internal/entity/serviceaccount_mapper.go`)
   - Renders `.Secrets[]` as deterministic sorted JSON of NAMES ONLY (no UID, no ResourceVersion — never values, ever)
   - Renders `.ImagePullSecrets[]` as deterministic sorted JSON of NAMES
   - Renders `.AutomountServiceAccountToken` as `"true"` / `"false"` / `""` (nil)
   - Closed metadata allow-list: cluster, cluster_id, namespace, name, kind, emitter, secrets_count, secrets_json, image_pull_secrets_count, image_pull_secrets_json, automount_service_account_token
   - User labels / annotations never copied through (ACL invariant per ADR-0007 §ACL)
   - Belt-and-braces test asserts Secret reference UID/ResourceVersion never leak

2. **`ServiceAccountReconciler`** (`operator/internal/controller/serviceaccount_controller.go`)
   - Same shape as `serviceaccount_controller.go` peers: Get → upsert publish, IsNotFound → deletion stub
   - `RecordEmit("ServiceAccount", &sa)` called BEFORE `Publish` on the upsert branch only — matches the placement wired across the other 25 controllers
   - Wired into the existing #158 setup helper in `cmd/manager/main.go`
   - Added to `buildCacheSizeKinds` unconditional list so `informer_cache_objects{kind="ServiceAccount"}` reports

3. **Tests**: 10 mapper unit tests + 7 controller tests = 17 new tests (all passing)
   - Mapper: envelope, ACL allow-list, default SA, with secrets, with image pull secrets, automount true/false, deterministic JSON, namespace fallback, Secret-value-leak invariant
   - Controller: 4 preconditions + create/update/delete lifecycle

4. **RBAC + docs**:
   - `helm/omniscience-operator/templates/rbac.yaml` clusterrole gains `get`/`list`/`watch` on `serviceaccounts` only
   - Parity matrix flips `ServiceAccount` row to **COVERED** with PR/issue ref; rollup counts bumped (COVERED 16→17, NOT-COVERED 9→8)
   - Release-blocker checklist: ServiceAccount struck through with #206 reference
   - CHANGELOG \`[Unreleased] → Added\` entry

## Quality gates actually run

| Gate | Result |
|------|--------|
| \`go build ./...\` | green |
| \`go vet ./...\` | green |
| \`go test -race -count=1 ./...\` | **221 / 221 pass** in 8 packages |
| \`TestACL_NoForbiddenLabels\` | pass |
| \`TestACL_WorkspaceIDInfoLabels_AreSafe\` | pass |
| Grep audit \`WithLabelValues\` / \`MustRegisterWith\` on changed files | zero hits — clean |
| \`helm lint helm/omniscience-operator\` | clean |
| \`go mod tidy\` | clean (no new deps; \`core/v1\` ServiceAccount already imported transitively) |

## Gates deferred to CI / reviewer

- \`golangci-lint v1.61\` with project config (same posture as #201, #203, #205)
- Kind-cluster smoke (no kind binary locally) — please verify \`informer_cache_objects{kind=\"ServiceAccount\"}\` panel lights up after install

## Solo execution disclosure

Same situation as PRs #201, #203, #205: agent-spawn primitive does not register a callable schema. Lead executed all four roles in this single session, applying every gate the multi-role team would have. Real multi-perspective review process did not happen.

## Scope guardrails respected

Did NOT touch:
- The \`RecordEmit\` helper itself (#198)
- The 7 other NOT-COVERED gaps from epic #199 (separate issues each)
- \`OMNISCIENCE_K8S_AGENTIC_ALLOWED\` server-side flag wiring (separate issue)
- \`apps/server/\`, \`packages/connectors/\` — different components
- Secret content (only Secret reference NAMES emitted; values are the Secret watcher's domain per #166)