### PR TITLE
feat: operator PersistentVolumeClaim watcher (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tracked under epic #199. RBAC adds `get`/`list`/`watch` on
   `serviceaccounts`; no other verbs.
 
+- **Operator: `PersistentVolumeClaim` watcher (issue #208).** The
+  operator now watches `core/v1 PersistentVolumeClaim` cluster-wide and
+  emits access modes, storage class, bound PV name, volume mode,
+  requests/limits storage, and status phase. Closes one of the v0.4
+  default-flip parity gaps tracked under epic #199. RBAC adds
+  `get`/`list`/`watch` on `persistentvolumeclaims`; no other verbs.
+
 ### Deprecated
 
 - **`k8s-agentic` connector deprecation announced (issue #168, ADR-0011).**

--- a/docs/connectors/k8s-agentic-vs-operator-parity.md
+++ b/docs/connectors/k8s-agentic-vs-operator-parity.md
@@ -62,7 +62,7 @@ migration described in the
 | `Namespace` | yes | yes (`namespace_controller.go`, `namespace.go`) | **COVERED** | Operator additionally emits a synthetic `Cluster` anchor (issue #159) — strict superset. |
 | `Node` | yes | yes (`node_controller.go`, `node.go`) | **COVERED** | |
 | `PersistentVolume` | yes | yes (`persistentvolume_controller.go`, `persistentvolume.go`) | **COVERED** | |
-| `PersistentVolumeClaim` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Operator covers `PersistentVolume` but not `PersistentVolumeClaim`. Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+| `PersistentVolumeClaim` | yes | yes (`persistentvolumeclaim_controller.go`, `persistentvolumeclaim_mapper.go`) | **COVERED** | Operator emits via watch (issue #208). Mapper renders access modes (sorted JSON), storage class name, bound PV name, volume mode, requests/limits storage, and status phase. Namespace appears only in `external_id` and base metadata, never as a metric label. |
 | `Pod` | yes | yes (`pod_controller.go`, `entity.go::PodToEvent`) | **COVERED** | Note: agentic's `_DEFAULT_EXCLUDE_KINDS` lists Pod, but the LLM is allowed to override and the explicit `_KIND_CORE` mapping is present. Operator covers Pod as a first-class kind. |
 | `ReplicationController` | yes (`_KIND_CORE`) | **no** | **NOT-COVERED** (low priority) | Legacy kind; superseded by `ReplicaSet` upstream. Most clusters have zero `ReplicationController` resources. **Acceptable v0.5 gap** if customer telemetry confirms zero usage; flagged for explicit confirmation before v0.4 cut. |
 | `ResourceQuota` | yes | yes (`resourcequota_controller.go`, `resourcequota_mapper.go`) | **COVERED** | Operator emits via watch (issue #204). Mapper renders `spec.hard`, `spec.scopes`, and `spec.scopeSelector` as deterministic JSON in metadata; namespace appears only in `external_id` and base metadata, never as a metric label. |
@@ -156,23 +156,23 @@ migration described in the
 
 | Status | Count | Kinds |
 |---|---|---|
-| **COVERED** | 17 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota, ServiceAccount |
+| **COVERED** | 18 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota, ServiceAccount, PersistentVolumeClaim |
 | **PARTIAL** | 7 | Argo Rollouts (Rollout), ArgoCD (Application, ApplicationSet), DRA (DeviceClass, ResourceClaim, ResourceClaimTemplate, ResourceSlice) — all gated on customer cluster CRD installation |
-| **NOT-COVERED** | 8 | PersistentVolumeClaim, ReplicationController (low priority), CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
+| **NOT-COVERED** | 7 | ReplicationController (low priority), CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
 | **OPERATOR-ONLY** | 3 | Secret (redacted), StorageClass, Cluster (synthetic) |
 | **NEITHER** | 1 | Event |
 
-Total: 17 + 7 + 8 + 3 + 1 = **36 rows**.
+Total: 18 + 7 + 7 + 3 + 1 = **36 rows**.
 
 ### Release-blocker summary for v0.4 default-disable
 
-The following 7 kinds are **NOT-COVERED** by the operator and emit
+The following 6 kinds are **NOT-COVERED** by the operator and emit
 from the agentic connector's `_DEFAULT_INCLUDE_KINDS`. Each must be
 addressed before the v0.4 release flips
 `OMNISCIENCE_K8S_AGENTIC_ALLOWED` to `false` by default:
 
 1. ~~`LimitRange`~~ — **DONE** in issue #202 (namespace resource caps).
-2. `PersistentVolumeClaim` — persistent storage requests
+2. ~~`PersistentVolumeClaim`~~ — **DONE** in issue #208 (persistent storage requests).
 3. ~~`ResourceQuota`~~ — **DONE** in issue #204 (namespace quota enforcement).
 4. ~~`ServiceAccount`~~ — **DONE** in issue #206 (workload identity).
 5. `CronJob` — scheduled batch workloads

--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -58,6 +58,13 @@ rules:
     resources: ["serviceaccounts"]
     verbs: ["get", "list", "watch"]
   # ── end #206 ──────────────────────────────────────────────────────────
+  # ── #208 PersistentVolumeClaim watcher (epic #199 v0.4 parity) ────────
+  # Read-only verbs only. PVC is namespaced under core/v1; the bound PV
+  # is already covered cluster-wide by #159.
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  # ── end #208 ──────────────────────────────────────────────────────────
   # --- BEGIN issue #159: cluster-scoped watcher RBAC ---
   # Node, Namespace, PersistentVolume — all cluster-scoped under the core
   # API group. ClusterRole + ClusterRoleBinding above already grants the

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -466,6 +466,12 @@ func setupNetworkingAndConfigWatchers(
 	} else if err := sa.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("serviceaccount reconciler setup: %w", err)
 	}
+	// ── #208 PersistentVolumeClaim watcher (epic #199 v0.4 parity) ─────────
+	if pvc, err := controller.NewPersistentVolumeClaimReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("persistentvolumeclaim reconciler init: %w", err)
+	} else if err := pvc.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("persistentvolumeclaim reconciler setup: %w", err)
+	}
 	return nil
 }
 
@@ -667,6 +673,8 @@ func buildCacheSizeKinds(mgr ctrl.Manager, argoPresent bool, logger interface {
 		{kind: "ResourceQuota", listFactory: func() client.ObjectList { return &corev1.ResourceQuotaList{} }},
 		// Identity (#206)
 		{kind: "ServiceAccount", listFactory: func() client.ObjectList { return &corev1.ServiceAccountList{} }},
+		// Storage claims (#208)
+		{kind: "PersistentVolumeClaim", listFactory: func() client.ObjectList { return &corev1.PersistentVolumeClaimList{} }},
 		// Cluster-scoped (#159)
 		{kind: "Node", listFactory: func() client.ObjectList { return &corev1.NodeList{} }},
 		{kind: "Namespace", listFactory: func() client.ObjectList { return &corev1.NamespaceList{} }},

--- a/operator/internal/controller/persistentvolumeclaim_controller.go
+++ b/operator/internal/controller/persistentvolumeclaim_controller.go
@@ -1,0 +1,105 @@
+// persistentvolumeclaim_controller.go: controller for corev1.PersistentVolumeClaim (issue #208).
+//
+// Sub-task of epic #199 (v0.4 default-flip parity push). Mirrors the
+// LimitRange (#202) / ResourceQuota (#204) / ServiceAccount (#206) shape.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// PersistentVolumeClaimReconciler watches PVCs and publishes change events.
+type PersistentVolumeClaimReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewPersistentVolumeClaimReconciler returns a reconciler with sane
+// defaults. Same precondition checks as every other controller.
+func NewPersistentVolumeClaimReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*PersistentVolumeClaimReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &PersistentVolumeClaimReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every PVC add / update /
+// delete.
+func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"persistentvolumeclaim", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var pvc corev1.PersistentVolumeClaim
+	err := r.Client.Get(ctx, req.NamespacedName, &pvc)
+	switch {
+	case err == nil:
+		ev := entity.PersistentVolumeClaimToEvent(&pvc, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("PersistentVolumeClaim", &pvc) // #198/#201 freshness probe
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish persistentvolumeclaim event: %w", perr)
+		}
+		logger.V(1).Info("published persistentvolumeclaim upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &corev1.PersistentVolumeClaim{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.PersistentVolumeClaimToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish persistentvolumeclaim deletion: %w", perr)
+		}
+		logger.V(1).Info("published persistentvolumeclaim deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get persistentvolumeclaim failed")
+		return ctrl.Result{}, fmt.Errorf("get persistentvolumeclaim %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.PersistentVolumeClaim{}).
+		Named("persistentvolumeclaim-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/persistentvolumeclaim_controller_test.go
+++ b/operator/internal/controller/persistentvolumeclaim_controller_test.go
@@ -1,0 +1,172 @@
+// persistentvolumeclaim_controller_test.go: tests for PersistentVolumeClaimReconciler (#208).
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/100rd/omniscience/operator/internal/controller"
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+func pvcCtrlQty(s string) resource.Quantity { return resource.MustParse(s) }
+
+// ─── Constructor preconditions ─────────────────────────────────────────────
+
+func TestNewPVCReconciler_RejectsZeroWorkspace(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewPersistentVolumeClaimReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+}
+
+func TestNewPVCReconciler_RejectsNilPublisher(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewPersistentVolumeClaimReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+}
+
+func TestNewPVCReconciler_RejectsEmptyClusterName(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewPersistentVolumeClaimReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+}
+
+func TestNewPVCReconciler_RejectsNilClient(t *testing.T) {
+	if _, err := controller.NewPersistentVolumeClaimReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+// ─── Lifecycle: create / update / delete ───────────────────────────────────
+
+func pvcFixture(ns, name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: pvcCtrlQty("10Gi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+}
+
+func TestPVCReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	pvc := pvcFixture("team-a", "data")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pvc).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewPersistentVolumeClaimReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "data")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	ev := got[0]
+	if ev.Action != entity.ActionUpdated {
+		t.Fatalf("action = %q", ev.Action)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/PersistentVolumeClaim/team-a/data" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["status_phase"] != "Pending" {
+		t.Fatalf("status_phase = %q", ev.Metadata["status_phase"])
+	}
+	if ev.Metadata["requests_storage"] != "10Gi" {
+		t.Fatalf("requests_storage = %q", ev.Metadata["requests_storage"])
+	}
+}
+
+// Update path: status phase change between reconciles flows through.
+func TestPVCReconciler_UpdateEmitsSecondUpdated(t *testing.T) {
+	s := newScheme(t)
+	pvc := pvcFixture("team-a", "data")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pvc).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewPersistentVolumeClaimReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, req("team-a", "data")); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	var live corev1.PersistentVolumeClaim
+	if err := c.Get(ctx, req("team-a", "data").NamespacedName, &live); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	live.Status.Phase = corev1.ClaimBound
+	live.Spec.VolumeName = "pv-12345"
+	if err := c.Update(ctx, &live); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if _, err := r.Reconcile(ctx, req("team-a", "data")); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("publisher saw %d events, want 2", len(got))
+	}
+	if got[0].Metadata["status_phase"] != "Pending" {
+		t.Fatalf("first status_phase = %q", got[0].Metadata["status_phase"])
+	}
+	if got[1].Metadata["volume_name"] != "pv-12345" {
+		t.Fatalf("second volume_name = %q (update should reflect bound state)", got[1].Metadata["volume_name"])
+	}
+}
+
+// Delete path: empty client → IsNotFound → Deleted event for stub.
+func TestPVCReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewPersistentVolumeClaimReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "data")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	if got[0].Action != entity.ActionDeleted {
+		t.Fatalf("action = %q", got[0].Action)
+	}
+	if got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/PersistentVolumeClaim/team-a/data" {
+		t.Fatalf("external_id = %q", got[0].ExternalID)
+	}
+	if got[0].Metadata["status_phase"] != "" {
+		t.Fatalf("stub deletion should have empty status; status_phase = %q", got[0].Metadata["status_phase"])
+	}
+}

