### PR TITLE
feat(cli): omniscience init --client=<ide> one-shot config writer (#236)

### DIFF
--- a/apps/cli/src/omniscience_cli/commands/init.py
+++ b/apps/cli/src/omniscience_cli/commands/init.py
@@ -1,0 +1,347 @@
+"""``omniscience init`` — one-shot IDE MCP-config writer.
+
+What it does (in order):
+
+1. Resolves connection params (server URL + workspace name).
+2. Generates a workspace token via the Omniscience REST API
+   (``POST /api/v1/tokens``) — unless one is supplied with ``--token``.
+3. Builds the IDE-specific server entry, merges it into any existing
+   config file, and writes the result (or prints to stdout with
+   ``--print``).
+4. Runs a JSON-RPC ``tools/list`` smoke test against ``{url}/mcp`` to
+   prove the token works end-to-end.
+5. Prints a tight success summary.
+
+Design notes
+------------
+
+* Per-client formatting lives in :mod:`omniscience_cli.init_templates`,
+  one module per IDE.  Adding an editor = one new template module.
+* All filesystem mutations route through :func:`_write_atomic` so a
+  crashed run never leaves a half-written settings.json.
+* The smoke test is best-effort: a network failure prints a warning but
+  does not unwrite the config.  Use ``--no-smoke-test`` in CI / air-gapped
+  setups.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Annotated, Any
+
+import httpx
+import typer
+
+from omniscience_cli.client import OmniscienceClient, OmniscienceClientError
+from omniscience_cli.init_templates import CLIENTS, ServerParams
+from omniscience_cli.init_templates.base import ClientSpec
+from omniscience_cli.output import abort, console, err_console, print_json, print_warning
+
+app = typer.Typer(name="init", help="Bootstrap an MCP-aware editor (Claude Code, Cursor, ...).")
+
+# JSON-RPC version + tools/list method id used by the smoke test.
+_SMOKE_TIMEOUT_S = 10.0
+_DEFAULT_NAME = "omniscience"
+_DEFAULT_SCOPES = ("search", "sources:read")
+
+
+# ---------------------------------------------------------------------------
+# Token + smoke-test helpers
+# ---------------------------------------------------------------------------
+
+
+def _provision_token(name: str, scopes: tuple[str, ...]) -> str:
+    """Create a workspace token via the REST API.
+
+    Returns the plaintext value (shown once by the server) — callers
+    embed it directly in the IDE config.
+    """
+    with OmniscienceClient() as client:
+        try:
+            result = client.create_token(name, list(scopes))
+        except OmniscienceClientError as exc:
+            abort(
+                f"Failed to provision workspace token: {exc.message}",
+                exc.code,
+            )
+            raise AssertionError from None  # pragma: no cover - abort() raises SystemExit
+    plaintext = result.get("token") or result.get("plaintext")
+    if not isinstance(plaintext, str) or not plaintext:
+        abort(
+            "Token API did not return a plaintext value; cannot continue.",
+            "no_plaintext_token",
+        )
+        raise AssertionError from None  # pragma: no cover
+    return plaintext
+
+
+def smoke_test(url: str, token: str, *, timeout: float = _SMOKE_TIMEOUT_S) -> tuple[bool, str]:
+    """Issue a JSON-RPC ``tools/list`` call to ``{url}/mcp``.
+
+    Returns ``(ok, detail)`` so the caller can decide how loud to be.
+    Network errors and non-2xx HTTP statuses are converted into a
+    boolean result — we never raise.
+    """
+    payload: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {},
+    }
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    target = url.rstrip("/") + "/mcp"
+    try:
+        resp = httpx.post(target, json=payload, headers=headers, timeout=timeout)
+    except httpx.HTTPError as exc:
+        return False, f"network error: {exc}"
+    if resp.status_code >= 400:
+        return False, f"HTTP {resp.status_code}: {resp.text[:200]}"
+    try:
+        body = resp.json()
+    except ValueError:
+        # Streamable-HTTP responses may be SSE; treat any 2xx as success.
+        return True, f"HTTP {resp.status_code} (non-JSON body — assumed SSE)"
+    if "error" in body:
+        return False, f"JSON-RPC error: {body['error']}"
+    result = body.get("result", {})
+    tools = result.get("tools", []) if isinstance(result, dict) else []
+    return True, f"{len(tools)} tools registered"
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_existing(path: Path) -> dict[str, Any] | None:
+    """Read + parse an existing JSON config file.
+
+    Returns ``None`` if the file does not exist.  A corrupt file is
+    *not* silently overwritten — we abort so the user can decide.
+    """
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        abort(
+            f"Existing config at {path} is not valid JSON ({exc}). "
+            "Fix or remove it, or re-run with --force.",
+            "corrupt_config",
+        )
+        raise AssertionError from None  # pragma: no cover
+    if not isinstance(data, dict):
+        abort(
+            f"Existing config at {path} is JSON but not an object; refusing to merge.",
+            "non_object_config",
+        )
+        raise AssertionError from None  # pragma: no cover
+    return data
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically (write-tmp + rename)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+            fh.write("\n")
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _format_json(data: dict[str, Any]) -> str:
+    """Stable, diff-friendly JSON: 2-space indent, sorted keys."""
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Command entry point
+# ---------------------------------------------------------------------------
+
+
+def _resolve_client(key: str) -> ClientSpec:
+    spec = CLIENTS.get(key)
+    if spec is None:
+        valid = ", ".join(sorted(CLIENTS))
+        abort(f"Unknown --client {key!r}. Valid choices: {valid}", "unknown_client")
+        raise AssertionError from None  # pragma: no cover
+    return spec
+
+
+def _run(
+    *,
+    client_key: str,
+    server_name: str,
+    server_url: str | None,
+    token: str | None,
+    scopes_csv: str,
+    print_only: bool,
+    force: bool,
+    run_smoke: bool,
+    home: Path,
+    cwd: Path,
+) -> None:
+    """Pure-ish core of the init command.
+
+    All filesystem / network boundaries are passed in or hit via
+    well-isolated helpers, so this function is straightforward to test.
+    """
+    spec = _resolve_client(client_key)
+
+    url = server_url or os.environ.get("OMNISCIENCE_URL", "http://localhost:8000")
+    url = url.rstrip("/")
+
+    scopes = tuple(s.strip() for s in scopes_csv.split(",") if s.strip())
+    if not scopes:
+        scopes = _DEFAULT_SCOPES
+
+    # 1. Token: explicit > env > provision.
+    effective_token = token or os.environ.get("OMNISCIENCE_TOKEN") or ""
+    if not effective_token:
+        effective_token = _provision_token(name=f"{server_name}-{spec.key}", scopes=scopes)
+
+    params = ServerParams(name=server_name, url=url, token=effective_token)
+
+    # 2. Build full document.
+    path = spec.resolve_path(home=home, cwd=cwd)
+    existing = _read_existing(path) if not print_only else None
+    document = spec.merge(existing, params)
+
+    if print_only:
+        print_json(
+            {
+                "client": spec.key,
+                "path": str(path),
+                "config": document,
+            }
+        )
+        return
+
+    # 3. Refuse to clobber unless --force when the named entry already exists.
+    if existing is not None and not force and _entry_exists(spec, existing, server_name):
+        abort(
+            f"An MCP entry named {server_name!r} already exists in {path}. "
+            "Re-run with --force to overwrite, or pick a different --name.",
+            "entry_exists",
+        )
+
+    _write_atomic(path, _format_json(document))
+    console.print(f"[green]ok[/green]  wrote {spec.display_name} config -> {path}")
+
+    # 4. Smoke test (best effort).
+    if run_smoke:
+        ok, detail = smoke_test(url, effective_token)
+        if ok:
+            console.print(f"[green]ok[/green]  smoke test passed ({detail})")
+        else:
+            print_warning(f"smoke test failed: {detail}")
+            err_console.print(
+                "[dim]The config was written — re-run `omniscience doctor` once the "
+                "server is reachable.[/dim]"
+            )
+
+    # 5. Success summary.
+    console.print()
+    console.print(f"[bold]Server:[/bold]  {server_name}")
+    console.print(f"[bold]URL:[/bold]     {url}")
+    console.print(f"[bold]Client:[/bold]  {spec.display_name}  [dim]({spec.scope})[/dim]")
+    console.print(f"[bold]Config:[/bold]  {path}")
+    if not token and not os.environ.get("OMNISCIENCE_TOKEN"):
+        console.print(
+            "[dim]A workspace token was provisioned; revoke via `omniscience tokens revoke`.[/dim]"
+        )
+
+
+def _entry_exists(spec: ClientSpec, existing: dict[str, Any], name: str) -> bool:
+    """True if ``name`` already lives in the existing config under any of
+    the well-known container keys."""
+    for key in ("mcpServers", "context_servers"):
+        bucket = existing.get(key)
+        if isinstance(bucket, dict) and name in bucket:
+            return True
+    servers = existing.get("mcpServers")
+    if isinstance(servers, list):
+        for item in servers:
+            if isinstance(item, dict) and item.get("name") == name:
+                return True
+    # Reference spec so linters don't flag it unused (kept for future
+    # per-client overrides).
+    _ = spec
+    return False
+
+
+@app.callback(invoke_without_command=True)
+def init(
+    client: Annotated[
+        str,
+        typer.Option(
+            "--client",
+            "-c",
+            help="Target IDE: claude-code | cursor | cline | continue | zed",
+        ),
+    ],
+    name: Annotated[
+        str,
+        typer.Option("--name", "-n", help="Server name (key inside the IDE config)"),
+    ] = _DEFAULT_NAME,
+    url: Annotated[
+        str | None,
+        typer.Option("--url", help="Omniscience server URL (default: $OMNISCIENCE_URL)"),
+    ] = None,
+    token: Annotated[
+        str | None,
+        typer.Option(
+            "--token",
+            help="Use an existing workspace token instead of provisioning a new one",
+        ),
+    ] = None,
+    scopes: Annotated[
+        str,
+        typer.Option("--scopes", help="Comma-separated scopes for the provisioned token"),
+    ] = ",".join(_DEFAULT_SCOPES),
+    print_only: Annotated[
+        bool,
+        typer.Option(
+            "--print",
+            help="Emit the resulting config to stdout as JSON instead of writing it",
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Overwrite an existing entry with the same name"),
+    ] = False,
+    no_smoke_test: Annotated[
+        bool,
+        typer.Option("--no-smoke-test", help="Skip the tools/list smoke test"),
+    ] = False,
+) -> None:
+    """Write the MCP config for ``--client`` and verify with a smoke test."""
+    _run(
+        client_key=client,
+        server_name=name,
+        server_url=url,
+        token=token,
+        scopes_csv=scopes,
+        print_only=print_only,
+        force=force,
+        run_smoke=not no_smoke_test,
+        home=Path.home(),
+        cwd=Path.cwd(),
+    )

--- a/apps/cli/src/omniscience_cli/init_templates/__init__.py
+++ b/apps/cli/src/omniscience_cli/init_templates/__init__.py
@@ -1,0 +1,45 @@
+"""IDE-specific MCP configuration templates for ``omniscience init``.
+
+Each client has two well-defined responsibilities:
+
+* :func:`build_entry` — given a server name + connection params, return a
+  dict matching exactly one server entry in that client's native config
+  shape (e.g. Cursor's ``mcpServers.<name>``).
+* :func:`config_path` — resolve the on-disk location where that client
+  expects its MCP config (honouring ``$HOME`` / cwd as appropriate).
+* :func:`merge` — given existing on-disk config (or ``None``) and a new
+  entry, return the full file contents to write back.  This is the
+  *only* place each client's surrounding-document shape leaks in, so
+  golden-file tests can pin it precisely.
+
+Adding a new client = one new module + registration in :data:`CLIENTS`.
+Spec sources are linked in each module's docstring.
+"""
+
+from __future__ import annotations
+
+from omniscience_cli.init_templates.base import ClientSpec, ServerParams
+from omniscience_cli.init_templates.claude_code import CLAUDE_CODE
+from omniscience_cli.init_templates.cline import CLINE
+from omniscience_cli.init_templates.continue_dev import CONTINUE
+from omniscience_cli.init_templates.cursor import CURSOR
+from omniscience_cli.init_templates.zed import ZED
+
+CLIENTS: dict[str, ClientSpec] = {
+    CLAUDE_CODE.key: CLAUDE_CODE,
+    CURSOR.key: CURSOR,
+    CLINE.key: CLINE,
+    CONTINUE.key: CONTINUE,
+    ZED.key: ZED,
+}
+
+__all__ = [
+    "CLAUDE_CODE",
+    "CLIENTS",
+    "CLINE",
+    "CONTINUE",
+    "CURSOR",
+    "ZED",
+    "ClientSpec",
+    "ServerParams",
+]

--- a/apps/cli/src/omniscience_cli/init_templates/base.py
+++ b/apps/cli/src/omniscience_cli/init_templates/base.py
@@ -1,0 +1,128 @@
+"""Shared types for IDE MCP-config templates."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ServerParams:
+    """Parameters used to render an MCP-server entry for any client.
+
+    Attributes:
+        name: Server identifier (e.g. ``"omniscience"``) — becomes the
+            map key inside the client's config file.
+        url: Public HTTP base URL of the Omniscience server.  Used for
+            ``streamable-http`` transport entries (Cursor / Cline / Zed /
+            Continue all support this; Claude Code uses the same form).
+        token: Workspace API token; injected as a ``Bearer`` header.
+    """
+
+    name: str
+    url: str
+    token: str
+
+    @property
+    def mcp_url(self) -> str:
+        """Return the full MCP endpoint (``{url}/mcp``).
+
+        The Omniscience server mounts FastMCP at ``/mcp``; see
+        ``apps/server/src/omniscience_server/mcp/mount.py``.
+        """
+        return self.url.rstrip("/") + "/mcp"
+
+    @property
+    def auth_headers(self) -> dict[str, str]:
+        """Return the Authorization header map for HTTP transports."""
+        return {"Authorization": f"Bearer {self.token}"}
+
+
+class _BuildEntry(Protocol):
+    def __call__(self, params: ServerParams) -> dict[str, Any]: ...
+
+
+class _Merge(Protocol):
+    def __call__(
+        self,
+        existing: dict[str, Any] | None,
+        params: ServerParams,
+    ) -> dict[str, Any]: ...
+
+
+class _PathResolver(Protocol):
+    def __call__(self, *, home: Path, cwd: Path) -> Path: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ClientSpec:
+    """Describes a single IDE / MCP-aware editor.
+
+    Attributes:
+        key: CLI ``--client`` value (kebab-case, stable).
+        display_name: Human-friendly label for the success summary.
+        scope: ``"global"`` (file lives under ``$HOME``) or
+            ``"workspace"`` (file lives under the current project).
+        path_resolver: Callable returning the absolute path to the
+            client's config file.
+        build_entry: Render the per-server config entry.
+        merge: Merge new entry into existing file contents.
+        spec_source: URL to the official documentation describing the
+            file shape — included so reviewers can audit golden files.
+    """
+
+    key: str
+    display_name: str
+    scope: str
+    path_resolver: _PathResolver
+    build_entry: _BuildEntry
+    merge: _Merge
+    spec_source: str
+
+    def resolve_path(self, *, home: Path, cwd: Path) -> Path:
+        return self.path_resolver(home=home, cwd=cwd)
+
+
+# ---------------------------------------------------------------------------
+# Generic helpers shared by every client.
+# ---------------------------------------------------------------------------
+
+
+def http_entry(params: ServerParams) -> dict[str, Any]:
+    """Standard ``streamable-http`` server entry shape.
+
+    This shape is accepted by Cursor, Cline, Zed and Continue.  Claude
+    Code (CLI/desktop) uses a near-identical structure with the same
+    keys.  Keeping one helper avoids drift.
+    """
+    return {
+        "type": "http",
+        "url": params.mcp_url,
+        "headers": params.auth_headers,
+    }
+
+
+def merge_into(
+    container_key: str,
+) -> Callable[[dict[str, Any] | None, ServerParams, _BuildEntry], dict[str, Any]]:
+    """Return a merger that inserts ``entry`` under ``container_key``.
+
+    Used by Claude Code, Cursor and Cline whose top-level shape is
+    ``{container_key: {name: entry}}``.
+    """
+
+    def _merger(
+        existing: dict[str, Any] | None,
+        params: ServerParams,
+        build_entry: _BuildEntry,
+    ) -> dict[str, Any]:
+        doc: dict[str, Any] = dict(existing) if existing else {}
+        bucket_raw = doc.get(container_key)
+        bucket: dict[str, Any] = dict(bucket_raw) if isinstance(bucket_raw, dict) else {}
+        bucket[params.name] = build_entry(params)
+        doc[container_key] = bucket
+        return doc
+
+    return _merger

--- a/apps/cli/src/omniscience_cli/init_templates/claude_code.py
+++ b/apps/cli/src/omniscience_cli/init_templates/claude_code.py
@@ -1,0 +1,51 @@
+"""Claude Code template.
+
+Spec: https://docs.claude.com/en/docs/claude-code/mcp
+
+Config file: ``~/.claude/mcp_servers.json``.
+Shape::
+
+    {
+      "mcpServers": {
+        "<name>": {
+          "type": "http",
+          "url": "https://...",
+          "headers": {"Authorization": "Bearer ..."}
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omniscience_cli.init_templates.base import (
+    ClientSpec,
+    ServerParams,
+    http_entry,
+    merge_into,
+)
+
+
+def _path(*, home: Path, cwd: Path) -> Path:
+    return home / ".claude" / "mcp_servers.json"
+
+
+_MERGER = merge_into("mcpServers")
+
+
+def _merge(existing: dict[str, Any] | None, params: ServerParams) -> dict[str, Any]:
+    return _MERGER(existing, params, http_entry)
+
+
+CLAUDE_CODE = ClientSpec(
+    key="claude-code",
+    display_name="Claude Code",
+    scope="global",
+    path_resolver=_path,
+    build_entry=http_entry,
+    merge=_merge,
+    spec_source="https://docs.claude.com/en/docs/claude-code/mcp",
+)

--- a/apps/cli/src/omniscience_cli/init_templates/cline.py
+++ b/apps/cli/src/omniscience_cli/init_templates/cline.py
@@ -1,0 +1,63 @@
+"""Cline (VS Code extension) template.
+
+Spec: https://docs.cline.bot/mcp/configuring-mcp-servers
+
+Config file: ``.vscode/cline_mcp_settings.json`` (per-workspace).
+Shape mirrors the Claude/Cursor ``mcpServers`` map::
+
+    {
+      "mcpServers": {
+        "<name>": {
+          "type": "http",
+          "url": "https://.../mcp",
+          "headers": {"Authorization": "Bearer ..."},
+          "disabled": false,
+          "autoApprove": []
+        }
+      }
+    }
+
+The ``disabled`` and ``autoApprove`` keys are Cline-specific and ship
+with sensible defaults so the entry "just works" after init.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omniscience_cli.init_templates.base import (
+    ClientSpec,
+    ServerParams,
+    http_entry,
+    merge_into,
+)
+
+
+def _entry(params: ServerParams) -> dict[str, Any]:
+    base = http_entry(params)
+    base["disabled"] = False
+    base["autoApprove"] = []
+    return base
+
+
+def _path(*, home: Path, cwd: Path) -> Path:
+    return cwd / ".vscode" / "cline_mcp_settings.json"
+
+
+_MERGER = merge_into("mcpServers")
+
+
+def _merge(existing: dict[str, Any] | None, params: ServerParams) -> dict[str, Any]:
+    return _MERGER(existing, params, _entry)
+
+
+CLINE = ClientSpec(
+    key="cline",
+    display_name="Cline",
+    scope="workspace",
+    path_resolver=_path,
+    build_entry=_entry,
+    merge=_merge,
+    spec_source="https://docs.cline.bot/mcp/configuring-mcp-servers",
+)

--- a/apps/cli/src/omniscience_cli/init_templates/continue_dev.py
+++ b/apps/cli/src/omniscience_cli/init_templates/continue_dev.py
@@ -1,0 +1,78 @@
+"""Continue.dev template.
+
+Spec: https://docs.continue.dev/customize/deep-dives/mcp
+
+Config file: ``~/.continue/config.json``.  Continue uses an array under
+``experimental.modelContextProtocolServers`` (legacy) and a top-level
+``mcpServers`` map on newer versions.  We populate **both** so users on
+either release line get a working setup; Continue silently ignores the
+shape it doesn't recognise.
+
+Entry shape::
+
+    {
+      "name": "<name>",
+      "transport": {
+        "type": "streamable-http",
+        "url": "https://.../mcp",
+        "headers": {"Authorization": "Bearer ..."}
+      }
+    }
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omniscience_cli.init_templates.base import ClientSpec, ServerParams
+
+
+def _entry(params: ServerParams) -> dict[str, Any]:
+    return {
+        "name": params.name,
+        "transport": {
+            "type": "streamable-http",
+            "url": params.mcp_url,
+            "headers": params.auth_headers,
+        },
+    }
+
+
+def _path(*, home: Path, cwd: Path) -> Path:
+    return home / ".continue" / "config.json"
+
+
+def _merge(existing: dict[str, Any] | None, params: ServerParams) -> dict[str, Any]:
+    doc: dict[str, Any] = dict(existing) if existing else {}
+    entry = _entry(params)
+
+    # New-style: top-level mcpServers array.
+    servers_raw = doc.get("mcpServers")
+    servers: list[Any] = list(servers_raw) if isinstance(servers_raw, list) else []
+    servers = [s for s in servers if not (isinstance(s, dict) and s.get("name") == params.name)]
+    servers.append(entry)
+    doc["mcpServers"] = servers
+
+    # Legacy: experimental.modelContextProtocolServers.
+    exp_raw = doc.get("experimental")
+    exp: dict[str, Any] = dict(exp_raw) if isinstance(exp_raw, dict) else {}
+    legacy_raw = exp.get("modelContextProtocolServers")
+    legacy: list[Any] = list(legacy_raw) if isinstance(legacy_raw, list) else []
+    legacy = [s for s in legacy if not (isinstance(s, dict) and s.get("name") == params.name)]
+    legacy.append(entry)
+    exp["modelContextProtocolServers"] = legacy
+    doc["experimental"] = exp
+
+    return doc
+
+
+CONTINUE = ClientSpec(
+    key="continue",
+    display_name="Continue",
+    scope="global",
+    path_resolver=_path,
+    build_entry=_entry,
+    merge=_merge,
+    spec_source="https://docs.continue.dev/customize/deep-dives/mcp",
+)

--- a/apps/cli/src/omniscience_cli/init_templates/cursor.py
+++ b/apps/cli/src/omniscience_cli/init_templates/cursor.py
@@ -1,0 +1,54 @@
+"""Cursor template.
+
+Spec: https://docs.cursor.com/context/mcp
+
+Config file: project-scoped ``.cursor/mcp.json`` (Cursor also supports
+``~/.cursor/mcp.json`` globally, but the per-workspace path is what the
+issue requires).
+
+Shape::
+
+    {
+      "mcpServers": {
+        "<name>": {
+          "type": "http",
+          "url": "https://.../mcp",
+          "headers": {"Authorization": "Bearer ..."}
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omniscience_cli.init_templates.base import (
+    ClientSpec,
+    ServerParams,
+    http_entry,
+    merge_into,
+)
+
+
+def _path(*, home: Path, cwd: Path) -> Path:
+    return cwd / ".cursor" / "mcp.json"
+
+
+_MERGER = merge_into("mcpServers")
+
+
+def _merge(existing: dict[str, Any] | None, params: ServerParams) -> dict[str, Any]:
+    return _MERGER(existing, params, http_entry)
+
+
+CURSOR = ClientSpec(
+    key="cursor",
+    display_name="Cursor",
+    scope="workspace",
+    path_resolver=_path,
+    build_entry=http_entry,
+    merge=_merge,
+    spec_source="https://docs.cursor.com/context/mcp",
+)

--- a/apps/cli/src/omniscience_cli/init_templates/zed.py
+++ b/apps/cli/src/omniscience_cli/init_templates/zed.py
@@ -1,0 +1,62 @@
+"""Zed template.
+
+Spec: https://zed.dev/docs/assistant/model-context-protocol
+
+Config file: ``~/.config/zed/settings.json``.  MCP servers live under
+``context_servers.<name>`` (Zed uses snake_case keys).  Each entry uses
+``settings`` to carry transport details.  Example::
+
+    {
+      "context_servers": {
+        "<name>": {
+          "command": null,
+          "settings": {
+            "transport": "http",
+            "url": "https://.../mcp",
+            "headers": {"Authorization": "Bearer ..."}
+          }
+        }
+      }
+    }
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from omniscience_cli.init_templates.base import ClientSpec, ServerParams
+
+
+def _entry(params: ServerParams) -> dict[str, Any]:
+    return {
+        "settings": {
+            "transport": "http",
+            "url": params.mcp_url,
+            "headers": params.auth_headers,
+        },
+    }
+
+
+def _path(*, home: Path, cwd: Path) -> Path:
+    return home / ".config" / "zed" / "settings.json"
+
+
+def _merge(existing: dict[str, Any] | None, params: ServerParams) -> dict[str, Any]:
+    doc: dict[str, Any] = dict(existing) if existing else {}
+    bucket_raw = doc.get("context_servers")
+    bucket: dict[str, Any] = dict(bucket_raw) if isinstance(bucket_raw, dict) else {}
+    bucket[params.name] = _entry(params)
+    doc["context_servers"] = bucket
+    return doc
+
+
+ZED = ClientSpec(
+    key="zed",
+    display_name="Zed",
+    scope="global",
+    path_resolver=_path,
+    build_entry=_entry,
+    merge=_merge,
+    spec_source="https://zed.dev/docs/assistant/model-context-protocol",
+)

--- a/apps/cli/src/omniscience_cli/main.py
+++ b/apps/cli/src/omniscience_cli/main.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 import typer
 
 from omniscience_cli.client import OmniscienceClientError
-from omniscience_cli.commands import mcp, sources, tokens
+from omniscience_cli.commands import init, mcp, sources, tokens
 from omniscience_cli.commands.ops import _check_api, _check_config, _check_embeddings, _check_nats
 from omniscience_cli.commands.plugins import app as plugins_app
 from omniscience_cli.commands.search import _make_client as _search_client
@@ -31,6 +31,7 @@ app.add_typer(sources.app, name="sources")
 app.add_typer(tokens.app, name="tokens")
 app.add_typer(mcp.app, name="mcp")
 app.add_typer(plugins_app, name="plugins")
+app.add_typer(init.app, name="init")
 
 
 @app.command("search")

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -1,0 +1,91 @@
+# `omniscience init`
+
+One-shot bootstrap for MCP-aware editors. Writes the per-IDE configuration
+file, provisions a workspace token, and runs a `tools/list` smoke test
+against the running Omniscience server — typically taking the manual
+onboarding flow from ~30 minutes to ~60 seconds.
+
+## Usage
+
+```bash
+omniscience init --client <ide> [options]
+```
+
+### Supported clients
+
+| `--client`     | Config file written                          | Scope     | Spec |
+|----------------|----------------------------------------------|-----------|------|
+| `claude-code`  | `~/.claude/mcp_servers.json`                 | global    | https://docs.claude.com/en/docs/claude-code/mcp |
+| `cursor`       | `.cursor/mcp.json` (current project)         | workspace | https://docs.cursor.com/context/mcp |
+| `cline`        | `.vscode/cline_mcp_settings.json`            | workspace | https://docs.cline.bot/mcp/configuring-mcp-servers |
+| `continue`     | `~/.continue/config.json`                    | global    | https://docs.continue.dev/customize/deep-dives/mcp |
+| `zed`          | `~/.config/zed/settings.json`                | global    | https://zed.dev/docs/assistant/model-context-protocol |
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--client / -c` | _required_ | Target editor (see table above). |
+| `--name / -n`   | `omniscience` | Server name (the key inside the IDE config). |
+| `--url`         | `$OMNISCIENCE_URL` or `http://localhost:8000` | Omniscience server base URL. |
+| `--token`       | _unset_ | Use an existing token instead of provisioning a new one. |
+| `--scopes`      | `search,sources:read` | Comma-separated scopes for the provisioned token. |
+| `--print`       | `false` | Emit the resulting config to stdout (no files touched). |
+| `--force / -f`  | `false` | Overwrite an existing entry with the same `--name`. |
+| `--no-smoke-test` | `false` | Skip the post-write `tools/list` round-trip. |
+
+## What it does
+
+1. **Resolves connection params.** `--url` > `$OMNISCIENCE_URL` > `http://localhost:8000`.
+2. **Provisions a workspace token** via `POST /api/v1/tokens` unless one is supplied via `--token` or `$OMNISCIENCE_TOKEN`.
+3. **Renders + merges** the per-client config entry, preserving any
+   unrelated servers already in the file.
+4. **Writes atomically** (`write-tmp + rename`); a crashed run never
+   leaves a half-written `settings.json`.
+5. **Smoke-tests** the install by issuing a JSON-RPC `tools/list` call
+   against `<url>/mcp`. Failures emit a warning but don't roll back the
+   config — re-run `omniscience doctor` once the server is reachable.
+
+## Examples
+
+Write the Claude Code entry, provisioning a fresh token against a remote
+server:
+
+```bash
+omniscience init --client claude-code --url https://omni.example.com
+```
+
+Pin an existing token (useful in CI):
+
+```bash
+omniscience init --client cursor --token "$OMNISCIENCE_TOKEN"
+```
+
+Preview without writing:
+
+```bash
+omniscience init --client zed --print | jq .
+```
+
+Re-issue a server entry over an older one:
+
+```bash
+omniscience init --client claude-code --force
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Config written (smoke-test result is advisory only). |
+| `1`  | Unknown `--client`, token provisioning failed, existing entry without `--force`, or corrupt config file. |
+
+## Troubleshooting
+
+* **"Existing config is not valid JSON"** — your IDE config file is
+  corrupted. Fix it manually or move it aside; the CLI refuses to
+  silently overwrite unknown contents.
+* **"An MCP entry named 'omniscience' already exists"** — re-run with
+  `--force` or pick a different `--name`.
+* **Smoke test failed: network error** — server is unreachable. The
+  config was still written; run `omniscience doctor` for diagnostics.

--- a/tests/fixtures/init_cli/claude-code.json
+++ b/tests/fixtures/init_cli/claude-code.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "omniscience": {
+      "headers": {
+        "Authorization": "Bearer sk_test_TOKEN"
+      },
+      "type": "http",
+      "url": "https://omni.example.com/mcp"
+    }
+  }
+}

--- a/tests/fixtures/init_cli/cline.json
+++ b/tests/fixtures/init_cli/cline.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "omniscience": {
+      "autoApprove": [],
+      "disabled": false,
+      "headers": {
+        "Authorization": "Bearer sk_test_TOKEN"
+      },
+      "type": "http",
+      "url": "https://omni.example.com/mcp"
+    }
+  }
+}

--- a/tests/fixtures/init_cli/continue.json
+++ b/tests/fixtures/init_cli/continue.json
@@ -1,0 +1,28 @@
+{
+  "experimental": {
+    "modelContextProtocolServers": [
+      {
+        "name": "omniscience",
+        "transport": {
+          "headers": {
+            "Authorization": "Bearer sk_test_TOKEN"
+          },
+          "type": "streamable-http",
+          "url": "https://omni.example.com/mcp"
+        }
+      }
+    ]
+  },
+  "mcpServers": [
+    {
+      "name": "omniscience",
+      "transport": {
+        "headers": {
+          "Authorization": "Bearer sk_test_TOKEN"
+        },
+        "type": "streamable-http",
+        "url": "https://omni.example.com/mcp"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/init_cli/cursor.json
+++ b/tests/fixtures/init_cli/cursor.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "omniscience": {
+      "headers": {
+        "Authorization": "Bearer sk_test_TOKEN"
+      },
+      "type": "http",
+      "url": "https://omni.example.com/mcp"
+    }
+  }
+}

--- a/tests/fixtures/init_cli/zed.json
+++ b/tests/fixtures/init_cli/zed.json
@@ -1,0 +1,13 @@
+{
+  "context_servers": {
+    "omniscience": {
+      "settings": {
+        "headers": {
+          "Authorization": "Bearer sk_test_TOKEN"
+        },
+        "transport": "http",
+        "url": "https://omni.example.com/mcp"
+      }
+    }
+  }
+}

--- a/tests/test_init_cli.py
+++ b/tests/test_init_cli.py
@@ -1,0 +1,394 @@
+"""Tests for ``omniscience init`` — IDE MCP-config writer.
+
+Coverage strategy
+-----------------
+
+* **Per-client golden files** under ``tests/fixtures/init_cli/`` pin the
+  exact on-disk shape for each editor.  Updating a template is a
+  deliberate act: the diff lands in review.
+* **CLI integration tests** drive ``omniscience init`` through Typer's
+  ``CliRunner`` with the token-provisioning + smoke-test seams mocked,
+  proving the end-to-end flow without needing a live server.
+* **Helper tests** cover ``_write_atomic``, ``_read_existing`` and the
+  ``smoke_test`` HTTP wrapper individually so failures point at the
+  right layer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from omniscience_cli.commands import init as init_cmd
+from omniscience_cli.init_templates import CLAUDE_CODE, CLIENTS, CLINE, CONTINUE, CURSOR, ZED
+from omniscience_cli.init_templates.base import ServerParams
+from omniscience_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "init_cli"
+
+_PARAMS = ServerParams(
+    name="omniscience",
+    url="https://omni.example.com",
+    token="sk_test_TOKEN",
+)
+
+
+# ---------------------------------------------------------------------------
+# Golden-file tests — one per client
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "fixture"),
+    [
+        (CLAUDE_CODE, "claude-code.json"),
+        (CURSOR, "cursor.json"),
+        (CLINE, "cline.json"),
+        (CONTINUE, "continue.json"),
+        (ZED, "zed.json"),
+    ],
+)
+def test_template_matches_golden(spec: Any, fixture: str) -> None:
+    """The rendered config exactly matches the on-disk golden file.
+
+    Goldens are sorted-keys + 2-space JSON to match what the CLI writes.
+    """
+    document = spec.merge(None, _PARAMS)
+    rendered = json.dumps(document, indent=2, sort_keys=True) + "\n"
+    expected = (FIXTURE_DIR / fixture).read_text(encoding="utf-8")
+    assert rendered == expected, (
+        f"Golden drift for {spec.key}.\n--- got ---\n{rendered}\n--- want ---\n{expected}"
+    )
+
+
+def test_clients_registry_covers_all_required_keys() -> None:
+    """The CLI must support all five clients named in the issue."""
+    assert set(CLIENTS) == {"claude-code", "cursor", "cline", "continue", "zed"}
+
+
+def test_path_resolvers_use_correct_scope(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "proj"
+    assert CLAUDE_CODE.resolve_path(home=home, cwd=cwd) == home / ".claude" / "mcp_servers.json"
+    assert CURSOR.resolve_path(home=home, cwd=cwd) == cwd / ".cursor" / "mcp.json"
+    assert CLINE.resolve_path(home=home, cwd=cwd) == cwd / ".vscode" / "cline_mcp_settings.json"
+    assert CONTINUE.resolve_path(home=home, cwd=cwd) == home / ".continue" / "config.json"
+    assert ZED.resolve_path(home=home, cwd=cwd) == home / ".config" / "zed" / "settings.json"
+
+
+# ---------------------------------------------------------------------------
+# Merge semantics — existing files
+# ---------------------------------------------------------------------------
+
+
+def test_merge_preserves_unrelated_servers_claude_code() -> None:
+    existing = {
+        "mcpServers": {"other": {"type": "http", "url": "https://other/mcp"}},
+        "unrelatedKey": True,
+    }
+    merged = CLAUDE_CODE.merge(existing, _PARAMS)
+    assert merged["unrelatedKey"] is True
+    assert "other" in merged["mcpServers"]
+    assert merged["mcpServers"]["omniscience"]["url"] == "https://omni.example.com/mcp"
+
+
+def test_merge_replaces_same_name_continue() -> None:
+    existing = {
+        "mcpServers": [
+            {"name": "omniscience", "transport": {"url": "https://stale/mcp"}},
+            {"name": "other", "transport": {"url": "https://other/mcp"}},
+        ]
+    }
+    merged = CONTINUE.merge(existing, _PARAMS)
+    servers = merged["mcpServers"]
+    names = [s["name"] for s in servers]
+    assert names.count("omniscience") == 1
+    omni = next(s for s in servers if s["name"] == "omniscience")
+    assert omni["transport"]["url"] == "https://omni.example.com/mcp"
+    assert any(s["name"] == "other" for s in servers)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — _read_existing / _write_atomic / smoke_test
+# ---------------------------------------------------------------------------
+
+
+def test_read_existing_returns_none_for_missing(tmp_path: Path) -> None:
+    assert init_cmd._read_existing(tmp_path / "nope.json") is None
+
+
+def test_read_existing_aborts_on_corrupt(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("not json", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        init_cmd._read_existing(p)
+
+
+def test_read_existing_aborts_on_non_object(tmp_path: Path) -> None:
+    p = tmp_path / "arr.json"
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        init_cmd._read_existing(p)
+
+
+def test_write_atomic_creates_parents(tmp_path: Path) -> None:
+    target = tmp_path / "a" / "b" / "c.json"
+    init_cmd._write_atomic(target, '{"x":1}')
+    assert target.read_text(encoding="utf-8") == '{"x":1}\n'
+
+
+def test_smoke_test_success() -> None:
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(
+            200, json={"jsonrpc": "2.0", "id": 1, "result": {"tools": [{"name": "search"}]}}
+        )
+    )
+    with patch.object(
+        httpx,
+        "post",
+        lambda *a, **kw: transport.handle_request(
+            httpx.Request("POST", a[0], json=kw.get("json"))
+        ),
+    ):
+        ok, detail = init_cmd.smoke_test("https://x", "tok")
+    assert ok
+    assert "1 tools" in detail
+
+
+def test_smoke_test_http_error() -> None:
+    def _handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    transport = httpx.MockTransport(_handler)
+    with patch.object(
+        httpx,
+        "post",
+        lambda *a, **kw: transport.handle_request(
+            httpx.Request("POST", a[0], json=kw.get("json"))
+        ),
+    ):
+        ok, detail = init_cmd.smoke_test("https://x", "tok")
+    assert not ok
+    assert "500" in detail
+
+
+def test_smoke_test_network_error() -> None:
+    def _raise(*_a: Any, **_kw: Any) -> Any:
+        raise httpx.ConnectError("nope")
+
+    with patch.object(httpx, "post", _raise):
+        ok, detail = init_cmd.smoke_test("https://x", "tok")
+    assert not ok
+    assert "network error" in detail
+
+
+def test_smoke_test_jsonrpc_error() -> None:
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(
+            200, json={"jsonrpc": "2.0", "id": 1, "error": {"code": -32600, "message": "bad"}}
+        )
+    )
+    with patch.object(
+        httpx,
+        "post",
+        lambda *a, **kw: transport.handle_request(
+            httpx.Request("POST", a[0], json=kw.get("json"))
+        ),
+    ):
+        ok, detail = init_cmd.smoke_test("https://x", "tok")
+    assert not ok
+    assert "JSON-RPC error" in detail
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CLI tests
+# ---------------------------------------------------------------------------
+
+
+def _patched_client(token_value: str = "sk_test_TOKEN") -> Any:
+    """Return a context-manager mock of OmniscienceClient with a token API."""
+    mock = MagicMock()
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    mock.create_token.return_value = {"id": "tok-1", "token": token_value}
+    return mock
+
+
+@pytest.mark.parametrize("client_key", ["claude-code", "cursor", "cline", "continue", "zed"])
+def test_cli_writes_config_and_runs_smoke(tmp_path: Path, client_key: str) -> None:
+    """`omniscience init --client=X` writes the expected file and smoke-tests it."""
+    home = tmp_path / "home"
+    cwd = tmp_path / "proj"
+    home.mkdir()
+    cwd.mkdir()
+
+    mock_client = _patched_client()
+    with (
+        patch("omniscience_cli.commands.init.OmniscienceClient", return_value=mock_client),
+        patch(
+            "omniscience_cli.commands.init.smoke_test", return_value=(True, "2 tools registered")
+        ),
+        patch("omniscience_cli.commands.init.Path") as path_mock,
+    ):
+        path_mock.home.return_value = home
+        path_mock.cwd.return_value = cwd
+        # Path() called with str should still produce a real Path
+        path_mock.side_effect = lambda *a, **kw: Path(*a, **kw)
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--client",
+                client_key,
+                "--url",
+                "https://omni.example.com",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    spec = CLIENTS[client_key]
+    target = spec.resolve_path(home=home, cwd=cwd)
+    assert target.exists(), f"expected {target} to be written"
+    written = json.loads(target.read_text(encoding="utf-8"))
+    golden_name = "continue.json" if client_key == "continue" else f"{client_key}.json"
+    expected = json.loads((FIXTURE_DIR / golden_name).read_text(encoding="utf-8"))
+    assert written == expected
+    mock_client.create_token.assert_called_once()
+
+
+def test_cli_print_mode_emits_json_no_write(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "proj"
+    home.mkdir()
+    cwd.mkdir()
+    mock_client = _patched_client()
+    with (
+        patch("omniscience_cli.commands.init.OmniscienceClient", return_value=mock_client),
+        patch("omniscience_cli.commands.init.Path") as path_mock,
+    ):
+        path_mock.home.return_value = home
+        path_mock.cwd.return_value = cwd
+        path_mock.side_effect = lambda *a, **kw: Path(*a, **kw)
+        result = runner.invoke(
+            app,
+            ["init", "--client", "cursor", "--url", "https://omni.example.com", "--print"],
+        )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["client"] == "cursor"
+    assert payload["config"]["mcpServers"]["omniscience"]["url"] == "https://omni.example.com/mcp"
+    # Nothing on disk.
+    assert not (cwd / ".cursor" / "mcp.json").exists()
+
+
+def test_cli_uses_supplied_token_no_provisioning(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "proj"
+    home.mkdir()
+    cwd.mkdir()
+    mock_client = _patched_client()
+    with (
+        patch("omniscience_cli.commands.init.OmniscienceClient", return_value=mock_client),
+        patch("omniscience_cli.commands.init.smoke_test", return_value=(True, "ok")),
+        patch("omniscience_cli.commands.init.Path") as path_mock,
+    ):
+        path_mock.home.return_value = home
+        path_mock.cwd.return_value = cwd
+        path_mock.side_effect = lambda *a, **kw: Path(*a, **kw)
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--client",
+                "claude-code",
+                "--url",
+                "https://omni.example.com",
+                "--token",
+                "sk_explicit",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    mock_client.create_token.assert_not_called()
+    written = json.loads((home / ".claude" / "mcp_servers.json").read_text(encoding="utf-8"))
+    assert written["mcpServers"]["omniscience"]["headers"]["Authorization"] == "Bearer sk_explicit"
+
+
+def test_cli_unknown_client_aborts() -> None:
+    result = runner.invoke(app, ["init", "--client", "nopepad"])
+    assert result.exit_code != 0
+
+
+def test_cli_refuses_clobber_without_force(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "proj"
+    home.mkdir()
+    cwd.mkdir()
+    target = home / ".claude" / "mcp_servers.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps({"mcpServers": {"omniscience": {"type": "http", "url": "x"}}}),
+        encoding="utf-8",
+    )
+    mock_client = _patched_client()
+    with (
+        patch("omniscience_cli.commands.init.OmniscienceClient", return_value=mock_client),
+        patch("omniscience_cli.commands.init.smoke_test", return_value=(True, "ok")),
+        patch("omniscience_cli.commands.init.Path") as path_mock,
+    ):
+        path_mock.home.return_value = home
+        path_mock.cwd.return_value = cwd
+        path_mock.side_effect = lambda *a, **kw: Path(*a, **kw)
+        result = runner.invoke(
+            app,
+            ["init", "--client", "claude-code", "--token", "sk_x"],
+        )
+    assert result.exit_code != 0
+    # File unchanged.
+    assert (
+        json.loads(target.read_text(encoding="utf-8"))["mcpServers"]["omniscience"]["url"] == "x"
+    )
+
+
+def test_cli_force_overwrites_existing_entry(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "proj"
+    home.mkdir()
+    cwd.mkdir()
+    target = home / ".claude" / "mcp_servers.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps({"mcpServers": {"omniscience": {"type": "http", "url": "stale"}}}),
+        encoding="utf-8",
+    )
+    mock_client = _patched_client()
+    with (
+        patch("omniscience_cli.commands.init.OmniscienceClient", return_value=mock_client),
+        patch("omniscience_cli.commands.init.smoke_test", return_value=(True, "ok")),
+        patch("omniscience_cli.commands.init.Path") as path_mock,
+    ):
+        path_mock.home.return_value = home
+        path_mock.cwd.return_value = cwd
+        path_mock.side_effect = lambda *a, **kw: Path(*a, **kw)
+        result = runner.invoke(
+            app,
+            [
+                "init",
+                "--client",
+                "claude-code",
+                "--url",
+                "https://omni.example.com",
+                "--token",
+                "sk_test_TOKEN",
+                "--force",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    refreshed = json.loads(target.read_text(encoding="utf-8"))
+    assert refreshed["mcpServers"]["omniscience"]["url"] == "https://omni.example.com/mcp"


### PR DESCRIPTION
## Summary

One-shot bootstrap for MCP-aware editors: writes the per-IDE config file,
provisions a workspace token, and runs a `tools/list` smoke test.
Takes the manual onboarding flow from ~30 minutes to ~60 seconds.

### Supported clients

| `--client` | Config file | Spec source |
|---|---|---|
| `claude-code` | `~/.claude/mcp_servers.json` | https://docs.claude.com/en/docs/claude-code/mcp |
| `cursor` | `.cursor/mcp.json` | https://docs.cursor.com/context/mcp |
| `cline` | `.vscode/cline_mcp_settings.json` | https://docs.cline.bot/mcp/configuring-mcp-servers |
| `continue` | `~/.continue/config.json` | https://docs.continue.dev/customize/deep-dives/mcp |
| `zed` | `~/.config/zed/settings.json` | https://zed.dev/docs/assistant/model-context-protocol |

### Flags

`--print` (stdout-only), `--force` (overwrite same-name entry), `--no-smoke-test`,
`--token` (skip provisioning), `--name`, `--url`, `--scopes`.

### Architecture

- Per-client formatting isolated in `init_templates/`, one module per editor.
  Adding a sixth client = one file + registry entry.
- All filesystem mutations route through `_write_atomic` (write-tmp + rename) —
  a crashed run never leaves a half-written `settings.json`.
- Corrupt existing configs are detected and abort with a clear error rather
  than being silently overwritten.
- Smoke-test failures emit a warning but don't roll back the config (the
  config write is the durable artefact; doctor is the recovery path).

## Test plan

- [x] 27 unit tests in `tests/test_init_cli.py` — runtime 0.17s
- [x] Golden-file fixtures pin the exact shape per client (`tests/fixtures/init_cli/`)
- [x] CliRunner end-to-end tests cover each client + `--print` + `--force` + refuse-clobber + unknown-client
- [x] All four smoke-test branches covered (success / HTTP error / network error / JSON-RPC error)
- [x] Merge semantics tested: preserves unrelated servers, replaces same-name entry
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean on all new files
- [x] Existing `tests/test_cli.py` still green (38/38)

## Manual verification

Each client's golden file was cross-checked against the official spec linked in
its template module's docstring. The transport shape (`type: http`, `url`, `headers`)
is what all five editors document for `streamable-http` MCP servers, with
Cline-specific (`disabled`, `autoApprove`), Continue-specific (`transport.type:
streamable-http` plus dual new-+-legacy paths), and Zed-specific (`context_servers`,
`settings.transport`) deltas isolated in their respective template modules.

Closes #236