### PR TITLE
feat: operator CronJob watcher (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default-flip parity gaps tracked under epic #199. RBAC adds
   `get`/`list`/`watch` on `persistentvolumeclaims`; no other verbs.
 
+- **Operator: `CronJob` watcher (issue #210).** The operator now
+  watches `batch/v1 CronJob` cluster-wide and emits schedule, timezone,
+  suspend, concurrencyPolicy, deadline/history limits, and status
+  (lastScheduleTime, lastSuccessfulTime, active job count). The embedded
+  JobTemplate is intentionally not emitted — the existing Job watcher
+  (#157) covers the spawned Jobs. Closes one of the v0.4 default-flip
+  parity gaps tracked under epic #199. RBAC adds `cronjobs` to the
+  existing `batch` apiGroup verbs; no new apiGroup added.
+
 ### Deprecated
 
 - **`k8s-agentic` connector deprecation announced (issue #168, ADR-0011).**

--- a/docs/connectors/k8s-agentic-vs-operator-parity.md
+++ b/docs/connectors/k8s-agentic-vs-operator-parity.md
@@ -88,7 +88,7 @@ migration described in the
 | Kind | agentic.emits | operator.emits | Status | Notes |
 |---|---|---|---|---|
 | `Job` | yes | yes (`job_controller.go`, `job.go`) | **COVERED** | |
-| `CronJob` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Operator covers `Job` but not `CronJob`. Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. |
+| `CronJob` | yes | yes (`cronjob_controller.go`, `cronjob_mapper.go`) | **COVERED** | Operator emits via watch (issue #210). Mapper renders schedule, timezone, suspend, concurrencyPolicy, deadline/history limits, and status (lastScheduleTime, lastSuccessfulTime, active count). The embedded JobTemplate is intentionally not emitted — the Job watcher (#157) covers the spawned Jobs. |
 
 ---
 
@@ -156,17 +156,17 @@ migration described in the
 
 | Status | Count | Kinds |
 |---|---|---|
-| **COVERED** | 18 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota, ServiceAccount, PersistentVolumeClaim |
+| **COVERED** | 19 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota, ServiceAccount, PersistentVolumeClaim, CronJob |
 | **PARTIAL** | 7 | Argo Rollouts (Rollout), ArgoCD (Application, ApplicationSet), DRA (DeviceClass, ResourceClaim, ResourceClaimTemplate, ResourceSlice) — all gated on customer cluster CRD installation |
-| **NOT-COVERED** | 7 | ReplicationController (low priority), CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
+| **NOT-COVERED** | 6 | ReplicationController (low priority), Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
 | **OPERATOR-ONLY** | 3 | Secret (redacted), StorageClass, Cluster (synthetic) |
 | **NEITHER** | 1 | Event |
 
-Total: 18 + 7 + 7 + 3 + 1 = **36 rows**.
+Total: 19 + 7 + 6 + 3 + 1 = **36 rows**.
 
 ### Release-blocker summary for v0.4 default-disable
 
-The following 6 kinds are **NOT-COVERED** by the operator and emit
+The following 5 kinds are **NOT-COVERED** by the operator and emit
 from the agentic connector's `_DEFAULT_INCLUDE_KINDS`. Each must be
 addressed before the v0.4 release flips
 `OMNISCIENCE_K8S_AGENTIC_ALLOWED` to `false` by default:
@@ -175,7 +175,7 @@ addressed before the v0.4 release flips
 2. ~~`PersistentVolumeClaim`~~ — **DONE** in issue #208 (persistent storage requests).
 3. ~~`ResourceQuota`~~ — **DONE** in issue #204 (namespace quota enforcement).
 4. ~~`ServiceAccount`~~ — **DONE** in issue #206 (workload identity).
-5. `CronJob` — scheduled batch workloads
+5. ~~`CronJob`~~ — **DONE** in issue #210 (scheduled batch workloads).
 6. `Role` — namespaced RBAC
 7. `RoleBinding` — namespaced RBAC binding
 8. `ClusterRole` — cluster-scoped RBAC

--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -18,10 +18,11 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
     verbs: ["get", "list", "watch"]
-  # Workload watcher (issue #157): Job. CronJob is deferred to a follow-up
-  # sub-issue — do NOT add "cronjobs" here until that issue lands.
+  # Workload watcher (issue #157): Job + CronJob (issue #210).
+  # CronJob is the parent template that spawns Jobs on a schedule; the Job
+  # watcher already covers the spawned Jobs themselves.
   - apiGroups: ["batch"]
-    resources: ["jobs"]
+    resources: ["jobs", "cronjobs"]
     verbs: ["get", "list", "watch"]
   # ── #158 networking + config watchers ──────────────────────────────────
   # Read-only verbs only. The Secret get/list permission is unavoidable for

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -472,6 +472,12 @@ func setupNetworkingAndConfigWatchers(
 	} else if err := pvc.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("persistentvolumeclaim reconciler setup: %w", err)
 	}
+	// ── #210 CronJob watcher (epic #199 v0.4 parity) ───────────────────────
+	if cj, err := controller.NewCronJobReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("cronjob reconciler init: %w", err)
+	} else if err := cj.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("cronjob reconciler setup: %w", err)
+	}
 	return nil
 }
 
@@ -675,6 +681,8 @@ func buildCacheSizeKinds(mgr ctrl.Manager, argoPresent bool, logger interface {
 		{kind: "ServiceAccount", listFactory: func() client.ObjectList { return &corev1.ServiceAccountList{} }},
 		// Storage claims (#208)
 		{kind: "PersistentVolumeClaim", listFactory: func() client.ObjectList { return &corev1.PersistentVolumeClaimList{} }},
+		// Scheduled batch (#210)
+		{kind: "CronJob", listFactory: func() client.ObjectList { return &batchv1.CronJobList{} }},
 		// Cluster-scoped (#159)
 		{kind: "Node", listFactory: func() client.ObjectList { return &corev1.NodeList{} }},
 		{kind: "Namespace", listFactory: func() client.ObjectList { return &corev1.NamespaceList{} }},

--- a/operator/internal/controller/cronjob_controller.go
+++ b/operator/internal/controller/cronjob_controller.go
@@ -1,0 +1,106 @@
+// cronjob_controller.go: controller for batchv1.CronJob (issue #210).
+//
+// Sub-task of epic #199 (v0.4 default-flip parity push). The Job watcher
+// from #157 already covers the actual Jobs that this CronJob spawns; this
+// adds the parent CronJob entity (schedule + status) without duplicating
+// the per-Job spec.
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// CronJobReconciler watches CronJobs and publishes change events.
+type CronJobReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+// NewCronJobReconciler returns a reconciler with sane defaults.
+func NewCronJobReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*CronJobReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &CronJobReconciler{
+		Client:      c,
+		Publisher:   pub,
+		WorkspaceID: workspaceID,
+		ClusterID:   clusterID,
+		ClusterName: clusterName,
+		Now:         time.Now,
+	}, nil
+}
+
+// Reconcile is invoked by controller-runtime on every CronJob add / update /
+// delete.
+func (r *CronJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues(
+		"cronjob", req.String(),
+		"workspace_id", r.WorkspaceID.String(),
+	)
+
+	var cj batchv1.CronJob
+	err := r.Client.Get(ctx, req.NamespacedName, &cj)
+	switch {
+	case err == nil:
+		ev := entity.CronJobToEvent(&cj, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("CronJob", &cj) // #198/#201 freshness probe
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish cronjob event: %w", perr)
+		}
+		logger.V(1).Info("published cronjob upsert", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	case apierrors.IsNotFound(err):
+		stub := &batchv1.CronJob{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.CronJobToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish deletion failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish cronjob deletion: %w", perr)
+		}
+		logger.V(1).Info("published cronjob deletion", "external_id", ev.ExternalID)
+		return ctrl.Result{}, nil
+
+	default:
+		logger.Error(err, "get cronjob failed")
+		return ctrl.Result{}, fmt.Errorf("get cronjob %s: %w", req.NamespacedName, err)
+	}
+}
+
+// SetupWithManager registers the reconciler with the manager.
+func (r *CronJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&batchv1.CronJob{}).
+		Named("cronjob-watcher").
+		Complete(r)
+}

--- a/operator/internal/controller/cronjob_controller_test.go
+++ b/operator/internal/controller/cronjob_controller_test.go
@@ -1,0 +1,169 @@
+// cronjob_controller_test.go: tests for CronJobReconciler (#210).
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/100rd/omniscience/operator/internal/controller"
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// ─── Constructor preconditions ─────────────────────────────────────────────
+
+func TestNewCronJobReconciler_RejectsZeroWorkspace(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewCronJobReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+}
+
+func TestNewCronJobReconciler_RejectsNilPublisher(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewCronJobReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+}
+
+func TestNewCronJobReconciler_RejectsEmptyClusterName(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewCronJobReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+}
+
+func TestNewCronJobReconciler_RejectsNilClient(t *testing.T) {
+	if _, err := controller.NewCronJobReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+// ─── Lifecycle: create / update / delete ───────────────────────────────────
+
+func cjFixture(ns, name string) *batchv1.CronJob {
+	return &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          "0 2 * * *",
+			ConcurrencyPolicy: batchv1.AllowConcurrent,
+		},
+	}
+}
+
+func TestCronJobReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	cj := cjFixture("team-a", "nightly")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cj).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewCronJobReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "nightly")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	ev := got[0]
+	if ev.Action != entity.ActionUpdated {
+		t.Fatalf("action = %q", ev.Action)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/CronJob/team-a/nightly" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["schedule"] != "0 2 * * *" {
+		t.Fatalf("schedule = %q", ev.Metadata["schedule"])
+	}
+	if ev.Metadata["concurrency_policy"] != "Allow" {
+		t.Fatalf("concurrency_policy = %q", ev.Metadata["concurrency_policy"])
+	}
+}
+
+// Update path: spec change between reconciles is reflected in the second
+// event. (We test a spec field rather than a status field because the
+// controller-runtime fake client's Update() does not propagate to the
+// status subresource by default; see status subresource semantics.)
+func TestCronJobReconciler_UpdateEmitsSecondUpdated(t *testing.T) {
+	s := newScheme(t)
+	cj := cjFixture("team-a", "nightly")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cj).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewCronJobReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	ctx := context.Background()
+	if _, err := r.Reconcile(ctx, req("team-a", "nightly")); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	var live batchv1.CronJob
+	if err := c.Get(ctx, req("team-a", "nightly").NamespacedName, &live); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	suspend := true
+	live.Spec.Suspend = &suspend
+	if err := c.Update(ctx, &live); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if _, err := r.Reconcile(ctx, req("team-a", "nightly")); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("publisher saw %d events, want 2", len(got))
+	}
+	if got[0].Metadata["suspend"] != "" {
+		t.Fatalf("first suspend = %q, want empty (nil)", got[0].Metadata["suspend"])
+	}
+	if got[1].Metadata["suspend"] != "true" {
+		t.Fatalf("second suspend = %q, want \"true\" (spec update should flow through)", got[1].Metadata["suspend"])
+	}
+}
+
+// Delete path: empty client → IsNotFound → Deleted event for stub.
+func TestCronJobReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+
+	r, err := controller.NewCronJobReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	r.Now = fixedNowFunc()
+
+	if _, err := r.Reconcile(context.Background(), req("team-a", "nightly")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("publisher saw %d events, want 1", len(got))
+	}
+	if got[0].Action != entity.ActionDeleted {
+		t.Fatalf("action = %q", got[0].Action)
+	}
+	if got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/CronJob/team-a/nightly" {
+		t.Fatalf("external_id = %q", got[0].ExternalID)
+	}
+	if got[0].Metadata["schedule"] != "" {
+		t.Fatalf("stub deletion should have empty schedule; got %q", got[0].Metadata["schedule"])
+	}
+}

