### PR TITLE
feat(incidents): timeline endpoint with as_of (#235)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -11,6 +11,7 @@ import { IngestionPage } from "./pages/IngestionPage";
 import { SearchPage } from "./pages/SearchPage";
 import { FreshnessPage } from "./pages/FreshnessPage";
 import { RetentionPage } from "./pages/RetentionPage";
+import { IncidentTimelinePage } from "./pages/IncidentTimelinePage";
 
 function AppInner() {
   const { token } = useTokenContext();
@@ -44,6 +45,10 @@ function AppInner() {
             />
             <Route path="/freshness" element={<FreshnessPage />} />
             <Route path="/retention" element={<RetentionPage />} />
+            <Route
+              path="/incidents"
+              element={<IncidentTimelinePage addToast={addToast} />}
+            />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -301,6 +301,45 @@ export interface RetentionRunNowResponse {
   lag_seconds: number;
 }
 
+/*
+ * Wire format for `GET /api/v1/incidents/{id}/timeline` (Issue #235).
+ *
+ * Mirrors the Pydantic `IncidentTimelineResponse` /  `TimelineEvent`
+ * defined in `apps/server/src/omniscience_server/incident_timeline.py`.
+ * Each event represents one bitemporal state change for an entity in
+ * the alert's blast radius. `change_kind` is "created" when the row's
+ * `valid_from` projects forward, or "ended" when its `valid_to` does.
+ */
+export type TimelineChangeKind = "created" | "ended";
+
+export interface TimelineEvent {
+  ts: string;
+  entity_id: string;
+  entity_type: string;
+  change_kind: TimelineChangeKind;
+  before_state_summary: string | null;
+  after_state_summary: string | null;
+  source: string;
+}
+
+export interface IncidentTimelineResponse {
+  alert_id: string;
+  events: TimelineEvent[];
+  effective_as_of: string;
+  window_from: string | null;
+  window_to: string | null;
+  entity_types_filter: string[] | null;
+  truncated: boolean;
+}
+
+export interface IncidentTimelineQuery {
+  from?: string;
+  to?: string;
+  entity_types?: string[];
+  as_of?: string;
+  max_depth?: number;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -513,5 +552,61 @@ export class ApiClient {
       "POST",
       "/api/v1/admin/retention/run-now"
     );
+  }
+
+  // Incident timeline (Issue #235)
+  async incidentTimeline(
+    alertId: string,
+    query: IncidentTimelineQuery = {},
+    signal?: AbortSignal
+  ): Promise<IncidentTimelineResponse> {
+    const qs = new URLSearchParams();
+    if (query.from) qs.set("from", query.from);
+    if (query.to) qs.set("to", query.to);
+    if (query.as_of) qs.set("as_of", query.as_of);
+    if (query.max_depth != null) qs.set("max_depth", String(query.max_depth));
+    if (query.entity_types) {
+      for (const t of query.entity_types) qs.append("entity_types", t);
+    }
+    const suffix = qs.toString() ? `?${qs}` : "";
+    return this.request<IncidentTimelineResponse>(
+      "GET",
+      `/api/v1/incidents/${encodeURIComponent(alertId)}/timeline${suffix}`,
+      undefined,
+      signal
+    );
+  }
+
+  async incidentTimelineMermaid(
+    alertId: string,
+    query: IncidentTimelineQuery = {},
+    signal?: AbortSignal
+  ): Promise<string> {
+    const qs = new URLSearchParams();
+    qs.set("format", "mermaid");
+    if (query.from) qs.set("from", query.from);
+    if (query.to) qs.set("to", query.to);
+    if (query.as_of) qs.set("as_of", query.as_of);
+    if (query.max_depth != null) qs.set("max_depth", String(query.max_depth));
+    if (query.entity_types) {
+      for (const t of query.entity_types) qs.append("entity_types", t);
+    }
+    const path = `/api/v1/incidents/${encodeURIComponent(alertId)}/timeline?${qs}`;
+    const res = await fetch(path, {
+      method: "GET",
+      headers: this.token ? { Authorization: `Bearer ${this.token}` } : undefined,
+      signal,
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({ detail: res.statusText }));
+      const detail =
+        typeof data?.detail === "string"
+          ? data.detail
+          : typeof data?.detail?.message === "string"
+            ? data.detail.message
+            : JSON.stringify(data?.detail ?? data);
+      throw new ApiError(res.status, detail);
+    }
+    return await res.text();
   }
 }

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { to: "/sources", label: "Sources" },
   { to: "/freshness", label: "Freshness" },
   { to: "/retention", label: "Retention" },
+  { to: "/incidents", label: "Incidents" },
   { to: "/tokens", label: "Tokens" },
   { to: "/ingestion", label: "Ingestion" },
   { to: "/search", label: "Search Playground" },

--- a/apps/admin/src/pages/IncidentTimelinePage.tsx
+++ b/apps/admin/src/pages/IncidentTimelinePage.tsx
@@ -1,0 +1,292 @@
+/*
+ * IncidentTimelinePage — `/incidents` deep-dive (Issue #235, H5 Track 1).
+ *
+ * Operators enter an alert id and an optional from/to/entity_types
+ * filter; the page calls `GET /api/v1/incidents/{id}/timeline?format=mermaid`
+ * and renders the returned block via Mermaid (loaded from the
+ * `unpkg.com` CDN on demand to avoid adding a build-time npm dep).
+ *
+ * The page is read-only. Workspace scoping is implicit — every call
+ * goes through the bearer token in `TokenContext`.
+ *
+ * No raw colour literals — Tailwind theme tokens only (per the
+ * `check-no-raw-colors.mjs` lint).
+ */
+
+import { useState, FormEvent, useEffect, useRef } from "react";
+import { useTokenContext } from "../context/TokenContext";
+import {
+  ApiError,
+  IncidentTimelineResponse,
+  TimelineEvent,
+} from "../api/client";
+
+interface ToastFn {
+  (msg: string, type?: "success" | "error" | "info"): void;
+}
+
+interface Props {
+  addToast: ToastFn;
+}
+
+// Mermaid is loaded lazily from CDN the first time the page renders a
+// non-empty diagram. The script tag is appended to <head> and the
+// `mermaid` global becomes available; we then call `mermaid.run()` over
+// the `.mermaid` blocks on the page. Failures are surfaced as a toast
+// but do not block the JSON view.
+const MERMAID_CDN = "https://unpkg.com/mermaid@10/dist/mermaid.min.js";
+
+interface MermaidAPI {
+  initialize: (cfg: Record<string, unknown>) => void;
+  run: (opts?: { nodes?: Element[] }) => Promise<void>;
+}
+
+declare global {
+  interface Window {
+    mermaid?: MermaidAPI;
+  }
+}
+
+let mermaidLoadPromise: Promise<MermaidAPI> | null = null;
+
+function loadMermaid(): Promise<MermaidAPI> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("window not available"));
+  }
+  if (window.mermaid) {
+    return Promise.resolve(window.mermaid);
+  }
+  if (mermaidLoadPromise) {
+    return mermaidLoadPromise;
+  }
+  mermaidLoadPromise = new Promise<MermaidAPI>((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = MERMAID_CDN;
+    script.async = true;
+    script.onload = () => {
+      const m = window.mermaid;
+      if (!m) {
+        reject(new Error("mermaid global not registered after script load"));
+        return;
+      }
+      m.initialize({ startOnLoad: false, theme: "dark" });
+      resolve(m);
+    };
+    script.onerror = () => reject(new Error("failed to load mermaid CDN"));
+    document.head.appendChild(script);
+  });
+  return mermaidLoadPromise;
+}
+
+function formatTs(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+function EventRow({ event }: { event: TimelineEvent }) {
+  const summary =
+    event.after_state_summary ?? event.before_state_summary ?? "";
+  return (
+    <li className="bg-elevation-1 rounded-lg border border-border p-3">
+      <div className="flex items-baseline justify-between gap-3 mb-1">
+        <span className="text-sm font-medium text-text font-mono">
+          {event.entity_id}
+        </span>
+        <span className="text-xs text-text-muted tabular-nums">
+          {formatTs(event.ts)}
+        </span>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-text-muted mb-1">
+        <span className="font-mono bg-elevation-2 text-text-secondary rounded px-1.5 py-0.5">
+          {event.entity_type}
+        </span>
+        <span className="font-mono bg-elevation-2 text-text-secondary rounded px-1.5 py-0.5">
+          {event.change_kind}
+        </span>
+        <span>source: {event.source}</span>
+      </div>
+      {summary && (
+        <p className="text-sm text-text-secondary leading-relaxed">
+          {summary}
+        </p>
+      )}
+    </li>
+  );
+}
+
+export function IncidentTimelinePage({ addToast }: Props) {
+  const { client } = useTokenContext();
+
+  const [alertId, setAlertId] = useState("");
+  const [fromTs, setFromTs] = useState("");
+  const [toTs, setToTs] = useState("");
+  const [entityTypesRaw, setEntityTypesRaw] = useState("");
+
+  const [json, setJson] = useState<IncidentTimelineResponse | null>(null);
+  const [mermaidSrc, setMermaidSrc] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const mermaidRef = useRef<HTMLDivElement | null>(null);
+
+  // Re-render the Mermaid block whenever the source changes.
+  useEffect(() => {
+    if (!mermaidSrc || !mermaidRef.current) return;
+    const node = mermaidRef.current;
+    node.innerHTML = `<div class="mermaid">${mermaidSrc
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")}</div>`;
+    loadMermaid()
+      .then((m) => m.run({ nodes: [node.firstElementChild!] }))
+      .catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        addToast(`Mermaid render failed: ${msg}`, "error");
+      });
+  }, [mermaidSrc, addToast]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!alertId.trim()) return;
+    setLoading(true);
+    try {
+      const entity_types = entityTypesRaw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      const query = {
+        from: fromTs || undefined,
+        to: toTs || undefined,
+        entity_types: entity_types.length ? entity_types : undefined,
+      };
+      // Fetch JSON + Mermaid in parallel — same query, two formats.
+      const [jsonResult, mermaidResult] = await Promise.all([
+        client.incidentTimeline(alertId.trim(), query),
+        client.incidentTimelineMermaid(alertId.trim(), query),
+      ]);
+      setJson(jsonResult);
+      setMermaidSrc(mermaidResult);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.detail : String(err);
+      addToast(`Timeline failed: ${msg}`, "error");
+      setJson(null);
+      setMermaidSrc(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-text mb-6">
+        Incident Timeline
+      </h1>
+
+      <form
+        onSubmit={handleSubmit}
+        className="bg-elevation-1 rounded-xl border border-border shadow-sm p-5 mb-6 space-y-4"
+      >
+        <div>
+          <label className="block text-sm font-medium text-text-secondary mb-1">
+            Alert ID
+          </label>
+          <input
+            type="text"
+            value={alertId}
+            onChange={(e) => setAlertId(e.target.value)}
+            placeholder="alert://pagerduty/INC-2026-04-12-001"
+            className="w-full border border-border bg-elevation-2 text-text placeholder:text-text-muted rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
+          />
+        </div>
+
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              From (ISO-8601 UTC)
+            </label>
+            <input
+              type="text"
+              value={fromTs}
+              onChange={(e) => setFromTs(e.target.value)}
+              placeholder="2026-04-12T00:00:00Z"
+              className="w-full border border-border bg-elevation-2 text-text placeholder:text-text-muted rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              To (ISO-8601 UTC)
+            </label>
+            <input
+              type="text"
+              value={toTs}
+              onChange={(e) => setToTs(e.target.value)}
+              placeholder="2026-04-13T00:00:00Z"
+              className="w-full border border-border bg-elevation-2 text-text placeholder:text-text-muted rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-text-secondary mb-1">
+              Entity types (comma-separated)
+            </label>
+            <input
+              type="text"
+              value={entityTypesRaw}
+              onChange={(e) => setEntityTypesRaw(e.target.value)}
+              placeholder="k8s_pod, pull_request"
+              className="w-full border border-border bg-elevation-2 text-text placeholder:text-text-muted rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+            />
+          </div>
+        </div>
+
+        <button
+          type="submit"
+          disabled={loading || !alertId.trim()}
+          className="px-5 py-2 text-sm bg-accent text-accent-fg rounded-lg hover:bg-accent-hover disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          {loading ? "Loading…" : "Render timeline"}
+        </button>
+      </form>
+
+      {json && (
+        <div className="space-y-6">
+          <div className="bg-elevation-1 rounded-xl border border-border shadow-sm p-5">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="text-lg font-semibold text-text">Mermaid</h2>
+              <span className="text-xs text-text-muted">
+                {json.events.length} event{json.events.length === 1 ? "" : "s"}
+                {json.truncated ? " (truncated)" : ""}
+              </span>
+            </div>
+            <div
+              ref={mermaidRef}
+              className="bg-elevation-2 rounded-lg p-4 overflow-x-auto"
+            />
+            <details className="mt-3">
+              <summary className="text-xs text-text-muted cursor-pointer hover:text-text">
+                View raw Mermaid source
+              </summary>
+              <pre className="mt-2 text-xs text-text-secondary bg-elevation-2 rounded-lg p-3 overflow-x-auto whitespace-pre">
+                {mermaidSrc}
+              </pre>
+            </details>
+          </div>
+
+          <div className="bg-elevation-1 rounded-xl border border-border shadow-sm p-5">
+            <h2 className="text-lg font-semibold text-text mb-3">Events</h2>
+            {json.events.length === 0 ? (
+              <p className="text-sm text-text-muted">
+                No events match the current filters.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {json.events.map((event, idx) => (
+                  <EventRow key={`${event.entity_id}-${event.change_kind}-${idx}`} event={event} />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/server/src/omniscience_server/incident_timeline.py
+++ b/apps/server/src/omniscience_server/incident_timeline.py
@@ -1,0 +1,463 @@
+"""Incident timeline composition (issue #235, H5 Track 1 of epic #230).
+
+Given an ``alert_id``, this module walks the alert's blast-radius
+neighbourhood via ``GraphStore.find_related`` (workspace-scoped,
+``as_of``-aware) and projects each entity's bitemporal triple into a
+chronologically ordered list of change events.  The result is the
+"5-minute wow" demo for SRE pilots: a story-ready timeline rendered as
+either JSON or a Mermaid block embeddable in markdown.
+
+Composition shape
+-----------------
+
+1. **Parse** ``alert_id``: reuses :func:`~omniscience_server.incidents._validate_alert_id`
+   so the contract is byte-identical to ``resolve_incident``
+   (``invalid_alert_id`` on bad shapes).
+2. **Resolve** the seed alert via :meth:`GraphStore.get_entity`.
+   ``404 alert_not_found`` on absence — cross-workspace alerts are
+   indistinguishable from "not found" by design (#117).
+3. **Traverse** outward via :meth:`GraphStore.find_related` (depth
+   :data:`TIMELINE_MAX_DEPTH`, no edge filter — we want every neighbour
+   in the blast radius represented).
+4. **Project** each ``EntityNodeView`` into one or two events:
+   - ``valid_from`` -> ``"created"`` event.
+   - ``valid_to`` -> ``"ended"`` event (only when populated).
+5. **Filter** by ``[from, to)`` event-timestamp window and optional
+   ``entity_types`` allowlist.
+6. **Order** the resulting events by ``ts`` ascending; ties broken by
+   ``entity_id`` for deterministic output.
+
+ACL invariant
+-------------
+
+``workspace_id`` is taken from the caller's bearer token; never trusted
+from input.  Every store call carries it.  Cross-workspace data is
+unreachable per the protocol's ACL contract (ADR-0005 / #117).
+
+Determinism
+-----------
+
+The Mermaid renderer escapes the small set of glyphs that break
+``timeline`` syntax (``:``, newline, pipe, quote) so any canonical name
+in the codebase (``alert://`` / ``arn:`` / ``slack://channel/...``) is
+safe to embed.  The renderer is pure; the basic parse-check used by the
+integration test is local to the test module.
+
+Bitemporal contract
+-------------------
+
+ADR-0008 §1 — entity rows carry ``valid_from``, ``valid_to``, and
+``recorded_at``.  Legacy pre-#130 rows leave them ``None`` and are
+filtered out of the timeline (we cannot place them on a clock).  Events
+expose both ``ts`` (the user-visible change time, sourced from
+``valid_from``/``valid_to``) and ``source`` (the connector that wrote
+the row) so reviewers can audit provenance without a second lookup.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Final, Literal
+
+from fastapi import FastAPI
+from omniscience_core.storage import EntityNodeView, GraphResultView, GraphStore
+from pydantic import BaseModel, Field
+
+from omniscience_server.as_of import (
+    enforce_utc,
+    record_request_duration,
+    resolve_effective_as_of,
+)
+from omniscience_server.incidents import (
+    ALERT_NOT_FOUND_CODE,
+    _validate_alert_id,  # re-used: same alert_id grammar as resolve_incident
+)
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+#: Default BFS depth when composing a timeline.  Matches
+#: :data:`~omniscience_server.incidents.DEFAULT_MAX_DEPTH` so the timeline
+#: window sees the same blast radius that ``resolve_incident`` does.
+TIMELINE_MAX_DEPTH: Final[int] = 2
+
+#: Hard cap on events returned in a single response.  Mirrors the
+#: pagination floor used by other admin endpoints — incidents with more
+#: than this many state changes need a paged view (#236 follow-on).
+MAX_EVENTS_RETURNED: Final[int] = 500
+
+#: Change kinds emitted by the timeline projection.  ``Literal`` so the
+#: REST/MCP wire schema is closed and mypy-checked.
+ChangeKind = Literal["created", "ended"]
+
+#: Output formats supported by the REST endpoint.
+TimelineFormat = Literal["json", "mermaid"]
+
+# ---------------------------------------------------------------------------
+# Pydantic response schemas (wire format)
+# ---------------------------------------------------------------------------
+
+
+class TimelineEvent(BaseModel):
+    """A single bitemporal change projected from an entity row."""
+
+    ts: datetime = Field(description="Event timestamp (UTC, ISO-8601).")
+    entity_id: str = Field(description="Canonical entity name.")
+    entity_type: str = Field(description="Entity kind (e.g. 'k8s_pod', 'pull_request').")
+    change_kind: ChangeKind = Field(description="'created' or 'ended'.")
+    before_state_summary: str | None = Field(
+        default=None,
+        description=(
+            "Human-readable description of the prior state. Null for "
+            "'created' events (no prior state)."
+        ),
+    )
+    after_state_summary: str | None = Field(
+        default=None,
+        description=(
+            "Human-readable description of the resulting state. Null "
+            "for 'ended' events (the entity no longer has a valid state)."
+        ),
+    )
+    source: str = Field(
+        description=(
+            "Connector / source identifier that wrote the underlying "
+            "row (provenance — see ADR-0008 §1 recorded_at companion)."
+        ),
+    )
+
+
+class IncidentTimelineResponse(BaseModel):
+    """The full timeline payload — events plus envelope metadata."""
+
+    alert_id: str
+    events: list[TimelineEvent] = Field(default_factory=list)
+    effective_as_of: datetime
+    window_from: datetime | None = None
+    window_to: datetime | None = None
+    entity_types_filter: list[str] | None = None
+    truncated: bool = Field(
+        default=False,
+        description="True iff the result was clipped at MAX_EVENTS_RETURNED.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal projection dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _ProjectedEvent:
+    """Pre-validation view of a single event candidate."""
+
+    ts: datetime
+    entity_id: str
+    entity_type: str
+    change_kind: ChangeKind
+    before_state_summary: str | None
+    after_state_summary: str | None
+    source: str
+
+
+# ---------------------------------------------------------------------------
+# Public composition entry point
+# ---------------------------------------------------------------------------
+
+
+async def mcp_incident_timeline(
+    app: FastAPI,
+    *,
+    alert_id: str,
+    workspace_id: uuid.UUID,
+    as_of: datetime | None = None,
+    from_ts: datetime | None = None,
+    to_ts: datetime | None = None,
+    entity_types: list[str] | None = None,
+    max_depth: int = TIMELINE_MAX_DEPTH,
+) -> dict[str, Any]:
+    """Compose the timeline payload for ``alert_id`` within ``workspace_id``.
+
+    Returns a JSON-serialisable dict matching :class:`IncidentTimelineResponse`.
+
+    Parameters
+    ----------
+    app:
+        FastAPI app exposing ``app.state.graph_store``.
+    alert_id:
+        Canonical alert URI ``alert://{provider}/{provider_alert_id}``.
+    workspace_id:
+        REQUIRED. Forwarded to every store call (ACL invariant).
+    as_of:
+        Optional bitemporal anchor.  Forwarded to ``GraphStore``;
+        timeline events are projected from the row state visible at T.
+    from_ts, to_ts:
+        Half-open event-time window ``[from_ts, to_ts)`` applied to
+        the projected events.  ``None`` on either side leaves that
+        side unbounded.  Both bounds must be timezone-aware UTC per
+        the as_of contract.
+    entity_types:
+        Optional allowlist of entity ``kind`` strings.  Empty list /
+        ``None`` means "no filter".
+    max_depth:
+        BFS depth from the alert seed.  Defaults to
+        :data:`TIMELINE_MAX_DEPTH`.
+    """
+    _validate_alert_id(alert_id)
+    normalised_as_of = enforce_utc(as_of)
+    normalised_from = enforce_utc(from_ts)
+    normalised_to = enforce_utc(to_ts)
+    clamped_depth = max(1, min(max_depth, 5))
+    type_filter: set[str] | None = {t for t in entity_types if t} if entity_types else None
+
+    graph_store: GraphStore | None = getattr(app.state, "graph_store", None)
+    if graph_store is None:
+        raise RuntimeError("graph_store not available on app.state")
+
+    with record_request_duration(
+        surface="mcp", tool="incident_timeline", as_of=normalised_as_of
+    ) as patcher:
+        seed = await graph_store.get_entity(
+            entity_name=alert_id,
+            workspace_id=workspace_id,
+            as_of=normalised_as_of,
+        )
+        if seed is None:
+            if normalised_as_of is not None:
+                patcher.mark_pre_history()
+            raise ValueError(f"{ALERT_NOT_FOUND_CODE}:{alert_id}")
+
+        try:
+            graph_result = await graph_store.find_related(
+                entity_name=alert_id,
+                workspace_id=workspace_id,
+                as_of=normalised_as_of,
+                max_depth=clamped_depth,
+            )
+        except ValueError as exc:
+            if str(exc).startswith("entity_not_found:"):
+                # Race against re-ingestion — keep the timeline alert-only.
+                graph_result = GraphResultView(seed=seed, related=[], edges=[])
+            else:
+                raise
+
+        projected = _project_events(seed=seed, result=graph_result)
+        filtered = _apply_filters(
+            projected,
+            from_ts=normalised_from,
+            to_ts=normalised_to,
+            entity_types=type_filter,
+        )
+        ordered = sorted(filtered, key=lambda e: (e.ts, e.entity_id, e.change_kind))
+
+        truncated = len(ordered) > MAX_EVENTS_RETURNED
+        if truncated:
+            ordered = ordered[:MAX_EVENTS_RETURNED]
+
+        response = IncidentTimelineResponse(
+            alert_id=alert_id,
+            events=[_to_wire(e) for e in ordered],
+            effective_as_of=resolve_effective_as_of(normalised_as_of),
+            window_from=normalised_from,
+            window_to=normalised_to,
+            entity_types_filter=(sorted(type_filter) if type_filter else None),
+            truncated=truncated,
+        )
+        return response.model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Projection helpers — pure, unit-testable
+# ---------------------------------------------------------------------------
+
+
+def _project_events(
+    *,
+    seed: EntityNodeView,
+    result: GraphResultView,
+) -> list[_ProjectedEvent]:
+    """Project the seed + every neighbour into ``_ProjectedEvent`` candidates.
+
+    One ``created`` event per row with a populated ``valid_from``; one
+    ``ended`` event per row that also carries ``valid_to`` (i.e. the
+    state has been tombstoned or superseded — ADR-0008 §5).
+    """
+    candidates: list[EntityNodeView] = [seed, *result.related]
+    out: list[_ProjectedEvent] = []
+    for node in candidates:
+        out.extend(_events_for_node(node))
+    return out
+
+
+def _events_for_node(node: EntityNodeView) -> list[_ProjectedEvent]:
+    """Emit zero, one, or two events for a single entity row."""
+    events: list[_ProjectedEvent] = []
+    summary = _summarise(node)
+    if node.valid_from is not None:
+        events.append(
+            _ProjectedEvent(
+                ts=_to_utc(node.valid_from),
+                entity_id=node.name,
+                entity_type=node.kind,
+                change_kind="created",
+                before_state_summary=None,
+                after_state_summary=summary,
+                source=node.source,
+            )
+        )
+    if node.valid_to is not None:
+        events.append(
+            _ProjectedEvent(
+                ts=_to_utc(node.valid_to),
+                entity_id=node.name,
+                entity_type=node.kind,
+                change_kind="ended",
+                before_state_summary=summary,
+                after_state_summary=None,
+                source=node.source,
+            )
+        )
+    return events
+
+
+def _summarise(node: EntityNodeView) -> str:
+    """Build a compact human-readable summary for the event row.
+
+    Uses the chunk text when present (it's the connector's most
+    detailed prose) and falls back to ``"{kind} {name}"``.  Truncated to
+    keep wire payloads small.
+    """
+    if node.chunk_text:
+        text = node.chunk_text.strip()
+        if len(text) > 200:
+            text = text[:197] + "..."
+        return text
+    return f"{node.kind} {node.name}"
+
+
+def _to_utc(ts: datetime) -> datetime:
+    """Coerce to UTC; fixtures sometimes carry naive times — be defensive."""
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts.astimezone(UTC)
+
+
+def _apply_filters(
+    events: list[_ProjectedEvent],
+    *,
+    from_ts: datetime | None,
+    to_ts: datetime | None,
+    entity_types: set[str] | None,
+) -> list[_ProjectedEvent]:
+    """Apply the ``[from, to)`` window and ``entity_types`` allowlist."""
+    out: list[_ProjectedEvent] = []
+    for event in events:
+        if from_ts is not None and event.ts < from_ts:
+            continue
+        if to_ts is not None and event.ts >= to_ts:
+            continue
+        if entity_types is not None and event.entity_type not in entity_types:
+            continue
+        out.append(event)
+    return out
+
+
+def _to_wire(event: _ProjectedEvent) -> TimelineEvent:
+    """Convert the internal dataclass to the public Pydantic model."""
+    return TimelineEvent(
+        ts=event.ts,
+        entity_id=event.entity_id,
+        entity_type=event.entity_type,
+        change_kind=event.change_kind,
+        before_state_summary=event.before_state_summary,
+        after_state_summary=event.after_state_summary,
+        source=event.source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mermaid renderer
+# ---------------------------------------------------------------------------
+
+#: Mermaid timeline header.  ``title`` is required so renderers display
+#: the alert id at the top of the diagram.
+_MERMAID_HEADER: Final[str] = "timeline"
+
+#: Glyphs that break Mermaid ``timeline`` syntax when embedded in a
+#: section/event label.  ``:`` is the section terminator; newlines and
+#: pipes are control characters; quotes confuse the lexer.
+_MERMAID_ESCAPES: Final[dict[str, str]] = {
+    ":": "-",  # Mermaid section/event terminator; replace with hyphen
+    "\n": " ",
+    "\r": " ",
+    "|": "/",
+    '"': "'",
+}
+
+
+def render_mermaid(payload: dict[str, Any]) -> str:
+    """Render an :class:`IncidentTimelineResponse` payload as Mermaid.
+
+    The output is a single ``timeline`` block ready to embed in any
+    markdown renderer that supports Mermaid (GitHub, GitLab, Notion,
+    most static-site generators).  Days are used as the section
+    granularity so multi-day incidents stay readable.
+
+    The function is pure and side-effect-free; it accepts the already
+    serialised wire dict so callers can render the same payload they'd
+    return as JSON.
+    """
+    lines: list[str] = [_MERMAID_HEADER]
+    title = _escape(f"Incident {payload.get('alert_id', '<unknown>')}")
+    lines.append(f"    title {title}")
+
+    events = payload.get("events") or []
+    if not events:
+        # Mermaid renderers accept an empty timeline but mostly render
+        # a blank box — surface a single explanatory section.
+        lines.append("    section No events in window")
+        lines.append("        (empty) : Try widening from/to or entity_types")
+        return "\n".join(lines)
+
+    current_section: str | None = None
+    for event in events:
+        ts_iso: str = str(event.get("ts", ""))
+        section = ts_iso[:10] if ts_iso else "unknown"
+        if section != current_section:
+            lines.append(f"    section {_escape(section)}")
+            current_section = section
+
+        time_part = ts_iso[11:19] if len(ts_iso) >= 19 else ts_iso
+        entity = _escape(str(event.get("entity_id", "")))
+        kind = _escape(str(event.get("entity_type", "")))
+        change = _escape(str(event.get("change_kind", "")))
+        summary = event.get("after_state_summary") or event.get("before_state_summary") or ""
+        summary_short = _escape(str(summary))[:120]
+        label = f"{time_part} {kind} {change}"
+        body = f"{entity} - {summary_short}" if summary_short else entity
+        lines.append(f"        {label} : {body}")
+
+    return "\n".join(lines)
+
+
+def _escape(value: str) -> str:
+    """Replace Mermaid-breaking glyphs with safe equivalents."""
+    out = value
+    for needle, replacement in _MERMAID_ESCAPES.items():
+        out = out.replace(needle, replacement)
+    return out
+
+
+__all__ = [
+    "MAX_EVENTS_RETURNED",
+    "TIMELINE_MAX_DEPTH",
+    "ChangeKind",
+    "IncidentTimelineResponse",
+    "TimelineEvent",
+    "TimelineFormat",
+    "mcp_incident_timeline",
+    "render_mermaid",
+]

--- a/apps/server/src/omniscience_server/mcp/incident_timeline.py
+++ b/apps/server/src/omniscience_server/mcp/incident_timeline.py
@@ -1,0 +1,94 @@
+"""MCP tool: ``incident_timeline`` (issue #235).
+
+Same shape as the REST surface ``GET /api/v1/incidents/{id}/timeline``.
+Registered in ``omniscience_server.mcp.server`` alongside the other
+incident tools.
+
+Wire signature
+--------------
+
+``incident_timeline(alert_id, from_ts=None, to_ts=None, entity_types=None,
+as_of=None, max_depth=2)`` -> ``dict`` matching
+:class:`~omniscience_server.incident_timeline.IncidentTimelineResponse`.
+
+ACL & auth
+----------
+
+- Scope: ``search`` (same as ``resolve_incident``).
+- Workspace-scoped token REQUIRED; unscoped tokens are rejected with
+  ``forbidden``.  Cross-workspace alert ids return ``alert_not_found``
+  (no existence leak — #117 / ADR-0005).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from fastapi import FastAPI
+from mcp.server.fastmcp import Context
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+
+from omniscience_server.incident_timeline import (
+    TIMELINE_MAX_DEPTH,
+    mcp_incident_timeline,
+)
+
+log = structlog.get_logger(__name__)
+
+
+async def incident_timeline_tool(
+    *,
+    app: FastAPI,
+    ctx: Context[Any, Any, Any],
+    resolve_token: Any,  # async callable -> ApiToken | None
+    require_scope: Any,  # callable(token, scope) -> None
+    parse_as_of: Any,  # callable(str | None) -> datetime | None
+    record_invocation: Any,  # callable(*, tool_name, token) -> None
+    alert_id: str,
+    from_ts: str | None,
+    to_ts: str | None,
+    entity_types: list[str] | None,
+    as_of: str | None,
+    max_depth: int,
+) -> dict[str, Any]:
+    """Inner implementation invoked by the FastMCP-registered shim.
+
+    The function is parameterised over the auth / parsing helpers
+    (``resolve_token``, ``require_scope``, ``parse_as_of``,
+    ``record_invocation``) so this module can be unit-tested without
+    pulling in the FastMCP server-module globals.  The shim in
+    :mod:`omniscience_server.mcp.server` wires the real implementations.
+    """
+    token = await resolve_token(ctx)
+    require_scope(token, Scope.search)
+    record_invocation(tool_name="incident_timeline", token=token)
+    assert token is not None  # noqa: S101 — narrows type for mypy
+
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "mcp_incident_timeline_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise ValueError("forbidden:Incident timeline requires a workspace-scoped token")
+
+    parsed_as_of = parse_as_of(as_of)
+    parsed_from = parse_as_of(from_ts)
+    parsed_to = parse_as_of(to_ts)
+    clamped_depth = max(1, min(max_depth, 5))
+
+    return await mcp_incident_timeline(
+        app=app,
+        alert_id=alert_id,
+        workspace_id=workspace_id,
+        as_of=parsed_as_of,
+        from_ts=parsed_from,
+        to_ts=parsed_to,
+        entity_types=entity_types,
+        max_depth=clamped_depth,
+    )
+
+
+__all__ = ["TIMELINE_MAX_DEPTH", "incident_timeline_tool"]

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -56,6 +56,10 @@ from omniscience_server.incidents import (
     MAX_MAX_DEPTH,
     MIN_MAX_DEPTH,
 )
+from omniscience_server.mcp.incident_timeline import (
+    TIMELINE_MAX_DEPTH,
+    incident_timeline_tool,
+)
 from omniscience_server.mcp.tools import (
     mcp_get_document,
     mcp_get_entity,
@@ -488,6 +492,54 @@ async def resolve_incident(
         if msg.startswith(f"{ALERT_NOT_FOUND_CODE}:"):
             raise
         raise
+
+
+# ---------------------------------------------------------------------------
+# Tool: incident_timeline (issue #235)
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    name="incident_timeline",
+    description=(
+        "Render the bitemporal state-change timeline for entities in an "
+        "alerts blast radius. alert_id MUST be of the form "
+        "alert://{provider}/{provider_alert_id}. Optional from/to bound "
+        "the event-time window; optional entity_types is an allowlist of "
+        "entity kinds. Returns events sorted ascending by timestamp with "
+        "before/after summaries and source provenance per ADR-0008 1. "
+        "Requires a workspace-scoped token."
+    ),
+)
+async def incident_timeline(
+    alert_id: str,
+    ctx: Context[Any, Any, Any],
+    from_ts: str | None = None,
+    to_ts: str | None = None,
+    entity_types: list[str] | None = None,
+    as_of: str | None = None,
+    max_depth: int = TIMELINE_MAX_DEPTH,
+) -> dict[str, Any]:
+    """incident_timeline tool requires scope search AND a workspace token.
+
+    Mirrors the auth posture of resolve_incident workspace-scoped,
+    fail-closed, no existence leak for cross-workspace alert ids
+    (issue #117 / ADR-0005).
+    """
+    return await incident_timeline_tool(
+        app=_get_app(),
+        ctx=ctx,
+        resolve_token=_resolve_token,
+        require_scope=_require_scope,
+        parse_as_of=_parse_as_of,
+        record_invocation=_record_tool_invocation,
+        alert_id=alert_id,
+        from_ts=from_ts,
+        to_ts=to_ts,
+        entity_types=entity_types,
+        as_of=as_of,
+        max_depth=max_depth,
+    )
 
 
 __all__ = ["mcp_server", "set_fastapi_app"]

--- a/apps/server/src/omniscience_server/rest/incident_timeline.py
+++ b/apps/server/src/omniscience_server/rest/incident_timeline.py
@@ -1,0 +1,238 @@
+"""Incident-timeline REST endpoint (issue #235).
+
+``GET /api/v1/incidents/{alert_id}/timeline``
+
+Returns the ordered list of bitemporal state changes for entities in
+the alert's blast radius.  Optional query params:
+
+- ``from``, ``to``       — half-open event-time window (ISO-8601 UTC).
+- ``entity_types``       — repeatable allowlist of entity kinds.
+- ``as_of``              — bitemporal anchor (ADR-0008 §5).
+- ``format=mermaid``     — return ``text/plain`` Mermaid block instead
+                           of JSON for embedding in markdown.
+
+Workspace scoping mirrors the existing ``resolve_incident`` endpoint:
+the caller's ``workspace_id`` is resolved from the bearer token; an
+``alert_id`` not visible to the caller's workspace returns
+``404 alert_not_found`` (no existence leak).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any
+from urllib.parse import unquote
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import PlainTextResponse
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken
+
+from omniscience_server.as_of import (
+    INVALID_TIMEZONE_CODE,
+    INVALID_TIMEZONE_MESSAGE,
+    enforce_utc,
+)
+from omniscience_server.incident_timeline import (
+    TIMELINE_MAX_DEPTH,
+    mcp_incident_timeline,
+    render_mermaid,
+)
+from omniscience_server.incidents import (
+    ALERT_NOT_FOUND_CODE,
+    INVALID_ALERT_ID_CODE,
+    INVALID_ALERT_ID_MESSAGE,
+)
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["incidents"])
+
+# Module-level Depends singletons (avoids ruff B008).
+_search_scope_dep: Any = Depends(require_scope(Scope.search))
+_current_token_dep: Any = Depends(get_current_token)
+
+# Query parameter annotations.
+_FromQuery = Annotated[
+    datetime | None,
+    Query(
+        alias="from",
+        description=(
+            "Inclusive start of the event-time window (ISO-8601 UTC). "
+            "Naive or non-UTC values are rejected with 400 invalid_timezone."
+        ),
+    ),
+]
+_ToQuery = Annotated[
+    datetime | None,
+    Query(
+        alias="to",
+        description=(
+            "Exclusive end of the event-time window (ISO-8601 UTC). "
+            "Naive or non-UTC values are rejected with 400 invalid_timezone."
+        ),
+    ),
+]
+_EntityTypesQuery = Annotated[
+    list[str] | None,
+    Query(
+        description=(
+            "Repeatable allowlist of entity kinds "
+            "(e.g. 'k8s_pod', 'pull_request'). Omitted means no filter."
+        ),
+    ),
+]
+_AsOfQuery = Annotated[
+    datetime | None,
+    Query(
+        description=(
+            "Optional ISO-8601 timezone-aware UTC datetime anchoring the "
+            "bitemporal traversal per ADR-0008 §5."
+        ),
+    ),
+]
+_FormatQuery = Annotated[
+    str | None,
+    Query(
+        description=(
+            "Output format: 'json' (default) or 'mermaid' to receive a "
+            "text/plain Mermaid timeline block ready to embed in markdown."
+        ),
+    ),
+]
+_MaxDepthQuery = Annotated[
+    int,
+    Query(
+        ge=1,
+        le=5,
+        description="BFS depth from the alert seed (1-5).",
+    ),
+]
+
+
+def _validate_window(
+    value: datetime | None,
+    *,
+    field: str,
+) -> datetime | None:
+    """Normalise an event-window bound to UTC, mapping errors to 400."""
+    try:
+        return enforce_utc(value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": INVALID_TIMEZONE_CODE,
+                "message": f"{field}: {INVALID_TIMEZONE_MESSAGE}",
+            },
+        ) from exc
+
+
+@router.get(
+    "/incidents/{alert_id:path}/timeline",
+    summary="Render entity state changes around an incident window.",
+    dependencies=[_search_scope_dep],
+)
+async def incident_timeline(
+    alert_id: str,
+    request: Request,
+    from_ts: _FromQuery = None,
+    to_ts: _ToQuery = None,
+    entity_types: _EntityTypesQuery = None,
+    as_of: _AsOfQuery = None,
+    format: _FormatQuery = None,  # noqa: A002 — REST convention; shadows builtin
+    max_depth: _MaxDepthQuery = TIMELINE_MAX_DEPTH,
+    token: ApiToken = _current_token_dep,
+) -> Any:
+    """Return the ordered timeline of state changes for ``alert_id``.
+
+    Mirrors :func:`omniscience_server.mcp.incident_timeline.incident_timeline`
+    so the two transports are interchangeable.  Cross-workspace alerts
+    return ``404 alert_not_found`` to preserve the "no existence leak"
+    invariant (#117 / ADR-0005).
+    """
+    decoded_alert_id = unquote(alert_id)
+    normalised_as_of = _validate_window(as_of, field="as_of")
+    normalised_from = _validate_window(from_ts, field="from")
+    normalised_to = _validate_window(to_ts, field="to")
+
+    if (
+        normalised_from is not None
+        and normalised_to is not None
+        and normalised_from > normalised_to
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_window",
+                "message": "'from' must be <= 'to'",
+            },
+        )
+
+    fmt = (format or "json").lower()
+    if fmt not in {"json", "mermaid"}:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_format",
+                "message": "format must be one of: json, mermaid",
+            },
+        )
+
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "incident_timeline_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Incident timeline requires a workspace-scoped token",
+            },
+        )
+
+    try:
+        payload = await mcp_incident_timeline(
+            app=request.app,
+            alert_id=decoded_alert_id,
+            workspace_id=workspace_id,
+            as_of=normalised_as_of,
+            from_ts=normalised_from,
+            to_ts=normalised_to,
+            entity_types=entity_types,
+            max_depth=max_depth,
+        )
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith(f"{INVALID_ALERT_ID_CODE}:"):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": INVALID_ALERT_ID_CODE,
+                    "message": INVALID_ALERT_ID_MESSAGE,
+                },
+            ) from exc
+        if msg.startswith(f"{ALERT_NOT_FOUND_CODE}:"):
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": ALERT_NOT_FOUND_CODE,
+                    "message": f"Alert '{decoded_alert_id}' not found",
+                },
+            ) from exc
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "bad_request", "message": msg},
+        ) from exc
+
+    if fmt == "mermaid":
+        return PlainTextResponse(content=render_mermaid(payload))
+    return payload
+
+
+__all__ = ["router"]

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter
 from omniscience_server.rest.documents import router as documents_router
 from omniscience_server.rest.entities import router as entities_router
 from omniscience_server.rest.freshness import router as freshness_router
+from omniscience_server.rest.incident_timeline import router as incident_timeline_router
 from omniscience_server.rest.incidents import router as incidents_router
 from omniscience_server.rest.incidents_admin import router as incidents_admin_router
 from omniscience_server.rest.ingestion_runs import router as ingestion_runs_router
@@ -32,6 +33,7 @@ api_v1_router.include_router(retention_router)
 api_v1_router.include_router(otlp_router)
 api_v1_router.include_router(operator_router)
 api_v1_router.include_router(incidents_router)
+api_v1_router.include_router(incident_timeline_router)
 api_v1_router.include_router(incidents_admin_router)
 
 __all__ = ["api_v1_router"]

--- a/tests/integration/test_incident_timeline.py
+++ b/tests/integration/test_incident_timeline.py
@@ -1,0 +1,434 @@
+"""Integration tests for the incident-timeline endpoint (issue #235).
+
+Reuses the ``tests/fixtures/incident_demo/workspace_a.json`` fixture
+that the H5 demo path already depends on — workspace_a plants an alert
+plus six neighbours (pod, two PRs, two Slack threads, one OTel trace),
+each carrying a ``valid_from``.  That gives the timeline projection
+six "created" events from neighbours plus one for the seed alert — well
+above the issue's "5+ ordered events" acceptance bar.
+
+What this exercises
+-------------------
+
+1. The full composition path ``alert_id`` -> ``GraphStore.find_related``
+   -> bitemporal projection -> sorted ``TimelineEvent`` list.
+2. The ``[from, to)`` event-window filter.
+3. The ``entity_types`` allowlist filter.
+4. Cross-workspace isolation (alert from workspace_b is ``not_found``
+   when queried as workspace_a).
+5. The Mermaid renderer produces a parseable ``timeline`` block whose
+   sections and events line up with the JSON payload.
+6. Provenance: every event carries the ``source`` field the connector
+   wrote (ADR-0008 §1).
+
+Runs in the default CI lane — no env-var opt-in, no testcontainers.
+The in-memory store is the contract surface, matching
+``test_incident_demo.py``'s posture.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_server.incident_timeline import (
+    MAX_EVENTS_RETURNED,
+    mcp_incident_timeline,
+    render_mermaid,
+)
+from omniscience_server.incidents import (
+    ALERT_NOT_FOUND_CODE,
+    INVALID_ALERT_ID_CODE,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_FIXTURE_DIR: Path = Path(__file__).parent.parent / "fixtures" / "incident_demo"
+
+#: Acceptance floor from issue #235: "fixture incident -> 5+ ordered events".
+_MIN_EVENT_COUNT: int = 5
+
+
+# ---------------------------------------------------------------------------
+# Fixture / store helpers (mirror test_incident_demo.py)
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(filename: str) -> dict[str, Any]:
+    return json.loads((_FIXTURE_DIR / filename).read_text(encoding="utf-8"))
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _node_from_dict(payload: dict[str, Any]) -> EntityNodeView:
+    return EntityNodeView(
+        name=payload["name"],
+        kind=payload["kind"],
+        source=payload["source"],
+        chunk_text=payload.get("chunk_text"),
+        depth=int(payload.get("depth", 0)),
+        edge_type=payload.get("edge_type"),
+        valid_from=_parse_dt(payload.get("valid_from")),
+        valid_to=_parse_dt(payload.get("valid_to")),
+        recorded_at=_parse_dt(payload.get("recorded_at")),
+    )
+
+
+def _edge_from_dict(payload: dict[str, Any]) -> GraphEdgeView:
+    return GraphEdgeView(
+        from_entity=payload["from_entity"],
+        to_entity=payload["to_entity"],
+        edge_type=payload["edge_type"],
+    )
+
+
+class _TimelineGraphStore:
+    """In-memory ``GraphStore`` fake — same shape as ``_DemoGraphStore``.
+
+    Stores entities and neighbour lists keyed by ``(workspace_id, name)``
+    and honours the ACL invariant (cross-workspace lookups return
+    ``None`` / ``entity_not_found``).
+    """
+
+    def __init__(self) -> None:
+        self._entities: dict[tuple[uuid.UUID, str], EntityNodeView] = {}
+        self._neighbours: dict[tuple[uuid.UUID, str], list[EntityNodeView]] = {}
+        self._edges: dict[tuple[uuid.UUID, str], list[GraphEdgeView]] = {}
+
+    def plant_workspace(self, payload: dict[str, Any]) -> None:
+        workspace_id = uuid.UUID(payload["workspace_id"])
+        alert = _node_from_dict(payload["alert"])
+        self._entities[(workspace_id, alert.name)] = alert
+        neighbours = [_node_from_dict(n) for n in payload["neighbours"]]
+        for n in neighbours:
+            self._entities[(workspace_id, n.name)] = n
+        self._neighbours[(workspace_id, alert.name)] = neighbours
+        self._edges[(workspace_id, alert.name)] = [_edge_from_dict(e) for e in payload["edges"]]
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> EntityNodeView | None:
+        return self._entities.get((workspace_id, entity_name))
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        seed = self._entities.get((workspace_id, entity_name))
+        if seed is None:
+            raise ValueError(f"entity_not_found:{entity_name}")
+        related = list(self._neighbours.get((workspace_id, entity_name), []))
+        edges = list(self._edges.get((workspace_id, entity_name), []))
+        return GraphResultView(seed=seed, related=related, edges=edges)
+
+
+def _build_app() -> tuple[FastAPI, dict[str, Any], dict[str, Any]]:
+    ws_a = _load_fixture("workspace_a.json")
+    ws_b = _load_fixture("workspace_b.json")
+    store = _TimelineGraphStore()
+    store.plant_workspace(ws_a)
+    store.plant_workspace(ws_b)
+    app = FastAPI()
+    app.state.graph_store = store
+    return app, ws_a, ws_b
+
+
+# ---------------------------------------------------------------------------
+# 1. Acceptance: 5+ ordered events with provenance
+# ---------------------------------------------------------------------------
+
+
+class TestTimelineAcceptance:
+    """Issue #235 acceptance: 5+ ordered events with correct provenance."""
+
+    async def test_returns_at_least_five_events(self) -> None:
+        app, ws_a, _ = _build_app()
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        assert len(result["events"]) >= _MIN_EVENT_COUNT, (
+            f"acceptance: fixture must produce >= {_MIN_EVENT_COUNT} events; "
+            f"got {len(result['events'])}"
+        )
+
+    async def test_events_are_strictly_ordered_by_ts(self) -> None:
+        app, ws_a, _ = _build_app()
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        timestamps = [_parse_dt(e["ts"]) for e in result["events"]]
+        for prev, curr in pairwise(timestamps):
+            assert prev is not None and curr is not None
+            assert prev <= curr, (
+                f"events must be sorted ascending by ts; {prev.isoformat()} > {curr.isoformat()}"
+            )
+
+    async def test_every_event_has_provenance(self) -> None:
+        """ADR-0008 §1: every event carries the ``source`` connector id."""
+        app, ws_a, _ = _build_app()
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        sources = [e["source"] for e in result["events"]]
+        assert all(s for s in sources), "every event must carry a source"
+        # Sanity: the fixture uses src-* prefixes; ensure those flow through.
+        assert any(s.startswith("src-") for s in sources)
+
+    async def test_event_shape_matches_acceptance_spec(self) -> None:
+        """Each event has the seven fields the issue enumerates."""
+        app, ws_a, _ = _build_app()
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        required = {
+            "ts",
+            "entity_id",
+            "entity_type",
+            "change_kind",
+            "before_state_summary",
+            "after_state_summary",
+            "source",
+        }
+        for event in result["events"]:
+            assert required.issubset(event.keys()), (
+                f"event missing required field(s): {required - set(event.keys())}"
+            )
+
+    async def test_seed_alert_is_in_the_timeline(self) -> None:
+        """The seed alert's ``valid_from`` must project to a 'created' event."""
+        app, ws_a, _ = _build_app()
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        alert_events = [
+            e
+            for e in result["events"]
+            if e["entity_id"] == ws_a["alert"]["name"] and e["change_kind"] == "created"
+        ]
+        assert len(alert_events) == 1, "seed alert must appear exactly once as 'created'"
+
+
+# ---------------------------------------------------------------------------
+# 2. Window & entity-type filters
+# ---------------------------------------------------------------------------
+
+
+class TestTimelineFilters:
+    """``from`` / ``to`` / ``entity_types`` query-param semantics."""
+
+    async def test_from_filter_drops_earlier_events(self) -> None:
+        app, ws_a, _ = _build_app()
+        # Cut at the alert's fire time — earlier "created" events are dropped.
+        from_ts = _parse_dt(ws_a["alert_fired_at"])
+        assert from_ts is not None
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            from_ts=from_ts,
+        )
+        for event in result["events"]:
+            ts = _parse_dt(event["ts"])
+            assert ts is not None and ts >= from_ts
+
+    async def test_to_filter_drops_later_events(self) -> None:
+        app, ws_a, _ = _build_app()
+        # to is exclusive; pick a bound an hour before the alert fired.
+        fired = _parse_dt(ws_a["alert_fired_at"])
+        assert fired is not None
+        to_ts = fired - timedelta(hours=1)
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            to_ts=to_ts,
+        )
+        for event in result["events"]:
+            ts = _parse_dt(event["ts"])
+            assert ts is not None and ts < to_ts
+
+    async def test_entity_types_filter_drops_other_kinds(self) -> None:
+        app, ws_a, _ = _build_app()
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            entity_types=["pull_request"],
+        )
+        kinds = {e["entity_type"] for e in result["events"]}
+        assert kinds == {"pull_request"}, (
+            f"entity_types allowlist must filter to only 'pull_request'; got {kinds}"
+        )
+
+    async def test_empty_filter_returns_empty_envelope(self) -> None:
+        """A non-overlapping window returns zero events, not 404."""
+        app, ws_a, _ = _build_app()
+        far_future = datetime(2099, 1, 1, tzinfo=UTC)
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            from_ts=far_future,
+        )
+        assert result["events"] == []
+        assert result["alert_id"] == ws_a["alert"]["name"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Error contract (parity with resolve_incident)
+# ---------------------------------------------------------------------------
+
+
+class TestTimelineErrors:
+    async def test_unknown_alert_raises_alert_not_found(self) -> None:
+        app, ws_a, _ = _build_app()
+        with pytest.raises(ValueError) as excinfo:
+            await mcp_incident_timeline(
+                app=app,
+                alert_id="alert://pagerduty/does-not-exist",
+                workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            )
+        assert str(excinfo.value).startswith(f"{ALERT_NOT_FOUND_CODE}:")
+
+    async def test_cross_workspace_alert_is_not_found(self) -> None:
+        """workspace_a may NOT see workspace_b's alert."""
+        app, ws_a, ws_b = _build_app()
+        with pytest.raises(ValueError) as excinfo:
+            await mcp_incident_timeline(
+                app=app,
+                alert_id=ws_b["alert"]["name"],
+                workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            )
+        assert str(excinfo.value).startswith(f"{ALERT_NOT_FOUND_CODE}:")
+
+    async def test_malformed_alert_id_raises_invalid_alert_id(self) -> None:
+        app, ws_a, _ = _build_app()
+        with pytest.raises(ValueError) as excinfo:
+            await mcp_incident_timeline(
+                app=app,
+                alert_id="not-an-alert-uri",
+                workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            )
+        assert str(excinfo.value).startswith(f"{INVALID_ALERT_ID_CODE}:")
+
+
+# ---------------------------------------------------------------------------
+# 4. Mermaid renderer
+# ---------------------------------------------------------------------------
+
+
+def _is_valid_mermaid_timeline(block: str) -> bool:
+    """Cheap structural check — full Mermaid render is not required here.
+
+    Verifies the block starts with ``timeline``, declares a ``title``,
+    contains at least one ``section`` header, and that every non-blank
+    body line is indented (Mermaid is whitespace-sensitive).
+    """
+    lines = block.splitlines()
+    if not lines or lines[0].strip() != "timeline":
+        return False
+    has_title = any(line.strip().startswith("title ") for line in lines[1:])
+    has_section = any(line.strip().startswith("section ") for line in lines[1:])
+    indented = all(
+        (not line.strip()) or line.startswith(" ") or line.strip() == "timeline" for line in lines
+    )
+    return has_title and has_section and indented
+
+
+class TestTimelineMermaid:
+    async def test_mermaid_block_parses(self) -> None:
+        app, ws_a, _ = _build_app()
+        payload = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        block = render_mermaid(payload)
+        assert _is_valid_mermaid_timeline(block), (
+            f"render_mermaid output failed basic Mermaid timeline checks:\n{block}"
+        )
+
+    async def test_mermaid_escapes_colon_in_canonical_names(self) -> None:
+        """Canonical names use ``://`` and ``:`` which break Mermaid section labels."""
+        app, ws_a, _ = _build_app()
+        payload = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        block = render_mermaid(payload)
+        # The alert name uses 'alert://' which contains a colon. The
+        # renderer must escape it; the raw form should never appear in
+        # a Mermaid section label position.
+        for line in block.splitlines():
+            if line.strip().startswith("section "):
+                assert ":" not in line.strip()[len("section ") :], (
+                    f"section labels must not contain ':' — Mermaid breaks: {line!r}"
+                )
+
+    async def test_mermaid_empty_payload_still_parses(self) -> None:
+        """A timeline with zero events renders an explanatory empty block."""
+        app, ws_a, _ = _build_app()
+        far_future = datetime(2099, 1, 1, tzinfo=UTC)
+        payload = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+            from_ts=far_future,
+        )
+        block = render_mermaid(payload)
+        assert _is_valid_mermaid_timeline(block)
+        assert "No events" in block
+
+
+# ---------------------------------------------------------------------------
+# 5. Truncation safety
+# ---------------------------------------------------------------------------
+
+
+class TestTimelineTruncation:
+    async def test_truncated_flag_is_false_for_small_fixture(self) -> None:
+        app, ws_a, _ = _build_app()
+        result = await mcp_incident_timeline(
+            app=app,
+            alert_id=ws_a["alert"]["name"],
+            workspace_id=uuid.UUID(ws_a["workspace_id"]),
+        )
+        assert result["truncated"] is False
+        assert len(result["events"]) <= MAX_EVENTS_RETURNED


### PR DESCRIPTION
## Summary

Adds the H5 Track-1 incident-timeline surface (closes #235): a REST endpoint, an MCP tool, and an admin UI page that render entity state changes around an incident window. Reuses the existing bitemporal graph (ADR-0008 §5) — no new storage primitives, no migrations.

- **REST**: `GET /api/v1/incidents/{alert_id}/timeline?from=...&to=...&entity_types=...&as_of=...&format=mermaid`
- **MCP**: `incident_timeline(alert_id, from_ts?, to_ts?, entity_types?, as_of?, max_depth?)` — same wire shape
- **Admin UI**: new `/incidents` page renders the Mermaid block (lazy CDN, no new npm deps) alongside a JSON event list
- **Composition**: `omniscience_server.incident_timeline` walks `GraphStore.find_related` and projects each row's `valid_from`/`valid_to` into ordered `TimelineEvent`s with full provenance (`source` field per ADR-0008 §1)

Auth posture mirrors `resolve_incident`: workspace-scoped tokens required, cross-workspace alerts surface `404 alert_not_found` (no existence leak — #117 / ADR-0005).

## Mermaid sample (workspace_a fixture)

```mermaid
timeline
    title Incident alert-//pagerduty/INC-2026-04-12-001
    section 2026-04-05
        19:30:00 pull_request created : https-//github.com/acme/api/pull/4099 - PR #4099- Refactor logging — merged 7 days ago
    section 2026-04-07
        12:00:00 slack_thread created : slack-//channel/C0RANDOM/thread/1744000000.000700 - bob- lunch order — sushi or pizza?
    section 2026-04-12
        15:00:00 k8s_pod created : pod/api-7f9b9d4c-xj4kp - k8s_pod pod/api-7f9b9d4c-xj4kp
        15:30:00 pull_request created : https-//github.com/acme/api/pull/4242 - PR #4242- Bump api request timeout to 5s
        19:29:55 otel_trace created : trace-//4bf92f3577b34da6a3ce929d0e0e4736 - otel_trace trace-//4bf92f3577b34da6a3ce929d0e0e4736
        19:30:00 alert created : alert-//pagerduty/INC-2026-04-12-001 - PagerDuty- api pod 5xx spike — pod/api-7f9b9d4c-xj4kp
        19:32:00 slack_thread created : slack-//channel/C0INCIDENTS/thread/1744486200.001100 - alice- pod/api-7f9b9d4c-xj4kp is throwing 5xx — see https-//github.com/acme/api/pull/4242
```

(`:` is replaced with `-` because the Mermaid `timeline` lexer treats `:` as the section/event terminator.)

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — 295 files already formatted
- [x] `uv run mypy apps/ packages/` — Success: no issues found in 189 source files
- [x] `uv run pytest tests/integration/test_incident_timeline.py -v --no-cov` — 16 passed in 0.32s
- [x] `uv run pytest tests/ -k "incident or timeline" -v --no-cov` — 61 passed, 2 skipped (no regressions in `test_mcp_resolve_incident.py`, `test_incident_demo.py`, `test_incident_demo_historical.py`)

## Files

**Added**
- `apps/server/src/omniscience_server/incident_timeline.py` — composition core + Mermaid renderer
- `apps/server/src/omniscience_server/rest/incident_timeline.py` — REST handler
- `apps/server/src/omniscience_server/mcp/incident_timeline.py` — MCP tool shim
- `tests/integration/test_incident_timeline.py` — 16 tests covering acceptance, filters, errors, Mermaid, truncation
- `apps/admin/src/pages/IncidentTimelinePage.tsx` — admin UI page

**Modified (additive only, within allowed scope)**
- `apps/server/src/omniscience_server/rest/router.py` — registers new router
- `apps/server/src/omniscience_server/mcp/server.py` — registers new tool
- `apps/admin/src/App.tsx`, `Layout.tsx`, `api/client.ts` — page route, nav entry, typed client methods

Closes #235.