--- a/operator/internal/entity/persistentvolumeclaim_mapper.go
+++ b/operator/internal/entity/persistentvolumeclaim_mapper.go
@@ -1,0 +1,117 @@
+// persistentvolumeclaim_mapper.go: corev1.PersistentVolumeClaim -> Event mapper (issue #208).
+//
+// PersistentVolumeClaim is a namespaced storage request. The mapper emits
+// ONLY the closed allow-list of fields from baseMetadata plus a flat
+// representation of the spec essentials (access modes, storage class,
+// bound PV name, volume mode, requests/limits storage) and the status
+// phase.
+//
+// SECURITY POSTURE — same as every other operator mapper:
+//
+//   - User-supplied labels and annotations are NEVER copied through.
+//   - `namespace` appears in baseMetadata + external_id ONLY.
+//   - `selector` (label selector) is NEVER emitted — it would leak labels.
+//   - `dataSource` / `dataSourceRef` are NEVER emitted — they reference
+//     other resources (snapshots, PVCs) and are graph-linking concerns
+//     better expressed via separate edges if needed.
+package entity
+
+import (
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EntityKindPersistentVolumeClaim is the K8s kind segment in PVC external_ids.
+const EntityKindPersistentVolumeClaim = "PersistentVolumeClaim"
+
+// PersistentVolumeClaimToEvent maps a corev1.PersistentVolumeClaim plus an
+// action into an Event. Pure function — no I/O, no clients, no clock beyond
+// `now`.
+//
+// Emitted metadata:
+//
+//   - Base allow-list: cluster, cluster_id, namespace, name, kind, emitter
+//   - "access_modes_json":   sorted JSON array of access mode strings
+//                            (e.g. ["ReadWriteOnce"]). Absent when empty.
+//   - "storage_class_name":  string; empty when nil. The empty string is
+//                            distinct from a literal "" storage class name
+//                            (cluster-default storage class) — be aware.
+//   - "volume_name":         the bound PV name; empty when unbound.
+//   - "volume_mode":         "Filesystem" / "Block"; empty when nil.
+//   - "requests_storage":    storage request quantity (.String()); empty
+//                            when not set.
+//   - "limits_storage":      storage limit quantity (.String()); empty
+//                            when not set.
+//   - "status_phase":        "Pending" / "Bound" / "Lost"; empty when not set.
+func PersistentVolumeClaimToEvent(pvc *corev1.PersistentVolumeClaim, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(pvc.Namespace)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindPersistentVolumeClaim, pvc.Name)
+
+	if len(pvc.Spec.AccessModes) > 0 {
+		raw, err := marshalAccessModes(pvc.Spec.AccessModes)
+		if err != nil {
+			meta["access_modes_json"] = ""
+		} else {
+			meta["access_modes_json"] = raw
+		}
+	}
+
+	if pvc.Spec.StorageClassName != nil {
+		meta["storage_class_name"] = *pvc.Spec.StorageClassName
+	} else {
+		meta["storage_class_name"] = ""
+	}
+
+	meta["volume_name"] = pvc.Spec.VolumeName
+
+	if pvc.Spec.VolumeMode != nil {
+		meta["volume_mode"] = string(*pvc.Spec.VolumeMode)
+	} else {
+		meta["volume_mode"] = ""
+	}
+
+	if q, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+		meta["requests_storage"] = q.String()
+	} else {
+		meta["requests_storage"] = ""
+	}
+
+	if q, ok := pvc.Spec.Resources.Limits[corev1.ResourceStorage]; ok {
+		meta["limits_storage"] = q.String()
+	} else {
+		meta["limits_storage"] = ""
+	}
+
+	meta["status_phase"] = string(pvc.Status.Phase)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindPersistentVolumeClaim, namespace, pvc.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindPersistentVolumeClaim, pvc.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// marshalAccessModes renders []PersistentVolumeAccessMode as a sorted JSON
+// array of strings. Sorting keeps the output stable across operator
+// restarts.
+func marshalAccessModes(modes []corev1.PersistentVolumeAccessMode) (string, error) {
+	out := make([]string, 0, len(modes))
+	for _, m := range modes {
+		out = append(out, string(m))
+	}
+	sort.Strings(out)
+	b, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/operator/internal/entity/persistentvolumeclaim_mapper_test.go
+++ b/operator/internal/entity/persistentvolumeclaim_mapper_test.go
@@ -1,0 +1,250 @@
+// persistentvolumeclaim_mapper_test.go: pure unit tests for PersistentVolumeClaimToEvent (#208).
+package entity_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+var (
+	pvcTestWorkspace   = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	pvcTestClusterID   = uuid.MustParse("99999999-8888-7777-6666-555555555555")
+	pvcTestClusterName = "prod-eu"
+	pvcTestNow         = time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+)
+
+func pvcQty(s string) resource.Quantity { return resource.MustParse(s) }
+
+func strPtr(s string) *string { return &s }
+
+func volModePtr(m corev1.PersistentVolumeMode) *corev1.PersistentVolumeMode { return &m }
+
+// ─── Envelope ─────────────────────────────────────────────────────────────
+
+func TestPVCToEvent_EnvelopeStampsWorkspaceFromConfig(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "data",
+			Labels: map[string]string{
+				"omniscience.io/workspace": "evil-ws",
+				"team":                     "platform",
+			},
+			Annotations: map[string]string{
+				"omniscience.io/index-data": "true",
+			},
+		},
+	}
+	ev := entity.PersistentVolumeClaimToEvent(pvc, entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+
+	if ev.WorkspaceID != pvcTestWorkspace {
+		t.Fatalf("workspace_id = %s, want %s — adversarial label honoured!", ev.WorkspaceID, pvcTestWorkspace)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/PersistentVolumeClaim/team-a/data" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.URI != "kube://prod-eu/team-a/PersistentVolumeClaim/data" {
+		t.Fatalf("uri = %q", ev.URI)
+	}
+	if !ev.EmittedAt.Equal(pvcTestNow) {
+		t.Fatalf("emitted_at = %s", ev.EmittedAt)
+	}
+}
+
+// ACL invariant: only the closed allow-list of metadata keys is emitted.
+func TestPVCToEvent_ACL_NoUserLabelsOrAnnotationsLeak(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "data",
+			Labels: map[string]string{
+				"team":          "platform",
+				"cost-center":   "eng-42",
+				"app.k8s.io/of": "checkout",
+			},
+			Annotations: map[string]string{
+				"description": "team-a data volume",
+				"owner":       "alice@example.com",
+			},
+		},
+	}
+	ev := entity.PersistentVolumeClaimToEvent(pvc, entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+
+	allowed := map[string]struct{}{
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"access_modes_json": {}, "storage_class_name": {}, "volume_name": {}, "volume_mode": {},
+		"requests_storage": {}, "limits_storage": {}, "status_phase": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("metadata leaked key %q (value=%q) — ACL allow-list violated", k, ev.Metadata[k])
+		}
+	}
+	for forbidden := range pvc.Labels {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user label %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+	for forbidden := range pvc.Annotations {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user annotation %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+}
+
+// ─── Fixture 1: unbound PVC (Pending), nothing set yet ────────────────────
+
+func TestPVCToEvent_UnboundPending(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "data"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: pvcQty("10Gi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+	ev := entity.PersistentVolumeClaimToEvent(pvc, entity.ActionCreated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+
+	if ev.Metadata["status_phase"] != "Pending" {
+		t.Fatalf("status_phase = %q", ev.Metadata["status_phase"])
+	}
+	if ev.Metadata["volume_name"] != "" {
+		t.Fatalf("volume_name = %q (should be empty when unbound)", ev.Metadata["volume_name"])
+	}
+	if ev.Metadata["requests_storage"] != "10Gi" {
+		t.Fatalf("requests_storage = %q", ev.Metadata["requests_storage"])
+	}
+	var modes []string
+	if err := json.Unmarshal([]byte(ev.Metadata["access_modes_json"]), &modes); err != nil {
+		t.Fatalf("access_modes_json: %v", err)
+	}
+	if len(modes) != 1 || modes[0] != "ReadWriteOnce" {
+		t.Fatalf("access_modes = %#v", modes)
+	}
+}
+
+// ─── Fixture 2: bound PVC with storage class, volume name, multiple access modes ──
+
+func TestPVCToEvent_BoundWithStorageClass(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "data"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce, corev1.ReadOnlyMany},
+			StorageClassName: strPtr("fast-ssd"),
+			VolumeName:       "pv-12345",
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: pvcQty("100Gi")},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound},
+	}
+	ev := entity.PersistentVolumeClaimToEvent(pvc, entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+
+	if ev.Metadata["status_phase"] != "Bound" {
+		t.Fatalf("status_phase = %q", ev.Metadata["status_phase"])
+	}
+	if ev.Metadata["volume_name"] != "pv-12345" {
+		t.Fatalf("volume_name = %q", ev.Metadata["volume_name"])
+	}
+	if ev.Metadata["storage_class_name"] != "fast-ssd" {
+		t.Fatalf("storage_class_name = %q", ev.Metadata["storage_class_name"])
+	}
+	var modes []string
+	if err := json.Unmarshal([]byte(ev.Metadata["access_modes_json"]), &modes); err != nil {
+		t.Fatalf("access_modes_json: %v", err)
+	}
+	if len(modes) != 2 || modes[0] != "ReadOnlyMany" || modes[1] != "ReadWriteOnce" {
+		t.Fatalf("access_modes = %#v (must be sorted)", modes)
+	}
+}
+
+// ─── Fixture 3: with limits, Block volume mode ────────────────────────────
+
+func TestPVCToEvent_WithLimitsAndBlockVolumeMode(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "raw-block"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			VolumeMode:  volModePtr(corev1.PersistentVolumeBlock),
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: pvcQty("50Gi")},
+				Limits:   corev1.ResourceList{corev1.ResourceStorage: pvcQty("100Gi")},
+			},
+		},
+	}
+	ev := entity.PersistentVolumeClaimToEvent(pvc, entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+	if ev.Metadata["volume_mode"] != "Block" {
+		t.Fatalf("volume_mode = %q", ev.Metadata["volume_mode"])
+	}
+	if ev.Metadata["limits_storage"] != "100Gi" {
+		t.Fatalf("limits_storage = %q", ev.Metadata["limits_storage"])
+	}
+	if ev.Metadata["requests_storage"] != "50Gi" {
+		t.Fatalf("requests_storage = %q", ev.Metadata["requests_storage"])
+	}
+}
+
+// ─── Fixture 4: nil storage class pointer (uses cluster default) ──────────
+
+func TestPVCToEvent_NilStorageClass(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "default-sc"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			// StorageClassName explicitly nil — falls back to cluster default.
+		},
+	}
+	ev := entity.PersistentVolumeClaimToEvent(pvc, entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+	if ev.Metadata["storage_class_name"] != "" {
+		t.Fatalf("storage_class_name = %q, want empty for nil pointer", ev.Metadata["storage_class_name"])
+	}
+	if ev.Metadata["volume_mode"] != "" {
+		t.Fatalf("volume_mode = %q, want empty for nil pointer", ev.Metadata["volume_mode"])
+	}
+}
+
+// ─── Determinism ──────────────────────────────────────────────────────────
+
+func TestPVCToEvent_DeterministicAccessModesJSON(t *testing.T) {
+	build := func() *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				// Reverse-alphabetical — mapper must sort.
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany, corev1.ReadOnlyMany, corev1.ReadWriteOnce},
+			},
+		}
+	}
+	a := entity.PersistentVolumeClaimToEvent(build(), entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+	b := entity.PersistentVolumeClaimToEvent(build(), entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+	if a.Metadata["access_modes_json"] != b.Metadata["access_modes_json"] {
+		t.Fatalf("non-deterministic access_modes_json:\nA: %s\nB: %s", a.Metadata["access_modes_json"], b.Metadata["access_modes_json"])
+	}
+	if a.Metadata["access_modes_json"] != `["ReadOnlyMany","ReadWriteMany","ReadWriteOnce"]` {
+		t.Fatalf("access_modes_json not in expected sorted form: %s", a.Metadata["access_modes_json"])
+	}
+}
+
+// ─── Default namespace fallback ───────────────────────────────────────────
+
+func TestPVCToEvent_EmptyNamespaceFallsBackToDefault(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	pvc.Name = "x"
+	ev := entity.PersistentVolumeClaimToEvent(pvc, entity.ActionUpdated, pvcTestWorkspace, pvcTestClusterID, pvcTestClusterName, pvcTestNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/PersistentVolumeClaim/default/x" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["namespace"] != "default" {
+		t.Fatalf("namespace = %q", ev.Metadata["namespace"])
+	}
+}


### PR DESCRIPTION
Closes #208. Sub-task of epic #199 (v0.4 default-flip parity push).

## Summary

Adds a `core/v1 PersistentVolumeClaim` watcher mirroring the LimitRange (#202, PR #203) / ResourceQuota (#204, PR #205) / ServiceAccount (#206, PR #207) shape. The operator already covered `PersistentVolume` cluster-wide (#159) — this adds the namespaced PVC counterpart.

After this PR merges, **6 NOT-COVERED gaps remain**: CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HPA.

## What landed

1. **`entity.PersistentVolumeClaimToEvent` mapper**
   - Renders `spec.accessModes` as deterministic sorted JSON
   - Renders `spec.storageClassName` (with explicit empty string for nil pointer — distinct from literal "")
   - Renders `spec.volumeName` (bound PV name; empty when unbound)
   - Renders `spec.volumeMode` (Filesystem/Block; empty when nil)
   - Renders `spec.resources.requests/limits` storage as canonical quantity strings
   - Renders `status.phase` (Pending/Bound/Lost)
   - Excluded by design: `dataSource`/`dataSourceRef` (graph-linking concerns), `selector` (label leak risk), user labels/annotations
   - Closed metadata allow-list: cluster, cluster_id, namespace, name, kind, emitter, access_modes_json, storage_class_name, volume_name, volume_mode, requests_storage, limits_storage, status_phase

2. **`PersistentVolumeClaimReconciler`**
   - Same shape as peers: Get → upsert publish, IsNotFound → deletion stub
   - `RecordEmit("PersistentVolumeClaim", obj)` BEFORE `Publish` on the upsert branch only — matches the placement across the other 26 controllers
   - Wired into the existing #158 setup helper in `cmd/manager/main.go`
   - Added to `buildCacheSizeKinds` unconditional list

3. **Tests**: 7 mapper unit tests + 7 controller tests = 14 new tests (all passing)
   - Mapper: envelope, ACL allow-list, unbound Pending, bound with storage class + multiple access modes, with limits + Block volume mode, nil storage class, deterministic JSON, namespace fallback
   - Controller: 4 preconditions + create/update (with Pending→Bound status transition)/delete lifecycle

4. **RBAC + docs**:
   - Helm clusterrole gains `get`/`list`/`watch` on `persistentvolumeclaims` only
   - Parity matrix flips PVC row to **COVERED**; rollup counts bumped (COVERED 17→18, NOT-COVERED 8→7)
   - Release-blocker checklist: PVC struck through with #208 reference
   - CHANGELOG \`[Unreleased] → Added\` entry

## Quality gates actually run

| Gate | Result |
|------|--------|
| \`go build ./...\` | green |
| \`go vet ./...\` | green |
| \`go test -race -count=1 ./...\` | **236 / 236 pass** in 8 packages |
| \`TestACL_NoForbiddenLabels\` | pass |
| \`TestACL_WorkspaceIDInfoLabels_AreSafe\` | pass |
| Grep audit \`WithLabelValues\` / \`MustRegisterWith\` on changed files | zero hits |
| \`helm lint helm/omniscience-operator\` | clean |
| \`go mod tidy\` | clean (no new deps) |

## Gates deferred to CI / reviewer

- \`golangci-lint v1.61\` with project config (same posture as #201, #203, #205, #207)
- Kind-cluster smoke (no kind binary locally)

## Solo execution disclosure

Same situation as PRs #201, #203, #205, #207: agent-spawn primitive does not register a callable schema. Lead executed all four roles in this single session, applying every gate the multi-role team would have. Real multi-perspective review process did not happen.

## Scope guardrails respected

Did NOT touch:
- The \`RecordEmit\` helper itself (#198)
- The 6 other NOT-COVERED gaps from epic #199 (separate issues each)
- \`OMNISCIENCE_K8S_AGENTIC_ALLOWED\` server-side flag wiring (separate issue)
- \`apps/server/\`, \`packages/connectors/\` — different components
- VolumeSnapshot CRD coverage — separate concern