### PR TITLE
feat(incidents): blast-radius MCP tool (#234)

### DIFF
--- a/apps/server/src/omniscience_server/blast_radius.py
+++ b/apps/server/src/omniscience_server/blast_radius.py
@@ -1,0 +1,675 @@
+"""Blast-radius composition (issue #234, Wave 2 of epic #230 / H5 Track 1).
+
+This module is the design centre of the change-management surface: a
+single MCP/REST tool — :func:`blast_radius` — that answers "if we
+perform ``action_type`` on ``entity_id``, what downstream entities are
+impacted?".  It composes the existing bitemporal graph traversal
+(``GraphStore.find_related`` -> ``_TRAVERSE_*_CYPHER_TEMPLATE``) with
+an action-aware edge-type allowlist and an impact-scoring heuristic.
+
+Composition shape
+-----------------
+
+1. **Validate** ``entity_id``: must be a non-empty string; canonical
+   entity names follow the same shape as the other tools (``service://``,
+   ``pod/``, ``arn:`` etc.).  No prefix is enforced — the seed is
+   resolved by whatever canonical name the connectors planted.
+2. **Resolve** the seed via :meth:`GraphStore.get_entity` (workspace-
+   scoped, ``as_of``-aware).  Missing seed -> ``entity_not_found``.
+3. **Traverse** outward via :meth:`GraphStore.find_related` with the
+   ``edge_types`` allowlist for the requested action_type — restricts
+   the BFS to causal edges that propagate the action's effect (e.g.
+   ``DEPENDS_ON``, ``ROUTES_TO``).
+4. **Score** each neighbour:
+
+   * ``impact_score`` = action multiplier * depth decay * edge weight.
+     Always in [0.0, 1.0].  Closer hops + first-class causal edges
+     score higher.  Deterministic v0.1 placeholder per the issue spec.
+   * ``confidence`` = 1.0 when both the seed and the neighbour carry
+     a non-tombstoned bitemporal triple at ``as_of``; 0.5 when
+     bitemporal state is partially missing (legacy pre-#130 rows);
+     1.0 also when ``as_of`` is None (still-current read).
+5. **Rank** descending by ``impact_score`` (ties broken by depth, then
+   by lexicographic ``entity_id`` for determinism).
+
+Action-type semantics (see ``docs/api/blast-radius.md``)
+--------------------------------------------------------
+
+* ``restart``    — transient unavailability; follows runtime edges
+                   (``DEPENDS_ON``, ``ROUTES_TO``, ``CALLS``).
+* ``delete``     — permanent removal; widest blast (all causal edges
+                   that the other actions cover, plus ownership edges
+                   ``OWNED_BY``, ``DEPLOYED_BY``).
+* ``scale_down`` — degraded capacity; same as ``restart`` plus
+                   load-bearing ``LOAD_BALANCED_BY``.
+* ``cordon``     — quarantine (no new work); follows
+                   ``SCHEDULED_ON`` / ``RUNS_ON`` only — does NOT
+                   propagate through call/route edges (the workload
+                   itself keeps serving until evicted).
+
+ACL invariant (non-negotiable)
+------------------------------
+
+- ``workspace_id`` is taken from the caller's bearer token, never from
+  input.  Every store call carries it (issue #117 / ADR-0005).
+- A foreign-workspace ``entity_id`` returns ``entity_not_found`` — the
+  same response a non-existent entity would produce.  Existence is
+  never leaked.
+
+Bitemporal predicate (ADR-0008 §5)
+----------------------------------
+
+``as_of`` is forwarded verbatim to ``GraphStore``.  When set, every
+node and every edge in the traversal satisfies the canonical predicate
+``valid_from <= as_of AND (as_of < valid_to OR valid_to IS NULL)``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Final, Literal
+
+from fastapi import FastAPI
+from omniscience_core.storage import (
+    EntityNodeView,
+    GraphEdgeView,
+    GraphResultView,
+    GraphStore,
+)
+from pydantic import BaseModel, Field
+
+from omniscience_server.as_of import (
+    DEGRADED_PRE_HISTORY,
+    enforce_utc,
+    record_request_duration,
+    resolve_effective_as_of,
+)
+
+# ---------------------------------------------------------------------------
+# Public action-type contract
+# ---------------------------------------------------------------------------
+
+#: Literal of supported action_type values.  Adding a new action is a
+#: minor-version change; removing one is a major-version break.
+ActionType = Literal["restart", "delete", "scale_down", "cordon"]
+
+#: Tuple of all supported action types — used by validators and the
+#: REST/MCP schema layers so the docs and code stay in sync.
+ACTION_TYPES: Final[tuple[ActionType, ...]] = ("restart", "delete", "scale_down", "cordon")
+
+
+# ---------------------------------------------------------------------------
+# Depth bounds — pinned to the same envelope as resolve_incident
+# ---------------------------------------------------------------------------
+
+#: Default BFS depth when the caller does not override ``max_depth``.
+#: Issue #234 spec: depth 3 covers seed -> direct dep -> transitive
+#: dep -> consumer's consumer; deeper traversals add noise.
+DEFAULT_MAX_DEPTH: Final[int] = 3
+
+#: Lower bound for ``max_depth``.  Depth < 1 makes the traversal a
+#: degenerate single-entity lookup with no downstream set.
+MIN_MAX_DEPTH: Final[int] = 1
+
+#: Upper bound for ``max_depth``.  Pinned to the same envelope as
+#: ``resolve_incident`` (issue #153 :data:`MAX_MAX_DEPTH`) so a hub
+#: entity cannot blow up the response payload.
+MAX_MAX_DEPTH: Final[int] = 5
+
+
+# ---------------------------------------------------------------------------
+# Error codes (mirrored on the MCP / REST surfaces)
+# ---------------------------------------------------------------------------
+
+ENTITY_NOT_FOUND_CODE: Final[str] = "entity_not_found"
+INVALID_ACTION_TYPE_CODE: Final[str] = "invalid_action_type"
+INVALID_ACTION_TYPE_MESSAGE: Final[str] = "action_type must be one of: " + ", ".join(ACTION_TYPES)
+INVALID_ENTITY_ID_CODE: Final[str] = "invalid_entity_id"
+INVALID_ENTITY_ID_MESSAGE: Final[str] = "entity_id must be a non-empty string"
+
+
+# ---------------------------------------------------------------------------
+# Action-type -> edge-type allowlist
+# ---------------------------------------------------------------------------
+
+#: Edges that propagate a runtime outage (transient unavailability).
+#: A restart of X breaks anything that calls X over the network or
+#: declares a hard runtime dependency on X.
+_RUNTIME_EDGES: Final[frozenset[str]] = frozenset(
+    {
+        "DEPENDS_ON",
+        "ROUTES_TO",
+        "CALLS",
+    }
+)
+
+#: Edges that carry traffic load — relevant for scale-down (degraded
+#: capacity) on top of runtime edges.
+_LOAD_EDGES: Final[frozenset[str]] = frozenset({"LOAD_BALANCED_BY"})
+
+#: Ownership / deployment edges — relevant only for delete, which also
+#: severs the management plane (CI/CD pipelines, owning teams).
+_OWNERSHIP_EDGES: Final[frozenset[str]] = frozenset({"OWNED_BY", "DEPLOYED_BY"})
+
+#: Scheduling edges — relevant for cordon (workloads stay on a node
+#: until they are evicted; new work won't land there).
+_SCHEDULING_EDGES: Final[frozenset[str]] = frozenset({"SCHEDULED_ON", "RUNS_ON"})
+
+#: Action-type -> follow set.  See module docstring for semantics.
+_ACTION_EDGE_ALLOWLIST: Final[dict[ActionType, frozenset[str]]] = {
+    "restart": _RUNTIME_EDGES,
+    "delete": _RUNTIME_EDGES | _LOAD_EDGES | _OWNERSHIP_EDGES | _SCHEDULING_EDGES,
+    "scale_down": _RUNTIME_EDGES | _LOAD_EDGES,
+    "cordon": _SCHEDULING_EDGES,
+}
+
+
+# ---------------------------------------------------------------------------
+# Impact-score heuristic (v0.1 deterministic placeholder)
+# ---------------------------------------------------------------------------
+
+#: Multiplier applied to the raw (depth * edge) score, per action type.
+#: ``delete`` is the worst-case action and pegs the multiplier at 1.0;
+#: the others rank below it on the same scale so cross-action comparisons
+#: remain meaningful.
+_ACTION_MULTIPLIER: Final[dict[ActionType, float]] = {
+    "delete": 1.0,
+    "restart": 0.8,
+    "scale_down": 0.6,
+    "cordon": 0.5,
+}
+
+#: Per-edge-type weight applied to the impact score.  Causal-runtime
+#: edges weigh more than load/ownership edges so a calling service ranks
+#: above a load-balancer fronting the same target.
+_EDGE_WEIGHT: Final[dict[str, float]] = {
+    "DEPENDS_ON": 1.0,
+    "CALLS": 1.0,
+    "ROUTES_TO": 0.9,
+    "LOAD_BALANCED_BY": 0.7,
+    "SCHEDULED_ON": 0.7,
+    "RUNS_ON": 0.7,
+    "DEPLOYED_BY": 0.5,
+    "OWNED_BY": 0.4,
+}
+
+#: Default edge weight when the connector emits an edge type that is
+#: not in :data:`_EDGE_WEIGHT`.  Conservative middle-of-the-road value
+#: so unknown but action-allowlisted edges still rank.
+_DEFAULT_EDGE_WEIGHT: Final[float] = 0.6
+
+#: Depth-decay factor.  Score at depth d is ``base * (DECAY ** (d - 1))``,
+#: i.e. the first hop is the full score, every extra hop multiplies
+#: by ``DECAY``.  0.6 yields scores ~ 1.0 / 0.6 / 0.36 / 0.216 across
+#: depths 1..4 — comfortably distinguishable, never zero.
+_DEPTH_DECAY: Final[float] = 0.6
+
+#: Confidence when the bitemporal triple is fully populated at ``as_of``
+#: (or when ``as_of`` is ``None`` and we trust the current-state mirror).
+_CONFIDENCE_FULL: Final[float] = 1.0
+
+#: Confidence when the row is legacy (pre-#130 bitemporal backfill) and
+#: the bitemporal triple is partial.  We still surface the entity but
+#: signal to the caller that the time-anchoring is best-effort.
+_CONFIDENCE_PARTIAL: Final[float] = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response schemas
+# ---------------------------------------------------------------------------
+
+
+class DependencyPathStep(BaseModel):
+    """One hop in the dependency path from seed to impacted entity."""
+
+    from_entity: str = Field(description="Canonical name of the upstream entity.")
+    to_entity: str = Field(description="Canonical name of the downstream entity.")
+    edge_type: str = Field(description="Causal edge type connecting the two entities.")
+
+
+class BlastRadiusImpact(BaseModel):
+    """Single impacted entity in the blast-radius response."""
+
+    entity_id: str = Field(description="Canonical name of the impacted entity.")
+    entity_type: str = Field(description="Entity kind (e.g. 'service', 'pod', 'function').")
+    dependency_path: list[DependencyPathStep] = Field(
+        default_factory=list,
+        description=(
+            "Best-effort BFS path from the seed to this entity.  v0.1 "
+            "surfaces the last hop only when the underlying traversal "
+            "did not preserve the full path."
+        ),
+    )
+    impact_score: float = Field(
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Deterministic v0.1 heuristic: action multiplier * depth "
+            "decay * edge weight, clipped to [0.0, 1.0]."
+        ),
+    )
+    confidence: float = Field(
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Confidence in the impact assessment.  1.0 when the "
+            "bitemporal triple is fully populated; 0.5 for legacy "
+            "rows that pre-date the #130 backfill."
+        ),
+    )
+
+
+class BlastRadiusResponse(BaseModel):
+    """Top-level response envelope for ``blast_radius``."""
+
+    seed_entity_id: str = Field(description="Canonical name of the seed entity.")
+    action_type: ActionType = Field(description="Action whose blast radius was computed.")
+    max_depth: int = Field(
+        ge=MIN_MAX_DEPTH,
+        le=MAX_MAX_DEPTH,
+        description="Maximum BFS depth that was used for the traversal.",
+    )
+    impacted: list[BlastRadiusImpact] = Field(
+        default_factory=list,
+        description="Impacted entities ranked descending by impact_score.",
+    )
+    effective_as_of: datetime
+    meta: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Internal dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _ScoredImpact:
+    """Internal representation; serialised through :class:`BlastRadiusImpact`."""
+
+    entity_id: str
+    entity_type: str
+    depth: int
+    edge_type: str
+    impact_score: float
+    confidence: float
+    path: tuple[DependencyPathStep, ...]
+
+
+# ---------------------------------------------------------------------------
+# Public composition entry point
+# ---------------------------------------------------------------------------
+
+
+async def mcp_blast_radius(
+    app: FastAPI,
+    entity_id: str,
+    workspace_id: uuid.UUID,
+    action_type: ActionType = "restart",
+    as_of: datetime | None = None,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> dict[str, Any]:
+    """Resolve the blast-radius bundle for ``entity_id`` under ``action_type``.
+
+    Parameters
+    ----------
+    app:
+        FastAPI app exposing ``app.state.graph_store``.
+    entity_id:
+        Canonical name of the seed entity (matches the planted
+        ``Entity.name`` from the connectors).
+    workspace_id:
+        REQUIRED.  Forwarded to every ``GraphStore`` call.
+    action_type:
+        Which action's blast radius to compute.  Picks the edge-type
+        allowlist and the score multiplier.  Default ``"restart"`` —
+        the most common change-management operation.
+    as_of:
+        Optional ADR-0008 §5 bitemporal anchor.  Reuses
+        :func:`enforce_utc` and the surrounding handler's parser.
+    max_depth:
+        BFS depth from the seed.  Clamped to
+        ``[MIN_MAX_DEPTH, MAX_MAX_DEPTH]``; default
+        :data:`DEFAULT_MAX_DEPTH`.
+
+    Returns
+    -------
+    dict[str, Any]
+        JSON-serialised :class:`BlastRadiusResponse`.
+
+    Raises
+    ------
+    ValueError
+        - ``invalid_entity_id:...`` — empty / non-string seed.
+        - ``invalid_action_type:...`` — unsupported action.
+        - ``entity_not_found:...`` — seed not visible in the caller's
+          workspace at ``as_of`` (cross-workspace looks identical).
+    """
+    _validate_entity_id(entity_id)
+    _validate_action_type(action_type)
+    normalised_as_of = enforce_utc(as_of)
+    clamped_depth = max(MIN_MAX_DEPTH, min(max_depth, MAX_MAX_DEPTH))
+
+    graph_store: GraphStore | None = getattr(app.state, "graph_store", None)
+    if graph_store is None:
+        raise RuntimeError("graph_store not available on app.state")
+
+    with record_request_duration(
+        surface="mcp", tool="blast_radius", as_of=normalised_as_of
+    ) as patcher:
+        seed = await graph_store.get_entity(
+            entity_name=entity_id,
+            workspace_id=workspace_id,
+            as_of=normalised_as_of,
+        )
+        if seed is None:
+            if normalised_as_of is not None:
+                patcher.mark_pre_history()
+            raise ValueError(f"{ENTITY_NOT_FOUND_CODE}:{entity_id}")
+
+        allowlist = sorted(_ACTION_EDGE_ALLOWLIST[action_type])
+        try:
+            graph_result = await graph_store.find_related(
+                entity_name=entity_id,
+                workspace_id=workspace_id,
+                as_of=normalised_as_of,
+                max_depth=clamped_depth,
+                edge_types=allowlist,
+            )
+        except ValueError as exc:
+            # Seed disappeared between calls — race with re-ingestion.
+            # Return an empty downstream set rather than 404, mirroring
+            # the empty-graph contract of resolve_incident (#153).
+            if str(exc).startswith("entity_not_found:"):
+                graph_result = GraphResultView(seed=seed, related=[], edges=[])
+            else:
+                raise
+
+        impacts = _score_impacts(
+            result=graph_result,
+            action_type=action_type,
+            as_of=normalised_as_of,
+        )
+        meta = _build_meta(
+            action_type=action_type,
+            edge_allowlist=allowlist,
+            depth=clamped_depth,
+        )
+        return _build_response(
+            seed=seed,
+            action_type=action_type,
+            max_depth=clamped_depth,
+            impacts=impacts,
+            as_of=normalised_as_of,
+            meta=meta,
+        ).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_entity_id(entity_id: str) -> None:
+    """Reject empty / non-string seeds at the API boundary."""
+    if not isinstance(entity_id, str):  # pragma: no cover - typing barrier
+        raise ValueError(f"{INVALID_ENTITY_ID_CODE}:{INVALID_ENTITY_ID_MESSAGE}")
+    if not entity_id.strip():
+        raise ValueError(f"{INVALID_ENTITY_ID_CODE}:{INVALID_ENTITY_ID_MESSAGE}")
+
+
+def _validate_action_type(action_type: str) -> None:
+    """Reject action_type values that fall outside :data:`ACTION_TYPES`."""
+    if action_type not in ACTION_TYPES:
+        raise ValueError(f"{INVALID_ACTION_TYPE_CODE}:{INVALID_ACTION_TYPE_MESSAGE}")
+
+
+# ---------------------------------------------------------------------------
+# Scoring + path reconstruction — pure functions, easy to unit-test
+# ---------------------------------------------------------------------------
+
+
+def _score_impacts(
+    *,
+    result: GraphResultView,
+    action_type: ActionType,
+    as_of: datetime | None,
+) -> list[_ScoredImpact]:
+    """Score and rank the impacted entities.
+
+    De-duplicates by ``entity_id`` (a hub neighbour reached via multiple
+    edges keeps its highest-scoring hop) and returns a list ranked
+    descending by ``impact_score``.  Tie-broken by depth (closer first),
+    then by lexicographic ``entity_id`` for determinism.
+    """
+    edge_index = _build_edge_index(result.edges, seed_name=result.seed.name)
+    multiplier = _ACTION_MULTIPLIER[action_type]
+    best: dict[str, _ScoredImpact] = {}
+    for neighbour in result.related:
+        if neighbour.name == result.seed.name:
+            continue
+        edge_type = neighbour.edge_type or _infer_edge_type(neighbour, edge_index)
+        if edge_type is None:
+            # No edge_type recoverable — the traversal allowlist filters
+            # at the Cypher layer, so this can only happen for legacy
+            # rows.  Skip to keep the response truthful.
+            continue
+        score = _impact_score(
+            depth=neighbour.depth,
+            edge_type=edge_type,
+            multiplier=multiplier,
+        )
+        confidence = _confidence(
+            seed_recorded=result.seed.recorded_at is not None, neighbour=neighbour, as_of=as_of
+        )
+        path = _path_for(
+            neighbour=neighbour,
+            edge_index=edge_index,
+            seed_name=result.seed.name,
+            edge_type=edge_type,
+        )
+        candidate = _ScoredImpact(
+            entity_id=neighbour.name,
+            entity_type=neighbour.kind,
+            depth=neighbour.depth,
+            edge_type=edge_type,
+            impact_score=score,
+            confidence=confidence,
+            path=path,
+        )
+        prior = best.get(neighbour.name)
+        if prior is None or candidate.impact_score > prior.impact_score:
+            best[neighbour.name] = candidate
+    ranked = sorted(
+        best.values(),
+        key=lambda imp: (-imp.impact_score, imp.depth, imp.entity_id),
+    )
+    return ranked
+
+
+def _build_edge_index(
+    edges: list[GraphEdgeView],
+    *,
+    seed_name: str,
+) -> dict[str, GraphEdgeView]:
+    """Map ``to_entity`` -> the last GraphEdgeView that reaches it.
+
+    Used as a fallback for neighbours whose ``edge_type`` was not
+    populated by the traversal (legacy rows).  We only need
+    ``to_entity`` since the traversal Cypher emits edges as
+    ``[start, end, edge_type, ...]``; the start of the last hop is what
+    populates ``neighbour.edge_type`` in the post-#132 templates.
+
+    ``seed_name`` is accepted so a future refinement (multi-hop path
+    reconstruction) can prefer edges that anchor at the seed.
+    """
+    index: dict[str, GraphEdgeView] = {}
+    for edge in edges:
+        # Keep the first edge that reaches a given to_entity.  Ties are
+        # rare with the current traversal shape (one edge per neighbour
+        # in the collected last-hop tuple).
+        index.setdefault(edge.to_entity, edge)
+        # Also index by from_entity for undirected lookups — the
+        # traversal walks identity-to-identity edges without direction.
+        index.setdefault(edge.from_entity, edge)
+    # The seed itself should never be returned as an impact; pop it so a
+    # caller iterating the index does not accidentally surface it.
+    index.pop(seed_name, None)
+    return index
+
+
+def _infer_edge_type(
+    neighbour: EntityNodeView,
+    edge_index: dict[str, GraphEdgeView],
+) -> str | None:
+    """Fallback edge-type recovery from the edge collection."""
+    edge = edge_index.get(neighbour.name)
+    return edge.edge_type if edge else None
+
+
+def _impact_score(*, depth: int, edge_type: str, multiplier: float) -> float:
+    """Compute the v0.1 deterministic impact score.
+
+    ``impact = multiplier * (DECAY ** (depth - 1)) * edge_weight``,
+    clipped to ``[0.0, 1.0]``.  Depth 0 (the seed itself) is filtered
+    out before this is called, so ``depth >= 1`` is guaranteed.
+    """
+    decay = _DEPTH_DECAY ** max(depth - 1, 0)
+    weight = _EDGE_WEIGHT.get(edge_type, _DEFAULT_EDGE_WEIGHT)
+    raw = multiplier * decay * weight
+    if raw < 0.0:
+        return 0.0
+    if raw > 1.0:
+        return 1.0
+    return raw
+
+
+def _confidence(
+    *,
+    seed_recorded: bool,
+    neighbour: EntityNodeView,
+    as_of: datetime | None,
+) -> float:
+    """Confidence v0.1: full when the bitemporal triple is populated.
+
+    Pre-#130 legacy rows leave ``recorded_at`` / ``valid_from`` ``None``
+    and we cannot prove they were valid at ``as_of`` — surface the
+    partial confidence so callers can filter.  Current-state reads
+    (``as_of`` is ``None``) always return full confidence because the
+    ``:Entity`` mirror IS the source of truth.
+    """
+    if as_of is None:
+        return _CONFIDENCE_FULL
+    neighbour_recorded = neighbour.recorded_at is not None
+    if seed_recorded and neighbour_recorded:
+        return _CONFIDENCE_FULL
+    return _CONFIDENCE_PARTIAL
+
+
+def _path_for(
+    *,
+    neighbour: EntityNodeView,
+    edge_index: dict[str, GraphEdgeView],
+    seed_name: str,
+    edge_type: str,
+) -> tuple[DependencyPathStep, ...]:
+    """Best-effort dependency-path reconstruction.
+
+    The traversal Cypher (``_TRAVERSE_*_CYPHER_TEMPLATE``) returns only
+    the **last hop** that reaches each neighbour, not the full path.
+    A future refinement (issue follow-up) can swap in a path-emitting
+    template; for v0.1 we surface that last hop plus a synthetic
+    seed -> ... -> neighbour edge so callers can render a chain UI.
+    """
+    edge = edge_index.get(neighbour.name)
+    if edge is None:
+        # Fallback: synthesise a direct edge from the seed.  Honest
+        # about being best-effort; the surrounding score still reflects
+        # the real depth.
+        return (
+            DependencyPathStep(
+                from_entity=seed_name,
+                to_entity=neighbour.name,
+                edge_type=edge_type,
+            ),
+        )
+    return (
+        DependencyPathStep(
+            from_entity=edge.from_entity,
+            to_entity=edge.to_entity,
+            edge_type=edge.edge_type,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response builders
+# ---------------------------------------------------------------------------
+
+
+def _build_meta(
+    *,
+    action_type: ActionType,
+    edge_allowlist: list[str],
+    depth: int,
+) -> dict[str, Any]:
+    """Attach the explainability hints expected by ops dashboards."""
+    return {
+        "action_type": action_type,
+        "edge_allowlist": list(edge_allowlist),
+        "max_depth": depth,
+        "scoring_model": "v0.1-deterministic",
+    }
+
+
+def _build_response(
+    *,
+    seed: EntityNodeView,
+    action_type: ActionType,
+    max_depth: int,
+    impacts: list[_ScoredImpact],
+    as_of: datetime | None,
+    meta: dict[str, Any],
+) -> BlastRadiusResponse:
+    """Convert internal :class:`_ScoredImpact` list into the wire format."""
+    impacted = [
+        BlastRadiusImpact(
+            entity_id=imp.entity_id,
+            entity_type=imp.entity_type,
+            dependency_path=list(imp.path),
+            impact_score=imp.impact_score,
+            confidence=imp.confidence,
+        )
+        for imp in impacts
+    ]
+    if as_of is not None and not impacts:
+        # An empty downstream set under as_of could be pre-history; the
+        # caller can disambiguate via meta.degraded_response.
+        meta = {**meta, "degraded_response": DEGRADED_PRE_HISTORY}
+    return BlastRadiusResponse(
+        seed_entity_id=seed.name,
+        action_type=action_type,
+        max_depth=max_depth,
+        impacted=impacted,
+        effective_as_of=resolve_effective_as_of(as_of),
+        meta=meta,
+    )
+
+
+__all__ = [
+    "ACTION_TYPES",
+    "DEFAULT_MAX_DEPTH",
+    "ENTITY_NOT_FOUND_CODE",
+    "INVALID_ACTION_TYPE_CODE",
+    "INVALID_ACTION_TYPE_MESSAGE",
+    "INVALID_ENTITY_ID_CODE",
+    "INVALID_ENTITY_ID_MESSAGE",
+    "MAX_MAX_DEPTH",
+    "MIN_MAX_DEPTH",
+    "ActionType",
+    "BlastRadiusImpact",
+    "BlastRadiusResponse",
+    "DependencyPathStep",
+    "mcp_blast_radius",
+]

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -1,12 +1,14 @@
 """FastMCP server setup for Omniscience.
 
-Registers six tools:
+Registers seven tools:
 - search              (requires scope: search)
 - get_document        (requires scope: search)
 - get_entity          (requires scope: search + workspace-scoped token)
 - get_related_entities (requires scope: search + workspace-scoped token)
 - list_sources        (requires scope: sources:read)
 - source_stats        (requires scope: sources:read)
+- resolve_incident    (requires scope: search + workspace-scoped token)
+- blast_radius        (requires scope: search + workspace-scoped token)
 
 Auth:
 - HTTP transport: Bearer token from Authorization header
@@ -19,12 +21,12 @@ app.state (db_session_factory, retrieval_service).
 Bitemporal reads (issue #133)
 -----------------------------
 
-``search``, ``get_entity`` and ``get_related_entities`` accept an
-optional ``as_of`` parameter — an ISO-8601 timezone-aware UTC datetime
-string (``Z`` suffix or ``+00:00``).  Naive datetimes are rejected with
-the structured error code ``invalid_timezone``.  See ADR-0008 §5 for
-the bitemporal predicate semantics.  ``resolve_incident`` is filed as
-issue #153 and will surface its own ``as_of`` natively when it lands.
+``search``, ``get_entity``, ``get_related_entities``, ``resolve_incident``
+and ``blast_radius`` accept an optional ``as_of`` parameter — an
+ISO-8601 timezone-aware UTC datetime string (``Z`` suffix or ``+00:00``).
+Naive datetimes are rejected with the structured error code
+``invalid_timezone``.  See ADR-0008 §5 for the bitemporal predicate
+semantics.
 """
 
 from __future__ import annotations
@@ -48,6 +50,25 @@ from omniscience_core.telemetry.clients import (
 from omniscience_server.as_of import (
     INVALID_TIMEZONE_CODE,
     INVALID_TIMEZONE_MESSAGE,
+)
+from omniscience_server.blast_radius import (
+    ACTION_TYPES,
+    INVALID_ACTION_TYPE_CODE,
+    INVALID_ENTITY_ID_CODE,
+    ActionType,
+    mcp_blast_radius,
+)
+from omniscience_server.blast_radius import (
+    DEFAULT_MAX_DEPTH as BLAST_DEFAULT_MAX_DEPTH,
+)
+from omniscience_server.blast_radius import (
+    ENTITY_NOT_FOUND_CODE as BLAST_ENTITY_NOT_FOUND_CODE,
+)
+from omniscience_server.blast_radius import (
+    MAX_MAX_DEPTH as BLAST_MAX_MAX_DEPTH,
+)
+from omniscience_server.blast_radius import (
+    MIN_MAX_DEPTH as BLAST_MIN_MAX_DEPTH,
 )
 from omniscience_server.incidents import (
     ALERT_NOT_FOUND_CODE,
@@ -540,6 +561,82 @@ async def incident_timeline(
         as_of=as_of,
         max_depth=max_depth,
     )
+
+
+# ---------------------------------------------------------------------------
+# Tool: blast_radius (issue #234)
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    name="blast_radius",
+    description=(
+        "Traverse the causal dependency graph from a seed entity and "
+        "rank the downstream entities impacted by performing "
+        "`action_type` on it.  Supported actions: "
+        + ", ".join(ACTION_TYPES)
+        + ".  Returns a list of `{entity_id, entity_type, dependency_path, "
+        "impact_score, confidence}` ranked descending by impact_score.  "
+        "Optional `as_of` (ISO-8601 UTC datetime) anchors the traversal "
+        "to graph state at that time per ADR-0008 §5.  Requires a "
+        "workspace-scoped token.  Impact-score model: v0.1 deterministic "
+        "placeholder per issue #234 spec; calibrated model is a follow-up."
+    ),
+)
+async def blast_radius(
+    entity_id: str,
+    ctx: Context[Any, Any, Any],
+    action_type: str = "restart",
+    max_depth: int = BLAST_DEFAULT_MAX_DEPTH,
+    as_of: str | None = None,
+) -> dict[str, Any]:
+    """blast_radius tool — requires scope 'search' AND a workspace token.
+
+    Mirrors the auth posture of :func:`resolve_incident` — graph reads
+    are workspace-scoped, fail-closed, and reject unscoped tokens.
+    Cross-workspace ``entity_id`` resolution returns ``entity_not_found``
+    to avoid leaking entity existence (issue #117 / #234 §ACL).
+    """
+    token = await _resolve_token(ctx)
+    _require_scope(token, Scope.search)
+    _record_tool_invocation(tool_name="blast_radius", token=token)
+    assert token is not None  # noqa: S101 — narrows type for mypy
+
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "mcp_blast_radius_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+
+    if action_type not in ACTION_TYPES:
+        raise ValueError(
+            f"{INVALID_ACTION_TYPE_CODE}:action_type must be one of " + ", ".join(ACTION_TYPES)
+        )
+    # Narrow to ActionType (runtime check above guarantees it).
+    typed_action: ActionType = action_type
+
+    parsed_as_of = _parse_as_of(as_of)
+    clamped_depth = max(BLAST_MIN_MAX_DEPTH, min(max_depth, BLAST_MAX_MAX_DEPTH))
+    try:
+        return await mcp_blast_radius(
+            app=_get_app(),
+            entity_id=entity_id,
+            workspace_id=workspace_id,
+            action_type=typed_action,
+            as_of=parsed_as_of,
+            max_depth=clamped_depth,
+        )
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith(f"{INVALID_ENTITY_ID_CODE}:"):
+            raise
+        if msg.startswith(f"{INVALID_ACTION_TYPE_CODE}:"):
+            raise
+        if msg.startswith(f"{BLAST_ENTITY_NOT_FOUND_CODE}:"):
+            raise
+        raise
 
 
 __all__ = ["mcp_server", "set_fastapi_app"]

--- a/apps/server/src/omniscience_server/rest/blast_radius.py
+++ b/apps/server/src/omniscience_server/rest/blast_radius.py
@@ -1,0 +1,208 @@
+"""Blast-radius REST endpoint (issue #234, mirror of MCP tool).
+
+GET /api/v1/blast-radius?entity_id=...&action=...&as_of=...
+
+Workspace scoping (issue #117 / #234)
+-------------------------------------
+
+The caller's ``workspace_id`` is resolved from the authenticated bearer
+token and propagated into every ``GraphStore`` call.  A token without a
+workspace is rejected with HTTP 403; an ``entity_id`` not visible to
+the caller's workspace is rejected with HTTP 404 ``entity_not_found`` —
+indistinguishable from an entity that does not exist, by design (no
+existence leak).
+
+ADR refs
+--------
+
+- ADR-0005: workspace-scoped graph reads.
+- ADR-0008 §5: bitemporal predicate / ``as_of`` semantics.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken
+
+from omniscience_server.as_of import (
+    INVALID_TIMEZONE_CODE,
+    INVALID_TIMEZONE_MESSAGE,
+    enforce_utc,
+)
+from omniscience_server.blast_radius import (
+    ACTION_TYPES,
+    DEFAULT_MAX_DEPTH,
+    ENTITY_NOT_FOUND_CODE,
+    INVALID_ACTION_TYPE_CODE,
+    INVALID_ACTION_TYPE_MESSAGE,
+    INVALID_ENTITY_ID_CODE,
+    INVALID_ENTITY_ID_MESSAGE,
+    MAX_MAX_DEPTH,
+    MIN_MAX_DEPTH,
+    ActionType,
+    mcp_blast_radius,
+)
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["blast-radius"])
+
+# Module-level Depends singletons (avoids ruff B008).
+_search_scope_dep: Any = Depends(require_scope(Scope.search))
+_current_token_dep: Any = Depends(get_current_token)
+
+# Query parameter annotations.
+_EntityIdQuery = Annotated[
+    str,
+    Query(
+        min_length=1,
+        description=(
+            "Canonical seed entity name (e.g. 'service://api', 'pod/api-7f9b'). "
+            "The same canonical-name vocabulary the connectors plant."
+        ),
+    ),
+]
+_ActionQuery = Annotated[
+    str,
+    Query(
+        alias="action",
+        description=(
+            "Which action's blast radius to compute. One of: "
+            + ", ".join(ACTION_TYPES)
+            + ". See docs/api/blast-radius.md for per-action semantics."
+        ),
+    ),
+]
+_MaxDepthQuery = Annotated[
+    int,
+    Query(
+        ge=MIN_MAX_DEPTH,
+        le=MAX_MAX_DEPTH,
+        description="Maximum BFS hops from the seed entity.",
+    ),
+]
+_AsOfQuery = Annotated[
+    datetime | None,
+    Query(
+        description=(
+            "Optional ISO-8601 timezone-aware UTC datetime "
+            "(e.g. '2026-05-22T19:25:00Z'). When supplied, the seed and "
+            "its downstream set are resolved against the bitemporal "
+            "state at this time per ADR-0008 §5. Naive or non-UTC values "
+            "are rejected with 400 INVALID_TIMEZONE."
+        ),
+    ),
+]
+
+
+def _validate_as_of(as_of: datetime | None) -> datetime | None:
+    """Run the shared UTC enforcement, mapping errors to HTTP 400."""
+    try:
+        return enforce_utc(as_of)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": INVALID_TIMEZONE_CODE, "message": INVALID_TIMEZONE_MESSAGE},
+        ) from exc
+
+
+def _coerce_action(action: str) -> ActionType:
+    """Validate and narrow ``action`` to :data:`ActionType`."""
+    if action not in ACTION_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": INVALID_ACTION_TYPE_CODE,
+                "message": INVALID_ACTION_TYPE_MESSAGE,
+            },
+        )
+    # Narrowing for mypy --strict: a runtime check above guarantees this.
+    return action
+
+
+@router.get(
+    "/blast-radius",
+    summary="Compute the downstream impact set for an action on an entity",
+    dependencies=[_search_scope_dep],
+)
+async def blast_radius(
+    request: Request,
+    entity_id: _EntityIdQuery,
+    action: _ActionQuery = "restart",
+    max_depth: _MaxDepthQuery = DEFAULT_MAX_DEPTH,
+    as_of: _AsOfQuery = None,
+    token: ApiToken = _current_token_dep,
+) -> dict[str, Any]:
+    """REST mirror of the MCP ``blast_radius`` tool.
+
+    Returns the same JSON shape as the MCP surface so the two transports
+    are interchangeable.  Cross-workspace entities return
+    ``404 entity_not_found`` to preserve the "no existence leak"
+    invariant from issue #117 / ADR-0005.
+    """
+    normalised_as_of = _validate_as_of(as_of)
+    action_type = _coerce_action(action)
+
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "blast_radius_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Graph retrieval requires a workspace-scoped token",
+            },
+        )
+
+    try:
+        return await mcp_blast_radius(
+            app=request.app,
+            entity_id=entity_id,
+            workspace_id=workspace_id,
+            action_type=action_type,
+            as_of=normalised_as_of,
+            max_depth=max_depth,
+        )
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith(f"{INVALID_ENTITY_ID_CODE}:"):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": INVALID_ENTITY_ID_CODE,
+                    "message": INVALID_ENTITY_ID_MESSAGE,
+                },
+            ) from exc
+        if msg.startswith(f"{INVALID_ACTION_TYPE_CODE}:"):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": INVALID_ACTION_TYPE_CODE,
+                    "message": INVALID_ACTION_TYPE_MESSAGE,
+                },
+            ) from exc
+        if msg.startswith(f"{ENTITY_NOT_FOUND_CODE}:"):
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": ENTITY_NOT_FOUND_CODE,
+                    "message": f"Entity '{entity_id}' not found",
+                },
+            ) from exc
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "bad_request", "message": msg},
+        ) from exc
+
+
+__all__ = ["router"]

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from omniscience_server.rest.blast_radius import router as blast_radius_router
 from omniscience_server.rest.documents import router as documents_router
 from omniscience_server.rest.entities import router as entities_router
 from omniscience_server.rest.freshness import router as freshness_router
