### PR TITLE
fix(server): guard mypy_boto3_s3 import with TYPE_CHECKING (#220)

### DIFF
--- a/apps/server/src/omniscience_server/retention_archive.py
+++ b/apps/server/src/omniscience_server/retention_archive.py
@@ -23,14 +23,16 @@ import io
 import uuid
 from dataclasses import dataclass
 from datetime import date
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import boto3
 import pyarrow as pa
 import pyarrow.parquet as pq
 import structlog
 from botocore.config import Config as BotoConfig
-from mypy_boto3_s3.client import S3Client
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.client import S3Client
 
 from omniscience_server.retention_constants import (
     ARCHIVE_KEY_TEMPLATE,


### PR DESCRIPTION
## Summary
- Move `from mypy_boto3_s3.client import S3Client` under `TYPE_CHECKING` — it was being evaluated at runtime but the stub is dev-only (`boto3-stubs[s3]` in `dependency-groups.dev`).
- Runtime Dockerfile installs with `uv sync --frozen --no-dev`, so the import always crashed in-image: `docker compose up` brings `app` into a restart loop and `admin` (depends on `app: service_healthy`) never starts.
- `from __future__ import annotations` is already enabled in the file, so existing `S3Client` annotations remain valid as forward-ref strings at runtime — no further code changes needed.

## Test plan
- [x] `uv run mypy apps/server/src/omniscience_server/retention_archive.py` — clean
- [x] `uv run ruff check apps/server/src/omniscience_server/retention_archive.py` — clean
- [x] `uv run pytest tests/ -k retention_archive` — 10 passed / 1 skipped
- [x] Runtime simulation (block `mypy_boto3_*` from sys.meta_path, then `from omniscience_server.retention_archive import build_s3_client, write_archive_object`) — passes
- [ ] After merge: `docker compose up -d` → `app (healthy)`, `admin Up`, `curl localhost:8000/health` returns 200

Closes #220