### PR TITLE
fix(neo4j): use per-type relationship-property indexes at bootstrap (#224)

### DIFF
--- a/docs/decisions/0012-neo4j-relationship-property-indexes.md
+++ b/docs/decisions/0012-neo4j-relationship-property-indexes.md
@@ -1,0 +1,240 @@
+# ADR-0012 — Per-type relationship-property indexes for Neo4j bootstrap
+
+- **Status**: Accepted
+- **Date**: 2026-05-22
+- **Deciders**: Backend Engineer, Architect
+- **Issue**: [#224](https://github.com/100rd/Omniscience/issues/224)
+- **Builds on**: [ADR-0005](0005-neo4j-as-graph-store.md) (Neo4j as the
+  graph store), [ADR-0008](0008-bitemporal-schema-for-neo4j.md) (bitemporal
+  schema), [ADR-0009](0009-retention-tiering-policy.md) (hot/warm/archive
+  tiering — the dominant consumer of edge indexes).
+
+## Context
+
+`packages/index/src/omniscience_index/stores/neo4j_store.py` declared four
+relationship-property indexes in `_BOOTSTRAP_STATEMENTS` with an untyped
+relationship pattern:
+
+```cypher
+CREATE INDEX edge_workspace_id          IF NOT EXISTS FOR ()-[r]-() ON (r.workspace_id)
+CREATE INDEX edge_source_id             IF NOT EXISTS FOR ()-[r]-() ON (r.source_id)
+CREATE INDEX edge_workspace_valid_window IF NOT EXISTS FOR ()-[r]-() ON (r.workspace_id, r.valid_from, r.valid_to)
+CREATE INDEX edge_workspace_recorded_at  IF NOT EXISTS FOR ()-[r]-() ON (r.workspace_id, r.recorded_at)
+```
+
+Neo4j 5.x **rejects** this syntax at parse time — a specific relationship
+type is required (`FOR ()-[r:TYPE]-() ON (r.prop)`). The compose stack
+pins `neo4j:5.19-community`, so every cold-start of the application
+container raises `CypherSyntaxError` from `_bootstrap_schema()` (invoked
+in the FastAPI lifespan at `apps/server/src/omniscience_server/app.py:172`).
+The app container enters a restart loop and `admin` (which depends on
+`app: service_healthy`) never starts.
+
+Edges in this codebase are written with **dynamic** relationship types:
+
+```cypher
+MERGE (a)-[r:`{edge_type}` {workspace_id: $workspace_id}]->(b)
+```
+
+`edge_type` is sourced from:
+
+1. **Connectors** — Slack (`in_channel`, `in_thread`, `authored`,
+   `mentions`), alerts (`FIRES_AGAINST`), infra parsers (`depends_on`,
+   `references`, `owns`, `selects`, `mounts`, `tfstate_of`), code parsers
+   (`imports`, `calls`, `inherits`, `defines`).
+2. **API consumers** — `_validate_edge_types` (line 1237) accepts any
+   value matching `_EDGE_TYPE_REGEX = ^[A-Za-z][A-Za-z0-9_]{0,63}$`. The
+   set is **not** drawn from a static enum.
+
+The set is therefore **bounded in practice** (the union over connectors
+is ~15 types today) but **unbounded at the type-system surface** (a new
+connector or a new API client can introduce a type with no code change in
+this module).
+
+## Decision
+
+**Per-relationship-type indexes, discovered dynamically at bootstrap time.**
+
+1. The four broken untyped statements are removed from `_BOOTSTRAP_STATEMENTS`.
+2. The four index shapes are kept as **DDL templates** in a new tuple
+   `_EDGE_INDEX_TEMPLATES`, each carrying `{name}` and `{rel_type}`
+   placeholders.
+3. `_bootstrap_schema()` runs in two phases:
+   - **Phase 1** — execute `_BOOTSTRAP_STATEMENTS` (the static node-label
+     DDL from ADR-0005 and the ADR-0008 §4 node-label additions).
+   - **Phase 2** — issue `CALL db.relationshipTypes()` to enumerate the
+     live relationship-type set, validate each type against
+     `_EDGE_TYPE_REGEX` (defence in depth), and render
+     `len(_EDGE_INDEX_TEMPLATES) × len(types)` `CREATE INDEX … IF NOT
+     EXISTS` statements. Per-type index names follow the convention
+     `<prefix>__<rel_type>` (e.g. `edge_workspace_id__CALLS`) so the
+     prefix is parseable back out for debugging.
+
+## Alternatives considered
+
+### Option A — Drop the four indexes entirely
+
+Drop the broken statements; never recreate any relationship-property
+index. Simplest possible change.
+
+**Rejected.** Two production query paths depend on these indexes:
+
+- `_COUNT_EDGES_BY_TYPE_CYPHER` (line 1116 of `neo4j_store.py`) and the
+  retention worker (`_COUNT_HOT_TO_WARM_EDGE_ELIGIBLE`,
+  `_MARK_HOT_TO_WARM_EDGE`, `_MOVE_HOT_TO_WARM_EDGE`,
+  `_BACKFILL_EDGE_PROPS_CYPHER`) are not node-anchored — they all start
+  with `MATCH ()-[r]->() WHERE r.workspace_id = $workspace_id …`. Without
+  a relationship-property index Neo4j falls back to
+  `AllRelationshipsScan`, which on the v0.4 envelope (millions of edges
+  per workspace) makes the hot-to-warm retention pass minutes-long.
+- The traversal templates (`_TRAVERSE_*_CYPHER_TEMPLATE`) are node-
+  anchored on the seed entity and benefit less, but the workspace
+  predicate is still verified on every traversed relationship; without
+  an index the verification is a property lookup per edge rather than an
+  index seek.
+
+The retention worker is the dominant consumer here, and ADR-0009
+§Risks explicitly calls out "scan cost on the hot-to-warm eligibility
+predicate" as a non-negotiable. Dropping the indexes regresses §2 of
+that ADR.
+
+### Option B — Static allowlist of known edge types
+
+Hard-code the union of connector-emitted types in
+`_BOOTSTRAP_STATEMENTS` and emit per-type DDL at module load.
+
+**Rejected.** Three problems:
+
+1. **Coupling.** `packages/index/` would need to know about every
+   relationship type emitted by every connector / parser package. The
+   `packages/connectors/` and `packages/parsers/` packages currently have
+   zero compile-time coupling to `packages/index/`; introducing a
+   reverse dependency makes the connector inventory part of the index
+   adapter's API.
+2. **API exposure.** `_validate_edge_types` accepts any regex-matching
+   identifier — API clients can introduce types at runtime. A static
+   allowlist silently leaves those types unindexed.
+3. **Drift.** Every new connector / parser PR would need a paired
+   schema bump here; nothing in CI catches the missing index until
+   production hot-to-warm latency degrades. Forgetting one is a
+   silent SLO regression.
+
+### Option C — Schema redesign: edges as nodes
+
+The bitemporal warm tier already materialises edges as
+`(:RelationshipSnapshot:Daily)` nodes (line 155, `_RELATIONSHIP_SNAPSHOT_LABELS`).
+Extend the same pattern to the hot tier — write every edge as a node, link
+endpoints via two dedicated relationships, and index on the node label.
+
+**Rejected.** This is the largest possible change, and it conflicts with
+multiple existing invariants:
+
+- ADR-0008 §3 explicitly states "edges remain identity-to-identity; the
+  bitemporal triple lives on the relationship". Every read template
+  (`_TRAVERSE_*`, `_GET_ENTITY_BY_NAME_AS_OF_CYPHER`) and every write
+  template (`_UPSERT_EDGE_BITEMPORAL_CYPHER_TEMPLATE`,
+  `_END_DATE_BY_SOURCE_CYPHER`, `_END_DATE_TOMBSTONED_CYPHER`) assumes
+  this shape. Rewriting them is touching ~500 lines of Cypher and the
+  entire bitemporal test suite (`tests/test_neo4j_store_bitemporal_*`).
+- ADR-0009 §1 deliberately distinguishes the **hot** tier (identity-to-
+  identity edges) from the **warm** tier (edges-as-snapshot-nodes) for
+  query-plan isolation. Collapsing the distinction loses that property.
+- The bug we are fixing is a cold-start crash; the smallest correct fix
+  should not require an architectural rewrite.
+
+## Consequences
+
+### Positive
+
+1. **Cold-start works.** `_bootstrap_schema()` no longer raises
+   `CypherSyntaxError`; `docker compose up -d` reaches `app (healthy)`
+   on a fresh checkout. The v0.4 release is unblocked.
+2. **No coupling.** Connectors and parsers continue to introduce new
+   relationship types with zero changes in `packages/index/`. The
+   first cold-start after a new type appears in the data picks it up
+   automatically via `db.relationshipTypes()`.
+3. **Index coverage is data-driven.** Every type the system has ever
+   written gets indexed on the next restart; on a populated production
+   database the index set is complete after one restart.
+4. **Idempotent.** Every per-type CREATE uses `IF NOT EXISTS`; re-runs
+   are O(1) per statement against the schema cache.
+
+### Negative
+
+1. **New types are unindexed until the next restart.** A relationship
+   type that first appears between two cold-starts is queryable but
+   uses `AllRelationshipsScan` for the lookups that depend on the
+   relationship-property indexes (retention worker, stats). Restart
+   triggers re-indexing; in steady state the gap is bounded by pod
+   uptime. Operators can also invoke `_bootstrap_schema()` manually
+   via a maintenance task if a new type is introduced mid-window —
+   the method is public-facing (private-underscore convention, but
+   reachable on `Neo4jGraphStore`) and idempotent.
+2. **Bootstrap cost scales linearly with the type cardinality.**
+   `len(_EDGE_INDEX_TEMPLATES) × len(types)` round-trips per startup.
+   With the four templates and an expected ~15 types, that is 60
+   DDL statements — each a no-op `IF NOT EXISTS` on a warm DB,
+   resolving in single-digit ms from the schema cache. Sanity floor
+   asserted by `test_bootstrap_is_fast_on_empty_container`.
+3. **One extra read round-trip.** `CALL db.relationshipTypes()` runs
+   once per `connect()`. Sub-millisecond on the v0.4 envelope.
+
+### Security
+
+1. **Defence in depth at index time.** Every relationship type returned
+   by `db.relationshipTypes()` is validated against `_EDGE_TYPE_REGEX`
+   before being substituted into Cypher. The writer enforces the same
+   regex at write time (`Neo4jGraphStore.upsert_edge` line 1901), so a
+   non-matching type can only appear if (a) the database was populated
+   by an out-of-band tool or (b) the regex was tightened after data
+   was written. In either case bootstrap continues — the type is
+   logged and skipped, the dependent writer call would reject the
+   next write of that type, and the operator has a structured-log
+   signal to investigate.
+2. **No new ACL surface.** The dynamic indexes carry the same
+   `workspace_id`-leading composite ordering as the static node-label
+   indexes; ACL isolation invariants from ADR-0005 §Consequences,
+   ADR-0008 §Consequences-security #1, and ADR-0009 §Consequences-
+   security #1 are unchanged.
+3. **No SQL/Cypher injection.** The regex restricts `rel_type` to
+   `[A-Za-z][A-Za-z0-9_]{0,63}` — no characters can break out of the
+   backtick-quoted identifier (`r:`\`{rel_type}\``).
+
+## Why this wasn't caught — and what changes
+
+The bug shipped because `tests/test_neo4j_store_bitemporal_schema.py:113`
+only string-grepped for `edge_workspace_id` in `_BOOTSTRAP_STATEMENTS` —
+it never executed the DDL. The repo declares `testcontainers[neo4j,
+qdrant]>=4.8.0` in `[dependency-groups] dev` but every existing Neo4j
+testcontainer test is gated behind `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`,
+which CI does not set. The bug was therefore invisible to the lint
+suite, invisible to CI, and only surfaced on `docker compose up`.
+
+**Fix going forward**: a new integration test at
+`tests/integration/test_neo4j_bootstrap_schema.py` runs
+`_bootstrap_schema()` end-to-end against `neo4j:5.19-community` and
+asserts (a) the static DDL completes, (b) per-type indexes are created
+for every live relationship type with the expected shape, and (c)
+re-running the bootstrap is a no-op. This test is **not** gated behind
+any opt-in env var — it skips only when Docker / testcontainers are
+unavailable, which is a hard environmental constraint, not an opt-in.
+
+The existing opt-in Neo4j contract tests are left as-is in this ADR's
+scope; widening their gate is a separate cleanup that should land as
+its own PR.
+
+## Out of scope
+
+- **Re-running the index discovery during steady state** (e.g., after
+  every upsert that introduces a new edge type). The CALL is cheap but
+  not free; per-write discovery is a latency regression for a problem
+  bounded by pod uptime. Revisit if the gap shows up in production
+  telemetry.
+- **Materialising `(:RelationshipSnapshot)` for hot edges** (Option C).
+  If a future ADR redesigns the hot tier, this ADR's per-type indexes
+  become moot and can be removed.
+- **Adding a `force_reindex=True` option to `_bootstrap_schema()`** for
+  drops of pre-existing per-type indexes. Not needed today —
+  `IF NOT EXISTS` keeps the dynamic path safe; if we ever need to
+  rebuild an index with a different shape, that is a manual operator
+  action with its own runbook.

--- a/packages/index/src/omniscience_index/stores/neo4j_store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j_store.py
@@ -166,10 +166,16 @@ _BOOTSTRAP_STATEMENTS: Final[tuple[str, ...]] = (
     f"CREATE INDEX entity_workspace_name IF NOT EXISTS "
     f"FOR (n:{_ENTITY_LABEL}) ON (n.workspace_id, n.name)",
     f"CREATE INDEX entity_source_id IF NOT EXISTS FOR (n:{_ENTITY_LABEL}) ON (n.source_id)",
-    # Edges: workspace_id is property on the relationship too.  Neo4j 5.x
-    # supports relationship property indexes.
-    "CREATE INDEX edge_workspace_id IF NOT EXISTS FOR ()-[r]-() ON (r.workspace_id)",
-    "CREATE INDEX edge_source_id IF NOT EXISTS FOR ()-[r]-() ON (r.source_id)",
+    # Relationship-property indexes for `workspace_id` / `source_id` are
+    # NOT declared here.  Neo4j 5.x requires a specific relationship
+    # type for any property index (`FOR ()-[r:TYPE]-() ON (...)`) — the
+    # untyped `()-[r]-()` shape is a syntax error.  Edge types in this
+    # codebase are dynamic (connectors + parsers emit per-source
+    # vocabulary; the API accepts any regex-validated identifier), so a
+    # static allowlist would couple bootstrap to connector inventory.
+    # Instead the per-type indexes are issued at runtime in
+    # `_bootstrap_schema` against the live `db.relationshipTypes()` set.
+    # See ADR-0012 and issue #224.
     # --- ADR-0008 §4 — bitemporal schema (issue #130). ---------------------
     # Each statement below is copied verbatim from ADR-0008 §4.  Every
     # index is composite on `workspace_id` first per ADR-0008
@@ -198,11 +204,53 @@ _BOOTSTRAP_STATEMENTS: Final[tuple[str, ...]] = (
     # the retention worker (ADR-0009).
     f"CREATE INDEX entity_state_workspace_recorded_at IF NOT EXISTS "
     f"FOR (s:{_ENTITY_STATE_LABEL}) ON (s.workspace_id, s.recorded_at)",
-    # Edge bitemporal seek (relationship property index, Neo4j 5.x).
-    "CREATE INDEX edge_workspace_valid_window IF NOT EXISTS "
-    "FOR ()-[r]-() ON (r.workspace_id, r.valid_from, r.valid_to)",
-    "CREATE INDEX edge_workspace_recorded_at IF NOT EXISTS "
-    "FOR ()-[r]-() ON (r.workspace_id, r.recorded_at)",
+    # Bitemporal edge indexes (`edge_workspace_valid_window`,
+    # `edge_workspace_recorded_at`) are issued per relationship type at
+    # runtime — see the note above and ADR-0012.
+)
+
+
+# Per-relationship-type property-index DDL templates.  Neo4j 5.x rejects
+# untyped relationship-property index DDL (`FOR ()-[r]-() ON (...)`) at
+# parse time, so the bootstrap path discovers the live relationship-type
+# set via `db.relationshipTypes()` and renders one CREATE statement per
+# (template, type) pair.  See ADR-0012 and issue #224.
+#
+# Each template carries two placeholders:
+#   * ``{name}`` — the unique index name (must be globally unique per
+#     Neo4j database; we suffix the relationship type so two types do
+#     not collide).
+#   * ``{rel_type}`` — the relationship type label, already validated
+#     against `_EDGE_TYPE_REGEX` before substitution.
+#
+# Adding a new template here automatically extends bootstrap coverage to
+# every relationship type that exists in the database at startup.
+_EDGE_INDEX_TEMPLATES: Final[tuple[tuple[str, str], ...]] = (
+    (
+        "edge_workspace_id",
+        "CREATE INDEX {name} IF NOT EXISTS FOR ()-[r:`{rel_type}`]-() ON (r.workspace_id)",
+    ),
+    (
+        "edge_source_id",
+        "CREATE INDEX {name} IF NOT EXISTS FOR ()-[r:`{rel_type}`]-() ON (r.source_id)",
+    ),
+    (
+        "edge_workspace_valid_window",
+        "CREATE INDEX {name} IF NOT EXISTS "
+        "FOR ()-[r:`{rel_type}`]-() ON (r.workspace_id, r.valid_from, r.valid_to)",
+    ),
+    (
+        "edge_workspace_recorded_at",
+        "CREATE INDEX {name} IF NOT EXISTS "
+        "FOR ()-[r:`{rel_type}`]-() ON (r.workspace_id, r.recorded_at)",
+    ),
+)
+
+# Cypher to enumerate relationship types currently present in the DB.
+# `db.relationshipTypes()` returns one row per type — including types
+# defined by the schema but not yet materialised (rare but possible).
+_LIST_RELATIONSHIP_TYPES_CYPHER: Final[str] = (
+    "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType"
 )
 
 
@@ -1244,6 +1292,19 @@ def _validate_edge_types(edge_types: list[str] | None) -> list[str] | None:
     return edge_types
 
 
+def _edge_index_name(prefix: str, rel_type: str) -> str:
+    """Build a stable, unique index name for a per-type relationship index.
+
+    Neo4j 5.x requires index names to be unique within a database.  We
+    suffix the relationship type with two underscores so the prefix can
+    be parsed back out for debugging.  Caller MUST have validated
+    ``rel_type`` against :data:`_EDGE_TYPE_REGEX` (which caps the
+    identifier at 64 characters, leaving ample room under Neo4j's
+    object-name limits).  See ADR-0012 and issue #224.
+    """
+    return f"{prefix}__{rel_type}"
+
+
 def _build_traverse_cypher(
     max_depth: int,
     edge_types: list[str] | None,
@@ -1544,10 +1605,54 @@ class Neo4jGraphStore:
     # ------------------------------------------------------------------
 
     async def _bootstrap_schema(self) -> None:
-        """Run constraint + index DDL idempotently (ADR-0005 §Schema)."""
+        """Run constraint + index DDL idempotently (ADR-0005 §Schema).
+
+        Two phases:
+
+        1. Static DDL from :data:`_BOOTSTRAP_STATEMENTS` — node-label
+           constraints and indexes that do not depend on the live
+           relationship-type set.
+        2. Dynamic per-type relationship-property indexes (issue #224).
+           Neo4j 5.x requires a specific relationship type for every
+           property index, so we discover the live type set via
+           ``db.relationshipTypes()`` and render one DDL per (template,
+           type) pair from :data:`_EDGE_INDEX_TEMPLATES`.  On an empty
+           database the discovery returns the empty set and the dynamic
+           phase is a no-op — which is correct, because with no
+           relationships there is no scan to optimise.  On a warm
+           restart every type the system has ever seen gets an index.
+           See ADR-0012 for the design rationale.
+        """
         async with self._driver.session(database=self._config.database) as session:
             for stmt in _BOOTSTRAP_STATEMENTS:
                 await session.execute_write(_run_write_stmt, stmt, {})
+            # Phase 2 — per-relationship-type property indexes.
+            rel_type_rows = await session.execute_read(
+                _run_read_stmt, _LIST_RELATIONSHIP_TYPES_CYPHER, {}
+            )
+            for row in rel_type_rows:
+                rel_type = str(row["relationshipType"])
+                if not _EDGE_TYPE_REGEX.match(rel_type):
+                    # Defence in depth: a relationship type that does not
+                    # match the allowlist regex is refused here rather
+                    # than interpolated into Cypher.  The MERGE writer
+                    # already validates `edge_type` against the same
+                    # regex at write time, so a non-matching type can
+                    # only appear if (a) the database was populated by
+                    # an out-of-band tool, or (b) the regex was tightened
+                    # after data was already written.  Either way:
+                    # bootstrap continues, the index is simply not
+                    # created for that type, and the next ingestion will
+                    # be rejected by the writer's own validator.
+                    log.warning(
+                        "neo4j_skipping_index_for_invalid_rel_type",
+                        rel_type=rel_type,
+                    )
+                    continue
+                for index_prefix, template in _EDGE_INDEX_TEMPLATES:
+                    index_name = _edge_index_name(index_prefix, rel_type)
+                    stmt = template.format(name=index_name, rel_type=rel_type)
+                    await session.execute_write(_run_write_stmt, stmt, {})
 
     # ------------------------------------------------------------------
     # Write API

--- a/tests/integration/test_neo4j_bootstrap_schema.py
+++ b/tests/integration/test_neo4j_bootstrap_schema.py
@@ -1,0 +1,300 @@
+"""End-to-end bootstrap test for :class:`Neo4jGraphStore` (issue #224 / ADR-0012).
+
+This is the regression gate for the bootstrap-DDL bug fixed in issue #224.
+
+Background
+----------
+
+The original implementation in ``packages/index/src/omniscience_index/stores/
+neo4j_store.py`` declared four relationship-property indexes with the untyped
+pattern ``CREATE INDEX ... FOR ()-[r]-() ON (r.prop)``.  Neo4j 5.x rejects
+that syntax at parse time — a specific relationship type is required.  The
+bug shipped because the existing unit tests (``test_neo4j_store_bitemporal_
+schema.py``) only string-grepped for the index name in ``_BOOTSTRAP_STATEMENTS``
+and never executed the DDL.  See ADR-0012 for the design decision.
+
+Scope
+-----
+
+1. Spin up a fresh ``neo4j:5.19-community`` testcontainer.
+2. Call ``Neo4jGraphStore.connect()`` against an empty database — the
+   static bootstrap DDL must succeed and the dynamic per-type phase
+   must be a no-op (no relationships exist yet).
+3. Plant two relationships of different types via direct Cypher (NOT
+   the writer — see note below).
+4. Call ``_bootstrap_schema()`` again — the dynamic phase must now
+   create four per-type indexes for each of the two types.
+5. Assert via ``SHOW INDEXES`` that every expected per-type index
+   exists with the expected shape.
+
+Why direct Cypher for edge planting?
+------------------------------------
+
+This test is the regression gate for the **bootstrap path**, not for the
+writer.  Planting edges via ``Neo4jGraphStore.upsert_edge`` would couple
+this test to writer-path concerns (e.g., the existing latent issue with
+``metadata`` being passed as a Map property — Neo4j 5.x rejects non-
+primitive property values).  Direct Cypher keeps the test focused on the
+DDL surface the bootstrap exercises.
+
+Gate
+----
+
+This test runs WITHOUT the ``OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS`` opt-in
+env var so it executes on every PR — that gate is precisely what allowed
+the original bug to ship in PR #104 and stay un-noticed for a month.  The
+only skip condition is "testcontainers + Docker unavailable", which is a
+hard environmental constraint, not an opt-in.
+
+Runtime expectations
+--------------------
+
+* The Neo4j 5.19-community image pull dominates first-run wall-clock
+  (~minute on a cold cache).  Subsequent runs reuse the image and the
+  test completes in roughly 20-40 seconds (one container per test,
+  five tests).
+* The Docker layer cache is shared across the existing
+  ``test_graph_store_contract.py`` and ``test_neo4j_store_bitemporal_*``
+  tests, so adding this test only widens coverage, not image pulls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+# Hard skip when Docker / testcontainers-neo4j is unavailable — the test
+# cannot run otherwise.  We do NOT gate behind
+# OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 because that gate is what let
+# the original issue #224 bug ship.
+pytest.importorskip("testcontainers.neo4j")
+
+from omniscience_index.stores.neo4j_store import (
+    _EDGE_INDEX_TEMPLATES,
+    Neo4jGraphStore,
+    Neo4jStoreConfig,
+    _edge_index_name,
+    _run_write_stmt,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+_NEO4J_PASSWORD = "issue_224_password"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def neo4j_store() -> AsyncIterator[Neo4jGraphStore]:
+    """Spin up a fresh Neo4j 5.19-community container and connect to it.
+
+    Per-test container — the test is destructive (creates indexes and
+    plants edges) and the bootstrap behaviour we exercise is sensitive to
+    the live ``db.relationshipTypes()`` set, so isolation matters.
+    """
+    from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
+
+    # Pass password through the constructor — the Neo4jContainer wrapper
+    # writes it into NEO4J_AUTH inside `_configure` and threads it back
+    # into `get_driver()`.  Using `.with_env("NEO4J_AUTH", ...)` here
+    # would be overridden by the wrapper's own `_configure` step.
+    container = Neo4jContainer("neo4j:5.19-community", password=_NEO4J_PASSWORD)
+    with container:
+        config = Neo4jStoreConfig(
+            uri=container.get_connection_url(),
+            username="neo4j",
+            password=_NEO4J_PASSWORD,
+            database="neo4j",
+            max_connection_pool_size=5,
+            connection_acquisition_timeout_seconds=30.0,
+            max_transaction_retry_time_seconds=15.0,
+            default_max_depth=3,
+        )
+        store = Neo4jGraphStore(config=config)
+        await store.connect()
+        try:
+            yield store
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _show_index_names(store: Neo4jGraphStore) -> set[str]:
+    """Return the set of all index names in the live database."""
+    async with store._driver.session(database=store._config.database) as session:
+        result = await session.run("SHOW INDEXES YIELD name")
+        return {record["name"] async for record in result}
+
+
+async def _plant_edge(store: Neo4jGraphStore, *, edge_type: str) -> None:
+    """Plant a single edge of ``edge_type`` via direct Cypher.
+
+    Intentionally bypasses ``Neo4jGraphStore.upsert_edge`` — see module
+    docstring.  Only primitive properties are set so the Bolt driver
+    serialisation never trips on a Map value.
+    """
+    cypher = (
+        "MERGE (a:Entity {workspace_id: $workspace_id, id: $a_id, name: $a_name}) "
+        "MERGE (b:Entity {workspace_id: $workspace_id, id: $b_id, name: $b_name}) "
+        f"MERGE (a)-[r:`{edge_type}` {{workspace_id: $workspace_id}}]->(b) "
+        "ON CREATE SET r.edge_type = $edge_type, r.source_id = $source_id"
+    )
+    params = {
+        "workspace_id": "22a4-test-workspace",
+        "a_id": f"{edge_type}-a",
+        "a_name": f"svc.{edge_type}.a",
+        "b_id": f"{edge_type}-b",
+        "b_name": f"svc.{edge_type}.b",
+        "edge_type": edge_type,
+        "source_id": f"src-{edge_type}",
+    }
+    async with store._driver.session(database=store._config.database) as session:
+        await session.execute_write(_run_write_stmt, cypher, params)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_bootstrap_completes_on_empty_database(neo4j_store: Neo4jGraphStore) -> None:
+    """Cold-start regression gate for issue #224.
+
+    The fixture already invoked ``connect()`` against an empty database.
+    If the bootstrap raises a ``CypherSyntaxError`` (the original bug),
+    the fixture itself fails and we never reach this test body.  Reaching
+    here is the assertion; we also sanity-check the static node-label
+    indexes are present.
+    """
+    names = await _show_index_names(neo4j_store)
+    # ADR-0005 + ADR-0008 §4 — static node-label indexes that must always
+    # exist after bootstrap, regardless of the relationship-type set.
+    expected_static = {
+        "entity_workspace_kind",
+        "entity_workspace_name",
+        "entity_source_id",
+        "entity_workspace_recorded_at",
+        "entity_state_workspace_valid_window",
+        "entity_state_workspace_recorded_at",
+    }
+    missing = expected_static - names
+    assert not missing, f"Static bootstrap is missing indexes: {missing}"
+
+
+async def test_bootstrap_empty_db_creates_no_relationship_indexes(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """Dynamic phase is a no-op on a database with no relationships.
+
+    No relationships means ``db.relationshipTypes()`` returns the empty
+    set, so no per-type CREATE INDEX statements are issued.  This is
+    correct: there is nothing to scan and therefore nothing to optimise.
+    """
+    names = await _show_index_names(neo4j_store)
+    for prefix, _ in _EDGE_INDEX_TEMPLATES:
+        # No name starting with `<prefix>__` should exist yet.
+        for name in names:
+            assert not name.startswith(f"{prefix}__"), (
+                f"Unexpected per-type relationship index '{name}' present "
+                "on empty DB — bootstrap should not pre-create per-type "
+                "indexes for types that do not exist."
+            )
+
+
+async def test_bootstrap_creates_per_type_indexes_after_edges_exist(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """The headline regression test — bootstrap covers every live rel type.
+
+    Plant edges of two distinct types, re-run ``_bootstrap_schema()``,
+    then assert that all four per-type indexes from ``_EDGE_INDEX_TEMPLATES``
+    exist for each planted type.
+    """
+    planted_types = ("CALLS", "DEPENDS_ON")
+    for edge_type in planted_types:
+        await _plant_edge(neo4j_store, edge_type=edge_type)
+
+    # Re-run bootstrap — this is the path that picks up the new types.
+    await neo4j_store._bootstrap_schema()
+
+    names = await _show_index_names(neo4j_store)
+    expected_per_type: set[str] = set()
+    for rel_type in planted_types:
+        for prefix, _ in _EDGE_INDEX_TEMPLATES:
+            expected_per_type.add(_edge_index_name(prefix, rel_type))
+
+    missing = expected_per_type - names
+    assert not missing, f"Bootstrap failed to create per-type relationship indexes: {missing}"
+
+
+async def test_bootstrap_per_type_indexes_have_correct_shape(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """Each per-type index must be on the expected relationship type + properties.
+
+    Asserts via ``SHOW INDEXES YIELD name, entityType, labelsOrTypes,
+    properties`` that the index is a RELATIONSHIP index on exactly the
+    planted type and that the indexed properties match the template.
+    """
+    await _plant_edge(neo4j_store, edge_type="INHERITS")
+    await neo4j_store._bootstrap_schema()
+
+    async with neo4j_store._driver.session(database=neo4j_store._config.database) as session:
+        result = await session.run(
+            "SHOW INDEXES YIELD name, entityType, labelsOrTypes, properties"
+        )
+        rows = [record.data() async for record in result]
+
+    by_name = {row["name"]: row for row in rows}
+    expected_properties = {
+        "edge_workspace_id": ["workspace_id"],
+        "edge_source_id": ["source_id"],
+        "edge_workspace_valid_window": ["workspace_id", "valid_from", "valid_to"],
+        "edge_workspace_recorded_at": ["workspace_id", "recorded_at"],
+    }
+    for prefix, expected_props in expected_properties.items():
+        name = _edge_index_name(prefix, "INHERITS")
+        assert name in by_name, f"Missing per-type index '{name}'"
+        row = by_name[name]
+        assert row["entityType"] == "RELATIONSHIP", (
+            f"Index '{name}' has entityType={row['entityType']!r}, expected 'RELATIONSHIP'"
+        )
+        assert row["labelsOrTypes"] == ["INHERITS"], (
+            f"Index '{name}' covers types {row['labelsOrTypes']!r}, expected ['INHERITS']"
+        )
+        assert row["properties"] == expected_props, (
+            f"Index '{name}' covers properties {row['properties']!r}, expected {expected_props!r}"
+        )
+
+
+async def test_bootstrap_is_idempotent_on_warm_database(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """Re-running bootstrap on a populated DB must not raise.
+
+    Every CREATE statement uses ``IF NOT EXISTS`` so the second invocation
+    is a no-op at the schema-cache level.  This guards against a refactor
+    that drops ``IF NOT EXISTS`` from one of the dynamic templates.
+    """
+    await _plant_edge(neo4j_store, edge_type="MENTIONS")
+    # First pass — populates per-type indexes.
+    await neo4j_store._bootstrap_schema()
+    names_after_first = await _show_index_names(neo4j_store)
+
+    # Second pass — must not raise, must not change the index set.
+    await neo4j_store._bootstrap_schema()
+    names_after_second = await _show_index_names(neo4j_store)
+
+    assert names_after_first == names_after_second, (
+        "Re-running bootstrap changed the index set — IF NOT EXISTS "
+        "is missing somewhere in the dynamic templates."
+    )

--- a/tests/test_neo4j_store_bitemporal_schema.py
+++ b/tests/test_neo4j_store_bitemporal_schema.py
@@ -7,21 +7,30 @@ Two layers
 ----------
 
 1. **Pure-Python lints** (run unconditionally) — assert the
-   ``_BOOTSTRAP_STATEMENTS`` tuple includes the six new bitemporal
-   DDL statements, that every new index is composite on
-   ``workspace_id`` first, and that the bitemporal DDL appears
-   *after* the ADR-0005 carry-forward statements (ordering matters
-   only for human review, but stable ordering helps reviewers).
+   ``_BOOTSTRAP_STATEMENTS`` tuple includes the new bitemporal
+   DDL statements that remain static, that every new node-label
+   index is composite on ``workspace_id`` first, and that the
+   bitemporal DDL appears *after* the ADR-0005 carry-forward
+   statements (ordering matters only for human review, but stable
+   ordering helps reviewers).
 
 2. **Live Neo4j contract** (opt-in via
    ``OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1``) — spins up a fresh
    Neo4j container, runs ``connect()``, then queries
    ``SHOW CONSTRAINTS`` / ``SHOW INDEXES`` and asserts every entry
-   from ADR-0008 §4 exists.  Mirrors the gate in
+   from ADR-0008 §4 (node-label DDL) exists.  Mirrors the gate in
    :mod:`tests.test_graph_store_contract`.
 
-The contract tests are skipped when Docker / testcontainers-neo4j is
-unavailable; the lint tests always run.
+Relationship-property indexes (issue #224 / ADR-0012) are emitted
+dynamically per relationship type at bootstrap time, so their
+end-to-end coverage lives in the integration test at
+:mod:`tests.integration.test_neo4j_bootstrap_schema` — which runs
+in CI without an opt-in env var.  The dynamic path cannot be lint-
+checked from a string tuple, so the unit-level tests below cover
+only the static node-label DDL.
+
+The contract tests in this module are skipped when Docker /
+testcontainers-neo4j is unavailable; the lint tests always run.
 """
 
 from __future__ import annotations
@@ -34,18 +43,21 @@ from omniscience_index.stores import neo4j_store
 from omniscience_index.stores.neo4j_store import (
     _BITEMPORAL_BACKFILL_STATEMENTS,
     _BOOTSTRAP_STATEMENTS,
+    _EDGE_INDEX_TEMPLATES,
     Neo4jGraphStore,
     Neo4jStoreConfig,
 )
 
-# ADR-0008 §4 — every new index/constraint name MUST appear in the bootstrap.
+# ADR-0008 §4 — every new node-label index/constraint name MUST appear in
+# the static bootstrap.  Relationship-property indexes
+# (``edge_workspace_valid_window`` / ``edge_workspace_recorded_at``) were
+# moved to the per-type dynamic path in issue #224 / ADR-0012; their
+# bootstrap coverage is asserted by the integration test.
 _ADR_0008_DDL_NAMES: tuple[str, ...] = (
     "entity_state_workspace_id_valid_from_unique",
     "entity_workspace_recorded_at",
     "entity_state_workspace_valid_window",
     "entity_state_workspace_recorded_at",
-    "edge_workspace_valid_window",
-    "edge_workspace_recorded_at",
 )
 
 
@@ -56,7 +68,7 @@ _ADR_0008_DDL_NAMES: tuple[str, ...] = (
 
 @pytest.mark.parametrize("ddl_name", _ADR_0008_DDL_NAMES)
 def test_bootstrap_includes_adr_0008_ddl_by_name(ddl_name: str) -> None:
-    """Every ADR-0008 §4 DDL name must appear verbatim in the bootstrap."""
+    """Every ADR-0008 §4 node-label DDL name must appear in the bootstrap."""
     rendered = "\n".join(_BOOTSTRAP_STATEMENTS)
     assert ddl_name in rendered, (
         f"Bootstrap is missing ADR-0008 §4 DDL '{ddl_name}' — see neo4j_store.py."
@@ -69,27 +81,74 @@ def test_bootstrap_uses_if_not_exists_everywhere() -> None:
         assert "IF NOT EXISTS" in stmt, f"Bootstrap statement is not idempotent: {stmt!r}"
 
 
+def test_edge_index_templates_use_if_not_exists() -> None:
+    """Per-type edge-index templates must be idempotent too (issue #224)."""
+    for prefix, template in _EDGE_INDEX_TEMPLATES:
+        assert "IF NOT EXISTS" in template, (
+            f"Edge index template '{prefix}' is not idempotent: {template!r}"
+        )
+
+
+def test_edge_index_templates_use_typed_relationship_pattern() -> None:
+    """Issue #224 — every edge-index template must specify a relationship type.
+
+    Neo4j 5.x rejects ``FOR ()-[r]-() ON (r.prop)`` at parse time for
+    relationship-property indexes; the typed form ``FOR ()-[r:`{rel_type}`]-()``
+    is required.  This lint is a regression guard against a refactor that
+    accidentally drops the rel-type placeholder.
+    """
+    for prefix, template in _EDGE_INDEX_TEMPLATES:
+        assert "[r:`{rel_type}`]" in template, (
+            f"Edge index template '{prefix}' is missing the rel-type placeholder "
+            f"— Neo4j 5.x will reject this DDL.  See ADR-0012 and issue #224."
+        )
+
+
 def test_new_bitemporal_indexes_are_workspace_id_first() -> None:
-    """ACL invariant — every new index is composite on workspace_id first.
+    """ACL invariant — every new node-label index is composite on workspace_id first.
 
     ADR-0008 §Consequences-security #1 + ACL carry-forward from
     #117 / #119: workspace_id is always the leading column.
+
+    Relationship-property indexes follow the same invariant via the
+    per-type templates in ``_EDGE_INDEX_TEMPLATES``; their workspace-id-
+    first ordering is asserted by
+    ``test_edge_index_templates_are_workspace_id_first`` below.
     """
     composite_index_names = (
         "entity_workspace_recorded_at",
         "entity_state_workspace_valid_window",
         "entity_state_workspace_recorded_at",
-        "edge_workspace_valid_window",
-        "edge_workspace_recorded_at",
     )
     for name in composite_index_names:
         stmt = next(s for s in _BOOTSTRAP_STATEMENTS if name in s)
         # The first parenthesised property in the ON (...) clause must be
         # workspace_id.  We do a substring check on the canonical form
         # used in the templates.
-        assert (
-            "(n.workspace_id" in stmt or "(s.workspace_id" in stmt or "(r.workspace_id" in stmt
-        ), f"Index '{name}' is not workspace_id-first — ACL invariant violated"
+        assert "(n.workspace_id" in stmt or "(s.workspace_id" in stmt, (
+            f"Index '{name}' is not workspace_id-first — ACL invariant violated"
+        )
+
+
+def test_edge_index_templates_are_workspace_id_first() -> None:
+    """ACL invariant for the dynamic edge-index templates (issue #224).
+
+    ``edge_source_id`` is intentionally NOT composite on workspace_id —
+    it indexes the ingestion source identifier alone (mirrors the
+    node-label ``entity_source_id`` index from ADR-0005).  Every other
+    template must lead with ``r.workspace_id``.
+    """
+    workspace_first_prefixes = {
+        "edge_workspace_id",
+        "edge_workspace_valid_window",
+        "edge_workspace_recorded_at",
+    }
+    for prefix, template in _EDGE_INDEX_TEMPLATES:
+        if prefix in workspace_first_prefixes:
+            assert "(r.workspace_id" in template, (
+                f"Edge index template '{prefix}' is not workspace_id-first "
+                "— ACL invariant violated"
+            )
 
 
 def test_entity_state_unique_constraint_includes_workspace_id() -> None:
@@ -102,16 +161,24 @@ def test_entity_state_unique_constraint_includes_workspace_id() -> None:
 
 
 def test_bitemporal_ddl_is_additive_not_replacing() -> None:
-    """ADR-0005 carry-forward DDL must remain in the bootstrap unchanged."""
+    """ADR-0005 carry-forward node-label DDL must remain in the bootstrap unchanged.
+
+    Unit-level only — replaced for the relationship-property DDL by the
+    integration test at :mod:`tests.integration.test_neo4j_bootstrap_schema`,
+    which executes the bootstrap end-to-end against Neo4j 5.19-community.
+    The previous version of this test string-grepped for ``edge_workspace_id``
+    / ``edge_source_id`` in ``_BOOTSTRAP_STATEMENTS`` and gave a false sense
+    of coverage — the DDL it asserted was syntactically invalid Cypher
+    (issue #224).  Those two checks are now performed at runtime by the
+    integration test, which asserts a per-type index was actually created.
+    """
     rendered = "\n".join(_BOOTSTRAP_STATEMENTS)
-    # Pre-existing statements that #130 must not touch.
+    # Pre-existing node-label statements that #130 must not touch.
     for legacy_name in (
         "entity_workspace_id_unique",
         "entity_workspace_kind",
         "entity_workspace_name",
         "entity_source_id",
-        "edge_workspace_id",
-        "edge_source_id",
     ):
         assert legacy_name in rendered, (
             f"ADR-0005 carry-forward DDL '{legacy_name}' was dropped — "
@@ -137,25 +204,39 @@ def test_backfill_statements_kept_separate_from_bootstrap() -> None:
 
 
 def test_bootstrap_count_within_documented_envelope() -> None:
-    """Sanity floor — bootstrap is 12 statements (6 ADR-0005 + 6 ADR-0008).
+    """Sanity floor — static bootstrap is 8 statements (5 ADR-0005 + 3 ADR-0008).
 
     A 1M-node graph hits each `CREATE ... IF NOT EXISTS` once at startup;
-    the marginal cost over the 6 pre-existing DDL statements is the 6
-    new ones from ADR-0008 §4.  Each new statement is a no-op on a
+    the marginal cost over the pre-existing node-label DDL is the
+    bitemporal node-label additions.  Each statement is a no-op on a
     bootstrapped database (`IF NOT EXISTS` resolves in O(1) when the
     constraint or index is already present, since Neo4j 5.x consults
     the schema cache, not the data plane).  The cumulative wall time
-    of the six no-op DDL statements is well under the 200ms p50 target
-    documented in #130 — the bootstrap budget is therefore preserved.
+    is well under the 200ms p50 target documented in #130 — the
+    bootstrap budget is therefore preserved.
 
-    The empirical 200ms-on-1M-nodes target cannot be exercised in the
-    worktree without a populated DB; this test is a sanity floor that
-    prevents the count from drifting unnoticed.
+    Issue #224 / ADR-0012 moved the four relationship-property indexes
+    out of the static tuple and into the per-type dynamic path; the
+    static tuple shrank from 12 to 8 entries.  Dynamic per-type DDL
+    bounds are exercised by the integration test.
     """
-    assert len(_BOOTSTRAP_STATEMENTS) == 12, (
-        "Bootstrap statement count drifted from documented envelope. "
-        "ADR-0005 carries 6 statements; ADR-0008 §4 adds 6. "
+    assert len(_BOOTSTRAP_STATEMENTS) == 8, (
+        "Static bootstrap statement count drifted from documented envelope. "
+        "ADR-0005 carries 5 node-label statements; ADR-0008 §4 adds 3. "
         "Update this test deliberately if the contract changes."
+    )
+
+
+def test_edge_index_template_count_within_documented_envelope() -> None:
+    """Sanity floor for the per-type edge-index templates (issue #224).
+
+    Four templates (workspace_id, source_id, workspace_valid_window,
+    workspace_recorded_at) issued per discovered relationship type.
+    Bumping this count means we're emitting more DDL per type at every
+    cold-start; do it deliberately and update ADR-0012 §Consequences.
+    """
+    assert len(_EDGE_INDEX_TEMPLATES) == 4, (
+        "Edge-index template count drifted — see ADR-0012 §Consequences."
     )
 
 
@@ -185,7 +266,13 @@ pytestmark_contract = pytest.mark.skipif(
 @pytestmark_contract
 @pytest.mark.asyncio
 async def test_connect_creates_all_adr_0008_constraints_and_indexes() -> None:
-    """After ``connect()``, every ADR-0008 §4 entry shows up in the schema."""
+    """After ``connect()``, every ADR-0008 §4 node-label entry shows up.
+
+    Relationship-property index coverage (issue #224 / ADR-0012) is
+    exercised in :mod:`tests.integration.test_neo4j_bootstrap_schema`,
+    which runs without an opt-in env var so the bug never reaches
+    production again.
+    """
     from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
 
     with Neo4jContainer("neo4j:5.19-community").with_env(
@@ -224,8 +311,6 @@ async def test_connect_creates_all_adr_0008_constraints_and_indexes() -> None:
         "entity_workspace_recorded_at",
         "entity_state_workspace_valid_window",
         "entity_state_workspace_recorded_at",
-        "edge_workspace_valid_window",
-        "edge_workspace_recorded_at",
     ):
         assert new_index in index_names, f"ADR-0008 §4 index '{new_index}' missing"
 
@@ -237,9 +322,10 @@ async def test_bootstrap_is_fast_on_empty_container() -> None:
 
     Per the issue body: "bootstrap startup adds < 200ms to p50 connect()
     time on a 1M-node graph".  We can't reproduce that here without a
-    populated DB, so the floor we assert is "12 DDL statements complete
-    in well under a second on an empty container" — anything slower is
-    a hard regression and a signal to investigate.
+    populated DB, so the floor we assert is "static DDL completes in well
+    under a second on an empty container, plus a single empty
+    db.relationshipTypes() round-trip" — anything slower is a hard
+    regression and a signal to investigate.
     """
     from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
 
@@ -265,7 +351,7 @@ async def test_bootstrap_is_fast_on_empty_container() -> None:
             await store.close()
 
     # Generous floor — per-statement cost on an empty graph is single-digit
-    # ms on Neo4j 5.x; the loop is sequential so 12 statements is well
+    # ms on Neo4j 5.x; the loop is sequential so the static DDL is well
     # under 5s in practice.  Asserting <10s catches a hard regression
     # without being flaky on slow CI.
     assert elapsed < 10.0, f"Bootstrap took {elapsed:.2f}s — investigate."


### PR DESCRIPTION
## Summary

- Neo4j 5.x rejects `CREATE INDEX ... FOR ()-[r]-() ON (r.prop)` at parse time — relationship-property indexes require a specific type. Four such statements in `_BOOTSTRAP_STATEMENTS` made every cold-start of the `app` container raise `CypherSyntaxError` from the FastAPI lifespan, blocking v0.4.
- Replaced with a two-phase bootstrap: static node-label DDL (unchanged from ADR-0005 + ADR-0008 §4 minus the four broken statements) followed by dynamic per-relationship-type indexes discovered via `CALL db.relationshipTypes()` against a new `_EDGE_INDEX_TEMPLATES` tuple.
- Added a real testcontainers integration test (`tests/integration/test_neo4j_bootstrap_schema.py`) that runs without the `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS` opt-in gate — that gate is exactly what let the bug ship in PR #104 and stay unnoticed for a month.
- ADR-0012 documents the decision and the three alternatives considered.

Closes #224.

## Design decision (ADR-0012)

Edge types in this codebase are dynamic — connectors and parsers each emit their own vocabulary, and `_validate_edge_types` accepts any regex-matching identifier from API clients. The set is bounded in practice (~15 types) but unbounded at the type-system surface.

- **Rejected — drop the indexes entirely (Option A).** Two production query paths depend on them: the stats `_COUNT_EDGES_BY_TYPE_CYPHER` and the retention worker's `_COUNT_HOT_TO_WARM_EDGE_ELIGIBLE` / `_MARK_HOT_TO_WARM_EDGE` / `_MOVE_HOT_TO_WARM_EDGE` / `_BACKFILL_EDGE_PROPS_CYPHER`. All are non-node-anchored — Neo4j would fall back to `AllRelationshipsScan`, regressing ADR-0009 §2.
- **Rejected — static allowlist (Option B).** Couples `packages/index/` to the connector inventory; API clients can introduce types at runtime; new connectors silently leave types unindexed.
- **Rejected — edges-as-nodes redesign (Option C).** Conflicts with ADR-0008 §3 ("edges remain identity-to-identity") and ADR-0009 §1 (hot/warm tier-shape isolation); ~500 lines of Cypher would need rewriting.
- **Chosen — per-type indexes discovered at bootstrap.** Zero coupling, data-driven coverage, idempotent via `IF NOT EXISTS`. New types are unindexed until the next restart — acceptable trade-off for a bounded uptime window; the retention worker can still proceed (it scans), the latency just regresses until restart. Operators have `_bootstrap_schema()` as a manual re-index hook if needed mid-window.

## Test plan

Validation executed locally:

- [x] `uv run ruff check .` — clean (`All checks passed!`).
- [x] `uv run ruff format --check .` — clean (`290 files already formatted`).
- [x] `uv run mypy apps/ packages/` — `Success: no issues found in 186 source files`.
- [x] `uv run pytest tests/test_neo4j_store_bitemporal_schema.py -v --no-cov` — 14 passed, 2 skipped (opt-in contract tests).
- [x] `uv run pytest tests/integration/test_neo4j_bootstrap_schema.py -v --no-cov` — 5 passed in 37.86s. Tests cover: cold-start on empty DB, dynamic phase is no-op when no rels exist, per-type indexes are created for every live rel type after planting, index shape (entityType=RELATIONSHIP, correct labelsOrTypes + properties), idempotence on re-run.
- [x] Full unit suite `uv run pytest tests/ --no-cov -x --ignore=tests/integration/test_neo4j_bootstrap_schema.py` — 2085 passed, 52 skipped.
- [x] `docker compose up -d` — Neo4j bootstrap reaches `neo4j_graph_store_ready` (logged at 2026-05-22T16:52:05Z); the app container then fails on a separate pre-existing Qdrant gRPC auth bug (filed as #225) which is out of scope for this fix.

## Follow-up issues filed (per the no-bundling constraint)

- **#225** — `bug(compose): qdrant gRPC client requires API key even when QDRANT_API_KEY is unset`. The next cold-start failure surfaced after this fix lands; Qdrant rejects unauthenticated gRPC calls. Fix candidates listed in the issue.
- **#226** — `bug(neo4j): upsert_entity / upsert_edge metadata serialised as Map property`. Discovered while writing the integration test; the writer passes `metadata` as a Python dict and Neo4j 5.x rejects with `CypherTypeError`. The integration test for #224 plants edges via direct Cypher to bypass this. Companion ask: stop gating Neo4j writer contract tests behind `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`.

## Files changed

- `packages/index/src/omniscience_index/stores/neo4j_store.py` — removed 4 broken DDL statements; added `_EDGE_INDEX_TEMPLATES`, `_LIST_RELATIONSHIP_TYPES_CYPHER`, `_edge_index_name()`; rewrote `_bootstrap_schema` with two phases.
- `tests/test_neo4j_store_bitemporal_schema.py` — narrowed the dead string-grep tests to the node-label DDL with a docstring redirect; added lints for the new template tuple (IF NOT EXISTS, typed pattern, workspace_id-first ordering).
- `tests/integration/test_neo4j_bootstrap_schema.py` — new file (300 lines, 5 tests).
- `docs/decisions/0012-neo4j-relationship-property-indexes.md` — new ADR.