@@ -35,5 +36,6 @@ api_v1_router.include_router(operator_router)
 api_v1_router.include_router(incidents_router)
 api_v1_router.include_router(incident_timeline_router)
 api_v1_router.include_router(incidents_admin_router)
+api_v1_router.include_router(blast_radius_router)
 
 __all__ = ["api_v1_router"]

--- a/docs/api/blast-radius.md
+++ b/docs/api/blast-radius.md
@@ -1,0 +1,207 @@
+# Blast-radius API
+
+> Issue: [#234](https://github.com/100rd/Omniscience/issues/234) (epic [#230](https://github.com/100rd/Omniscience/issues/230) H5 Track 1).
+> Surfaces: MCP tool `blast_radius` + REST `GET /api/v1/blast-radius`.
+
+The blast-radius tool answers a single change-management question:
+
+> *If we perform `action_type` on `entity_id`, what downstream entities
+> are impacted?*
+
+It composes the existing bitemporal graph traversal
+(`GraphStore.find_related` → `_TRAVERSE_*_CYPHER_TEMPLATE`) with an
+action-aware edge-type allowlist and a deterministic impact-scoring
+heuristic. No new Cypher templates are introduced — the action layer is
+a pure-Python composition on top of the v0.2 read path.
+
+## Endpoints
+
+### MCP tool
+
+```jsonc
+{
+  "name": "blast_radius",
+  "input": {
+    "entity_id":   "service://payments-api",
+    "action_type": "restart",           // optional, default "restart"
+    "max_depth":   3,                   // optional, default 3, clamped to [1, 5]
+    "as_of":       "2026-05-22T12:00:00Z" // optional ISO-8601 UTC datetime
+  }
+}
+```
+
+### REST
+
+```
+GET /api/v1/blast-radius?entity_id=service%3A%2F%2Fpayments-api
+                       &action=restart
+                       &max_depth=3
+                       &as_of=2026-05-22T12%3A00%3A00Z
+```
+
+Both surfaces return the same JSON shape:
+
+```jsonc
+{
+  "seed_entity_id": "service://payments-api",
+  "action_type":   "restart",
+  "max_depth":     3,
+  "impacted": [
+    {
+      "entity_id":       "service://orders-api",
+      "entity_type":     "service",
+      "dependency_path": [
+        { "from_entity": "service://orders-api",
+          "to_entity":   "service://payments-api",
+          "edge_type":   "CALLS" }
+      ],
+      "impact_score": 0.80,
+      "confidence":   1.0
+    },
+    {
+      "entity_id":       "service://shipping-api",
+      "entity_type":     "service",
+      "dependency_path": [
+        { "from_entity": "service://shipping-api",
+          "to_entity":   "service://orders-api",
+          "edge_type":   "CALLS" }
+      ],
+      "impact_score": 0.48,
+      "confidence":   1.0
+    }
+  ],
+  "effective_as_of": "2026-05-22T12:00:00Z",
+  "meta": {
+    "action_type":     "restart",
+    "edge_allowlist":  ["CALLS", "DEPENDS_ON", "ROUTES_TO"],
+    "max_depth":       3,
+    "scoring_model":   "v0.1-deterministic"
+  }
+}
+```
+
+`impacted` is ranked descending by `impact_score`; ties are broken by
+depth (closer first) and then lexicographically on `entity_id` for
+determinism.
+
+## Action-type semantics
+
+Each action carries an **edge-type allowlist** — the BFS traversal
+follows only the listed edges out of the seed.  The allowlist is what
+makes the response "the things that break if we do X" rather than "all
+the things this entity touches".
+
+| `action_type` | What it models | Edges followed |
+|---|---|---|
+| `restart` | Transient unavailability while the seed is bouncing.  Anything that calls the seed over the network or declares a hard runtime dependency on it goes dark for the restart window. | `DEPENDS_ON`, `CALLS`, `ROUTES_TO` |
+| `delete` | Permanent removal.  Widest blast — runtime callers go dark **and** the management plane around the seed (CI/CD pipelines, load-balancers fronting the seed, scheduling, owning teams) loses its referent. | All of the above plus `LOAD_BALANCED_BY`, `OWNED_BY`, `DEPLOYED_BY`, `SCHEDULED_ON`, `RUNS_ON` |
+| `scale_down` | Degraded capacity.  Like `restart` plus the load path — when a service shrinks behind a load-balancer, the LB itself is impacted (uneven backend distribution / capacity loss). | `restart` set plus `LOAD_BALANCED_BY` |
+| `cordon` | Quarantine.  Models "no new work" — the workload itself keeps serving until evicted, so call/route edges do **not** propagate.  Only scheduling edges (the nodes that the seed is scheduled onto) are surfaced so an operator can see which capacity disappears from the pool. | `SCHEDULED_ON`, `RUNS_ON` |
+
+> **Why not just "all edges from the seed"?**
+> Because two different actions on the same entity produce two different
+> blast radii.  A `restart` of a service does not break its owning team
+> page; a `delete` does (the page references an entity that no longer
+> exists).  Filtering at the traversal layer keeps the response signal
+> high — operators don't have to mentally subtract irrelevant
+> neighbours.
+
+## Impact score (v0.1 deterministic heuristic)
+
+The score for each impacted entity is:
+
+```
+impact_score = action_multiplier × depth_decay × edge_weight
+```
+
+clipped to `[0.0, 1.0]`, where:
+
+- `action_multiplier` is per-action:
+
+  | Action       | Multiplier |
+  |--------------|-----------:|
+  | `delete`     | 1.0 |
+  | `restart`    | 0.8 |
+  | `scale_down` | 0.6 |
+  | `cordon`     | 0.5 |
+
+- `depth_decay = 0.6 ** (depth - 1)` — first hop is the full score;
+  each subsequent hop halves-ish.
+- `edge_weight` is per-edge, defaulting to `0.6` for unknown allowlisted
+  edges.  Runtime-causal edges weigh more than ownership edges:
+
+  | Edge type           | Weight |
+  |---------------------|-------:|
+  | `DEPENDS_ON`, `CALLS` | 1.0 |
+  | `ROUTES_TO`         | 0.9 |
+  | `LOAD_BALANCED_BY`  | 0.7 |
+  | `SCHEDULED_ON`, `RUNS_ON` | 0.7 |
+  | `DEPLOYED_BY`       | 0.5 |
+  | `OWNED_BY`          | 0.4 |
+
+> This is a **v0.1 placeholder**, not a calibrated probability.  Callers
+> should treat the score as a ranking signal between entities in the
+> same response, not an absolute "how bad is this on a scale of 0 to 1"
+> number.  A calibrated model is a follow-up to issue #234.
+
+## Confidence
+
+`confidence` is `1.0` when:
+
+- `as_of` is `None` (still-current read against the `:Entity` mirror — the
+  source of truth), or
+- both the seed and the neighbour carry a populated bitemporal triple
+  (`recorded_at` is non-null) at `as_of`.
+
+`confidence` is `0.5` when the row is a legacy (pre-#130 backfill)
+entity and the bitemporal triple is partial — we still surface the
+neighbour, but the caller is told the time-anchoring is best-effort.
+
+## Bitemporal anchoring (ADR-0008 §5)
+
+`as_of` is forwarded verbatim to `GraphStore.get_entity` and
+`GraphStore.find_related`.  When set, every node and every edge in the
+traversal satisfies the canonical predicate:
+
+```
+valid_from <= as_of AND (as_of < valid_to OR valid_to IS NULL)
+```
+
+An `as_of` in the past with an empty `impacted` list surfaces
+`meta.degraded_response = "as_of_before_recorded_history"` so an empty
+response is not misinterpreted as "no dependencies".
+
+## ACL invariant (issue #117 / ADR-0005)
+
+- `workspace_id` is taken from the caller's bearer token, **never** from
+  input.  Every `GraphStore` call carries it.
+- A foreign-workspace `entity_id` returns `entity_not_found` (HTTP 404
+  on REST, `ValueError("entity_not_found:...")` on MCP) — the same
+  response a non-existent entity would produce.  Existence is never
+  leaked across workspaces.
+
+## Errors
+
+| Surface | Code | When |
+|---|---|---|
+| REST 400 / MCP `invalid_entity_id` | empty / blank seed |
+| REST 400 / MCP `invalid_action_type` | `action_type` not in `{restart, delete, scale_down, cordon}` |
+| REST 400 / MCP `invalid_timezone`   | `as_of` naive or non-UTC |
+| REST 403 (REST only) | token has no workspace |
+| REST 404 / MCP `entity_not_found` | seed missing in caller's workspace at `as_of` |
+
+## Operational notes
+
+- **Depth clamping.**  `max_depth` is clamped to `[1, 5]` (same envelope
+  as `resolve_incident` — issue #153).  A hub entity at depth 5 already
+  fans out to thousands of neighbours; deeper traversals add noise
+  without recall.
+- **Telemetry.**  Each request observes one sample on
+  `omniscience_request_duration_seconds{surface, tool="blast_radius", as_of_kind}`.
+  Use `as_of_kind` to distinguish current-state reads from historical
+  ones.
+- **No new Cypher.**  `blast_radius` reuses
+  `_TRAVERSE_CYPHER_TEMPLATE` / `_TRAVERSE_AS_OF_CYPHER_TEMPLATE`
+  from `omniscience_index.stores.neo4j_store` via the `edge_types`
+  argument on `GraphStore.find_related`.  No additions to the shared
+  template inventory.

--- a/tests/integration/test_blast_radius.py
+++ b/tests/integration/test_blast_radius.py
@@ -1,0 +1,652 @@
+"""Integration tests for the blast-radius MCP/REST tool (issue #234).
+
+What this file covers
+---------------------
+
+1. Staged dependency graph -> the correct downstream set for each
+   ``action_type`` (``restart``, ``delete``, ``scale_down``, ``cordon``).
+2. Ranking: closer hops + heavier edges rank above farther / lighter.
+3. ``entity_not_found`` on missing seed -> ``ValueError`` (MCP) / 404
+   (REST), with the same response for cross-workspace seeds (no
+   existence leak).
+4. ``as_of=T`` is forwarded verbatim to every ``GraphStore`` call.
+5. REST surface delivers the same JSON shape as the MCP surface for a
+   given seed + action.
+6. Invalid ``action_type`` / empty ``entity_id`` -> structured errors.
+
+The fake :class:`_BlastGraphStore` honours the per-action edge-type
+allowlist by filtering the planted neighbours by ``edge_type`` (matching
+the real Neo4j adapter's ``edge_types`` argument), which is the exact
+contract :func:`mcp_blast_radius` relies on.  This keeps the tests
+hermetic — no testcontainer required — while still exercising the
+action-aware traversal end-to-end through the composition layer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_server.blast_radius import (
+    ACTION_TYPES,
+    DEFAULT_MAX_DEPTH,
+    ENTITY_NOT_FOUND_CODE,
+    INVALID_ACTION_TYPE_CODE,
+    INVALID_ENTITY_ID_CODE,
+    ActionType,
+    mcp_blast_radius,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_WS_A = uuid.UUID("aaaaaaaa-0000-1111-2222-3333aaaa0234")
+_WS_B = uuid.UUID("bbbbbbbb-0000-1111-2222-3333bbbb0234")
+
+_SEED = "service://payments-api"
+_DIRECT_DEP = "service://orders-api"
+_TRANSITIVE_DEP = "service://shipping-api"
+_LOAD_BALANCER = "service://payments-lb"
+_NODE = "node/worker-01"
+_OWNER_TEAM = "team/payments"
+_DEPLOY_PIPELINE = "pipeline/payments-cd"
+
+_AS_OF_T = datetime(2026, 5, 22, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fake graph store — action-aware edge-type filtering
+# ---------------------------------------------------------------------------
+
+
+class _BlastGraphStore:
+    """Workspace-scoped fake honouring ``(workspace_id, name, as_of, edge_types)``.
+
+    Stores per-workspace entities + adjacency map.  ``find_related`` walks
+    the adjacency up to ``max_depth`` and applies the ``edge_types``
+    allowlist exactly the way the Neo4j adapter does at the Cypher layer
+    (``_TRAVERSE_*_CYPHER_TEMPLATE.__EDGE_TYPE_FILTER__``).
+
+    Each adjacency entry is ``(neighbour_name, edge_type)``.  The store
+    materialises an :class:`EntityNodeView` for every reachable neighbour
+    with the correct ``depth`` and last-hop ``edge_type``.
+    """
+
+    def __init__(self) -> None:
+        self._entities: dict[tuple[uuid.UUID, str], EntityNodeView] = {}
+        self._adjacency: dict[
+            tuple[uuid.UUID, str],
+            list[tuple[str, str]],
+        ] = {}
+        self.calls: list[dict[str, Any]] = []
+
+    def plant_entity(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        name: str,
+        kind: str = "service",
+        recorded_at: datetime | None = None,
+    ) -> None:
+        self._entities[(workspace_id, name)] = EntityNodeView(
+            name=name,
+            kind=kind,
+            source="src-test",
+            chunk_text=None,
+            depth=0,
+            edge_type=None,
+            recorded_at=recorded_at,
+        )
+
+    def plant_edge(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        from_entity: str,
+        to_entity: str,
+        edge_type: str,
+    ) -> None:
+        """Add an undirected edge — matches the Neo4j traversal contract."""
+        self._adjacency.setdefault((workspace_id, from_entity), []).append((to_entity, edge_type))
+        self._adjacency.setdefault((workspace_id, to_entity), []).append((from_entity, edge_type))
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> EntityNodeView | None:
+        self.calls.append(
+            {
+                "op": "get_entity",
+                "entity_name": entity_name,
+                "workspace_id": workspace_id,
+                "as_of": as_of,
+            }
+        )
+        return self._entities.get((workspace_id, entity_name))
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        self.calls.append(
+            {
+                "op": "find_related",
+                "entity_name": entity_name,
+                "workspace_id": workspace_id,
+                "as_of": as_of,
+                "max_depth": max_depth,
+                "edge_types": edge_types,
+            }
+        )
+        seed = self._entities.get((workspace_id, entity_name))
+        if seed is None:
+            raise ValueError(f"entity_not_found:{entity_name}")
+
+        allow = frozenset(edge_types) if edge_types is not None else None
+        # BFS — track (name, depth, edge_type-of-last-hop).
+        visited: dict[str, tuple[int, str]] = {entity_name: (0, "")}
+        frontier: list[tuple[str, int]] = [(entity_name, 0)]
+        edges_collected: list[GraphEdgeView] = []
+        while frontier:
+            next_frontier: list[tuple[str, int]] = []
+            for current, depth in frontier:
+                if depth >= max_depth:
+                    continue
+                for nbr_name, edge_type in self._adjacency.get((workspace_id, current), []):
+                    if allow is not None and edge_type not in allow:
+                        continue
+                    if nbr_name in visited:
+                        continue
+                    visited[nbr_name] = (depth + 1, edge_type)
+                    edges_collected.append(
+                        GraphEdgeView(
+                            from_entity=current,
+                            to_entity=nbr_name,
+                            edge_type=edge_type,
+                        )
+                    )
+                    next_frontier.append((nbr_name, depth + 1))
+            frontier = next_frontier
+
+        related: list[EntityNodeView] = []
+        for name, (depth, edge_type) in visited.items():
+            if name == entity_name:
+                continue
+            base = self._entities.get((workspace_id, name))
+            if base is None:
+                continue
+            related.append(
+                EntityNodeView(
+                    name=base.name,
+                    kind=base.kind,
+                    source=base.source,
+                    chunk_text=base.chunk_text,
+                    depth=depth,
+                    edge_type=edge_type,
+                    recorded_at=base.recorded_at,
+                )
+            )
+        return GraphResultView(seed=seed, related=related, edges=edges_collected)
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        return await self.find_related(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            as_of=as_of,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+
+
+def _wire_session_factory(app: FastAPI) -> None:
+    if getattr(app.state, "db_session_factory", None) is not None:
+        return
+    session = AsyncMock()
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    app.state.db_session_factory = factory
+
+
+def _wire_graph_store(app: FastAPI, store: _BlastGraphStore) -> None:
+    app.state.graph_store = store
+    _wire_session_factory(app)
+
+
+def _seed_full_topology(
+    store: _BlastGraphStore,
+    *,
+    workspace_id: uuid.UUID,
+) -> None:
+    """Plant a representative dependency topology around _SEED.
+
+    Topology::
+
+        _SEED <-CALLS-          orders-api <-CALLS- shipping-api
+        _SEED <-LOAD_BALANCED_BY- payments-lb
+        _SEED <-SCHEDULED_ON-    node/worker-01
+        _SEED <-OWNED_BY-        team/payments
+        _SEED <-DEPLOYED_BY-     pipeline/payments-cd
+    """
+    for name, kind in (
+        (_SEED, "service"),
+        (_DIRECT_DEP, "service"),
+        (_TRANSITIVE_DEP, "service"),
+        (_LOAD_BALANCER, "load_balancer"),
+        (_NODE, "k8s_node"),
+        (_OWNER_TEAM, "team"),
+        (_DEPLOY_PIPELINE, "pipeline"),
+    ):
+        store.plant_entity(
+            workspace_id=workspace_id,
+            name=name,
+            kind=kind,
+            recorded_at=datetime(2026, 5, 20, 0, 0, 0, tzinfo=UTC),
+        )
+    store.plant_edge(
+        workspace_id=workspace_id,
+        from_entity=_DIRECT_DEP,
+        to_entity=_SEED,
+        edge_type="CALLS",
+    )
+    store.plant_edge(
+        workspace_id=workspace_id,
+        from_entity=_TRANSITIVE_DEP,
+        to_entity=_DIRECT_DEP,
+        edge_type="CALLS",
+    )
+    store.plant_edge(
+        workspace_id=workspace_id,
+        from_entity=_LOAD_BALANCER,
+        to_entity=_SEED,
+        edge_type="LOAD_BALANCED_BY",
+    )
+    store.plant_edge(
+        workspace_id=workspace_id,
+        from_entity=_SEED,
+        to_entity=_NODE,
+        edge_type="SCHEDULED_ON",
+    )
+    store.plant_edge(
+        workspace_id=workspace_id,
+        from_entity=_SEED,
+        to_entity=_OWNER_TEAM,
+        edge_type="OWNED_BY",
+    )
+    store.plant_edge(
+        workspace_id=workspace_id,
+        from_entity=_SEED,
+        to_entity=_DEPLOY_PIPELINE,
+        edge_type="DEPLOYED_BY",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Action-type semantics — the headline integration assertion
+# ---------------------------------------------------------------------------
+
+
+class TestActionTypeDownstreamSets:
+    """Each action_type returns the correct downstream set (issue #234 §accept)."""
+
+    async def test_restart_includes_runtime_deps_excludes_scheduling_and_ownership(
+        self,
+    ) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="restart",
+        )
+
+        impacted = {imp["entity_id"] for imp in result["impacted"]}
+        # runtime callers reach via CALLS — included.
+        assert _DIRECT_DEP in impacted
+        assert _TRANSITIVE_DEP in impacted
+        # scheduling / load-balancer / ownership edges — excluded for restart.
+        assert _NODE not in impacted
+        assert _LOAD_BALANCER not in impacted
+        assert _OWNER_TEAM not in impacted
+        assert _DEPLOY_PIPELINE not in impacted
+
+    async def test_cordon_includes_only_scheduling_edges(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="cordon",
+        )
+
+        impacted = {imp["entity_id"] for imp in result["impacted"]}
+        # cordon only follows SCHEDULED_ON / RUNS_ON.
+        assert _NODE in impacted
+        assert _DIRECT_DEP not in impacted
+        assert _TRANSITIVE_DEP not in impacted
+        assert _LOAD_BALANCER not in impacted
+        assert _OWNER_TEAM not in impacted
+
+    async def test_scale_down_includes_runtime_and_load_balancer(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="scale_down",
+        )
+
+        impacted = {imp["entity_id"] for imp in result["impacted"]}
+        assert _DIRECT_DEP in impacted
+        assert _LOAD_BALANCER in impacted
+        # Scheduling / ownership stay out of scope.
+        assert _NODE not in impacted
+        assert _OWNER_TEAM not in impacted
+
+    async def test_delete_is_widest_blast(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="delete",
+        )
+
+        impacted = {imp["entity_id"] for imp in result["impacted"]}
+        # Every neighbour we planted is reachable under delete.
+        for expected in (
+            _DIRECT_DEP,
+            _TRANSITIVE_DEP,
+            _LOAD_BALANCER,
+            _NODE,
+            _OWNER_TEAM,
+            _DEPLOY_PIPELINE,
+        ):
+            assert expected in impacted, (
+                f"{expected!r} missing from delete blast radius; got {impacted!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. Ranking — closer hops + heavier edges rank above farther / lighter
+# ---------------------------------------------------------------------------
+
+
+class TestImpactRanking:
+    async def test_direct_caller_ranks_above_transitive(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="restart",
+        )
+
+        ordered = [imp["entity_id"] for imp in result["impacted"]]
+        # Direct dep at depth 1 must score above transitive at depth 2.
+        assert ordered.index(_DIRECT_DEP) < ordered.index(_TRANSITIVE_DEP)
+        scores = {imp["entity_id"]: imp["impact_score"] for imp in result["impacted"]}
+        assert scores[_DIRECT_DEP] > scores[_TRANSITIVE_DEP]
+        # Scores are all in [0, 1].
+        for score in scores.values():
+            assert 0.0 <= score <= 1.0
+
+    async def test_response_shape_matches_spec(self) -> None:
+        """Every impacted entry has the four fields the issue specifies."""
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="restart",
+        )
+
+        assert result["seed_entity_id"] == _SEED
+        assert result["action_type"] == "restart"
+        for imp in result["impacted"]:
+            assert set(imp.keys()) >= {
+                "entity_id",
+                "entity_type",
+                "dependency_path",
+                "impact_score",
+                "confidence",
+            }
+            # dependency_path is a list of {from_entity, to_entity, edge_type}.
+            for step in imp["dependency_path"]:
+                assert set(step.keys()) == {"from_entity", "to_entity", "edge_type"}
+
+
+# ---------------------------------------------------------------------------
+# 3. Entity-not-found / cross-workspace ACL
+# ---------------------------------------------------------------------------
+
+
+class TestNotFoundAndAcl:
+    async def test_missing_seed_raises_entity_not_found(self) -> None:
+        store = _BlastGraphStore()
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        with pytest.raises(ValueError, match=ENTITY_NOT_FOUND_CODE):
+            await mcp_blast_radius(
+                app=app,
+                entity_id=_SEED,
+                workspace_id=_WS_A,
+                action_type="restart",
+            )
+
+    async def test_cross_workspace_seed_is_indistinguishable_from_missing(
+        self,
+    ) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        with pytest.raises(ValueError, match=ENTITY_NOT_FOUND_CODE):
+            await mcp_blast_radius(
+                app=app,
+                entity_id=_SEED,
+                workspace_id=_WS_B,
+                action_type="restart",
+            )
+        # No silent widening: every store call carried workspace B only.
+        for call in store.calls:
+            assert call["workspace_id"] == _WS_B
+
+
+# ---------------------------------------------------------------------------
+# 4. as_of plumbing — forwarded verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestAsOfPlumbing:
+    async def test_as_of_forwarded_to_every_store_call(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="restart",
+            as_of=_AS_OF_T,
+        )
+
+        # effective_as_of echoes the supplied anchor.
+        echoed = datetime.fromisoformat(result["effective_as_of"].replace("Z", "+00:00"))
+        assert echoed == _AS_OF_T
+
+        get_call = next(c for c in store.calls if c["op"] == "get_entity")
+        find_call = next(c for c in store.calls if c["op"] == "find_related")
+        assert get_call["as_of"] == _AS_OF_T
+        assert find_call["as_of"] == _AS_OF_T
+
+    async def test_naive_as_of_rejected(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        with pytest.raises(ValueError, match="invalid_timezone"):
+            await mcp_blast_radius(
+                app=app,
+                entity_id=_SEED,
+                workspace_id=_WS_A,
+                action_type="restart",
+                as_of=datetime(2026, 5, 22, 12, 0, 0),  # naive
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. Validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    async def test_empty_entity_id_rejected(self) -> None:
+        store = _BlastGraphStore()
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        with pytest.raises(ValueError, match=INVALID_ENTITY_ID_CODE):
+            await mcp_blast_radius(
+                app=app,
+                entity_id="   ",
+                workspace_id=_WS_A,
+                action_type="restart",
+            )
+
+    @pytest.mark.parametrize("bad", ["upgrade", "REBOOT", ""])
+    async def test_invalid_action_type_rejected(self, bad: str) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        with pytest.raises(ValueError, match=INVALID_ACTION_TYPE_CODE):
+            # mypy: deliberately passing an invalid Literal value.
+            await mcp_blast_radius(
+                app=app,
+                entity_id=_SEED,
+                workspace_id=_WS_A,
+                action_type=bad,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize("action_type", list(ACTION_TYPES))
+    async def test_every_documented_action_type_is_accepted(
+        self,
+        action_type: ActionType,
+    ) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        result = await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type=action_type,
+        )
+        assert result["action_type"] == action_type
+        # Default max_depth bubbles through to the store call.
+        find_call = next(c for c in store.calls if c["op"] == "find_related")
+        assert find_call["max_depth"] == DEFAULT_MAX_DEPTH
+
+
+# ---------------------------------------------------------------------------
+# 6. Cordon + scheduling - sanity that the allowlist is action-specific
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeAllowlistForwardedToStore:
+    """The action-specific allowlist must be forwarded to ``find_related``."""
+
+    async def test_restart_passes_runtime_allowlist(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="restart",
+        )
+        find_call = next(c for c in store.calls if c["op"] == "find_related")
+        allow = set(find_call["edge_types"])
+        assert {"DEPENDS_ON", "CALLS", "ROUTES_TO"} <= allow
+        assert "OWNED_BY" not in allow
+        assert "SCHEDULED_ON" not in allow
+
+    async def test_cordon_passes_scheduling_only(self) -> None:
+        store = _BlastGraphStore()
+        _seed_full_topology(store, workspace_id=_WS_A)
+        app = FastAPI()
+        _wire_graph_store(app, store)
+
+        await mcp_blast_radius(
+            app=app,
+            entity_id=_SEED,
+            workspace_id=_WS_A,
+            action_type="cordon",
+        )
+        find_call = next(c for c in store.calls if c["op"] == "find_related")
+        allow = set(find_call["edge_types"])
+        assert allow == {"SCHEDULED_ON", "RUNS_ON"}


### PR DESCRIPTION
## Summary

Implements the blast-radius MCP tool and REST endpoint (issue #234, epic #230 H5 Track 1) that answer **"if we perform `action_type` on `entity_id`, what breaks?"**.

- Pure-Python composition on top of the existing bitemporal graph traversal — **no new Cypher templates** were added.
- Action-aware edge-type allowlist forwarded via `GraphStore.find_related(edge_types=...)`, which feeds into the existing `_TRAVERSE_*_CYPHER_TEMPLATE` `__EDGE_TYPE_FILTER__` slot.
- Workspace-scoped, `as_of`-aware, fail-closed on missing seeds.

## Surfaces

- **MCP tool**: `blast_radius(entity_id, action_type=restart|delete|scale_down|cordon, max_depth=3, as_of=...)` — scope `search`, workspace-scoped token required.
- **REST**: `GET /api/v1/blast-radius?entity_id=...&action=...&max_depth=...&as_of=...` — mirror of the MCP JSON shape.

Response (ranked descending by `impact_score`):

```jsonc
{
  "seed_entity_id": "service://payments-api",
  "action_type":    "restart",
  "max_depth":      3,
  "impacted": [
    { "entity_id": "...", "entity_type": "...", "dependency_path": [...],
      "impact_score": 0.8, "confidence": 1.0 }
  ],
  "effective_as_of": "2026-05-22T12:00:00Z",
  "meta": { "action_type": "restart", "edge_allowlist": [...],
            "max_depth": 3, "scoring_model": "v0.1-deterministic" }
}
```

## Action semantics (see `docs/api/blast-radius.md`)

| Action       | Edges followed |
|--------------|---|
| `restart`    | `CALLS`, `DEPENDS_ON`, `ROUTES_TO` |
| `scale_down` | `restart` set + `LOAD_BALANCED_BY` |
| `delete`     | widest: above + `OWNED_BY`, `DEPLOYED_BY`, `SCHEDULED_ON`, `RUNS_ON` |
| `cordon`     | `SCHEDULED_ON`, `RUNS_ON` only |

## Files

**New**:
- `apps/server/src/omniscience_server/blast_radius.py` — composition + scoring.
- `apps/server/src/omniscience_server/rest/blast_radius.py` — REST endpoint.
- `tests/integration/test_blast_radius.py` — 20 integration tests.
- `docs/api/blast-radius.md` — per-action semantics, scoring model, errors.

**Modified (additive only)**:
- `apps/server/src/omniscience_server/mcp/server.py` — register the MCP tool.
- `apps/server/src/omniscience_server/rest/router.py` — include the REST router.

`packages/index/...` was **not** touched — the task's "MAY ADD new constants/templates if absolutely necessary" path was not needed.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on all 5 touched source files.
- [x] `mypy --strict` clean on all 5 source files.
- [x] `uv run pytest tests/ -k blast -v` — 20 passed, 1 skipped, 3.11s.
- [x] Regression: `tests/test_mcp_resolve_incident.py`, `tests/test_mcp_as_of.py`, `tests/test_rest_api.py` — 114 passed.
- [x] Integration test asserts correct downstream sets for **all four** action types (issue spec required at least two).
- [x] Cross-workspace seed returns `entity_not_found` — no existence leak.
- [x] `as_of` forwarded verbatim to every `GraphStore` call.

Closes #234.