### PR TITLE
fix(operator): bump Go to 1.23 in Dockerfile + CI workflow

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache-dependency-path: operator/go.sum
       - run: go mod download
       - run: go build ./...

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -4,7 +4,7 @@
 # static so the operator carries no shell, no libc surface, and runs as
 # UID 65532 (nonroot) by default.
 
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.23
 FROM golang:${GO_VERSION}-alpine AS builder
 WORKDIR /workspace
 


### PR DESCRIPTION
## Summary

Fixes the **Operator CI** \"Build + cosign-sign image\" step that has been failing on every operator-touching PR merge to main since at least #207.

\`operator/go.mod\` requires \`go 1.23.0\` (raised by the \`k8s.io/api v0.32.x\` deps). Both the Dockerfile and the CI workflow pinned **Go 1.22**.

The CI test job appeared green because \`actions/setup-go@v5\` allows \`GOTOOLCHAIN\` auto-download (the 1.22.x runner pulls 1.23 transparently via go.mod's directive), but the Dockerfile alpine image sets \`GOTOOLCHAIN=local\` and fails:

\`\`\`
go: go.mod requires go >= 1.23.0 (running go 1.22.12; GOTOOLCHAIN=local)
\`\`\`

This left the operator image unpublishable since the divergence appeared, blocking reviewer-side kind smoke validation across all of #199's parity-push PRs.

## Changes

- \`operator/Dockerfile\`: \`ARG GO_VERSION=1.22\` → \`1.23\`
- \`.github/workflows/operator.yml\`: \`go-version: '1.22'\` → \`'1.23'\` (eliminates the silent GOTOOLCHAIN auto-upgrade so test runner matches the real minimum)

## Quality gates run locally

| Gate | Result |
|------|--------|
| \`go build ./operator/...\` | green |
| \`go test -race -count=1 ./operator/...\` | **291 / 291 pass** |

## Why this matters

Epic #98 (\"native Kubernetes operator\") has acceptance criteria \`Operator installed in a test cluster\` — that's been silently broken since the Go version drift. This PR unblocks epic #98 closure.