### PR TITLE
feat: wire OMNISCIENCE_K8S_AGENTIC_ALLOWED in dedup gate (#216) — closes epic #199

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adds a new `autoscaling` apiGroup with read-only verbs on
   `horizontalpodautoscalers`.
 
+- **Server: `OMNISCIENCE_K8S_AGENTIC_ALLOWED` flag wired in dedup gate
+  (issue #216, ADR-0011).** The server-side enforcement mechanism for
+  the v0.4 agentic default-flip is now in place. Default in v0.3 stays
+  `true` (no behavior change); when set to `false` the dedup gate
+  short-circuits every `source_type="k8s-agentic"` event BEFORE any DB
+  lookup, increments
+  `omniscience_ingestion_dedup_total{action="agentic_flag_disabled"}`,
+  and returns DROP. Operator and non-K8s emitters are unaffected. The
+  flag is enforced even when dedup itself is disabled (debug envs).
+  **Closes epic #199** — all v0.4 default-flip work for both the
+  operator parity push and the server-side mechanism is complete.
+
 ### Deprecated
 
 - **`k8s-agentic` connector deprecation announced (issue #168, ADR-0011).**

--- a/apps/server/src/omniscience_server/ingestion/dedup.py
+++ b/apps/server/src/omniscience_server/ingestion/dedup.py
@@ -147,6 +147,13 @@ ACTION_TTL_REASSIGN_TO_AGENTIC: Final[str] = "ttl_reassign_to_agentic"
 ACTION_DEDUP_DISABLED: Final[str] = "dedup_disabled"
 ACTION_NON_K8S_BYPASS: Final[str] = "non_k8s_bypass"
 
+# Set when the OMNISCIENCE_K8S_AGENTIC_ALLOWED flag is false AND an event
+# arrives from the k8s-agentic emitter.  The event is dropped at the gate
+# boundary BEFORE any DB lookup — this is the v0.4 server-side enforcement
+# of the agentic deprecation (ADR-0011, issue #216).  v0.3 default for
+# the flag is true so this action is never observed in v0.3 deployments.
+ACTION_AGENTIC_FLAG_DISABLED: Final[str] = "agentic_flag_disabled"
+
 # external_id shape produced by the operator (see
 # ``operator/internal/entity/entity.go``):
 #
@@ -201,6 +208,14 @@ class DedupConfig:
     agentic.  Always a finite real number; the
     ``-1`` disable sentinel collapses to ``enabled=False`` upstream."""
 
+    agentic_allowed: bool = True
+    """When False, every k8s-agentic event is dropped at the gate
+    boundary before any DB lookup (issue #216, v0.4 default-flip
+    enforcement per ADR-0011).  v0.3 default is True so the wiring is
+    a no-op in current deployments; v0.4 will flip the operator-shipped
+    default to False.  Operator and non-K8s emitters are unaffected by
+    this flag — only k8s-agentic short-circuits."""
+
 
 @dataclass(frozen=True, slots=True)
 class DedupDecision:
@@ -252,21 +267,25 @@ def config_from_env(
     *,
     enabled_env: str | None,
     ttl_hours_env: str | None,
+    agentic_allowed_env: str | None = None,
 ) -> DedupConfig:
-    """Translate the two environment variables into a :class:`DedupConfig`.
+    """Translate the dedup environment variables into a :class:`DedupConfig`.
 
-    Both env vars are honoured for documentation symmetry with the issue:
+    Env vars honoured:
 
-    * ``OMNISCIENCE_DEDUP_ENABLED`` = ``"false"`` -> disabled.
-    * ``OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`` = ``"-1"`` -> disabled.
+    * ``OMNISCIENCE_DEDUP_ENABLED`` = ``"false"`` -> dedup disabled.
+    * ``OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`` = ``"-1"`` -> dedup disabled.
     * ``OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`` = ``"0"`` -> sticky (no TTL).
-    * Any positive number -> TTL in hours.
+    * Any positive ``OMNISCIENCE_INGEST_DEDUP_TTL_HOURS`` -> TTL in hours.
+    * ``OMNISCIENCE_K8S_AGENTIC_ALLOWED`` = ``"false"`` -> drop k8s-agentic
+      events at the gate boundary (issue #216, ADR-0011).  Default ``True``
+      in v0.3; v0.4 flips the operator-shipped default to ``False``.
 
     Unparseable values fall back to the secure default
-    (``enabled=True``, ``ttl=24h``) and are logged at WARNING.  This
-    is the closed posture for a misconfiguration — the same posture
-    used elsewhere on the boundary (e.g. retention worker, OTel
-    receiver).
+    (``enabled=True``, ``ttl=24h``, ``agentic_allowed=True``) and are
+    logged at WARNING.  This is the closed posture for a misconfiguration
+    on every dial — the same posture used elsewhere on the boundary
+    (retention worker, OTel receiver).
     """
     enabled = True
     if enabled_env is not None:
@@ -303,7 +322,22 @@ def config_from_env(
             ttl_hours = DEFAULT_TTL_HOURS
 
     ttl_seconds: float | None = None if ttl_hours is None else float(ttl_hours) * 3600.0
-    return DedupConfig(enabled=enabled, ttl_seconds=ttl_seconds)
+
+    agentic_allowed = True
+    if agentic_allowed_env is not None:
+        agentic_allowed = agentic_allowed_env.strip().lower() not in {
+            "false",
+            "0",
+            "no",
+            "off",
+            "",
+        }
+
+    return DedupConfig(
+        enabled=enabled,
+        ttl_seconds=ttl_seconds,
+        agentic_allowed=agentic_allowed,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +382,25 @@ class DedupGate:
         deterministically.
         """
         kind = parse_kind_from_external_id(event.external_id)
+
+        # First: agentic-allowed flag (issue #216 / ADR-0011).  When the
+        # operator owns K8s coverage and the deployment has flipped the
+        # flag closed, drop k8s-agentic events at the gate boundary
+        # before any DB lookup.  Operator and non-K8s events are
+        # unaffected.  This check runs BEFORE the dedup-disabled
+        # short-circuit so the flag is enforced even in deployments
+        # that have explicitly turned dedup off (debug envs, etc.).
+        if not self._config.agentic_allowed and event.source_type == EMITTER_AGENTIC:
+            INGESTION_DEDUP_ACTION_TOTAL.labels(
+                kind=kind,
+                action=ACTION_AGENTIC_FLAG_DISABLED,
+            ).inc()
+            return DedupDecision(
+                action=DedupAction.drop,
+                reason=ACTION_AGENTIC_FLAG_DISABLED,
+                authority_emitter=EMITTER_OPERATOR,
+                kind=kind,
+            )
 
         # Fast path: dedup disabled or non-K8s emitter — bypass the table.
         if not self._config.enabled:

--- a/apps/server/src/omniscience_server/ingestion/worker.py
+++ b/apps/server/src/omniscience_server/ingestion/worker.py
@@ -67,6 +67,10 @@ from omniscience_server.ingestion.run_tracker import RunTracker
 # the full semantics.
 _DEDUP_ENABLED_ENV: str = "OMNISCIENCE_DEDUP_ENABLED"
 _DEDUP_TTL_HOURS_ENV: str = "OMNISCIENCE_INGEST_DEDUP_TTL_HOURS"
+# Issue #216 / ADR-0011: when set to "false", k8s-agentic events are
+# dropped at the dedup gate boundary.  Default unset => True in v0.3;
+# v0.4 will ship "false" as the operator-shipped default.
+_AGENTIC_ALLOWED_ENV: str = "OMNISCIENCE_K8S_AGENTIC_ALLOWED"
 
 # Action label emitted when the dedup gate drops an event.  Distinct
 # from the standard pipeline outcomes so dashboards can chart "events
@@ -126,6 +130,7 @@ class IngestionWorker:
             config: DedupConfig = config_from_env(
                 enabled_env=os.environ.get(_DEDUP_ENABLED_ENV),
                 ttl_hours_env=os.environ.get(_DEDUP_TTL_HOURS_ENV),
+                agentic_allowed_env=os.environ.get(_AGENTIC_ALLOWED_ENV),
             )
             self._dedup_gate: DedupGate = DedupGate(
                 session_factory=session_factory,

--- a/docs/decisions/0011-k8s-agentic-deprecation-schedule.md
+++ b/docs/decisions/0011-k8s-agentic-deprecation-schedule.md
@@ -95,11 +95,17 @@ connector:
 - The agentic module **moves out** of the base install.  Customers who
   want to keep using it must explicitly install
   `omniscience-connectors[k8s-agentic]`.
-- A new server-side feature flag
-  `OMNISCIENCE_K8S_AGENTIC_ALLOWED` is wired in the ingestion worker.
-  Default: **`false`** in v0.4.  When `false`, ingestion drops every
-  event with `source_type="k8s-agentic"` at the gate (before dedup);
-  `omniscience_ingest_emitter_disallowed_total` increments per drop.
+- The server-side feature flag `OMNISCIENCE_K8S_AGENTIC_ALLOWED` is
+  **already wired** in the dedup gate as of issue #216 (v0.3).  The
+  v0.4 cut only flips the operator-shipped default from `true` to
+  `false`; no code change is required at v0.4 release time.  When
+  `false`, the gate short-circuits every event with
+  `source_type="k8s-agentic"` BEFORE any DB lookup; the existing
+  `omniscience_ingestion_dedup_total{action="agentic_flag_disabled"}`
+  counter increments per drop.  (The ADR originally named a separate
+  `omniscience_ingest_emitter_disallowed_total` counter; #216 chose
+  to reuse the existing dedup-action counter with a new action label
+  to avoid extra metric cardinality and keep dashboards consistent.)
 - Customers still on the agentic path at v0.4 have a single Helm /
   env-var change to roll back: `OMNISCIENCE_K8S_AGENTIC_ALLOWED=true`.
   This is the **rollback switch**.

--- a/tests/test_ingestion_dedup.py
+++ b/tests/test_ingestion_dedup.py
@@ -35,6 +35,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from omniscience_server.ingestion.dedup import (
+    ACTION_AGENTIC_FLAG_DISABLED,
     ACTION_DEDUP_DISABLED,
     ACTION_FIRST_AUTHORITY_ASSIGNED,
     ACTION_NO_OP_AGENTIC_DROPPED,
@@ -211,6 +212,120 @@ class TestConfigFromEnv:
         for raw in ["false", "FALSE", "0", "no", "off", ""]:
             cfg = config_from_env(enabled_env=raw, ttl_hours_env=None)
             assert cfg.enabled is False, raw
+
+    # ── #216: OMNISCIENCE_K8S_AGENTIC_ALLOWED parsing ──────────────────────
+
+    def test_agentic_allowed_default_true_when_unset(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env=None)
+        assert cfg.agentic_allowed is True
+
+    def test_agentic_allowed_explicit_true_passes_through(self) -> None:
+        cfg = config_from_env(enabled_env=None, ttl_hours_env=None, agentic_allowed_env="true")
+        assert cfg.agentic_allowed is True
+
+    def test_agentic_allowed_falsy_synonyms(self) -> None:
+        for raw in ["false", "FALSE", "0", "no", "off", ""]:
+            cfg = config_from_env(enabled_env=None, ttl_hours_env=None, agentic_allowed_env=raw)
+            assert cfg.agentic_allowed is False, raw
+
+    def test_agentic_allowed_independent_of_dedup_enabled(self) -> None:
+        # Disabling dedup must NOT also disable the agentic-allowed flag.
+        # The two dials are orthogonal; the flag is enforced regardless of
+        # the dedup gate's enabled state.
+        cfg = config_from_env(enabled_env="false", ttl_hours_env=None, agentic_allowed_env="false")
+        assert cfg.enabled is False
+        assert cfg.agentic_allowed is False
+
+
+# ---------------------------------------------------------------------------
+# #216: agentic-allowed flag short-circuit at the gate boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAgenticAllowedFlag:
+    """The flag drops agentic events at the gate before any DB lookup,
+    leaves operator and non-K8s events alone, and is enforced even when
+    the dedup gate itself is disabled."""
+
+    async def test_flag_false_drops_agentic_event_before_db_lookup(self) -> None:
+        factory, session = _make_session(select_row=None)
+        gate = DedupGate(
+            factory,
+            DedupConfig(enabled=True, ttl_seconds=86400.0, agentic_allowed=False),
+        )
+        ws = uuid.uuid4()
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        before = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_AGENTIC_FLAG_DISABLED,
+        )
+        decision = await gate.evaluate(workspace_id=ws, event=event)
+        after = _counter(
+            INGESTION_DEDUP_ACTION_TOTAL,
+            kind="Pod",
+            action=ACTION_AGENTIC_FLAG_DISABLED,
+        )
+
+        assert decision.action == DedupAction.drop
+        assert decision.reason == ACTION_AGENTIC_FLAG_DISABLED
+        assert decision.authority_emitter == EMITTER_OPERATOR
+        assert after == before + 1
+        # Critical: NO database query happened.  The session factory was
+        # never invoked because the short-circuit returned before the
+        # ``async with`` block.
+        factory.assert_not_called()
+        session.execute.assert_not_called()
+
+    async def test_flag_false_leaves_operator_event_unchanged(self) -> None:
+        factory, _ = _make_session(select_row=None)
+        gate = DedupGate(
+            factory,
+            DedupConfig(enabled=True, ttl_seconds=86400.0, agentic_allowed=False),
+        )
+        event = _make_event(source_type=EMITTER_OPERATOR)
+
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+
+        assert decision.action == DedupAction.accept
+        # Operator event went through the normal first-write path.
+        assert decision.reason == ACTION_FIRST_AUTHORITY_ASSIGNED
+        factory.assert_called_once()
+
+    async def test_flag_false_leaves_non_k8s_event_unchanged(self) -> None:
+        factory, _ = _make_session(select_row=None)
+        gate = DedupGate(
+            factory,
+            DedupConfig(enabled=True, ttl_seconds=86400.0, agentic_allowed=False),
+        )
+        event = _make_event(source_type="git", external_id="git/path/to/file.py")
+
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+
+        # Non-K8s emitter takes the existing non-K8s bypass path.
+        assert decision.action == DedupAction.accept
+        assert decision.reason == ACTION_NON_K8S_BYPASS
+        # Non-K8s bypass also short-circuits before the DB lookup.
+        factory.assert_not_called()
+
+    async def test_flag_false_enforced_even_when_dedup_disabled(self) -> None:
+        # The flag check runs BEFORE the dedup-disabled short-circuit, so
+        # an operator that has dedup off in a debug env still gets agentic
+        # events dropped when the v0.4 flag is set.
+        factory, _session = _make_session(select_row=None)
+        gate = DedupGate(
+            factory,
+            DedupConfig(enabled=False, ttl_seconds=None, agentic_allowed=False),
+        )
+        event = _make_event(source_type=EMITTER_AGENTIC)
+
+        decision = await gate.evaluate(workspace_id=uuid.uuid4(), event=event)
+
+        assert decision.action == DedupAction.drop
+        assert decision.reason == ACTION_AGENTIC_FLAG_DISABLED
+        factory.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #216. **Final task of epic #199.** After this merges, both halves of the v0.4 default-flip work are complete:
- Operator parity push: 24 of 25 kinds COVERED (only ReplicationController low-pri remains, deferred to v0.5) — done across PRs #201, #203, #205, #207, #209, #211, #213, #215.
- Server-side enforcement mechanism: this PR.

The v0.4 release itself only needs to flip the operator-shipped default of \`OMNISCIENCE_K8S_AGENTIC_ALLOWED\` from \`true\` to \`false\` — no further code change required.

## What landed

### Mechanism (`apps/server/src/omniscience_server/ingestion/dedup.py`)

- `DedupConfig` gains `agentic_allowed: bool = True` (appended at the end of the frozen dataclass — existing keyword-arg test instantiations are unaffected).
- New action constant `ACTION_AGENTIC_FLAG_DISABLED`. The existing `INGESTION_DEDUP_ACTION_TOTAL` counter gets a new action label rather than a separate counter family — avoids cardinality cost and keeps dashboards consistent. (ADR-0011 originally named a separate `omniscience_ingest_emitter_disallowed_total`; #216 chose to fold into the existing counter and the ADR is updated to reflect this.)
- `config_from_env` reads `OMNISCIENCE_K8S_AGENTIC_ALLOWED` with the same `{false, 0, no, off, ""}=False` semantics as the existing `OMNISCIENCE_DEDUP_ENABLED`.
- `DedupGate.evaluate()` short-circuits `k8s-agentic` events to **DROP BEFORE any DB lookup AND BEFORE the dedup-disabled short-circuit**. This ordering matters: in a debug env that has dedup itself turned off, the v0.4 flag still gets enforced.
- Operator (`k8s-operator`) and non-K8s emitters (`git`, `slack`, …) are unaffected by the flag.

### Worker (`apps/server/src/omniscience_server/ingestion/worker.py`)

- New `_AGENTIC_ALLOWED_ENV = "OMNISCIENCE_K8S_AGENTIC_ALLOWED"` constant.
- Passed to `config_from_env` at construction (same pattern as the two existing dedup env vars).

### Tests (`tests/test_ingestion_dedup.py`)

- 4 new `TestConfigFromEnv` cases: default true, explicit true, falsy synonyms, independence from `OMNISCIENCE_DEDUP_ENABLED`.
- 4 new `TestAgenticAllowedFlag` evaluate cases: flag=false drops agentic before DB, flag=false leaves operator unchanged, flag=false leaves non-K8s unchanged, flag=false enforced even when dedup disabled.
- **All 35 pre-existing tests pass without modification** (default behavior unchanged).

### Docs

- ADR-0011 v0.4 section clarifies the flag is already wired (#216); v0.4 only flips the operator-shipped default. The metric-naming rationale (folded into existing counter vs separate one) is documented inline.
- CHANGELOG `[Unreleased] → Added` entry calls out that this closes epic #199.

## Quality gates actually run

| Gate | Result |
|------|--------|
| `uv run pytest tests/test_ingestion_dedup.py -v` | **43 / 43 pass** (8 new + 35 pre-existing) |
| `uv run pytest --no-cov` (full suite) | **2083 passed, 52 skipped** |
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 289 files already formatted |
| `uv run mypy apps/ packages/` | Success: no issues found in 186 source files |

## Hard scope guardrails respected

- Did NOT change `DedupConfig` field order — only appended at the end so existing keyword-arg instantiations work.
- Did NOT remove the agentic connector code (`packages/connectors/.../agentic/k8s.py`) — that's v0.5 work.
- Did NOT change v0.3 default (`true`) — only wired the mechanism. The v0.4 default-flip is a separate config-only change at release time.
- Did NOT touch operator code, helm charts, or other connectors.

## Solo execution disclosure

Same situation as PRs #201, #203, #205, #207, #209, #211, #213, #215: agent-spawn primitive does not register a callable schema in this orchestration session. Lead executed all four roles in this single session, applying every gate the multi-role team would have. Real multi-perspective review process did not happen.

## Epic #199 status after this merges

**All tracked work complete.** Suggest closing #199 once this lands. Optional follow-up issues to file if not already done:
- One-line config-only PR at v0.4 release time to flip `OMNISCIENCE_K8S_AGENTIC_ALLOWED` default in helm/values
- ReplicationController watcher (low-pri, v0.5)
- Connector code removal (v0.5, ADR-0011 removal phase)