### PR TITLE
feat: operator RBAC watchers — Role / RoleBinding / ClusterRole / ClusterRoleBinding (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parity gaps tracked under epic #199. RBAC adds `cronjobs` to the
   existing `batch` apiGroup verbs; no new apiGroup added.
 
+- **Operator: RBAC watchers — `Role`, `RoleBinding`, `ClusterRole`,
+  `ClusterRoleBinding` (issue #212).** The operator now watches all
+  four `rbac.authorization.k8s.io/v1` kinds cluster-wide. Role +
+  ClusterRole emit a deterministic-JSON representation of `rules` (each
+  per-rule string slice sorted, then rules sorted by JSON byte-form);
+  RoleBinding + ClusterRoleBinding emit `roleRef` and `subjects` (sorted
+  by kind, namespace, name). Closes 4 of the v0.4 default-flip parity
+  gaps tracked under epic #199 in a single PR. RBAC adds a new
+  `rbac.authorization.k8s.io` apiGroup with read-only verbs on the four
+  resources.
+
 ### Deprecated
 
 - **`k8s-agentic` connector deprecation announced (issue #168, ADR-0011).**

--- a/docs/connectors/k8s-agentic-vs-operator-parity.md
+++ b/docs/connectors/k8s-agentic-vs-operator-parity.md
@@ -105,10 +105,10 @@ migration described in the
 
 | Kind | agentic.emits | operator.emits | Status | Notes |
 |---|---|---|---|---|
-| `Role` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Listed in agentic's `_DEFAULT_INCLUDE_KINDS`. RBAC indexing is a security-posture-relevant capability. |
-| `RoleBinding` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Same as Role. |
-| `ClusterRole` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Same as Role. |
-| `ClusterRoleBinding` | yes | **no** | **NOT-COVERED** | **Release-blocker for v0.4.** Same as Role. |
+| `Role` | yes | yes (`role_controller.go`, `role_mapper.go`) | **COVERED** | Operator emits via watch (issue #212). Mapper renders `rules` as deterministic JSON with each per-rule string slice sorted, then rules sorted by JSON byte-form. Namespace appears only in `external_id` and base metadata. |
+| `RoleBinding` | yes | yes (`rolebinding_controller.go`, `rolebinding_mapper.go`) | **COVERED** | Operator emits via watch (issue #212). Mapper renders `roleRef` (kind/name/apiGroup) and `subjects` as deterministic JSON sorted by (kind, namespace, name). |
+| `ClusterRole` | yes | yes (`clusterrole_controller.go`, `role_mapper.go`) | **COVERED** | Operator emits via watch (issue #212). Same payload shape as Role; cluster-scoped. |
+| `ClusterRoleBinding` | yes | yes (`clusterrolebinding_controller.go`, `rolebinding_mapper.go`) | **COVERED** | Operator emits via watch (issue #212). Same payload shape as RoleBinding; cluster-scoped. |
 
 ---
 
@@ -156,18 +156,18 @@ migration described in the
 
 | Status | Count | Kinds |
 |---|---|---|
-| **COVERED** | 19 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota, ServiceAccount, PersistentVolumeClaim, CronJob |
+| **COVERED** | 23 | ConfigMap, Endpoints, LimitRange, Namespace, Node, PersistentVolume, Pod, Service, Deployment, DaemonSet, ReplicaSet, StatefulSet, Job, Ingress, NetworkPolicy, ResourceQuota, ServiceAccount, PersistentVolumeClaim, CronJob, Role, RoleBinding, ClusterRole, ClusterRoleBinding |
 | **PARTIAL** | 7 | Argo Rollouts (Rollout), ArgoCD (Application, ApplicationSet), DRA (DeviceClass, ResourceClaim, ResourceClaimTemplate, ResourceSlice) — all gated on customer cluster CRD installation |
-| **NOT-COVERED** | 6 | ReplicationController (low priority), Role, RoleBinding, ClusterRole, ClusterRoleBinding, HorizontalPodAutoscaler |
+| **NOT-COVERED** | 2 | ReplicationController (low priority), HorizontalPodAutoscaler |
 | **OPERATOR-ONLY** | 3 | Secret (redacted), StorageClass, Cluster (synthetic) |
 | **NEITHER** | 1 | Event |
 
-Total: 19 + 7 + 6 + 3 + 1 = **36 rows**.
+Total: 23 + 7 + 2 + 3 + 1 = **36 rows**.
 
 ### Release-blocker summary for v0.4 default-disable
 
-The following 5 kinds are **NOT-COVERED** by the operator and emit
-from the agentic connector's `_DEFAULT_INCLUDE_KINDS`. Each must be
+The following 1 kind is **NOT-COVERED** by the operator and emits
+from the agentic connector's `_DEFAULT_INCLUDE_KINDS`. It must be
 addressed before the v0.4 release flips
 `OMNISCIENCE_K8S_AGENTIC_ALLOWED` to `false` by default:
 
@@ -176,10 +176,10 @@ addressed before the v0.4 release flips
 3. ~~`ResourceQuota`~~ — **DONE** in issue #204 (namespace quota enforcement).
 4. ~~`ServiceAccount`~~ — **DONE** in issue #206 (workload identity).
 5. ~~`CronJob`~~ — **DONE** in issue #210 (scheduled batch workloads).
-6. `Role` — namespaced RBAC
-7. `RoleBinding` — namespaced RBAC binding
-8. `ClusterRole` — cluster-scoped RBAC
-9. `ClusterRoleBinding` — cluster-scoped RBAC binding
+6. ~~`Role`~~ — **DONE** in issue #212 (namespaced RBAC).
+7. ~~`RoleBinding`~~ — **DONE** in issue #212 (namespaced RBAC binding).
+8. ~~`ClusterRole`~~ — **DONE** in issue #212 (cluster-scoped RBAC).
+9. ~~`ClusterRoleBinding`~~ — **DONE** in issue #212 (cluster-scoped RBAC binding).
 10. `HorizontalPodAutoscaler` — workload autoscaling
 
 `ReplicationController` is also NOT-COVERED but acceptable as a v0.5

--- a/helm/omniscience-operator/templates/rbac.yaml
+++ b/helm/omniscience-operator/templates/rbac.yaml
@@ -66,6 +66,15 @@ rules:
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
   # ── end #208 ──────────────────────────────────────────────────────────
+  # ── #212 RBAC watchers (Role + RoleBinding + ClusterRole + ClusterRoleBinding) ──
+  # Read-only verbs only. The operator emits the RBAC graph itself — it
+  # never grants or revokes permissions. Role / RoleBinding are namespaced;
+  # ClusterRole / ClusterRoleBinding are cluster-scoped. All under
+  # rbac.authorization.k8s.io.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+    verbs: ["get", "list", "watch"]
+  # ── end #212 ──────────────────────────────────────────────────────────
   # --- BEGIN issue #159: cluster-scoped watcher RBAC ---
   # Node, Namespace, PersistentVolume — all cluster-scoped under the core
   # API group. ClusterRole + ClusterRoleBinding above already grants the

--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -18,6 +18,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	resourcev1beta1 "k8s.io/api/resource/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	unstructuredv1 "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -478,6 +479,27 @@ func setupNetworkingAndConfigWatchers(
 	} else if err := cj.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("cronjob reconciler setup: %w", err)
 	}
+	// ── #212 RBAC watchers (Role / RoleBinding / ClusterRole / ClusterRoleBinding) ──
+	if r, err := controller.NewRoleReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("role reconciler init: %w", err)
+	} else if err := r.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("role reconciler setup: %w", err)
+	}
+	if rb, err := controller.NewRoleBindingReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("rolebinding reconciler init: %w", err)
+	} else if err := rb.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("rolebinding reconciler setup: %w", err)
+	}
+	if cr, err := controller.NewClusterRoleReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("clusterrole reconciler init: %w", err)
+	} else if err := cr.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("clusterrole reconciler setup: %w", err)
+	}
+	if crb, err := controller.NewClusterRoleBindingReconciler(mgr.GetClient(), pub, workspaceID, clusterID, clusterName); err != nil {
+		return fmt.Errorf("clusterrolebinding reconciler init: %w", err)
+	} else if err := crb.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("clusterrolebinding reconciler setup: %w", err)
+	}
 	return nil
 }
 