--- a/operator/internal/entity/cronjob_mapper.go
+++ b/operator/internal/entity/cronjob_mapper.go
@@ -1,0 +1,113 @@
+// cronjob_mapper.go: batchv1.CronJob -> Event mapper (issue #210).
+//
+// CronJob is a namespaced scheduled batch workload. The mapper emits ONLY
+// the closed allow-list of fields from baseMetadata plus the schedule,
+// suspend / concurrency / history settings, and current status.
+//
+// SECURITY POSTURE — same as every other operator mapper:
+//
+//   - User-supplied labels and annotations are NEVER copied through.
+//   - `namespace` appears in baseMetadata + external_id ONLY.
+//   - The embedded `spec.jobTemplate` is NOT emitted — the actual Jobs that
+//     get created are already covered by the Job watcher (#157). Emitting
+//     the template here would duplicate without graph value.
+package entity
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+// EntityKindCronJob is the K8s kind segment in CronJob external_ids.
+const EntityKindCronJob = "CronJob"
+
+// CronJobToEvent maps a batchv1.CronJob plus an action into an Event.
+// Pure function — no I/O, no clients, no clock beyond `now`.
+//
+// Emitted metadata:
+//
+//   - Base allow-list: cluster, cluster_id, namespace, name, kind, emitter
+//   - "schedule":                       cron expression string
+//   - "time_zone":                      string; empty when nil
+//   - "suspend":                        "true" / "false" / "" (nil)
+//   - "concurrency_policy":             Allow / Forbid / Replace; empty when nil
+//   - "starting_deadline_seconds":      decimal string; empty when nil
+//   - "successful_jobs_history_limit":  decimal string; empty when nil
+//   - "failed_jobs_history_limit":      decimal string; empty when nil
+//   - "last_schedule_time":             RFC3339 string; empty when nil
+//   - "last_successful_time":           RFC3339 string; empty when nil
+//   - "active_count":                   decimal string of len(.Active)
+func CronJobToEvent(cj *batchv1.CronJob, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(cj.Namespace)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindCronJob, cj.Name)
+
+	meta["schedule"] = cj.Spec.Schedule
+	if cj.Spec.TimeZone != nil {
+		meta["time_zone"] = *cj.Spec.TimeZone
+	} else {
+		meta["time_zone"] = ""
+	}
+
+	meta["suspend"] = boolPtrToTriState(cj.Spec.Suspend)
+	meta["concurrency_policy"] = string(cj.Spec.ConcurrencyPolicy)
+
+	meta["starting_deadline_seconds"] = int64PtrToString(cj.Spec.StartingDeadlineSeconds)
+	meta["successful_jobs_history_limit"] = int32PtrToString(cj.Spec.SuccessfulJobsHistoryLimit)
+	meta["failed_jobs_history_limit"] = int32PtrToString(cj.Spec.FailedJobsHistoryLimit)
+
+	if cj.Status.LastScheduleTime != nil {
+		meta["last_schedule_time"] = cj.Status.LastScheduleTime.UTC().Format(time.RFC3339)
+	} else {
+		meta["last_schedule_time"] = ""
+	}
+	if cj.Status.LastSuccessfulTime != nil {
+		meta["last_successful_time"] = cj.Status.LastSuccessfulTime.UTC().Format(time.RFC3339)
+	} else {
+		meta["last_successful_time"] = ""
+	}
+	meta["active_count"] = strconv.Itoa(len(cj.Status.Active))
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindCronJob, namespace, cj.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindCronJob, cj.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// boolPtrToTriState renders *bool as "true" / "false" / "" (nil). Distinct
+// from a literal false so consumers can tell "explicitly nil" (defer to K8s
+// default which is `false`) from "explicitly false". Same shape used by the
+// ServiceAccount mapper (#206) for AutomountServiceAccountToken.
+func boolPtrToTriState(b *bool) string {
+	if b == nil {
+		return ""
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
+}
+
+// int64PtrToString renders *int64 as decimal string; empty when nil.
+func int64PtrToString(p *int64) string {
+	if p == nil {
+		return ""
+	}
+	return strconv.FormatInt(*p, 10)
+}
+
+// int32PtrToString renders *int32 as decimal string; empty when nil.
+func int32PtrToString(p *int32) string {
+	if p == nil {
+		return ""
+	}
+	return strconv.FormatInt(int64(*p), 10)
+}

--- a/operator/internal/entity/cronjob_mapper_test.go
+++ b/operator/internal/entity/cronjob_mapper_test.go
@@ -1,0 +1,252 @@
+// cronjob_mapper_test.go: pure unit tests for CronJobToEvent (#210).
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+var (
+	cjTestWorkspace   = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	cjTestClusterID   = uuid.MustParse("99999999-8888-7777-6666-555555555555")
+	cjTestClusterName = "prod-eu"
+	cjTestNow         = time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+)
+
+func cjBoolPtr(b bool) *bool      { return &b }
+func cjInt64Ptr(i int64) *int64   { return &i }
+func cjInt32Ptr(i int32) *int32   { return &i }
+func cjStrPtr(s string) *string   { return &s }
+
+// ─── Envelope ─────────────────────────────────────────────────────────────
+
+func TestCronJobToEvent_EnvelopeStampsWorkspaceFromConfig(t *testing.T) {
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "nightly-backup",
+			Labels: map[string]string{
+				"omniscience.io/workspace": "evil-ws",
+				"team":                     "platform",
+			},
+			Annotations: map[string]string{
+				"omniscience.io/index-data": "true",
+			},
+		},
+		Spec: batchv1.CronJobSpec{Schedule: "0 2 * * *"},
+	}
+	ev := entity.CronJobToEvent(cj, entity.ActionUpdated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+
+	if ev.WorkspaceID != cjTestWorkspace {
+		t.Fatalf("workspace_id = %s, want %s — adversarial label honoured!", ev.WorkspaceID, cjTestWorkspace)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/CronJob/team-a/nightly-backup" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.URI != "kube://prod-eu/team-a/CronJob/nightly-backup" {
+		t.Fatalf("uri = %q", ev.URI)
+	}
+	if ev.Metadata["schedule"] != "0 2 * * *" {
+		t.Fatalf("schedule = %q", ev.Metadata["schedule"])
+	}
+}
+
+// ACL invariant: only the closed allow-list of metadata keys is emitted.
+func TestCronJobToEvent_ACL_NoUserLabelsOrAnnotationsLeak(t *testing.T) {
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "nightly-backup",
+			Labels: map[string]string{
+				"team":          "platform",
+				"cost-center":   "eng-42",
+				"app.k8s.io/of": "checkout",
+			},
+			Annotations: map[string]string{
+				"description": "team-a nightly backup",
+				"owner":       "alice@example.com",
+			},
+		},
+		Spec: batchv1.CronJobSpec{Schedule: "0 2 * * *"},
+	}
+	ev := entity.CronJobToEvent(cj, entity.ActionUpdated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+
+	allowed := map[string]struct{}{
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"schedule": {}, "time_zone": {}, "suspend": {}, "concurrency_policy": {},
+		"starting_deadline_seconds": {}, "successful_jobs_history_limit": {}, "failed_jobs_history_limit": {},
+		"last_schedule_time": {}, "last_successful_time": {}, "active_count": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("metadata leaked key %q (value=%q) — ACL allow-list violated", k, ev.Metadata[k])
+		}
+	}
+	for forbidden := range cj.Labels {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user label %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+	for forbidden := range cj.Annotations {
+		if v, ok := ev.Metadata[forbidden]; ok {
+			t.Fatalf("user annotation %q leaked into metadata as %q", forbidden, v)
+		}
+	}
+}
+
+// ─── Fixture 1: minimal — only required schedule ──────────────────────────
+
+func TestCronJobToEvent_MinimalSchedule(t *testing.T) {
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "nightly"},
+		Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *"},
+	}
+	ev := entity.CronJobToEvent(cj, entity.ActionCreated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+
+	if ev.Metadata["schedule"] != "0 2 * * *" {
+		t.Fatalf("schedule = %q", ev.Metadata["schedule"])
+	}
+	// All optional fields render as empty when nil/unset.
+	for _, k := range []string{
+		"time_zone", "suspend", "starting_deadline_seconds",
+		"successful_jobs_history_limit", "failed_jobs_history_limit",
+		"last_schedule_time", "last_successful_time",
+	} {
+		if ev.Metadata[k] != "" {
+			t.Fatalf("optional field %q should be empty when unset; got %q", k, ev.Metadata[k])
+		}
+	}
+	if ev.Metadata["active_count"] != "0" {
+		t.Fatalf("active_count = %q, want 0", ev.Metadata["active_count"])
+	}
+}
+
+// ─── Fixture 2: with timezone, suspend=true, concurrency Forbid ───────────
+
+func TestCronJobToEvent_WithTimezoneSuspendConcurrency(t *testing.T) {
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "weekly"},
+		Spec: batchv1.CronJobSpec{
+			Schedule:                   "0 9 * * 1",
+			TimeZone:                   cjStrPtr("Europe/Berlin"),
+			Suspend:                    cjBoolPtr(true),
+			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
+			StartingDeadlineSeconds:    cjInt64Ptr(60),
+			SuccessfulJobsHistoryLimit: cjInt32Ptr(3),
+			FailedJobsHistoryLimit:     cjInt32Ptr(1),
+		},
+	}
+	ev := entity.CronJobToEvent(cj, entity.ActionUpdated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+
+	if ev.Metadata["time_zone"] != "Europe/Berlin" {
+		t.Fatalf("time_zone = %q", ev.Metadata["time_zone"])
+	}
+	if ev.Metadata["suspend"] != "true" {
+		t.Fatalf("suspend = %q", ev.Metadata["suspend"])
+	}
+	if ev.Metadata["concurrency_policy"] != "Forbid" {
+		t.Fatalf("concurrency_policy = %q", ev.Metadata["concurrency_policy"])
+	}
+	if ev.Metadata["starting_deadline_seconds"] != "60" {
+		t.Fatalf("starting_deadline_seconds = %q", ev.Metadata["starting_deadline_seconds"])
+	}
+	if ev.Metadata["successful_jobs_history_limit"] != "3" {
+		t.Fatalf("successful_jobs_history_limit = %q", ev.Metadata["successful_jobs_history_limit"])
+	}
+	if ev.Metadata["failed_jobs_history_limit"] != "1" {
+		t.Fatalf("failed_jobs_history_limit = %q", ev.Metadata["failed_jobs_history_limit"])
+	}
+}
+
+// ─── Fixture 3: with status.lastScheduleTime / lastSuccessfulTime / active ──
+
+func TestCronJobToEvent_WithStatusFields(t *testing.T) {
+	scheduledAt := time.Date(2026, 5, 4, 2, 0, 0, 0, time.UTC)
+	successAt := time.Date(2026, 5, 4, 2, 1, 23, 0, time.UTC)
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "nightly"},
+		Spec:       batchv1.CronJobSpec{Schedule: "0 2 * * *"},
+		Status: batchv1.CronJobStatus{
+			LastScheduleTime:   &metav1.Time{Time: scheduledAt},
+			LastSuccessfulTime: &metav1.Time{Time: successAt},
+			Active: []corev1.ObjectReference{
+				{Name: "nightly-1234567890"},
+				{Name: "nightly-1234567891"},
+			},
+		},
+	}
+	ev := entity.CronJobToEvent(cj, entity.ActionUpdated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+
+	if ev.Metadata["last_schedule_time"] != "2026-05-04T02:00:00Z" {
+		t.Fatalf("last_schedule_time = %q", ev.Metadata["last_schedule_time"])
+	}
+	if ev.Metadata["last_successful_time"] != "2026-05-04T02:01:23Z" {
+		t.Fatalf("last_successful_time = %q", ev.Metadata["last_successful_time"])
+	}
+	if ev.Metadata["active_count"] != "2" {
+		t.Fatalf("active_count = %q", ev.Metadata["active_count"])
+	}
+}
+
+// ─── Fixture 4: suspend=false (distinct from nil) ─────────────────────────
+
+func TestCronJobToEvent_SuspendFalseDistinctFromNil(t *testing.T) {
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "0 2 * * *",
+			Suspend:  cjBoolPtr(false),
+		},
+	}
+	ev := entity.CronJobToEvent(cj, entity.ActionUpdated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+	if ev.Metadata["suspend"] != "false" {
+		t.Fatalf("suspend = %q, want explicit false (distinct from nil)", ev.Metadata["suspend"])
+	}
+}
+
+// ─── Default namespace fallback ───────────────────────────────────────────
+
+func TestCronJobToEvent_EmptyNamespaceFallsBackToDefault(t *testing.T) {
+	cj := &batchv1.CronJob{Spec: batchv1.CronJobSpec{Schedule: "@daily"}}
+	cj.Name = "x"
+	ev := entity.CronJobToEvent(cj, entity.ActionUpdated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/CronJob/default/x" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["namespace"] != "default" {
+		t.Fatalf("namespace = %q", ev.Metadata["namespace"])
+	}
+}
+
+// ─── JobTemplate is intentionally NOT emitted ─────────────────────────────
+
+func TestCronJobToEvent_JobTemplateNotEmitted(t *testing.T) {
+	// Even with a complex JobTemplate, we should not emit anything from it.
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "0 2 * * *",
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"would-leak": "yes"},
+				},
+			},
+		},
+	}
+	ev := entity.CronJobToEvent(cj, entity.ActionUpdated, cjTestWorkspace, cjTestClusterID, cjTestClusterName, cjTestNow)
+	for k, v := range ev.Metadata {
+		if v == "yes" {
+			t.Fatalf("JobTemplate label leaked into metadata under key %q", k)
+		}
+		if k == "job_template" || k == "job_template_json" {
+			t.Fatalf("JobTemplate emitted as %q — should be left to Job watcher (#157)", k)
+		}
+	}
+}


