### PR TITLE
fix(qdrant): default QDRANT_API_KEY in dev to unblock gRPC bootstrap (#225)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,11 @@ GRAPH_BITEMPORAL=disabled
 QDRANT_HOST=qdrant
 QDRANT_GRPC_PORT=6334
 QDRANT_HTTP_PORT=6333
-# QDRANT_API_KEY=        # required in every non-dev environment
+# Dev default: the qdrant-client gRPC stack (>=1.12) returns UNAUTHENTICATED
+# when no bearer token is sent, even if the server was started with an empty
+# API key — so dev mirrors prod and always provides a key. Override per
+# environment; rotate this value before exposing the cluster off-host.
+QDRANT_API_KEY=qdrant_dev
 QDRANT_HTTPS=false
 QDRANT_PREFER_GRPC=true
 QDRANT_TIMEOUT_SECONDS=10.0

--- a/tests/test_qdrant_store_unit.py
+++ b/tests/test_qdrant_store_unit.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import uuid
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from omniscience_core.storage import ChunkPayload, VectorStore
@@ -275,3 +275,65 @@ async def test_upsert_is_unchanged_when_content_hash_matches() -> None:
     assert outcome.chunks_written == 0
     assert outcome.document_id == existing_doc_id
     client.upsert.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Client construction: the API key from QdrantConfig reaches AsyncQdrantClient
+# Regression coverage for issue #225 — the qdrant-client gRPC interceptor
+# in v1.12+ returns UNAUTHENTICATED when no bearer token is sent, so we MUST
+# forward whatever api_key the settings layer resolved (including None, which
+# is still a valid dev path on the HTTP transport).
+# ---------------------------------------------------------------------------
+
+
+def test_build_client_forwards_api_key_from_config() -> None:
+    """``_build_client`` must hand the configured api_key to ``AsyncQdrantClient``.
+
+    Regression for #225: without this, dev/staging/prod all crash at
+    ``_ensure_collection`` with ``StatusCode.UNAUTHENTICATED`` because the
+    gRPC interceptor refuses to send unauthenticated calls.
+    """
+    config = QdrantConfig(
+        host="qdrant.example",
+        grpc_port=6334,
+        http_port=6333,
+        api_key="secret-key-from-env",
+        https=True,
+        prefer_grpc=True,
+        timeout_seconds=12.5,
+    )
+    store = QdrantVectorStore(config=config, embedding_provider=_embedding_provider())
+
+    with patch("omniscience_index.stores.qdrant_store.AsyncQdrantClient") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock(spec=AsyncQdrantClient)
+        store._build_client()
+
+    mock_client_cls.assert_called_once()
+    kwargs = mock_client_cls.call_args.kwargs
+    assert kwargs["api_key"] == "secret-key-from-env"
+    assert kwargs["host"] == "qdrant.example"
+    assert kwargs["grpc_port"] == 6334
+    assert kwargs["port"] == 6333
+    assert kwargs["https"] is True
+    assert kwargs["prefer_grpc"] is True
+    # timeout is coerced to int per qdrant-client signature.
+    assert kwargs["timeout"] == 12
+
+
+def test_build_client_passes_none_api_key_when_unset() -> None:
+    """``api_key=None`` is still forwarded verbatim.
+
+    The HTTP transport tolerates ``None`` and that is the documented
+    air-gapped/test path; we therefore must not silently substitute an
+    empty string or omit the kwarg.
+    """
+    config = QdrantConfig(api_key=None)
+    store = QdrantVectorStore(config=config, embedding_provider=_embedding_provider())
+
+    with patch("omniscience_index.stores.qdrant_store.AsyncQdrantClient") as mock_client_cls:
+        mock_client_cls.return_value = MagicMock(spec=AsyncQdrantClient)
+        store._build_client()
+
+    kwargs = mock_client_cls.call_args.kwargs
+    assert "api_key" in kwargs
+    assert kwargs["api_key"] is None


### PR DESCRIPTION
## Summary

- `qdrant-client` gRPC interceptor (>=1.12) returns `StatusCode.UNAUTHENTICATED` when no bearer token is sent, even if the qdrant server is started with an empty key. Cold-start `docker compose up` therefore died at `QdrantVectorStore._ensure_collection -> collection_exists`.
- Wiring was already complete: `Settings.qdrant_api_key` -> `QdrantConfig.api_key` -> `AsyncQdrantClient(api_key=...)`. The only missing piece was a dev default — `.env.example` did not set `QDRANT_API_KEY`, so dev had no key to forward.
- Fix: set `QDRANT_API_KEY=qdrant_dev` in `.env.example`. Dev now mirrors prod posture (ADR-0006 §Deployment posture); `docker-compose.yml` already interpolates `QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}` correctly for the qdrant container.

## Why this approach

Considered the alternatives mentioned in #225:
- **Pin to an older qdrant image** — leaks a known-old version into prod parity and only hides the issue.
- **Force HTTP transport in dev** — diverges dev from the gRPC-primary prod path (ADR-0006 §Transport), which is precisely what we want to exercise in dev.
- **Disable `QDRANT__SERVICE__JWT_RBAC`** — qdrant v1.12 does not expose a clean toggle, and again diverges from prod.

Setting a dev key is the smallest change, keeps dev/prod identical, and the key is rotateable per-environment.

## Regression test

`tests/test_qdrant_store_unit.py::test_build_client_forwards_api_key_from_config` and `test_build_client_passes_none_api_key_when_unset` patch `AsyncQdrantClient` and assert `QdrantVectorStore._build_client` forwards `api_key` (and `None`) verbatim — so future refactors cannot silently drop the kwarg.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean (289 files)
- [x] `uv run mypy apps/ packages/` — Success: no issues found in 186 source files
- [x] `uv run pytest tests/ -k qdrant -v` — 54 passed, 9 container-tests skipped (~12.6s)
- [x] `docker compose up -d` from a clean state: qdrant container becomes healthy with `QDRANT__SERVICE__API_KEY=qdrant_dev`. In-network probe of the production qdrant-client code confirms `api_key=None` returns `UNAUTHENTICATED` (the #225 bug) and `api_key='qdrant_dev'` clears the auth check.
- App boot then progresses past `_build_qdrant_store` and fails downstream on the Neo4j relationship-index syntax bug (#227 territory, owned by another agent — not bundled here).

Closes #225