@@ -683,6 +705,11 @@ func buildCacheSizeKinds(mgr ctrl.Manager, argoPresent bool, logger interface {
 		{kind: "PersistentVolumeClaim", listFactory: func() client.ObjectList { return &corev1.PersistentVolumeClaimList{} }},
 		// Scheduled batch (#210)
 		{kind: "CronJob", listFactory: func() client.ObjectList { return &batchv1.CronJobList{} }},
+		// RBAC (#212)
+		{kind: "Role", listFactory: func() client.ObjectList { return &rbacv1.RoleList{} }},
+		{kind: "RoleBinding", listFactory: func() client.ObjectList { return &rbacv1.RoleBindingList{} }},
+		{kind: "ClusterRole", listFactory: func() client.ObjectList { return &rbacv1.ClusterRoleList{} }},
+		{kind: "ClusterRoleBinding", listFactory: func() client.ObjectList { return &rbacv1.ClusterRoleBindingList{} }},
 		// Cluster-scoped (#159)
 		{kind: "Node", listFactory: func() client.ObjectList { return &corev1.NodeList{} }},
 		{kind: "Namespace", listFactory: func() client.ObjectList { return &corev1.NamespaceList{} }},

--- a/operator/internal/controller/clusterrole_controller.go
+++ b/operator/internal/controller/clusterrole_controller.go
@@ -1,0 +1,77 @@
+// clusterrole_controller.go: controller for rbacv1.ClusterRole (issue #212).
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ClusterRoleReconciler watches ClusterRoles and publishes change events.
+type ClusterRoleReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+func NewClusterRoleReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ClusterRoleReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ClusterRoleReconciler{Client: c, Publisher: pub, WorkspaceID: workspaceID, ClusterID: clusterID, ClusterName: clusterName, Now: time.Now}, nil
+}
+
+func (r *ClusterRoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("clusterrole", req.String(), "workspace_id", r.WorkspaceID.String())
+
+	var obj rbacv1.ClusterRole
+	err := r.Client.Get(ctx, req.NamespacedName, &obj)
+	switch {
+	case err == nil:
+		ev := entity.ClusterRoleToEvent(&obj, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("ClusterRole", &obj)
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish clusterrole event: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	case apierrors.IsNotFound(err):
+		stub := &rbacv1.ClusterRole{}
+		stub.Name = req.Name
+		ev := entity.ClusterRoleToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			return ctrl.Result{}, fmt.Errorf("publish clusterrole deletion: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, fmt.Errorf("get clusterrole %s: %w", req.NamespacedName, err)
+	}
+}
+
+func (r *ClusterRoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&rbacv1.ClusterRole{}).Named("clusterrole-watcher").Complete(r)
+}

--- a/operator/internal/controller/clusterrolebinding_controller.go
+++ b/operator/internal/controller/clusterrolebinding_controller.go
@@ -1,0 +1,77 @@
+// clusterrolebinding_controller.go: controller for rbacv1.ClusterRoleBinding (issue #212).
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// ClusterRoleBindingReconciler watches ClusterRoleBindings and publishes change events.
+type ClusterRoleBindingReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+func NewClusterRoleBindingReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*ClusterRoleBindingReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &ClusterRoleBindingReconciler{Client: c, Publisher: pub, WorkspaceID: workspaceID, ClusterID: clusterID, ClusterName: clusterName, Now: time.Now}, nil
+}
+
+func (r *ClusterRoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("clusterrolebinding", req.String(), "workspace_id", r.WorkspaceID.String())
+
+	var obj rbacv1.ClusterRoleBinding
+	err := r.Client.Get(ctx, req.NamespacedName, &obj)
+	switch {
+	case err == nil:
+		ev := entity.ClusterRoleBindingToEvent(&obj, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("ClusterRoleBinding", &obj)
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish clusterrolebinding event: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	case apierrors.IsNotFound(err):
+		stub := &rbacv1.ClusterRoleBinding{}
+		stub.Name = req.Name
+		ev := entity.ClusterRoleBindingToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			return ctrl.Result{}, fmt.Errorf("publish clusterrolebinding deletion: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, fmt.Errorf("get clusterrolebinding %s: %w", req.NamespacedName, err)
+	}
+}
+
+func (r *ClusterRoleBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&rbacv1.ClusterRoleBinding{}).Named("clusterrolebinding-watcher").Complete(r)
+}

--- a/operator/internal/controller/rbac_controllers_test.go
+++ b/operator/internal/controller/rbac_controllers_test.go
@@ -1,0 +1,286 @@
+// rbac_controllers_test.go: tests for the four RBAC controllers (#212).
+//
+// Single test file covering all four reconcilers since the shape is
+// identical — only the kind, mapper, and metric label change. Each
+// reconciler gets a constructor-precondition pass, a create-emits-Updated
+// case, and a delete-emits-Deleted case. Update lifecycle is covered by
+// the per-mapper unit tests (mapper is the part that varies; controller
+// shape is invariant across kinds).
+package controller_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/100rd/omniscience/operator/internal/controller"
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// ─── Role ─────────────────────────────────────────────────────────────────
+
+func TestNewRoleReconciler_Preconditions(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewRoleReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+	if _, err := controller.NewRoleReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+	if _, err := controller.NewRoleReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+	if _, err := controller.NewRoleReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+func TestRoleReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	r := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "viewer"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"get", "list"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(r).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewRoleReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("team-a", "viewer")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionUpdated {
+		t.Fatalf("got %#v", got)
+	}
+	if got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Role/team-a/viewer" {
+		t.Fatalf("external_id = %q", got[0].ExternalID)
+	}
+	if got[0].Metadata["rules_count"] != "1" {
+		t.Fatalf("rules_count = %q", got[0].Metadata["rules_count"])
+	}
+}
+
+func TestRoleReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewRoleReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("team-a", "viewer")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionDeleted {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+// ─── RoleBinding ──────────────────────────────────────────────────────────
+
+func TestNewRoleBindingReconciler_Preconditions(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewRoleBindingReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+	if _, err := controller.NewRoleBindingReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+	if _, err := controller.NewRoleBindingReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+	if _, err := controller.NewRoleBindingReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+func TestRoleBindingReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "viewers"},
+		RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "viewer", APIGroup: "rbac.authorization.k8s.io"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "alice@example.com", APIGroup: "rbac.authorization.k8s.io"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(rb).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewRoleBindingReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("team-a", "viewers")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionUpdated {
+		t.Fatalf("got %#v", got)
+	}
+	if got[0].Metadata["role_ref_name"] != "viewer" {
+		t.Fatalf("role_ref_name = %q", got[0].Metadata["role_ref_name"])
+	}
+	if got[0].Metadata["subjects_count"] != "1" {
+		t.Fatalf("subjects_count = %q", got[0].Metadata["subjects_count"])
+	}
+}
+
+func TestRoleBindingReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewRoleBindingReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("team-a", "viewers")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionDeleted {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+// ─── ClusterRole ──────────────────────────────────────────────────────────
+
+func TestNewClusterRoleReconciler_Preconditions(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewClusterRoleReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+	if _, err := controller.NewClusterRoleReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+	if _, err := controller.NewClusterRoleReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+	if _, err := controller.NewClusterRoleReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+func TestClusterRoleReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(cr).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewClusterRoleReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("", "cluster-admin")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionUpdated {
+		t.Fatalf("got %#v", got)
+	}
+	if got[0].ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ClusterRole/default/cluster-admin" {
+		t.Fatalf("external_id = %q", got[0].ExternalID)
+	}
+}
+
+func TestClusterRoleReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewClusterRoleReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("", "cluster-admin")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionDeleted {
+		t.Fatalf("got %#v", got)
+	}
+}
+
+// ─── ClusterRoleBinding ───────────────────────────────────────────────────
+
+func TestNewClusterRoleBindingReconciler_Preconditions(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	if _, err := controller.NewClusterRoleBindingReconciler(c, &fakePublisher{}, uuid.UUID{}, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on zero workspace UUID")
+	}
+	if _, err := controller.NewClusterRoleBindingReconciler(c, nil, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil publisher")
+	}
+	if _, err := controller.NewClusterRoleBindingReconciler(c, &fakePublisher{}, tcWorkspace, fixedClusterID, ""); err == nil {
+		t.Fatalf("expected error on empty cluster name")
+	}
+	if _, err := controller.NewClusterRoleBindingReconciler(nil, &fakePublisher{}, tcWorkspace, fixedClusterID, tcClusterName); err == nil {
+		t.Fatalf("expected error on nil client")
+	}
+}
+
+func TestClusterRoleBindingReconciler_CreateEmitsUpdated(t *testing.T) {
+	s := newScheme(t)
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin-binding"},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin", APIGroup: "rbac.authorization.k8s.io"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "admin@example.com", APIGroup: "rbac.authorization.k8s.io"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(crb).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewClusterRoleBindingReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("", "cluster-admin-binding")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionUpdated {
+		t.Fatalf("got %#v", got)
+	}
+	if got[0].Metadata["role_ref_kind"] != "ClusterRole" {
+		t.Fatalf("role_ref_kind = %q", got[0].Metadata["role_ref_kind"])
+	}
+}
+
+func TestClusterRoleBindingReconciler_DeleteEmitsDeleted(t *testing.T) {
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	pub := &fakePublisher{}
+	rec, err := controller.NewClusterRoleBindingReconciler(c, pub, tcWorkspace, fixedClusterID, tcClusterName)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	rec.Now = fixedNowFunc()
+	if _, err := rec.Reconcile(context.Background(), req("", "cluster-admin-binding")); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got := pub.snapshot()
+	if len(got) != 1 || got[0].Action != entity.ActionDeleted {
+		t.Fatalf("got %#v", got)
+	}
+}

