### PR TITLE
fix(neo4j): JSON-encode metadata writes to satisfy Neo4j 5.x (#226)

### DIFF
--- a/apps/server/src/omniscience_server/retention_archive.py
+++ b/apps/server/src/omniscience_server/retention_archive.py
@@ -152,7 +152,21 @@ _EDGE_SCHEMA: pa.Schema = pa.schema(
 
 
 def _rows_to_table(rows: list[dict[str, Any]], schema: pa.Schema) -> pa.Table:
-    """Project ``rows`` onto ``schema`` field-by-field, JSON-encoding metadata."""
+    """Project ``rows`` onto ``schema`` field-by-field, JSON-encoding metadata.
+
+    ``metadata`` arrives in two shapes depending on the writer path
+    (issue #226):
+
+    * ``str`` — a JSON-encoded payload produced by
+      :func:`omniscience_index.stores.neo4j_store._serialise_metadata`.
+      The Neo4j 5.x writer path stores ``metadata`` as a string property
+      because Map-shaped property values are rejected.  Pass it through
+      verbatim (it is already canonical-form JSON).
+    * ``dict`` — an in-memory shape from a test fake or a pre-#226
+      legacy row that survived the migration.  JSON-encode it on the
+      way out so the parquet column is always a string.
+    * ``None`` / missing — emit ``"{}"`` so the column stays non-null.
+    """
     import json
 
     columns: dict[str, list[Any]] = {field.name: [] for field in schema}
@@ -160,10 +174,11 @@ def _rows_to_table(rows: list[dict[str, Any]], schema: pa.Schema) -> pa.Table:
         for field in schema:
             value = row.get(field.name)
             if field.name == "metadata_json":
-                # Source row ships ``metadata`` (dict); we store it as a
-                # JSON string to keep the schema flat.
-                meta = row.get("metadata") or {}
-                columns[field.name].append(json.dumps(meta, sort_keys=True, default=str))
+                meta = row.get("metadata")
+                if isinstance(meta, str):
+                    columns[field.name].append(meta or "{}")
+                else:
+                    columns[field.name].append(json.dumps(meta or {}, sort_keys=True, default=str))
             elif value is None:
                 columns[field.name].append(None)
             else:

--- a/docs/decisions/0013-neo4j-metadata-json-encoding.md
+++ b/docs/decisions/0013-neo4j-metadata-json-encoding.md
@@ -1,0 +1,132 @@
+# ADR-0013 — JSON-encoded `metadata` property for Neo4j entities and edges
+
+- **Status**: Accepted
+- **Date**: 2026-05-22
+- **Deciders**: Backend Engineer
+- **Issue**: [#226](https://github.com/100rd/Omniscience/issues/226)
+- **Builds on**: [ADR-0005](0005-neo4j-as-graph-store.md) (Neo4j as the
+  graph store), [ADR-0008](0008-bitemporal-schema-for-neo4j.md) (bitemporal
+  schema — `metadata` is part of the per-version state per §2/§3).
+
+## Context
+
+Neo4j 5.x property values are restricted to **primitive types or arrays
+of primitives**. A Cypher write like `SET n.metadata = $metadata` with
+`$metadata` bound to a Python `dict` triggers
+`Neo.ClientError.Statement.TypeError`:
+
+> Property values can only be of primitive types or arrays thereof.
+> Encountered: Map{}.
+
+This rejected every `Neo4jGraphStore.upsert_entity` /
+`Neo4jGraphStore.upsert_edge` call against a real Neo4j 5.x container
+(empty metadata included — the driver still serialised `{}` as `Map{}`).
+The bug shipped in PR #104 and stayed silent for a month because the
+writer contract suite at `tests/test_graph_store_contract.py` was gated
+behind `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`, which CI never sets.
+See issue #226 for the full incident.
+
+ADR-0005 §Schema and ADR-0008 §2/§3 reference `metadata` as part of the
+versioned state payload but do **not** prescribe an on-disk shape. No
+Cypher template in `packages/index/src/omniscience_index/` indexes into
+`metadata.<key>` (verified by
+`grep -rn "metadata\." packages/index/src/omniscience_index/`), so the
+property is opaque to query plans — we read the whole value at the
+application boundary or not at all.
+
+## Decision
+
+`metadata` is persisted on `:Entity`, `:EntityState`, every relationship
+type, and the corresponding warm snapshot labels as a **JSON-encoded
+string**. Encoding is deterministic
+(`json.dumps(obj, separators=(",",":"), sort_keys=True, default=str)`)
+so the on-disk representation is stable across Python interpreter
+versions and string equality on the property is meaningful.
+
+A pair of helpers in `packages/index/src/omniscience_index/stores/neo4j_store.py`
+keeps the encoding in one place:
+
+- `_serialise_metadata(value: Any) -> str` — encode at write time.
+- `_deserialise_metadata(raw: Any) -> dict[str, Any]` — decode at read
+  time. Tolerates `str` (post-#226), `dict` (test fakes, pre-#226
+  legacy rows), and `None`/missing.
+- `_serialise_metadata_param(params: dict[str, Any]) -> None` —
+  idempotent in-place rewrite invoked by every writer path.
+
+Empty/None mapping is documented:
+`_serialise_metadata(None) == _serialise_metadata({}) == "{}"` and
+`_deserialise_metadata("") == _deserialise_metadata(None) == {}`.
+
+### State fingerprint (ADR-0008 §2)
+
+The bitemporal writer computes `state_fingerprint` over the in-memory
+`metadata` dict **before** serialisation, so the fingerprint hash basis
+is unchanged by this ADR. Fingerprints persisted on existing
+`:Entity.state_fingerprint` / relationship `state_fingerprint`
+properties before the fix remain comparable to fingerprints computed
+after the fix — no spurious version bumps on the first post-fix upsert.
+
+### Retention archive (ADR-0009 §7)
+
+`apps/server/src/omniscience_server/retention_archive.py::_rows_to_table`
+already serialises `metadata` to a JSON string column
+(`metadata_json`) when building the parquet payload. It now accepts
+both shapes for the source value (post-#226 `str`, pre-#226 `dict`)
+and passes JSON strings through verbatim instead of double-encoding.
+
+## Consequences
+
+### Positive
+
+- Writer works against any Neo4j 5.x version, including 5.19-community
+  (the version pinned in `docker-compose.yml`).
+- The single-helper-pair shape keeps the encoding contract auditable —
+  one place to change if we ever switch to JSONB-on-Postgres semantics
+  or a different encoder.
+- Forward compatible: if a future Neo4j release loosens the property-
+  value restriction we can revert to Map by changing the helpers
+  without touching call sites.
+
+### Negative / accepted
+
+- Loss of server-side path queries into `metadata.<key>` — none exist
+  today, and Cypher does not provide a `JSONExtract` operator, so a
+  hypothetical future query of that shape would need a flattened
+  property (e.g. `metadata_team`) rather than `metadata.team`. We will
+  cross that bridge in a follow-up ADR if a use case materialises.
+- A migration is required for any existing production graph that was
+  written via the unit-test fake (which accepts dicts) and then read
+  from a real Neo4j container — none exist today because the writer
+  has been broken against real Neo4j for a month, but a one-shot
+  `MATCH (n:Entity) WHERE NOT n.metadata STARTS WITH '{' SET n.metadata = '{}'`
+  is the rescue script if someone seeded a dev DB via a different path.
+
+### Test gate
+
+The parametric writer contract suite at
+`tests/test_graph_store_contract.py` no longer gates on
+`OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`. The skip condition is now
+"testcontainers-neo4j package missing OR Docker daemon unreachable",
+matching the pattern from `tests/integration/test_neo4j_bootstrap_schema.py`
+(PR #227). A targeted regression test
+`tests/integration/test_neo4j_writer_metadata.py` exercises the
+upsert → read-back round trip on real Neo4j 5.19-community and is the
+fence against the bug recurring.
+
+## Alternatives considered
+
+1. **Flatten metadata into prefixed scalar properties** (e.g.
+   `metadata_team = "payments"`). Rejected — the metadata schema is
+   open-ended (connectors emit arbitrary keys) and a flat namespace
+   would conflict with the bitemporal triple (`valid_from`, `valid_to`,
+   `recorded_at`) and the `state_fingerprint` property. Would also
+   require schema migrations whenever a connector adds a new key.
+2. **Use Neo4j's `apoc.convert.toJson` for the encoding inside Cypher**.
+   Rejected — APOC is an optional plugin and `docker-compose.yml`
+   ships the community image without it. Adds a deploy-time dependency
+   for no functional gain over Python-side `json.dumps`.
+3. **Store `metadata` on a sibling `(:EntityMetadata)` node linked from
+   the identity**. Rejected — adds a write per upsert, doubles the
+   read-side surface for what is currently a single property read, and
+   complicates the bitemporal version chain (per ADR-0008 §2 the state
+   payload is one node, not a fan-out).

--- a/packages/index/src/omniscience_index/stores/neo4j_store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j_store.py
@@ -35,6 +35,7 @@ Design rules
 
 from __future__ import annotations
 
+import json
 import re
 import uuid
 from dataclasses import dataclass
@@ -1425,6 +1426,81 @@ def _coerce_metadata(value: Any) -> dict[str, Any]:
     raise TypeError(f"metadata must be dict, got {type(value).__name__}")
 
 
+# ---------------------------------------------------------------------------
+# Metadata JSON encoding (issue #226)
+# ---------------------------------------------------------------------------
+#
+# Neo4j 5.x rejects Map-shaped property values: a Cypher write like
+# ``SET n.metadata = $metadata`` with ``$metadata`` bound to a Python
+# ``dict`` fails with ``Neo.ClientError.Statement.TypeError`` —
+# *Property values can only be of primitive types or arrays thereof.
+# Encountered: Map{}.*  We sidestep the restriction by encoding the
+# ``metadata`` dict to a JSON string on the way in and decoding on the
+# way out.  The persisted shape is opaque to query plans (no Cypher
+# template in this package indexes into ``metadata.<key>``), so JSON-as-
+# string round-trips losslessly and is compatible with ADR-0005 §Schema
+# and ADR-0008 §2 — neither mandates a particular property shape for
+# metadata.
+#
+# Empty / None handling:
+#   _serialise_metadata(None) == _serialise_metadata({}) == "{}"
+#   _deserialise_metadata("") == _deserialise_metadata(None) == {}
+# so reading a freshly-created entity with no metadata returns ``{}``
+# rather than ``None`` — matches the contract of :func:`_coerce_metadata`
+# at the write boundary.
+
+
+def _serialise_metadata(value: Any) -> str:
+    """Encode a metadata dict (or ``None``) to a JSON string for Neo4j.
+
+    The encoding is deterministic (``sort_keys=True``, no spaces) so
+    string equality on the stored value is meaningful for diff tools and
+    so the on-disk shape is stable across Python interpreter versions.
+    """
+    coerced = _coerce_metadata(value)
+    return json.dumps(coerced, separators=(",", ":"), sort_keys=True, default=str)
+
+
+def _deserialise_metadata(raw: Any) -> dict[str, Any]:
+    """Decode a JSON string from Neo4j back into a ``dict[str, Any]``.
+
+    Tolerates three shapes for forward/backward compatibility:
+
+    * ``str``  — JSON-encoded payload (the post-#226 shape).  Empty
+      string is treated as ``{}``.
+    * ``dict`` — already-decoded; returned via :func:`_coerce_metadata`.
+      Covers in-memory test fakes that bypass the serialiser and any
+      legacy rows that pre-date this fix.
+    * ``None`` / missing — returns ``{}``.
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, str):
+        if not raw:
+            return {}
+        decoded = json.loads(raw)
+        if not isinstance(decoded, dict):
+            raise TypeError(f"metadata JSON must decode to dict, got {type(decoded).__name__}")
+        return {str(k): v for k, v in decoded.items()}
+    if isinstance(raw, dict):
+        return _coerce_metadata(raw)
+    raise TypeError(f"cannot deserialise metadata of type {type(raw).__name__}")
+
+
+def _serialise_metadata_param(params: dict[str, Any]) -> None:
+    """Replace ``params['metadata']`` (dict) with its JSON-encoded form.
+
+    Called immediately before the parameters are bound to a Cypher
+    statement so the Bolt driver sees a primitive string instead of a
+    Map.  No-op when ``metadata`` is already a string (idempotent — safe
+    to call twice on the same params dict).
+    """
+    current = params.get("metadata")
+    if isinstance(current, str):
+        return
+    params["metadata"] = _serialise_metadata(current)
+
+
 def _coerce_to_datetime(value: Any) -> datetime:
     """Coerce a Neo4j temporal-like value to a Python aware ``datetime``.
 
@@ -1829,6 +1905,10 @@ class Neo4jGraphStore:
             params = _entity_to_params(ext_ent, source_id, workspace_id, now)
             if bitemporal_enabled:
                 params["state_fingerprint"] = _entity_state_fingerprint(params)
+            # Issue #226 — JSON-encode metadata so the Bolt driver does
+            # not serialise a Python dict as a Cypher Map (rejected by
+            # Neo4j 5.x as a non-primitive property value).
+            _serialise_metadata_param(params)
             await tx.run(entity_cypher, params)
             name_to_id[str(params["name"])] = uuid.UUID(str(params["id"]))
             display = str(params.get("display_name") or "")
@@ -1846,6 +1926,8 @@ class Neo4jGraphStore:
                 continue
             if bitemporal_enabled:
                 edge_params["state_fingerprint"] = _edge_state_fingerprint(edge_params)
+            # Issue #226 — see entity loop above.
+            _serialise_metadata_param(edge_params)
             rendered = edge_template.replace("{edge_type}", str(edge_params["edge_type"]))
             await tx.run(rendered, edge_params)
 
@@ -1915,20 +1997,34 @@ class Neo4jGraphStore:
     def _select_entity_upsert_cypher(self, params: dict[str, Any]) -> str:
         """Pick legacy or bitemporal entity upsert Cypher; mutate params if needed.
 
-        Mutates ``params`` in place to add the ``state_fingerprint`` key
-        when the bitemporal path is active.  Keeps the call sites short
-        (``upsert_entity`` and ``_run_upsert_graph`` share this).
+        Mutates ``params`` in place: adds the ``state_fingerprint`` key
+        when the bitemporal path is active, and replaces ``metadata``
+        with its JSON-encoded form so Neo4j 5.x does not reject the
+        bind value as a Map (issue #226).  The fingerprint is computed
+        BEFORE serialisation — fingerprints stay stable across the fix
+        because they hash the in-memory dict, not the on-disk shape.
+        Keeps the call sites short (``upsert_entity`` and
+        ``_run_upsert_graph`` share this).
         """
         if not self._bitemporal_enabled:
+            _serialise_metadata_param(params)
             return _UPSERT_ENTITY_CYPHER
         params["state_fingerprint"] = _entity_state_fingerprint(params)
+        _serialise_metadata_param(params)
         return _UPSERT_ENTITY_BITEMPORAL_CYPHER
 
     def _select_edge_upsert_cypher(self, params: dict[str, Any], edge_type: str) -> str:
-        """Pick legacy or bitemporal edge upsert Cypher; render edge-type slot."""
+        """Pick legacy or bitemporal edge upsert Cypher; render edge-type slot.
+
+        Also JSON-encodes ``params['metadata']`` in place so Neo4j 5.x
+        accepts the bind value (issue #226).  Fingerprint is computed
+        BEFORE serialisation so the hash basis is unchanged.
+        """
         if not self._bitemporal_enabled:
+            _serialise_metadata_param(params)
             return _UPSERT_EDGE_CYPHER_TEMPLATE.replace("{edge_type}", edge_type)
         params["state_fingerprint"] = _edge_state_fingerprint(params)
+        _serialise_metadata_param(params)
         return _UPSERT_EDGE_BITEMPORAL_CYPHER_TEMPLATE.replace("{edge_type}", edge_type)
 
     async def delete_tombstoned(self, *, workspace_id: uuid.UUID | None = None) -> int:

--- a/tests/integration/test_neo4j_writer_metadata.py
+++ b/tests/integration/test_neo4j_writer_metadata.py
@@ -1,0 +1,319 @@
+"""End-to-end regression test for :class:`Neo4jGraphStore` metadata writes (issue #226).
+
+Background
+----------
+
+After PRs #222 and #227 landed, the writer path against a real Neo4j 5.x
+container failed on every ``upsert_entity`` / ``upsert_edge`` call::
+
+    neo4j.exceptions.CypherTypeError:
+      {neo4j_code: Neo.ClientError.Statement.TypeError}
+      {message: Property values can only be of primitive types or arrays
+       thereof. Encountered: Map{}.}
+
+The bug was the writer binding ``metadata`` as a Python ``dict``; the
+Bolt driver serialised it as a Cypher Map, which Neo4j 5.x rejects as a
+property value (even an empty ``Map{}``).  The fix is to JSON-encode
+``metadata`` at every write site — see
+``packages/index/src/omniscience_index/stores/neo4j_store.py::
+_serialise_metadata_param``.
+
+Why this regression slipped through CI
+--------------------------------------
+
+The parametric writer suite at ``tests/test_graph_store_contract.py``
+exercises the writer end-to-end against a Neo4j testcontainer, but it
+was gated behind ``OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`` which CI
+does NOT set.  As of this PR that gate is gone — the writer contract
+tests now run unconditionally whenever Docker + ``testcontainers-neo4j``
+are present, matching the pattern from
+``tests/integration/test_neo4j_bootstrap_schema.py`` (PR #227).
+
+Scope of this test
+------------------
+
+This file is the targeted regression fence for issue #226 — it does the
+*minimum* round-trip needed to prove the bug is fixed and won't recur:
+
+1. Spin up a fresh ``neo4j:5.19-community`` testcontainer.
+2. Call ``Neo4jGraphStore.upsert_entity`` with a non-empty ``metadata``
+   dict containing strings, ints, and a nested dict / list.  This is
+   the call that raised the ``CypherTypeError`` before the fix.
+3. Call ``Neo4jGraphStore.upsert_edge`` between two such entities, also
+   with non-empty ``metadata``.
+4. Read both properties back via raw Cypher and assert the JSON round-
+   trips losslessly through
+   :func:`omniscience_index.stores.neo4j_store._deserialise_metadata`.
+
+Gate
+----
+
+Runs on every PR — the only skip is "Docker / testcontainers
+unavailable", mirroring the post-#227 pattern.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+
+pytest.importorskip("testcontainers.neo4j")
+
+from omniscience_core.storage.graph import EdgeUpsert, EntityUpsert
+from omniscience_index.stores.neo4j_store import (
+    Neo4jGraphStore,
+    Neo4jStoreConfig,
+    _deserialise_metadata,
+    _run_read_stmt,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+_NEO4J_PASSWORD = "issue_226_password"
+_WORKSPACE_ID = uuid.UUID("26000000-0000-0000-0000-000000000226")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def neo4j_store() -> AsyncIterator[Neo4jGraphStore]:
+    """Spin up a fresh Neo4j 5.19-community container and connect to it.
+
+    Per-test container — the writer is destructive and we want the
+    metadata round-trip to be observed against a *brand-new* property,
+    not one carried over from a previous test's MERGE.
+    """
+    from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
+
+    container = Neo4jContainer("neo4j:5.19-community", password=_NEO4J_PASSWORD)
+    with container:
+        config = Neo4jStoreConfig(
+            uri=container.get_connection_url(),
+            username="neo4j",
+            password=_NEO4J_PASSWORD,
+            database="neo4j",
+            max_connection_pool_size=5,
+            connection_acquisition_timeout_seconds=30.0,
+            max_transaction_retry_time_seconds=15.0,
+            default_max_depth=3,
+        )
+        store = Neo4jGraphStore(config=config)
+        await store.connect()
+        try:
+            yield store
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _read_entity_metadata(
+    store: Neo4jGraphStore,
+    *,
+    entity_id: uuid.UUID,
+) -> dict[str, object]:
+    """Read the raw ``metadata`` property off the :Entity identity mirror."""
+    cypher = (
+        "MATCH (n:Entity {workspace_id: $workspace_id, id: $id}) RETURN n.metadata AS metadata"
+    )
+    params = {"workspace_id": str(_WORKSPACE_ID), "id": str(entity_id)}
+    async with store._driver.session(database=store._config.database) as session:
+        rows = await session.execute_read(_run_read_stmt, cypher, params)
+    assert rows, f"no entity row found for id={entity_id}"
+    raw = rows[0]["metadata"]
+    # The persisted shape must be a JSON string after the #226 fix —
+    # the property value MUST NOT be a Map (which would have failed at
+    # write time anyway).
+    assert isinstance(raw, str), (
+        f"metadata stored shape is {type(raw).__name__}, expected str — issue #226 fix regressed"
+    )
+    return _deserialise_metadata(raw)
+
+
+async def _read_edge_metadata(
+    store: Neo4jGraphStore,
+    *,
+    source_entity_id: uuid.UUID,
+    target_entity_id: uuid.UUID,
+    edge_type: str,
+) -> dict[str, object]:
+    """Read the raw ``metadata`` property off the relationship."""
+    cypher = (
+        "MATCH (a:Entity {workspace_id: $workspace_id, id: $src})"
+        f"-[r:`{edge_type}`]->"
+        "(b:Entity {workspace_id: $workspace_id, id: $tgt}) "
+        "RETURN r.metadata AS metadata"
+    )
+    params = {
+        "workspace_id": str(_WORKSPACE_ID),
+        "src": str(source_entity_id),
+        "tgt": str(target_entity_id),
+    }
+    async with store._driver.session(database=store._config.database) as session:
+        rows = await session.execute_read(_run_read_stmt, cypher, params)
+    assert rows, "no edge row found"
+    raw = rows[0]["metadata"]
+    assert isinstance(raw, str), (
+        f"edge metadata stored shape is {type(raw).__name__}, expected str — "
+        "issue #226 fix regressed"
+    )
+    return _deserialise_metadata(raw)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_upsert_entity_with_non_empty_metadata_round_trips(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """The headline regression — non-empty metadata MUST NOT raise.
+
+    Pre-fix this call raised ``CypherTypeError: ... Encountered: Map{}.``
+    on every invocation regardless of metadata content.  Post-fix it
+    persists as a JSON string and round-trips losslessly.
+    """
+    entity = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.checkout",
+        display_name="Checkout Service",
+        chunk_id=None,
+        metadata={
+            "team": "payments",
+            "tier": 1,
+            "tags": ["prod", "us-east-1"],
+            "owner": {"email": "owner@example.com", "oncall": True},
+        },
+    )
+
+    await neo4j_store.upsert_entity(entity=entity, workspace_id=_WORKSPACE_ID)
+
+    decoded = await _read_entity_metadata(neo4j_store, entity_id=entity.id)
+    assert decoded == {
+        "team": "payments",
+        "tier": 1,
+        "tags": ["prod", "us-east-1"],
+        "owner": {"email": "owner@example.com", "oncall": True},
+    }
+
+
+async def test_upsert_entity_with_empty_metadata_persists_empty_dict(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """Empty metadata (the default) persists as ``\"{}\"`` and decodes to ``{}``.
+
+    Pre-fix this STILL raised because the Bolt driver serialised an
+    empty Python ``dict`` as ``Map{}`` and Neo4j 5.x rejects Map regardless
+    of arity.  Post-fix the property is the string ``\"{}\"``.
+    """
+    entity = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.bare",
+        display_name="Bare Service",
+        chunk_id=None,
+        metadata={},
+    )
+
+    await neo4j_store.upsert_entity(entity=entity, workspace_id=_WORKSPACE_ID)
+
+    decoded = await _read_entity_metadata(neo4j_store, entity_id=entity.id)
+    assert decoded == {}
+
+
+async def test_upsert_edge_with_non_empty_metadata_round_trips(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """Edges carry metadata too — same fix, same round-trip contract."""
+    src = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.api",
+        display_name="API",
+        chunk_id=None,
+    )
+    tgt = EntityUpsert(
+        id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        entity_type="service",
+        name="svc.db",
+        display_name="DB",
+        chunk_id=None,
+    )
+    await neo4j_store.upsert_entity(entity=src, workspace_id=_WORKSPACE_ID)
+    await neo4j_store.upsert_entity(entity=tgt, workspace_id=_WORKSPACE_ID)
+
+    edge = EdgeUpsert(
+        source_entity_id=src.id,
+        target_entity_id=tgt.id,
+        edge_type="calls",
+        metadata={
+            "source_id": "ingestion-run-001",
+            "confidence": 0.92,
+            "evidence": ["span-1", "span-2"],
+        },
+    )
+
+    await neo4j_store.upsert_edge(edge=edge, workspace_id=_WORKSPACE_ID)
+
+    decoded = await _read_edge_metadata(
+        neo4j_store,
+        source_entity_id=src.id,
+        target_entity_id=tgt.id,
+        edge_type="calls",
+    )
+    assert decoded == {
+        "source_id": "ingestion-run-001",
+        "confidence": 0.92,
+        "evidence": ["span-1", "span-2"],
+    }
+
+
+async def test_upsert_entity_is_idempotent_on_metadata_change(
+    neo4j_store: Neo4jGraphStore,
+) -> None:
+    """A second upsert with mutated metadata overwrites the stored JSON.
+
+    Guards against an accidental regression where the serialiser is
+    only invoked on the ``ON CREATE`` branch and not on ``ON MATCH``.
+    """
+    entity_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    first = EntityUpsert(
+        id=entity_id,
+        source_id=source_id,
+        entity_type="service",
+        name="svc.upgrade",
+        display_name="Upgrade Service",
+        chunk_id=None,
+        metadata={"version": "v1"},
+    )
+    await neo4j_store.upsert_entity(entity=first, workspace_id=_WORKSPACE_ID)
+
+    second = EntityUpsert(
+        id=entity_id,
+        source_id=source_id,
+        entity_type="service",
+        name="svc.upgrade",
+        display_name="Upgrade Service",
+        chunk_id=None,
+        metadata={"version": "v2", "rollout": "canary"},
+    )
+    await neo4j_store.upsert_entity(entity=second, workspace_id=_WORKSPACE_ID)
+
+    decoded = await _read_entity_metadata(neo4j_store, entity_id=entity_id)
+    assert decoded == {"version": "v2", "rollout": "canary"}

--- a/tests/test_graph_store_contract.py
+++ b/tests/test_graph_store_contract.py
@@ -120,9 +120,7 @@ def _neo4j_factory() -> Callable[[], AsyncIterator[GraphStore]]:
         # through ``get_driver()``.  Using ``.with_env("NEO4J_AUTH", ...)``
         # here is silently overridden by the wrapper's own configure step
         # (the same trap the bootstrap test in PR #227 documents).
-        with Neo4jContainer(
-            "neo4j:5.19-community", password="contract_test_password"
-        ) as neo4j:
+        with Neo4jContainer("neo4j:5.19-community", password="contract_test_password") as neo4j:
             config = Neo4jStoreConfig(
                 uri=neo4j.get_connection_url(),
                 username="neo4j",

--- a/tests/test_graph_store_contract.py
+++ b/tests/test_graph_store_contract.py
@@ -34,10 +34,13 @@ drift fails here.
 
 from __future__ import annotations
 
-import os
+import shutil
+import socket
 import uuid
 from collections.abc import AsyncIterator, Callable
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 from omniscience_core.storage.graph import (
@@ -59,18 +62,47 @@ _WORKSPACE_B = uuid.UUID("bbbbbbbb-0000-0000-0000-0000000000b2")
 
 
 def _neo4j_available() -> bool:
-    """True iff testcontainers + Docker are available.
+    """True iff testcontainers + a reachable Docker daemon are present.
 
-    Controlled via env var ``OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`` —
-    opt-in so CI without Docker does not slow down on image pulls.
+    Issue #226 — this gate USED TO be opt-in via
+    ``OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1``, which silently skipped
+    the writer contract tests in CI for over a month and let the
+    metadata-as-Map bug ship.  We mirror the pattern from
+    ``tests/integration/test_neo4j_bootstrap_schema.py`` (PR #227):
+    skip only when the live dependency genuinely cannot be reached,
+    never on operator opt-in.
     """
-    if os.environ.get("OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS", "0") != "1":
-        return False
     try:
         import testcontainers.neo4j  # noqa: F401
-
-        return True
     except ImportError:
+        return False
+    if shutil.which("docker") is None:
+        return False
+    return _docker_daemon_reachable()
+
+
+def _docker_daemon_reachable() -> bool:
+    """Ping the Docker daemon endpoint; returns False on any failure.
+
+    testcontainers itself will raise on a missing/unreachable daemon
+    when the fixture spins up; pre-checking here keeps the pytest
+    output clean (skip vs. error) and matches the pattern used by
+    ``tests/integration/test_neo4j_bootstrap_schema.py``.
+    """
+    import os
+
+    host = os.environ.get("DOCKER_HOST")
+    if not host:
+        return Path("/var/run/docker.sock").exists()
+    parsed = urlparse(host)
+    if parsed.scheme in ("unix", ""):
+        return Path(parsed.path or host).exists()
+    if parsed.hostname is None or parsed.port is None:
+        return False
+    try:
+        with socket.create_connection((parsed.hostname, parsed.port), timeout=1.0):
+            return True
+    except OSError:
         return False
 
 
@@ -83,8 +115,13 @@ def _neo4j_factory() -> Callable[[], AsyncIterator[GraphStore]]:
     from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
 
     async def _factory() -> AsyncIterator[GraphStore]:
-        with Neo4jContainer("neo4j:5.19-community").with_env(
-            "NEO4J_AUTH", "neo4j/contract_test_password"
+        # Pass the password through the constructor — the wrapper writes
+        # it into NEO4J_AUTH inside ``_configure`` and threads it back
+        # through ``get_driver()``.  Using ``.with_env("NEO4J_AUTH", ...)``
+        # here is silently overridden by the wrapper's own configure step
+        # (the same trap the bootstrap test in PR #227 documents).
+        with Neo4jContainer(
+            "neo4j:5.19-community", password="contract_test_password"
         ) as neo4j:
             config = Neo4jStoreConfig(
                 uri=neo4j.get_connection_url(),


### PR DESCRIPTION
## Summary

`Neo4jGraphStore.upsert_entity` / `upsert_edge` raised
`Neo.ClientError.Statement.TypeError` on every call against a real
Neo4j 5.x container — the Bolt driver was binding the Python
`metadata` dict as a Cypher `Map{}`, which 5.x rejects as a
property value (even an empty one). The bug shipped a month ago in
PR #104 and stayed silent because the parametric writer contract
suite was hidden behind an opt-in env var that CI never sets.

### Fix

* New helpers in `neo4j_store.py` centralise the encoding:
  * `_serialise_metadata(value) -> str` — `json.dumps` with
    `sort_keys=True, separators=(",",":"), default=str`.
  * `_deserialise_metadata(raw) -> dict[str, Any]` — tolerates the
    post-#226 `str` shape, legacy `dict` (for in-memory test fakes
    and pre-fix rows), and `None`.
  * `_serialise_metadata_param(params)` — idempotent in-place
    rewrite invoked from `_select_entity_upsert_cypher`,
    `_select_edge_upsert_cypher`, and both write loops in
    `_run_upsert_graph`.
* Encoding happens **after** the state fingerprint is computed, so
  fingerprints persisted before this fix remain hash-comparable to
  fingerprints computed after — no spurious version bumps on the
  first post-fix upsert.
* `retention_archive._rows_to_table` now accepts both `str` (post-
  #226) and `dict` (test fakes / legacy rows) for the `metadata`
  source value and passes JSON strings through verbatim.

### Why JSON-as-string vs. flattened properties / APOC?

ADR-0005 / ADR-0008 do not prescribe an on-disk shape for `metadata`
and no Cypher in this package indexes into `metadata.<key>` — the
property is opaque to query plans. JSON-as-string is the safe
minimum that round-trips losslessly without an APOC dependency or a
schema migration. ADR-0013 (new) documents this and the rejected
alternatives.

## Companion — un-gate writer contract tests in CI

The bug shipped because `tests/test_graph_store_contract.py` skipped
in CI for over a month behind `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1`.
This PR removes that gate and replaces it with the docker-availability
pattern from PR #227 (`tests/integration/test_neo4j_bootstrap_schema.py`):
the suite skips only when `testcontainers.neo4j` is missing or the
Docker daemon is unreachable. The CI job will now pull
`neo4j:5.19-community` once per run and exercise the writer end-to-end.
A bonus fix: the fixture was using
`Neo4jContainer(...).with_env("NEO4J_AUTH", ...)` which the
testcontainers wrapper silently overrides; switched to the
constructor-arg form so it actually authenticates.

## Regression fence

`tests/integration/test_neo4j_writer_metadata.py` — four tests against
`neo4j:5.19-community`:

1. `test_upsert_entity_with_non_empty_metadata_round_trips`
2. `test_upsert_entity_with_empty_metadata_persists_empty_dict`
3. `test_upsert_edge_with_non_empty_metadata_round_trips`
4. `test_upsert_entity_is_idempotent_on_metadata_change`

Runtime: ~31s for the file (one container per test).

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] `uv run mypy apps/ packages/` — `Success: no issues found in 186 source files`.
- [x] Targeted suite (`tests/test_neo4j_store_bitemporal_schema.py tests/test_graph_store_contract.py tests/integration/test_neo4j_bootstrap_schema.py tests/integration/test_neo4j_writer_metadata.py -v`): 30 passed, 2 skipped (127s).
- [x] Full unit suite: 2062 passed, 44 skipped (115s).
- [x] `docker compose up -d` — Neo4j writer path no longer raises `Map{}` / `CypherTypeError` (zero hits in compose logs). The `app` container still crashes on the Qdrant API-key issue (#225, owned by another agent) — that is independent of this PR.
- [x] Verify in CI logs that `test_graph_store_contract.py` entries are collected, not skipped.

Closes #226