### PR DESCRIPTION
Closes #210. Sub-task of epic #199 (v0.4 default-flip parity push).

## Summary

Adds a `batch/v1 CronJob` watcher mirroring the established pattern. The operator already covered `Job` (#157) — this adds the parent CronJob entity (schedule + status) without duplicating the per-Job spec.

After this PR merges, **5 NOT-COVERED gaps remain**: Role, RoleBinding, ClusterRole, ClusterRoleBinding, HPA.

## What landed

1. **`entity.CronJobToEvent` mapper** — schedule, timezone, suspend (tri-state), concurrencyPolicy, deadline/history limits, status (lastScheduleTime, lastSuccessfulTime, active job count). The embedded `spec.jobTemplate` is intentionally NOT emitted — the Job watcher already covers spawned Jobs.

2. **`CronJobReconciler`** — same shape as peers, `RecordEmit("CronJob", obj)` BEFORE `Publish` on the upsert branch only. Wired into the #158 setup helper and added to `buildCacheSizeKinds`.

3. **Tests**: 8 mapper unit tests + 7 controller tests = 15 new tests (all passing). Includes a JobTemplate-non-emission belt-and-braces invariant.

4. **RBAC + docs**: \`cronjobs\` added to the existing \`batch\` apiGroup verbs (next to \`jobs\`); parity matrix flips CronJob row to COVERED (18→19); release-blocker checklist strikes CronJob with #210 ref; CHANGELOG entry.

## Quality gates actually run

| Gate | Result |
|------|--------|
| \`go build ./...\` | green |
| \`go vet ./...\` | green |
| \`go test -race -count=1 ./...\` | **251 / 251 pass** in 8 packages |
| \`TestACL_NoForbiddenLabels\` | pass |
| \`TestACL_WorkspaceIDInfoLabels_AreSafe\` | pass |
| Grep audit \`WithLabelValues\` / \`MustRegisterWith\` on changed files | zero hits |
| \`helm lint helm/omniscience-operator\` | clean |
| \`go mod tidy\` | clean |

## Note on update-path test

The update-path test mutates a spec field (\`suspend\`) rather than a status field, because the controller-runtime fake client's \`Update()\` does not propagate to the status subresource by default — a real envtest would use \`Status().Update()\` instead. The intent (\"spec change between reconciles flows through to the second event\") is preserved.

## Gates deferred to CI / reviewer

- \`golangci-lint v1.61\` with project config (same posture as #201, #203, #205, #207, #209)
- Kind-cluster smoke (no kind binary locally)

## Solo execution disclosure

Same situation as PRs #201, #203, #205, #207, #209: agent-spawn primitive does not register a callable schema. Lead executed all four roles in this single session, applying every gate the multi-role team would have. Real multi-perspective review process did not happen.

## Scope guardrails respected

Did NOT touch:
- The \`RecordEmit\` helper itself (#198)
- The 5 other NOT-COVERED gaps from epic #199 (separate issues each — Role / RoleBinding / ClusterRole / ClusterRoleBinding / HPA)
- \`OMNISCIENCE_K8S_AGENTIC_ALLOWED\` server-side flag wiring (separate)
- The embedded JobTemplate spec — covered by #157 Job watcher