--- a/operator/internal/controller/role_controller.go
+++ b/operator/internal/controller/role_controller.go
@@ -1,0 +1,78 @@
+// role_controller.go: controller for rbacv1.Role (issue #212).
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// RoleReconciler watches Roles and publishes change events.
+type RoleReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+func NewRoleReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*RoleReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &RoleReconciler{Client: c, Publisher: pub, WorkspaceID: workspaceID, ClusterID: clusterID, ClusterName: clusterName, Now: time.Now}, nil
+}
+
+func (r *RoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("role", req.String(), "workspace_id", r.WorkspaceID.String())
+
+	var obj rbacv1.Role
+	err := r.Client.Get(ctx, req.NamespacedName, &obj)
+	switch {
+	case err == nil:
+		ev := entity.RoleToEvent(&obj, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("Role", &obj)
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish role event: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	case apierrors.IsNotFound(err):
+		stub := &rbacv1.Role{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.RoleToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			return ctrl.Result{}, fmt.Errorf("publish role deletion: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, fmt.Errorf("get role %s: %w", req.NamespacedName, err)
+	}
+}
+
+func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&rbacv1.Role{}).Named("role-watcher").Complete(r)
+}

--- a/operator/internal/controller/rolebinding_controller.go
+++ b/operator/internal/controller/rolebinding_controller.go
@@ -1,0 +1,78 @@
+// rolebinding_controller.go: controller for rbacv1.RoleBinding (issue #212).
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+	opmetrics "github.com/100rd/omniscience/operator/internal/metrics"
+	"github.com/100rd/omniscience/operator/internal/publisher"
+)
+
+// RoleBindingReconciler watches RoleBindings and publishes change events.
+type RoleBindingReconciler struct {
+	Client      client.Client
+	Publisher   publisher.Publisher
+	WorkspaceID uuid.UUID
+	ClusterID   uuid.UUID
+	ClusterName string
+	Now         func() time.Time
+}
+
+func NewRoleBindingReconciler(c client.Client, pub publisher.Publisher, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string) (*RoleBindingReconciler, error) {
+	if c == nil {
+		return nil, errors.New("controller: client must not be nil")
+	}
+	if pub == nil {
+		return nil, errors.New("controller: publisher must not be nil")
+	}
+	if workspaceID.String() == "00000000-0000-0000-0000-000000000000" {
+		return nil, errors.New("controller: workspaceID must not be the zero UUID")
+	}
+	if clusterName == "" {
+		return nil, errors.New("controller: clusterName is required")
+	}
+	return &RoleBindingReconciler{Client: c, Publisher: pub, WorkspaceID: workspaceID, ClusterID: clusterID, ClusterName: clusterName, Now: time.Now}, nil
+}
+
+func (r *RoleBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx).WithValues("rolebinding", req.String(), "workspace_id", r.WorkspaceID.String())
+
+	var obj rbacv1.RoleBinding
+	err := r.Client.Get(ctx, req.NamespacedName, &obj)
+	switch {
+	case err == nil:
+		ev := entity.RoleBindingToEvent(&obj, entity.ActionUpdated, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		opmetrics.RecordEmit("RoleBinding", &obj)
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			logger.Error(perr, "publish failed; will requeue")
+			return ctrl.Result{}, fmt.Errorf("publish rolebinding event: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	case apierrors.IsNotFound(err):
+		stub := &rbacv1.RoleBinding{}
+		stub.Namespace = req.Namespace
+		stub.Name = req.Name
+		ev := entity.RoleBindingToEvent(stub, entity.ActionDeleted, r.WorkspaceID, r.ClusterID, r.ClusterName, r.Now())
+		if perr := r.Publisher.Publish(ctx, ev); perr != nil {
+			return ctrl.Result{}, fmt.Errorf("publish rolebinding deletion: %w", perr)
+		}
+		return ctrl.Result{}, nil
+	default:
+		return ctrl.Result{}, fmt.Errorf("get rolebinding %s: %w", req.NamespacedName, err)
+	}
+}
+
+func (r *RoleBindingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).For(&rbacv1.RoleBinding{}).Named("rolebinding-watcher").Complete(r)
+}

--- a/operator/internal/entity/role_mapper.go
+++ b/operator/internal/entity/role_mapper.go
@@ -1,0 +1,155 @@
+// role_mapper.go: rbacv1.Role + rbacv1.ClusterRole -> Event mappers (issue #212).
+//
+// Both kinds carry a []PolicyRule on .Rules. The mapper renders rules as
+// deterministic JSON with each per-rule string slice sorted, then rules
+// sorted by their JSON byte-form. ClusterRole is the cluster-scoped
+// counterpart — namespace is empty in baseMetadata for that kind.
+//
+// SECURITY POSTURE — same as every other operator mapper:
+//
+//   - User-supplied labels and annotations are NEVER copied through.
+//   - `namespace` appears in baseMetadata + external_id ONLY (Role).
+//   - PolicyRule contents are RBAC permission grants, not secret material;
+//     they describe what subjects bound to this role can do.
+//   - resourceNames lists are emitted as-is (sorted) — these are object
+//     names like "kube-system" or specific configmap names. They're not
+//     tenancy-revealing per ADR-0007 §ACL because they live in the
+//     graph/JSON payload, not as metric labels.
+package entity
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// EntityKindRole / EntityKindClusterRole are the K8s kind segments.
+const (
+	EntityKindRole        = "Role"
+	EntityKindClusterRole = "ClusterRole"
+)
+
+// RoleToEvent maps a rbacv1.Role plus an action into an Event.
+func RoleToEvent(r *rbacv1.Role, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(r.Namespace)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindRole, r.Name)
+	addRulesMetadata(meta, r.Rules)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindRole, namespace, r.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindRole, r.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// ClusterRoleToEvent maps a rbacv1.ClusterRole plus an action into an Event.
+// Cluster-scoped — namespace is empty (resolveNamespace returns "default" as
+// graph-fallback so external_id is well-formed; the graph consumer must
+// distinguish ClusterRole from Role via the kind field, not the namespace).
+func ClusterRoleToEvent(cr *rbacv1.ClusterRole, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace("") // ClusterRole has no namespace
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindClusterRole, cr.Name)
+	addRulesMetadata(meta, cr.Rules)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindClusterRole, namespace, cr.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindClusterRole, cr.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// addRulesMetadata writes rules_count + rules_json (when non-empty) into
+// the supplied metadata map. Shared by Role + ClusterRole because they
+// emit the same payload shape — only the kind label differs.
+func addRulesMetadata(meta map[string]string, rules []rbacv1.PolicyRule) {
+	meta["rules_count"] = strconv.Itoa(len(rules))
+	if len(rules) > 0 {
+		raw, err := marshalPolicyRules(rules)
+		if err != nil {
+			meta["rules_json"] = ""
+		} else {
+			meta["rules_json"] = raw
+		}
+	}
+}
+
+// policyRuleView is the deterministic JSON shape for one PolicyRule.
+// All slice fields are sorted; omitempty keeps optional fields out of the
+// JSON when absent.
+type policyRuleView struct {
+	Verbs           []string `json:"verbs"`
+	APIGroups       []string `json:"apiGroups,omitempty"`
+	Resources       []string `json:"resources,omitempty"`
+	ResourceNames   []string `json:"resourceNames,omitempty"`
+	NonResourceURLs []string `json:"nonResourceURLs,omitempty"`
+}
+
+// marshalPolicyRules renders []PolicyRule as deterministic JSON. Each rule
+// has its string slices sorted; the rules array itself is sorted by the
+// per-rule JSON byte-form so two operators emit identical bytes regardless
+// of source ordering.
+func marshalPolicyRules(rules []rbacv1.PolicyRule) (string, error) {
+	views := make([]policyRuleView, 0, len(rules))
+	for _, r := range rules {
+		views = append(views, policyRuleView{
+			Verbs:           sortedCopy(r.Verbs),
+			APIGroups:       sortedCopy(r.APIGroups),
+			Resources:       sortedCopy(r.Resources),
+			ResourceNames:   sortedCopy(r.ResourceNames),
+			NonResourceURLs: sortedCopy(r.NonResourceURLs),
+		})
+	}
+
+	// Sort rules by their JSON serialization for determinism. This is more
+	// expensive than struct-field sorting but it's the only stable way to
+	// order policy rules without inventing an arbitrary canonical key.
+	type sortable struct {
+		rule policyRuleView
+		key  string
+	}
+	keyed := make([]sortable, 0, len(views))
+	for _, v := range views {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		keyed = append(keyed, sortable{rule: v, key: string(b)})
+	}
+	sort.Slice(keyed, func(i, j int) bool { return keyed[i].key < keyed[j].key })
+
+	out := make([]policyRuleView, 0, len(keyed))
+	for _, k := range keyed {
+		out = append(out, k.rule)
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// sortedCopy returns a sorted copy of the input. Returns nil for empty
+// input so the caller's omitempty tag suppresses the field.
+func sortedCopy(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/operator/internal/entity/role_mapper_test.go
+++ b/operator/internal/entity/role_mapper_test.go
@@ -1,0 +1,209 @@
+// role_mapper_test.go: pure unit tests for RoleToEvent + ClusterRoleToEvent (#212).
+package entity_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+var (
+	rTestWorkspace   = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	rTestClusterID   = uuid.MustParse("99999999-8888-7777-6666-555555555555")
+	rTestClusterName = "prod-eu"
+	rTestNow         = time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+)
+
+// ─── Role envelope + ACL ──────────────────────────────────────────────────
+
+func TestRoleToEvent_EnvelopeStampsWorkspaceFromConfig(t *testing.T) {
+	r := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "viewer",
+			Labels: map[string]string{
+				"omniscience.io/workspace": "evil-ws",
+			},
+		},
+	}
+	ev := entity.RoleToEvent(r, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	if ev.WorkspaceID != rTestWorkspace {
+		t.Fatalf("workspace_id = %s — adversarial label honoured!", ev.WorkspaceID)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Role/team-a/viewer" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.URI != "kube://prod-eu/team-a/Role/viewer" {
+		t.Fatalf("uri = %q", ev.URI)
+	}
+}
+
+func TestRoleToEvent_ACL_NoUserLabelsLeak(t *testing.T) {
+	r := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "team-a",
+			Name:        "viewer",
+			Labels:      map[string]string{"team": "platform"},
+			Annotations: map[string]string{"description": "read-only"},
+		},
+	}
+	ev := entity.RoleToEvent(r, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	allowed := map[string]struct{}{
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"rules_count": {}, "rules_json": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("metadata leaked key %q (value=%q)", k, ev.Metadata[k])
+		}
+	}
+}
+
+// ─── Role rules: multi-rule with sorted strings + sorted rules ────────────
+
+func TestRoleToEvent_MultipleRules(t *testing.T) {
+	r := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "ops"},
+		Rules: []rbacv1.PolicyRule{
+			// Intentionally reverse-alphabetical inputs — mapper must sort.
+			{
+				Verbs:     []string{"watch", "list", "get"},
+				APIGroups: []string{""},
+				Resources: []string{"pods", "configmaps"},
+			},
+			{
+				Verbs:     []string{"create", "delete"},
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+			},
+		},
+	}
+	ev := entity.RoleToEvent(r, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	if ev.Metadata["rules_count"] != "2" {
+		t.Fatalf("rules_count = %q, want 2", ev.Metadata["rules_count"])
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(ev.Metadata["rules_json"]), &got); err != nil {
+		t.Fatalf("rules_json not valid JSON: %v\n%s", err, ev.Metadata["rules_json"])
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rules, want 2", len(got))
+	}
+
+	// Each rule's verbs/resources must be sorted within the rule.
+	for _, rule := range got {
+		verbs := rule["verbs"].([]any)
+		for i := 1; i < len(verbs); i++ {
+			if verbs[i-1].(string) > verbs[i].(string) {
+				t.Fatalf("verbs not sorted in rule %#v", rule)
+			}
+		}
+		if res, ok := rule["resources"].([]any); ok {
+			for i := 1; i < len(res); i++ {
+				if res[i-1].(string) > res[i].(string) {
+					t.Fatalf("resources not sorted in rule %#v", rule)
+				}
+			}
+		}
+	}
+}
+
+func TestRoleToEvent_DeterministicJSON(t *testing.T) {
+	build := func() *rbacv1.Role {
+		return &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+			Rules: []rbacv1.PolicyRule{
+				{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+				{Verbs: []string{"list"}, APIGroups: []string{""}, Resources: []string{"configmaps"}},
+			},
+		}
+	}
+	a := entity.RoleToEvent(build(), entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	b := entity.RoleToEvent(build(), entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	if a.Metadata["rules_json"] != b.Metadata["rules_json"] {
+		t.Fatalf("non-deterministic rules_json:\nA: %s\nB: %s", a.Metadata["rules_json"], b.Metadata["rules_json"])
+	}
+}
+
+func TestRoleToEvent_EmptyRules(t *testing.T) {
+	r := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "empty"},
+	}
+	ev := entity.RoleToEvent(r, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	if ev.Metadata["rules_count"] != "0" {
+		t.Fatalf("rules_count = %q", ev.Metadata["rules_count"])
+	}
+	if _, present := ev.Metadata["rules_json"]; present {
+		t.Fatalf("rules_json must be absent when rules empty")
+	}
+}
+
+// ─── ClusterRole ──────────────────────────────────────────────────────────
+
+func TestClusterRoleToEvent_NoNamespace(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+		Rules: []rbacv1.PolicyRule{
+			{Verbs: []string{"*"}, APIGroups: []string{"*"}, Resources: []string{"*"}},
+		},
+	}
+	ev := entity.ClusterRoleToEvent(cr, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	if ev.Metadata["kind"] != "ClusterRole" {
+		t.Fatalf("kind = %q", ev.Metadata["kind"])
+	}
+	if ev.Metadata["namespace"] != "default" {
+		t.Fatalf("namespace = %q (resolveNamespace fallback for cluster-scoped)", ev.Metadata["namespace"])
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ClusterRole/default/cluster-admin" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["rules_count"] != "1" {
+		t.Fatalf("rules_count = %q", ev.Metadata["rules_count"])
+	}
+}
+
+// ─── ClusterRole with non-resource URLs ───────────────────────────────────
+
+func TestClusterRoleToEvent_NonResourceURLs(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "metrics-reader"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:           []string{"get"},
+				NonResourceURLs: []string{"/metrics", "/healthz"},
+			},
+		},
+	}
+	ev := entity.ClusterRoleToEvent(cr, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(ev.Metadata["rules_json"]), &got); err != nil {
+		t.Fatalf("rules_json not valid JSON: %v", err)
+	}
+	urls := got[0]["nonResourceURLs"].([]any)
+	if len(urls) != 2 || urls[0] != "/healthz" || urls[1] != "/metrics" {
+		t.Fatalf("nonResourceURLs = %#v (must be sorted)", urls)
+	}
+}
+
+// ─── Default namespace fallback (Role with empty namespace string) ────────
+
+func TestRoleToEvent_EmptyNamespaceFallsBackToDefault(t *testing.T) {
+	r := &rbacv1.Role{}
+	r.Name = "x"
+	ev := entity.RoleToEvent(r, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/Role/default/x" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+}

--- a/operator/internal/entity/rolebinding_mapper.go
+++ b/operator/internal/entity/rolebinding_mapper.go
@@ -1,0 +1,132 @@
+// rolebinding_mapper.go: rbacv1.RoleBinding + rbacv1.ClusterRoleBinding -> Event mappers (issue #212).
+//
+// Both kinds carry a RoleRef and []Subject. The mapper renders both as
+// deterministic JSON. ClusterRoleBinding is the cluster-scoped counterpart
+// — namespace is empty in baseMetadata for that kind.
+//
+// SECURITY POSTURE — same as every other operator mapper:
+//
+//   - User-supplied labels and annotations are NEVER copied through.
+//   - `namespace` appears in baseMetadata + external_id ONLY (RoleBinding).
+//   - Subject names (e.g. ServiceAccount names, User emails, Group names)
+//     are emitted as-is in the JSON payload. They are not metric labels.
+//     If a future requirement to redact email-shaped User names emerges,
+//     it should hash User subjects at this boundary.
+package entity
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// EntityKindRoleBinding / EntityKindClusterRoleBinding are the K8s kind segments.
+const (
+	EntityKindRoleBinding        = "RoleBinding"
+	EntityKindClusterRoleBinding = "ClusterRoleBinding"
+)
+
+// RoleBindingToEvent maps a rbacv1.RoleBinding plus an action into an Event.
+func RoleBindingToEvent(rb *rbacv1.RoleBinding, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace(rb.Namespace)
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindRoleBinding, rb.Name)
+	addRoleRefMetadata(meta, rb.RoleRef)
+	addSubjectsMetadata(meta, rb.Subjects)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindRoleBinding, namespace, rb.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindRoleBinding, rb.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// ClusterRoleBindingToEvent maps a rbacv1.ClusterRoleBinding plus an action
+// into an Event. Cluster-scoped — namespace is empty (resolveNamespace
+// returns "default" for graph well-formedness; consumers distinguish via kind).
+func ClusterRoleBindingToEvent(crb *rbacv1.ClusterRoleBinding, action Action, workspaceID uuid.UUID, clusterID uuid.UUID, clusterName string, now time.Time) *Event {
+	namespace := resolveNamespace("") // ClusterRoleBinding has no namespace
+	meta := baseMetadata(clusterID, clusterName, namespace, EntityKindClusterRoleBinding, crb.Name)
+	addRoleRefMetadata(meta, crb.RoleRef)
+	addSubjectsMetadata(meta, crb.Subjects)
+
+	return &Event{
+		SourceID:    DeriveSourceID(workspaceID, clusterName),
+		SourceType:  SourceType,
+		ExternalID:  externalIDFor(clusterID, EntityKindClusterRoleBinding, namespace, crb.Name),
+		URI:         uriFor(clusterName, namespace, EntityKindClusterRoleBinding, crb.Name),
+		Action:      action,
+		WorkspaceID: workspaceID,
+		EmittedAt:   now.UTC(),
+		Metadata:    meta,
+	}
+}
+
+// addRoleRefMetadata writes role_ref_kind + role_ref_name + role_ref_api_group
+// into the supplied metadata map. RoleRef is always present (it's a required
+// field in the Kubernetes API), so no count or omitempty is needed.
+func addRoleRefMetadata(meta map[string]string, ref rbacv1.RoleRef) {
+	meta["role_ref_kind"] = ref.Kind
+	meta["role_ref_name"] = ref.Name
+	meta["role_ref_api_group"] = ref.APIGroup
+}
+
+// addSubjectsMetadata writes subjects_count + subjects_json (when non-empty)
+// into the supplied metadata map.
+func addSubjectsMetadata(meta map[string]string, subjects []rbacv1.Subject) {
+	meta["subjects_count"] = strconv.Itoa(len(subjects))
+	if len(subjects) > 0 {
+		raw, err := marshalSubjects(subjects)
+		if err != nil {
+			meta["subjects_json"] = ""
+		} else {
+			meta["subjects_json"] = raw
+		}
+	}
+}
+
+// subjectView is the deterministic JSON shape for one Subject. Optional
+// fields use omitempty.
+type subjectView struct {
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	APIGroup  string `json:"apiGroup,omitempty"`
+}
+
+// marshalSubjects renders []Subject as deterministic JSON, sorted by
+// (kind, namespace, name) tuple.
+func marshalSubjects(subjects []rbacv1.Subject) (string, error) {
+	views := make([]subjectView, 0, len(subjects))
+	for _, s := range subjects {
+		views = append(views, subjectView{
+			Kind:      s.Kind,
+			Name:      s.Name,
+			Namespace: s.Namespace,
+			APIGroup:  s.APIGroup,
+		})
+	}
+	sort.Slice(views, func(i, j int) bool {
+		if views[i].Kind != views[j].Kind {
+			return views[i].Kind < views[j].Kind
+		}
+		if views[i].Namespace != views[j].Namespace {
+			return views[i].Namespace < views[j].Namespace
+		}
+		return views[i].Name < views[j].Name
+	})
+
+	b, err := json.Marshal(views)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/operator/internal/entity/rolebinding_mapper_test.go
+++ b/operator/internal/entity/rolebinding_mapper_test.go
@@ -1,0 +1,181 @@
+// rolebinding_mapper_test.go: pure unit tests for RoleBindingToEvent + ClusterRoleBindingToEvent (#212).
+package entity_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/100rd/omniscience/operator/internal/entity"
+)
+
+// reuse rTestWorkspace / rTestClusterID / rTestClusterName / rTestNow from role_mapper_test.go
+
+// ─── RoleBinding envelope + ACL ───────────────────────────────────────────
+
+func TestRoleBindingToEvent_EnvelopeStampsWorkspaceFromConfig(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "team-a",
+			Name:      "viewers",
+			Labels:    map[string]string{"omniscience.io/workspace": "evil-ws"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "Role",
+			Name:     "viewer",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+	ev := entity.RoleBindingToEvent(rb, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	if ev.WorkspaceID != rTestWorkspace {
+		t.Fatalf("workspace_id = %s — adversarial label honoured!", ev.WorkspaceID)
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/RoleBinding/team-a/viewers" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["role_ref_kind"] != "Role" || ev.Metadata["role_ref_name"] != "viewer" {
+		t.Fatalf("role_ref = %q/%q", ev.Metadata["role_ref_kind"], ev.Metadata["role_ref_name"])
+	}
+}
+
+func TestRoleBindingToEvent_ACL_NoUserLabelsLeak(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "team-a",
+			Name:        "viewers",
+			Labels:      map[string]string{"team": "platform"},
+			Annotations: map[string]string{"description": "view team resources"},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "Role", Name: "viewer", APIGroup: "rbac.authorization.k8s.io"},
+	}
+	ev := entity.RoleBindingToEvent(rb, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	allowed := map[string]struct{}{
+		"cluster": {}, "cluster_id": {}, "namespace": {}, "name": {}, "kind": {}, "emitter": {},
+		"role_ref_kind": {}, "role_ref_name": {}, "role_ref_api_group": {},
+		"subjects_count": {}, "subjects_json": {},
+	}
+	for k := range ev.Metadata {
+		if _, ok := allowed[k]; !ok {
+			t.Fatalf("metadata leaked key %q (value=%q)", k, ev.Metadata[k])
+		}
+	}
+}
+
+// ─── RoleBinding subjects: multi-subject sorted by (kind, namespace, name) ──
+
+func TestRoleBindingToEvent_MultipleSubjects(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "viewers"},
+		RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "viewer", APIGroup: "rbac.authorization.k8s.io"},
+		Subjects: []rbacv1.Subject{
+			// Intentionally unsorted — mapper must sort by (kind, namespace, name).
+			{Kind: "User", Name: "bob@example.com", APIGroup: "rbac.authorization.k8s.io"},
+			{Kind: "ServiceAccount", Name: "default", Namespace: "team-a"},
+			{Kind: "Group", Name: "platform-eng", APIGroup: "rbac.authorization.k8s.io"},
+			{Kind: "User", Name: "alice@example.com", APIGroup: "rbac.authorization.k8s.io"},
+		},
+	}
+	ev := entity.RoleBindingToEvent(rb, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	if ev.Metadata["subjects_count"] != "4" {
+		t.Fatalf("subjects_count = %q", ev.Metadata["subjects_count"])
+	}
+
+	var got []map[string]any
+	if err := json.Unmarshal([]byte(ev.Metadata["subjects_json"]), &got); err != nil {
+		t.Fatalf("subjects_json not valid JSON: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("got %d subjects, want 4", len(got))
+	}
+	// Sorted by kind first: Group, ServiceAccount, User, User
+	if got[0]["kind"] != "Group" {
+		t.Fatalf("first subject kind = %q, want Group", got[0]["kind"])
+	}
+	if got[1]["kind"] != "ServiceAccount" {
+		t.Fatalf("second subject kind = %q, want ServiceAccount", got[1]["kind"])
+	}
+	// The two Users sorted by name: alice before bob.
+	if got[2]["kind"] != "User" || got[2]["name"] != "alice@example.com" {
+		t.Fatalf("third subject = %#v", got[2])
+	}
+	if got[3]["kind"] != "User" || got[3]["name"] != "bob@example.com" {
+		t.Fatalf("fourth subject = %#v", got[3])
+	}
+}
+
+func TestRoleBindingToEvent_DeterministicJSON(t *testing.T) {
+	build := func() *rbacv1.RoleBinding {
+		return &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "x"},
+			RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "viewer"},
+			Subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "z@example.com"},
+				{Kind: "User", Name: "a@example.com"},
+				{Kind: "Group", Name: "ops"},
+			},
+		}
+	}
+	a := entity.RoleBindingToEvent(build(), entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	b := entity.RoleBindingToEvent(build(), entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	if a.Metadata["subjects_json"] != b.Metadata["subjects_json"] {
+		t.Fatalf("non-deterministic subjects_json:\nA: %s\nB: %s", a.Metadata["subjects_json"], b.Metadata["subjects_json"])
+	}
+}
+
+func TestRoleBindingToEvent_EmptySubjects(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "team-a", Name: "empty"},
+		RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "x"},
+	}
+	ev := entity.RoleBindingToEvent(rb, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	if ev.Metadata["subjects_count"] != "0" {
+		t.Fatalf("subjects_count = %q", ev.Metadata["subjects_count"])
+	}
+	if _, present := ev.Metadata["subjects_json"]; present {
+		t.Fatalf("subjects_json must be absent when subjects empty")
+	}
+}
+
+// ─── ClusterRoleBinding ───────────────────────────────────────────────────
+
+func TestClusterRoleBindingToEvent_NoNamespace(t *testing.T) {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin-binding"},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin", APIGroup: "rbac.authorization.k8s.io"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "admin@example.com", APIGroup: "rbac.authorization.k8s.io"},
+		},
+	}
+	ev := entity.ClusterRoleBindingToEvent(crb, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+
+	if ev.Metadata["kind"] != "ClusterRoleBinding" {
+		t.Fatalf("kind = %q", ev.Metadata["kind"])
+	}
+	if ev.Metadata["namespace"] != "default" {
+		t.Fatalf("namespace = %q (resolveNamespace fallback)", ev.Metadata["namespace"])
+	}
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/ClusterRoleBinding/default/cluster-admin-binding" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+	if ev.Metadata["role_ref_kind"] != "ClusterRole" {
+		t.Fatalf("role_ref_kind = %q", ev.Metadata["role_ref_kind"])
+	}
+}
+
+// ─── Default namespace fallback (RoleBinding with empty namespace) ────────
+
+func TestRoleBindingToEvent_EmptyNamespaceFallsBackToDefault(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		RoleRef: rbacv1.RoleRef{Kind: "Role", Name: "x"},
+	}
+	rb.Name = "x"
+	ev := entity.RoleBindingToEvent(rb, entity.ActionUpdated, rTestWorkspace, rTestClusterID, rTestClusterName, rTestNow)
+	if ev.ExternalID != "k8s_resource/99999999-8888-7777-6666-555555555555/RoleBinding/default/x" {
+		t.Fatalf("external_id = %q", ev.ExternalID)
+	}
+}


### PR DESCRIPTION
Closes #212. Sub-task of epic #199 (v0.4 default-flip parity push).

## Summary

Adds all four `rbac.authorization.k8s.io/v1` watchers in a single PR — bundled because they share an apiGroup and have only two distinct payload shapes (rules vs roleRef+subjects). Closes 4 of 5 remaining NOT-COVERED operator gaps blocking the v0.4 default-flip.

After this PR merges, **only HPA remains** as a v0.4 default-flip release-blocker. ReplicationController is low-priority (deferred to v0.5).

## What landed

1. **2 mappers, 4 kinds**:
   - `RoleToEvent` / `ClusterRoleToEvent` share `marshalPolicyRules` — each per-rule string slice (verbs / apiGroups / resources / resourceNames / nonResourceURLs) sorted within the rule, then rules sorted by JSON byte-form for cross-operator determinism
   - `RoleBindingToEvent` / `ClusterRoleBindingToEvent` share `marshalSubjects` — RoleRef rendered flat (kind/name/apiGroup); subjects sorted by (kind, namespace, name)
   - Cluster-scoped kinds get the same `resolveNamespace` fallback to `"default"` used elsewhere — graph consumers distinguish via the `kind` field
   - Closed metadata allow-lists for both shapes; user labels/annotations never copied through (ACL invariant per ADR-0007 §ACL)

2. **4 thin reconcilers** (one per kind) — same shape as peers, `RecordEmit("Role"/"RoleBinding"/"ClusterRole"/"ClusterRoleBinding")` BEFORE `Publish` on the upsert branch only. All wired into `#158` setup helper and added to `buildCacheSizeKinds`.

3. **Tests**: 11 mapper unit tests + 12 controller tests = 23 new tests (all passing). Mapper tests cover envelope, ACL, multi-rule/multi-subject, deterministic JSON, empty inputs, namespace fallback. Controller tests cover preconditions + create + delete for each of the 4 (update lifecycle covered by per-mapper unit tests; controller shape is invariant across kinds).

4. **RBAC + docs**:
   - Helm clusterrole gains a new `rbac.authorization.k8s.io` apiGroup rule with read-only verbs on `roles`, `rolebindings`, `clusterroles`, `clusterrolebindings` (single new rule, four resources)
   - Parity matrix: 4 rows flipped to **COVERED** (COVERED 19→23, NOT-COVERED 6→2)
   - Release-blocker checklist: 4 RBAC rows struck through with #212 reference
   - CHANGELOG \`[Unreleased] → Added\` entry covering all four watchers

## Quality gates actually run

| Gate | Result |
|------|--------|
| \`go build ./...\` | green |
| \`go vet ./...\` | green |
| \`go test -race -count=1 ./...\` | **278 / 278 pass** in 8 packages |
| \`TestACL_NoForbiddenLabels\` | pass |
| \`TestACL_WorkspaceIDInfoLabels_AreSafe\` | pass |
| Grep audit \`WithLabelValues\` / \`MustRegisterWith\` on changed files | zero hits |
| \`helm lint helm/omniscience-operator\` | clean |
| \`go mod tidy\` | clean (no new deps; `rbac/v1` already imported transitively) |

## Why bundled into one PR

The 4 RBAC kinds share an apiGroup, two of them share each mapper helper, and the parity matrix flip is naturally atomic. Splitting into 4 PRs would mean 4× the ceremony (4 issues, 4 PRs, 4 CI runs, 4 parity-matrix-edit conflicts to resolve in sequence) for no review-quality benefit — a reviewer evaluating one of them needs to understand the others anyway.

## Gates deferred to CI / reviewer

- \`golangci-lint v1.61\` with project config (same posture as #201, #203, #205, #207, #209, #211)
- Kind-cluster smoke (no kind binary locally) — please verify `informer_cache_objects{kind="Role"|"RoleBinding"|"ClusterRole"|"ClusterRoleBinding"}` panels light up after install

## Solo execution disclosure

Same situation as PRs #201, #203, #205, #207, #209, #211: agent-spawn primitive does not register a callable schema. Lead executed all four roles in this single session, applying every gate the multi-role team would have. Real multi-perspective review process did not happen.

## Scope guardrails respected

Did NOT touch:
- The \`RecordEmit\` helper itself (#198)
- HPA — the last remaining release-blocker, separate issue
- ReplicationController — low priority, v0.5
- \`OMNISCIENCE_K8S_AGENTIC_ALLOWED\` server-side flag wiring (separate)
- \`apps/server/\`, \`packages/connectors/\` — different components