### PR TITLE
bench: scaffold MCP retrieval-quality corpus + runner (toward #241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Then ask your AI assistant a question — it will call `omniscience.search` and 
 - [Retrieval strategy (ADR 0004)](docs/decisions/0004-retrieval-strategy-staged.md) — hybrid → structural → GraphRAG-if-needed
 - [Architecture decisions](docs/decisions/)
 
+## Benchmarks
+
+MCP retrieval-quality benchmark suite under [bench/](bench/) (scaffolding subset of issue #241).
+
 ## License
 
 Apache 2.0. See [LICENSE](LICENSE).

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,150 @@
+# MCP retrieval-quality benchmark
+
+Public, reproducible benchmark suite for incident-response MCP servers.
+Defends the "best for SRE" claim with numbers — Omniscience vs
+HolmesGPT vs Sourcegraph MCP vs vanilla GitHub MCP on a canned 50-incident
+corpus.
+
+Tracks issue [#241](https://github.com/100rd/Omniscience/issues/241)
+(Wave 1, Track 4 of the benchmark + compliance epic).
+
+## What's in this PR (scaffolding subset)
+
+This PR lands the *plumbing* for the full benchmark — corpus structure,
+runner skeleton, scoring functions, and the first 12 incident fixtures.
+The remaining ~38 fixtures, the cross-vendor adapter matrix, the
+published Q2 results, and the CI integration land in the follow-up PR
+once Wave 1 features (#234, #235, #243) are stable enough to measure.
+
+```
+bench/
+├── README.md                          ← you are here
+├── __init__.py
+├── schema.py                          ← dataclass schema + validator
+├── scorers.py                         ← top-1, MRR, Brier, latency
+├── runner.py                          ← CLI runner + Omniscience HTTP adapter
+└── incidents/
+    ├── bench-0001-oom-memlimit-reduction.yaml
+    ├── bench-0002-oom-leak-after-cache-change.yaml
+    ├── bench-0003-cert-expiry-internal-ca.yaml
+    ├── bench-0004-cert-expiry-public-tls.yaml
+    ├── bench-0005-dns-coredns-config-typo.yaml
+    ├── bench-0006-dns-service-renamed.yaml
+    ├── bench-0007-deploy-rollback-image-tag.yaml
+    ├── bench-0008-deploy-rollback-helm-values.yaml
+    ├── bench-0009-config-drift-feature-flag.yaml
+    ├── bench-0010-dependency-outage-upstream-api.yaml
+    ├── bench-0011-noisy-neighbor-cpu-throttle.yaml
+    └── bench-0012-data-corruption-dual-write.yaml
+```
+
+Topical breakdown of the 12 scaffolding fixtures:
+
+| category            | count | notes                                                |
+| ------------------- | :---: | ---------------------------------------------------- |
+| oom                 |   2   | memlimit reduction vs slow leak                      |
+| cert-expiry         |   2   | internal mTLS vs public TLS                          |
+| dns                 |   2   | CoreDNS Corefile typo vs renamed Service             |
+| deploy-rollback     |   2   | bad image tag vs Helm-values HPA cut                 |
+| config-drift        |   1   | feature-flag manual override lost after restart      |
+| dependency-outage   |   1   | upstream payment processor degraded                  |
+| noisy-neighbor      |   1   | missing PodAntiAffinity, batch starves api           |
+| data-corruption     |   1   | dual-write back-fill silently exited after env rename|
+
+`data-corruption`, `noisy-neighbor`, `dependency-outage`, and
+`config-drift` will each grow to 4-6 fixtures in the follow-up PR.
+The `runner.py` `--validate-corpus` mode warns about uncovered
+categories.
+
+## How to use the runner today
+
+```bash
+# 1. Validate every fixture against the schema (no server needed):
+python bench/runner.py --validate-corpus
+
+# 2. Dry-run — exercises load/score path with a stub client:
+python bench/runner.py --mcp-endpoint http://localhost:8000 --dry-run
+
+# 3. Smoke run against a live Omniscience MCP server:
+docker compose up -d
+python bench/runner.py --mcp-endpoint http://localhost:8000
+
+# 4. Machine-readable output for downstream tooling:
+python bench/runner.py --mcp-endpoint http://localhost:8000 --json
+```
+
+## Fixture schema
+
+Each `bench/incidents/*.yaml` is one labelled incident:
+
+```yaml
+id: bench-XXXX
+category: oom | cert-expiry | dns | deploy-rollback | config-drift
+        | dependency-outage | noisy-neighbor | data-corruption
+description: one-paragraph human prose
+alert_payload:                     # opaque dict, handed verbatim to the MCP tool
+  provider: pagerduty | prometheus | argocd | sentry | ...
+  alert_id: ...
+  ...
+expected_root_cause:
+  summary: free-text golden
+  canonical_entities:              # ranked, index 0 is the top-1 target
+    - "https://github.com/acme/foo/pull/123"
+    - "deployment/foo"
+expected_runbook_step: "single-line remediation"
+expected_blast_radius:             # set of resources expected to be affected
+  - "service/foo"
+notes: optional
+source_files: optional             # other repo paths the fixture is drawn from
+```
+
+Validation is enforced by `bench/schema.py:parse_incident`. Run
+`python bench/runner.py --validate-corpus` after editing any fixture.
+
+## Metrics
+
+| metric              | formula                                                              | direction |
+| ------------------- | -------------------------------------------------------------------- | --------- |
+| top-1 accuracy      | `mean( retrieved[0] == golden_top1 )`                                | higher    |
+| MRR                 | `mean( 1/rank_of_first_golden_match  or  0 )`                        | higher    |
+| Brier score         | `mean( (confidence - 1{top-1 hit})^2 )`                              | lower     |
+| p50 / p99 latency   | nearest-rank percentile over per-fixture wall-clock                  | lower     |
+
+Errored calls count as RR=0 and top-1 miss. Errored calls are excluded
+from the Brier score (no confidence to score) and from latency
+percentiles (a network failure isn't a latency signal).
+
+## Follow-up PR scope
+
+This PR is ~1 of the 3 engineer-weeks the issue estimates. The
+follow-up will deliver:
+
+1. **~38 more fixtures** to reach the 50-incident target. Coverage
+   targets per category: oom 8, cert-expiry 6, dns 6, deploy-rollback
+   8, config-drift 6, dependency-outage 6, noisy-neighbor 5,
+   data-corruption 5.
+2. **Cross-vendor adapter matrix** — implementations of `MCPClient` for:
+   - HolmesGPT (`bench/vendors/holmesgpt.py`)
+   - Sourcegraph MCP (`bench/vendors/sourcegraph.py`)
+   - vanilla GitHub MCP (`bench/vendors/github.py`)
+   Each adapter normalises the vendor's flat-hits output into the same
+   `MCPResponse` shape so the existing scorers apply unchanged.
+3. **Published results** under `bench/results/2026-Q2.md` with a
+   leaderboard table that we also surface in the top-level `README.md`.
+4. **CI integration** via `.github/workflows/benchmark.yml`. Two modes:
+   - per-PR: runs against a Compose-spun Omniscience only, gates on a
+     top-1 regression threshold.
+   - nightly: runs the full vendor matrix and publishes a JSON artifact.
+5. **Blog-post draft / design-partner one-pager** summarising the
+   numbers — out of engineering scope, owned by product/marketing.
+
+## Reproducibility
+
+The scoring code is pure-Python with no external services. Every
+fixture is checked into the repo. The runner is deterministic given a
+deterministic server: the same corpus + same Omniscience build + same
+backing graph produces the same numbers.
+
+The follow-up PR will pin vendor versions (HolmesGPT image digest,
+Sourcegraph MCP commit SHA, GitHub MCP server commit SHA) in
+`bench/vendors/versions.json` so historical results stay comparable.

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,7 @@
+"""Public MCP retrieval-quality benchmark suite (issue #241).
+
+Scaffolding subset: corpus structure, runner skeleton, scoring functions,
+and the first 12 incident fixtures.  Remaining ~38 fixtures, the
+cross-vendor matrix (HolmesGPT, Sourcegraph MCP, vanilla GitHub MCP),
+and CI integration land in a follow-up PR — see ``bench/README.md``.
+"""

--- a/bench/incidents/bench-0001-oom-memlimit-reduction.yaml
+++ b/bench/incidents/bench-0001-oom-memlimit-reduction.yaml
@@ -1,0 +1,35 @@
+id: bench-0001
+category: oom
+description: >
+  api pod OOMKilled after a PR cut the memory limit from 1Gi to 256Mi.
+  Recency tie-break: the offending PR merged 4h before the alert; an
+  older logging refactor PR (7d before) must NOT win.
+
+alert_payload:
+  provider: pagerduty
+  alert_id: INC-2026-04-12-001
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-12T19:30:00+00:00"
+  summary: "api pod 5xx spike — OOMKilled"
+  target_entity: "pod/api-7f9b9d4c-xj4kp"
+
+expected_root_cause:
+  summary: "PR #4242 reduced memory limit from 1Gi to 256Mi; pod hit limit under normal traffic."
+  canonical_entities:
+    - "https://github.com/acme/api/pull/4242"
+    - "pod/api-7f9b9d4c-xj4kp"
+    - "deployment/api"
+
+expected_runbook_step: >
+  Revert PR #4242 and restore memory limit to 1Gi; scale replicas to 5 while traffic drains.
+
+expected_blast_radius:
+  - "service/api"
+  - "deployment/api"
+  - "ingress/api-public"
+
+notes: >
+  Mirrors tests/fixtures/incident_demo/workspace_a.json so the runner has a
+  fixture that exercises the same v0.1 demo path end-to-end.
+source_files:
+  - "tests/fixtures/incident_demo/workspace_a.json"

--- a/bench/incidents/bench-0002-oom-leak-after-cache-change.yaml
+++ b/bench/incidents/bench-0002-oom-leak-after-cache-change.yaml
@@ -1,0 +1,30 @@
+id: bench-0002
+category: oom
+description: >
+  Slow memory leak in worker pods after a caching library upgrade. Workers
+  fall over on a 6h cadence — OOMKills track the upgrade rollout, not the
+  alert time. The expected root cause is a dependency bump, not a config.
+
+alert_payload:
+  provider: pagerduty
+  alert_id: INC-2026-04-15-014
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-15T08:14:00+00:00"
+  summary: "worker pods crashlooping — OOMKilled (3rd cycle in 18h)"
+  target_entity: "deployment/worker"
+
+expected_root_cause:
+  summary: "PR #4380 bumped the in-process LRU cache library; new default unbounded mode leaks under load."
+  canonical_entities:
+    - "https://github.com/acme/worker/pull/4380"
+    - "deployment/worker"
+
+expected_runbook_step: >
+  Pin caching library to previous minor; set cache_max_entries=10000 explicitly; rolling-restart worker.
+
+expected_blast_radius:
+  - "deployment/worker"
+  - "queue/jobs"
+  - "service/api"
+
+notes: Topical contrast to bench-0001 — different OOM root cause (leak vs limit).

--- a/bench/incidents/bench-0003-cert-expiry-internal-ca.yaml
+++ b/bench/incidents/bench-0003-cert-expiry-internal-ca.yaml
@@ -1,0 +1,28 @@
+id: bench-0003
+category: cert-expiry
+description: >
+  Internal mTLS cert expired silently — cert-manager renewal was disabled
+  by a config-as-code change two months prior; nobody noticed until
+  service-to-service calls started failing.
+
+alert_payload:
+  provider: prometheus
+  alert_id: prom-cert-expired-payments-2026-04-18
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-18T03:47:00+00:00"
+  summary: "payments<->ledger mTLS handshake failures (cert expired)"
+  target_entity: "secret/payments-mtls"
+
+expected_root_cause:
+  summary: "PR #3801 disabled cert-manager auto-renew on payments-mtls; cert expired 60d later."
+  canonical_entities:
+    - "https://github.com/acme/platform/pull/3801"
+    - "secret/payments-mtls"
+
+expected_runbook_step: >
+  Re-enable renewer on Certificate/payments-mtls; force rotate via cmctl renew; restart payments/ledger pods.
+
+expected_blast_radius:
+  - "service/payments"
+  - "service/ledger"
+  - "service/checkout"

--- a/bench/incidents/bench-0004-cert-expiry-public-tls.yaml
+++ b/bench/incidents/bench-0004-cert-expiry-public-tls.yaml
@@ -1,0 +1,28 @@
+id: bench-0004
+category: cert-expiry
+description: >
+  Public TLS cert at the edge expired — Let's Encrypt renewal failed for
+  three consecutive cycles because the HTTP-01 challenge path was blocked
+  by a recent WAF rule.
+
+alert_payload:
+  provider: pagerduty
+  alert_id: INC-2026-04-19-003
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-19T11:02:00+00:00"
+  summary: "edge TLS cert expired — public traffic NXDOMAIN-equivalent (browser error)"
+  target_entity: "ingress/edge-public"
+
+expected_root_cause:
+  summary: "WAF rule from PR #5102 blocked /.well-known/acme-challenge/*; cert-manager could not renew."
+  canonical_entities:
+    - "https://github.com/acme/edge/pull/5102"
+    - "ingress/edge-public"
+
+expected_runbook_step: >
+  Exempt /.well-known/acme-challenge/* in the WAF rule; manually trigger renewal; verify chain.
+
+expected_blast_radius:
+  - "ingress/edge-public"
+  - "service/api"
+  - "service/web"

--- a/bench/incidents/bench-0005-dns-coredns-config-typo.yaml
+++ b/bench/incidents/bench-0005-dns-coredns-config-typo.yaml
@@ -1,0 +1,27 @@
+id: bench-0005
+category: dns
+description: >
+  CoreDNS Corefile change introduced a typo in a forward block; lookups
+  for cluster-external hostnames started returning SERVFAIL.
+
+alert_payload:
+  provider: prometheus
+  alert_id: prom-dns-servfail-rate-2026-04-20
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-20T14:22:00+00:00"
+  summary: "external DNS SERVFAIL rate >20%/min for 5m"
+  target_entity: "configmap/coredns"
+
+expected_root_cause:
+  summary: "PR #2210 misspelled 'forward . /etc/resolv.conf' as 'foward'; CoreDNS silently no-op'd the block."
+  canonical_entities:
+    - "https://github.com/acme/platform/pull/2210"
+    - "configmap/coredns"
+
+expected_runbook_step: >
+  Edit Corefile to correct 'foward' -> 'forward'; kubectl rollout restart deployment/coredns -n kube-system.
+
+expected_blast_radius:
+  - "namespace/default"
+  - "namespace/prod"
+  - "service/api"

--- a/bench/incidents/bench-0006-dns-service-renamed.yaml
+++ b/bench/incidents/bench-0006-dns-service-renamed.yaml
@@ -1,0 +1,25 @@
+id: bench-0006
+category: dns
+description: >
+  A Service was renamed but one stale client still hardcoded the old name.
+  Intermittent NXDOMAIN until the cached DNS entry expired client-side.
+
+alert_payload:
+  provider: pagerduty
+  alert_id: INC-2026-04-21-007
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-21T06:55:00+00:00"
+  summary: "checkout -> billing-v1 NXDOMAIN — intermittent (cache TTL = 60s)"
+  target_entity: "service/billing-v1"
+
+expected_root_cause:
+  summary: "PR #5300 renamed Service billing-v1 -> billing; checkout chart still pinned to old name."
+  canonical_entities:
+    - "https://github.com/acme/billing/pull/5300"
+    - "service/billing-v1"
+
+expected_runbook_step: >
+  Add a temporary ExternalName Service billing-v1 -> billing.default.svc.cluster.local; ship checkout fix.
+
+expected_blast_radius:
+  - "service/checkout"

--- a/bench/incidents/bench-0007-deploy-rollback-image-tag.yaml
+++ b/bench/incidents/bench-0007-deploy-rollback-image-tag.yaml
@@ -1,0 +1,26 @@
+id: bench-0007
+category: deploy-rollback
+description: >
+  A deploy promoted an unreviewed image tag with a broken migration step;
+  the deploy must be rolled back AND the migration reverted.
+
+alert_payload:
+  provider: argocd
+  alert_id: argocd-sync-degraded-2026-04-22
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-22T17:31:00+00:00"
+  summary: "ArgoCD app 'orders' degraded — pods crashlooping after sync"
+  target_entity: "deployment/orders"
+
+expected_root_cause:
+  summary: "PR #6101 promoted image orders:abc123 which fails on schema v32 migration."
+  canonical_entities:
+    - "https://github.com/acme/gitops/pull/6101"
+    - "deployment/orders"
+
+expected_runbook_step: >
+  argocd app rollback orders --revision <previous>; run migrate down v32; redeploy known-good tag.
+
+expected_blast_radius:
+  - "deployment/orders"
+  - "database/orders"

--- a/bench/incidents/bench-0008-deploy-rollback-helm-values.yaml
+++ b/bench/incidents/bench-0008-deploy-rollback-helm-values.yaml
@@ -1,0 +1,28 @@
+id: bench-0008
+category: deploy-rollback
+description: >
+  A Helm values change reduced HPA maxReplicas from 50 to 5 right before a
+  traffic surge; pods saturated, p99 latency spiked, no errors visible
+  upstream until the connection pool exhausted.
+
+alert_payload:
+  provider: prometheus
+  alert_id: prom-p99-latency-2026-04-23
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-23T20:08:00+00:00"
+  summary: "service/api p99 latency >2s for 10m; saturation alert"
+  target_entity: "horizontalpodautoscaler/api"
+
+expected_root_cause:
+  summary: "PR #6244 changed values.yaml hpa.maxReplicas: 50 -> 5; HPA hit the new ceiling."
+  canonical_entities:
+    - "https://github.com/acme/gitops/pull/6244"
+    - "horizontalpodautoscaler/api"
+    - "deployment/api"
+
+expected_runbook_step: >
+  Revert PR #6244; helm upgrade api --reuse-values --set hpa.maxReplicas=50; verify scale-up.
+
+expected_blast_radius:
+  - "service/api"
+  - "deployment/api"

--- a/bench/incidents/bench-0009-config-drift-feature-flag.yaml
+++ b/bench/incidents/bench-0009-config-drift-feature-flag.yaml
@@ -1,0 +1,29 @@
+id: bench-0009
+category: config-drift
+description: >
+  A feature flag was set to "on" in production via the admin UI (not via
+  GitOps), persisted only in the flag service. After a flag-service
+  restart re-read its on-disk state, the manual override was lost.
+
+alert_payload:
+  provider: pagerduty
+  alert_id: INC-2026-04-24-019
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-24T09:14:00+00:00"
+  summary: "feature 'new-checkout-flow' flipped off in prod after flag-service restart"
+  target_entity: "featureflag/new-checkout-flow"
+
+expected_root_cause:
+  summary: >
+    Flag was enabled via the admin UI but never committed to flags.yaml; flag-service restart
+    restored the GitOps-declared 'off' state.
+  canonical_entities:
+    - "audit-log://flags/new-checkout-flow#manual-enable-2026-04-22"
+    - "featureflag/new-checkout-flow"
+
+expected_runbook_step: >
+  Open PR to set new-checkout-flow=on in flags.yaml; merge; flag-service auto-reload picks it up.
+
+expected_blast_radius:
+  - "service/checkout"
+  - "service/web"

--- a/bench/incidents/bench-0010-dependency-outage-upstream-api.yaml
+++ b/bench/incidents/bench-0010-dependency-outage-upstream-api.yaml
@@ -1,0 +1,26 @@
+id: bench-0010
+category: dependency-outage
+description: >
+  Upstream payment processor degraded — our timeouts cascaded into the
+  checkout flow because the circuit breaker threshold was too high.
+
+alert_payload:
+  provider: pagerduty
+  alert_id: INC-2026-04-25-022
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-25T15:40:00+00:00"
+  summary: "checkout 5xx spike — stripe-api p99 1.8s -> 30s"
+  target_entity: "service/checkout"
+
+expected_root_cause:
+  summary: "Upstream Stripe API degradation; our circuit breaker threshold (50 failures) never tripped."
+  canonical_entities:
+    - "statuspage://stripe.com/incidents/2026-04-25-degraded-api"
+    - "service/checkout"
+
+expected_runbook_step: >
+  Open circuit breaker manually (set threshold=5 temporarily); enable degraded-mode banner; wait for upstream recovery.
+
+expected_blast_radius:
+  - "service/checkout"
+  - "service/orders"

--- a/bench/incidents/bench-0011-noisy-neighbor-cpu-throttle.yaml
+++ b/bench/incidents/bench-0011-noisy-neighbor-cpu-throttle.yaml
@@ -1,0 +1,28 @@
+id: bench-0011
+category: noisy-neighbor
+description: >
+  A batch job got co-scheduled with latency-sensitive api pods on the
+  same node; CPU throttling caused api p99 to spike. The expected root
+  cause is the missing PodAntiAffinity, not the batch job itself.
+
+alert_payload:
+  provider: prometheus
+  alert_id: prom-cpu-throttle-api-2026-04-26
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-26T02:11:00+00:00"
+  summary: "api pods CPU throttled >40%; p99 latency degraded"
+  target_entity: "deployment/api"
+
+expected_root_cause:
+  summary: "Missing PodAntiAffinity for nightly-etl Job; co-scheduled with api on node ip-10-0-1-42."
+  canonical_entities:
+    - "https://github.com/acme/gitops/pull/6310"
+    - "deployment/api"
+    - "job/nightly-etl"
+
+expected_runbook_step: >
+  Add PodAntiAffinity to api Deployment excluding label app=nightly-etl; cordon node ip-10-0-1-42 until next cycle.
+
+expected_blast_radius:
+  - "service/api"
+  - "deployment/api"

--- a/bench/incidents/bench-0012-data-corruption-dual-write.yaml
+++ b/bench/incidents/bench-0012-data-corruption-dual-write.yaml
@@ -1,0 +1,32 @@
+id: bench-0012
+category: data-corruption
+description: >
+  A dual-write migration (old table + new table) drifted because the
+  back-fill job stopped silently after an env var rename. New writes
+  hit both tables; old rows were never copied. Discovered when a read
+  fell through to the new table and 404'd on legacy ids.
+
+alert_payload:
+  provider: sentry
+  alert_id: sentry-issue-2026-04-27-NotFoundError-spike
+  workspace_id: aaaaaaaa-1111-2222-3333-4444aa000241
+  fired_at: "2026-04-27T13:05:00+00:00"
+  summary: "NotFoundError spike on /api/orders/<legacy-id> — 8% of reads"
+  target_entity: "table/orders_v2"
+
+expected_root_cause:
+  summary: >
+    Backfill CronJob orders-backfill silently exited after PR #6402 renamed env var
+    DB_URL -> ORDERS_DB_URL; legacy rows never copied to orders_v2.
+  canonical_entities:
+    - "https://github.com/acme/orders/pull/6402"
+    - "cronjob/orders-backfill"
+    - "table/orders_v2"
+
+expected_runbook_step: >
+  Patch CronJob env to use ORDERS_DB_URL; rerun backfill from last successful checkpoint; verify row counts.
+
+expected_blast_radius:
+  - "service/orders"
+  - "table/orders_v2"
+  - "service/reporting"

--- a/bench/runner.py
+++ b/bench/runner.py
@@ -1,0 +1,379 @@
+"""Benchmark runner skeleton (issue #241, scaffolding subset).
+
+Usage::
+
+    # Validate the corpus without running anything:
+    python bench/runner.py --validate-corpus
+
+    # Smoke-run against a live Omniscience MCP endpoint:
+    python bench/runner.py --mcp-endpoint http://localhost:8000
+
+    # Dry-run (no network) — exercises the load/score path with mocked
+    # responses, used in unit tests and as a smoke check on CI machines
+    # without a live server:
+    python bench/runner.py --mcp-endpoint http://localhost:8000 --dry-run
+
+The runner is deliberately a *skeleton* in this PR.  The HTTP client
+is wired enough to call ``resolve_incident`` against a live server, but
+the cross-vendor adapters (HolmesGPT, Sourcegraph MCP, GitHub MCP) land
+in the follow-up PR — see ``bench/README.md``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from collections.abc import Iterable
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Protocol
+
+# Allow `python bench/runner.py ...` to work in addition to
+# `python -m bench.runner ...`.  When invoked as a script, __package__
+# is empty and the sibling `bench.schema` import would fail.  We patch
+# sys.path to include the repo root in that case.
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import yaml
+
+from bench.schema import (
+    CATEGORIES,
+    IncidentFixture,
+    InvalidIncidentError,
+    parse_incident,
+)
+from bench.scorers import CorpusMetrics, FixtureResult, summarise
+
+LOG = logging.getLogger("bench.runner")
+
+#: Default location of the corpus relative to the repo root.
+DEFAULT_CORPUS_DIR = Path(__file__).resolve().parent / "incidents"
+
+#: Default HTTP timeout, seconds.  Generous: a slow server is part of
+#: what the benchmark is measuring — but a truly hung call shouldn't
+#: block the whole run.
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+# ---------------------------------------------------------------------------
+# Corpus loading
+# ---------------------------------------------------------------------------
+
+
+def load_corpus(corpus_dir: Path = DEFAULT_CORPUS_DIR) -> list[IncidentFixture]:
+    """Load every ``*.yaml`` file in ``corpus_dir`` as an :class:`IncidentFixture`.
+
+    Raises :class:`InvalidIncidentError` on the first invalid fixture so
+    a corrupted corpus fails the run loudly rather than silently
+    distorting metrics.
+    """
+    if not corpus_dir.is_dir():
+        raise FileNotFoundError(f"corpus directory not found: {corpus_dir}")
+
+    fixtures: list[IncidentFixture] = []
+    seen_ids: set[str] = set()
+    for path in sorted(corpus_dir.glob("*.yaml")):
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            raise InvalidIncidentError(
+                f"{path}: top-level YAML must be a mapping, got {type(raw).__name__}"
+            )
+        fixture = parse_incident(raw, path_hint=str(path))
+        if fixture.id in seen_ids:
+            raise InvalidIncidentError(f"{path}: duplicate fixture id {fixture.id!r}")
+        seen_ids.add(fixture.id)
+        fixtures.append(fixture)
+    return fixtures
+
+
+# ---------------------------------------------------------------------------
+# MCP client adapter — protocol-shaped so tests can substitute fakes.
+# ---------------------------------------------------------------------------
+
+
+class MCPClient(Protocol):
+    """Minimal interface the runner needs from any MCP client.
+
+    Vendor-specific adapters (HolmesGPT, Sourcegraph, GitHub) will
+    implement this in the follow-up PR.
+    """
+
+    def resolve_incident(
+        self, alert_payload: dict[str, Any], *, timeout: float
+    ) -> MCPResponse: ...
+
+
+class MCPResponse:
+    """Normalised response shape every adapter must return.
+
+    Carries a *ranked* list of canonical entity names (the IR-style
+    output the scorer needs) plus the server's self-reported
+    ``confidence`` score for the top result.
+    """
+
+    __slots__ = ("confidence", "retrieved_entities")
+
+    def __init__(
+        self,
+        retrieved_entities: Iterable[str],
+        confidence: float,
+    ) -> None:
+        self.retrieved_entities: tuple[str, ...] = tuple(retrieved_entities)
+        self.confidence: float = float(confidence)
+
+
+class OmniscienceHTTPClient:
+    """Adapter that calls a live Omniscience MCP server over HTTP.
+
+    Uses ``httpx`` (already a dev dependency).  The exact wire format
+    of the v0.1 ``resolve_incident`` MCP tool is in
+    ``apps/server/src/omniscience_server/incidents.py``; the adapter
+    flattens the returned bundle into the IR-style
+    ``retrieved_entities`` shape expected by the scorer:
+
+        rank 1: target_resource.name (if present)
+        rank 2: responsible_pr.name (if present)
+        rank 3+: slack_threads[].name in their bundle order
+
+    This ordering reflects the v0.1 demo's own ranking opinion (target
+    -> responsible PR -> discussion threads).  Vendors with a flat
+    "hits" list will report it directly.
+    """
+
+    def __init__(self, endpoint: str) -> None:
+        self.endpoint = endpoint.rstrip("/")
+
+    def resolve_incident(self, alert_payload: dict[str, Any], *, timeout: float) -> MCPResponse:
+        import httpx  # imported lazily so --validate-corpus stays dependency-light
+
+        url = f"{self.endpoint}/mcp/tools/resolve_incident"
+        response = httpx.post(url, json=alert_payload, timeout=timeout)
+        response.raise_for_status()
+        bundle = response.json()
+        return _bundle_to_response(bundle)
+
+
+def _bundle_to_response(bundle: dict[str, Any]) -> MCPResponse:
+    """Flatten a ``resolve_incident`` bundle into the IR shape."""
+    ranked: list[str] = []
+    target = bundle.get("target_resource")
+    if isinstance(target, dict) and "name" in target:
+        ranked.append(str(target["name"]))
+    pr = bundle.get("responsible_pr")
+    if isinstance(pr, dict) and "name" in pr:
+        ranked.append(str(pr["name"]))
+    for thread in bundle.get("slack_threads", []) or []:
+        if isinstance(thread, dict) and "name" in thread:
+            ranked.append(str(thread["name"]))
+    confidence = bundle.get("confidence_score", 0.0)
+    return MCPResponse(retrieved_entities=ranked, confidence=float(confidence))
+
+
+# ---------------------------------------------------------------------------
+# Dry-run client — used by CI smoke and unit tests
+# ---------------------------------------------------------------------------
+
+
+class DryRunClient:
+    """Returns the golden top-1 every time with confidence 1.0.
+
+    Lets ``--dry-run`` exercise the full load/score path without a
+    network server (and produces a "perfect" leaderboard, which is the
+    point — it lets ops verify the runner itself is wired correctly
+    before debating any actual model's quality).
+    """
+
+    def __init__(self, fixtures_by_payload: dict[str, IncidentFixture]) -> None:
+        self._by_payload = fixtures_by_payload
+
+    def resolve_incident(self, alert_payload: dict[str, Any], *, timeout: float) -> MCPResponse:
+        key = json.dumps(alert_payload, sort_keys=True)
+        fixture = self._by_payload[key]
+        return MCPResponse(
+            retrieved_entities=fixture.expected_root_cause.canonical_entities,
+            confidence=1.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Run loop
+# ---------------------------------------------------------------------------
+
+
+def run_corpus(
+    fixtures: list[IncidentFixture],
+    client: MCPClient,
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[FixtureResult]:
+    """Run every fixture through the client, collecting raw results."""
+    results: list[FixtureResult] = []
+    for fixture in fixtures:
+        start = time.perf_counter()
+        error: str | None = None
+        retrieved: tuple[str, ...] = ()
+        confidence = 0.0
+        try:
+            response = client.resolve_incident(fixture.alert_payload, timeout=timeout)
+            retrieved = response.retrieved_entities
+            confidence = response.confidence
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+            LOG.warning("fixture %s failed: %s", fixture.id, error)
+        elapsed = time.perf_counter() - start
+        results.append(
+            FixtureResult(
+                fixture_id=fixture.id,
+                category=fixture.category,
+                retrieved_entities=retrieved,
+                confidence=confidence,
+                latency_seconds=elapsed,
+                golden_top1=fixture.expected_root_cause.canonical_entities[0],
+                golden_all=fixture.expected_root_cause.canonical_entities,
+                error=error,
+            )
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def format_report(metrics: CorpusMetrics) -> str:
+    """Human-readable report — one screen, ready for CI logs or a PR body."""
+    lines = [
+        "MCP retrieval-quality benchmark — summary",
+        "=" * 45,
+        f"  fixtures run    : {metrics.n}",
+        f"  errored calls   : {metrics.n_errors}",
+        f"  top-1 accuracy  : {metrics.top1_accuracy:.3f}",
+        f"  MRR             : {metrics.mrr:.3f}",
+        f"  Brier score     : {metrics.brier:.4f}   (lower is better)",
+        f"  p50 latency (s) : {metrics.p50_latency_seconds:.4f}",
+        f"  p99 latency (s) : {metrics.p99_latency_seconds:.4f}",
+        "",
+        "  per-category breakdown:",
+    ]
+    for cat, cat_metrics in metrics.per_category.items():
+        lines.append(
+            f"    {cat:<20} n={cat_metrics.n:<3} "
+            f"top1={cat_metrics.top1_accuracy:.3f} mrr={cat_metrics.mrr:.3f}"
+        )
+    return "\n".join(lines)
+
+
+def metrics_to_json(metrics: CorpusMetrics) -> str:
+    """Machine-readable JSON dump of the metrics."""
+    payload = asdict(metrics)
+    # asdict turns CategoryMetrics into nested dicts already.
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bench/runner.py",
+        description=(
+            "Run the MCP retrieval-quality benchmark corpus against a server. "
+            "Scaffolding subset of issue #241."
+        ),
+    )
+    parser.add_argument(
+        "--mcp-endpoint",
+        default=None,
+        help="Base URL of the MCP server (e.g. http://localhost:8000). "
+        "Required unless --validate-corpus is set.",
+    )
+    parser.add_argument(
+        "--corpus-dir",
+        type=Path,
+        default=DEFAULT_CORPUS_DIR,
+        help=f"Directory of incident YAMLs (default: {DEFAULT_CORPUS_DIR}).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"Per-call HTTP timeout, seconds (default: {DEFAULT_TIMEOUT_SECONDS}).",
+    )
+    parser.add_argument(
+        "--validate-corpus",
+        action="store_true",
+        help="Load and validate every fixture, then exit. No server needed.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Exercise the runner with a stub client that returns goldens. "
+        "Useful as a CI smoke when no live server is available.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON metrics on stdout instead of the human-readable report.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="%(levelname)s %(name)s: %(message)s")
+
+    fixtures = load_corpus(args.corpus_dir)
+    LOG.info("loaded %d fixtures from %s", len(fixtures), args.corpus_dir)
+    _warn_on_uncovered_categories(fixtures)
+
+    if args.validate_corpus:
+        print(f"OK: {len(fixtures)} fixtures validated.")
+        return 0
+
+    if args.mcp_endpoint is None:
+        parser.error("--mcp-endpoint is required unless --validate-corpus is set")
+
+    client: MCPClient
+    if args.dry_run:
+        client = DryRunClient({json.dumps(f.alert_payload, sort_keys=True): f for f in fixtures})
+    else:
+        client = OmniscienceHTTPClient(args.mcp_endpoint)
+
+    results = run_corpus(fixtures, client, timeout=args.timeout)
+    metrics = summarise(results)
+
+    if args.json:
+        print(metrics_to_json(metrics))
+    else:
+        print(format_report(metrics))
+    return 0
+
+
+def _warn_on_uncovered_categories(fixtures: list[IncidentFixture]) -> None:
+    """Log a warning for any declared category with zero fixtures.
+
+    Sparse categories are expected during scaffolding (this PR covers
+    only ~12 fixtures across ~8 categories) but the warning keeps the
+    follow-up PR honest.
+    """
+    covered = {f.category for f in fixtures}
+    missing = sorted(set(CATEGORIES) - covered)
+    if missing:
+        LOG.warning("categories with no fixtures yet: %s", ", ".join(missing))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/schema.py
+++ b/bench/schema.py
@@ -1,0 +1,164 @@
+"""Schema for benchmark incident fixtures (issue #241).
+
+Each fixture in ``bench/incidents/`` is a YAML document with this shape:
+
+.. code-block:: yaml
+
+    id: bench-0001
+    category: oom                          # one of CATEGORIES
+    description: "Pod OOMKilled after memory-limit reduction"
+    alert_payload:                          # opaque dict — passed to MCP server
+      provider: pagerduty
+      alert_id: INC-2026-04-12-001
+      ...
+    expected_root_cause:                    # golden label, free-text + canonical
+      summary: "PR #4242 reduced memory limit from 1Gi to 256Mi"
+      canonical_entities:                   # ranked — index 0 is top-1 target
+        - "https://github.com/acme/api/pull/4242"
+    expected_runbook_step:                  # golden label, single string
+      "Revert PR #4242 and bump memory limit back to 1Gi"
+    expected_blast_radius:                  # golden label, set of resources
+      - "service/api"
+      - "deployment/api"
+    notes: optional reviewer-facing prose
+
+The runner does NOT need the YAML to declare entity-level confidence; the
+scorer uses ranked ``canonical_entities`` to compute MRR and the MCP
+server's own ``confidence_score`` against the binary correctness for the
+Brier score.
+
+This module is dependency-light by design: it uses ``dataclasses`` +
+manual validation rather than pydantic so the bench corpus can be loaded
+without the full server install (a reviewer cloning the repo for the
+fixtures should not need a Postgres + Qdrant + Neo4j toolchain).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Final
+
+#: Topical categories — used for stratified reporting in
+#: ``bench/results/<date>.md``.  Add new categories sparingly; the
+#: scorer reports per-category breakdowns and a sparse cell looks worse
+#: than no cell at all.
+CATEGORIES: Final[tuple[str, ...]] = (
+    "oom",  # memory limits / OOMKilled
+    "cert-expiry",  # TLS cert / secret rotation issues
+    "dns",  # DNS resolution / CoreDNS / service discovery
+    "deploy-rollback",  # bad deploy, rollback path
+    "config-drift",  # config/feature-flag drift
+    "dependency-outage",  # upstream/3rd-party outage
+    "noisy-neighbor",  # resource contention
+    "data-corruption",  # bad migration / dual-write skew
+)
+
+
+class InvalidIncidentError(ValueError):
+    """Raised when a fixture fails schema validation.
+
+    The message names the offending field and the fixture id so that
+    `python bench/runner.py --validate-corpus` produces actionable
+    output even on a large corpus.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ExpectedRootCause:
+    summary: str
+    canonical_entities: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class IncidentFixture:
+    """One golden-labelled incident for the benchmark corpus."""
+
+    id: str
+    category: str
+    description: str
+    alert_payload: dict[str, Any]
+    expected_root_cause: ExpectedRootCause
+    expected_runbook_step: str
+    expected_blast_radius: tuple[str, ...]
+    notes: str = ""
+    source_files: tuple[str, ...] = field(default_factory=tuple)
+
+
+def parse_incident(raw: dict[str, Any], *, path_hint: str = "<dict>") -> IncidentFixture:
+    """Validate ``raw`` (a parsed YAML/JSON dict) and return a fixture.
+
+    Validation is intentionally explicit (rather than handing it to a
+    schema library) so the error messages name the exact field and the
+    fixture path.
+    """
+
+    def _require(key: str, expect_type: type) -> Any:
+        if key not in raw:
+            raise InvalidIncidentError(f"{path_hint}: missing required field '{key}'")
+        value = raw[key]
+        if not isinstance(value, expect_type):
+            raise InvalidIncidentError(
+                f"{path_hint}: field '{key}' must be {expect_type.__name__}, "
+                f"got {type(value).__name__}"
+            )
+        return value
+
+    fixture_id = _require("id", str)
+    category = _require("category", str)
+    if category not in CATEGORIES:
+        raise InvalidIncidentError(f"{path_hint}: category {category!r} not in {CATEGORIES}")
+    description = _require("description", str)
+    alert_payload = _require("alert_payload", dict)
+
+    rc_raw = _require("expected_root_cause", dict)
+    rc_summary = rc_raw.get("summary")
+    rc_entities = rc_raw.get("canonical_entities")
+    if not isinstance(rc_summary, str) or not rc_summary:
+        raise InvalidIncidentError(
+            f"{path_hint}: expected_root_cause.summary must be a non-empty string"
+        )
+    if not isinstance(rc_entities, list) or not rc_entities:
+        raise InvalidIncidentError(
+            f"{path_hint}: expected_root_cause.canonical_entities must be a non-empty list"
+        )
+    if not all(isinstance(e, str) and e for e in rc_entities):
+        raise InvalidIncidentError(
+            f"{path_hint}: expected_root_cause.canonical_entities must be all non-empty strings"
+        )
+
+    runbook = _require("expected_runbook_step", str)
+    if not runbook:
+        raise InvalidIncidentError(f"{path_hint}: expected_runbook_step must be non-empty")
+
+    blast = _require("expected_blast_radius", list)
+    if not all(isinstance(b, str) and b for b in blast):
+        raise InvalidIncidentError(
+            f"{path_hint}: expected_blast_radius must be a list of non-empty strings"
+        )
+
+    notes_value = raw.get("notes", "")
+    if not isinstance(notes_value, str):
+        raise InvalidIncidentError(f"{path_hint}: notes must be a string if present")
+
+    source_files_raw = raw.get("source_files", [])
+    if not isinstance(source_files_raw, list) or not all(
+        isinstance(s, str) for s in source_files_raw
+    ):
+        raise InvalidIncidentError(
+            f"{path_hint}: source_files must be a list of strings if present"
+        )
+
+    return IncidentFixture(
+        id=fixture_id,
+        category=category,
+        description=description,
+        alert_payload=alert_payload,
+        expected_root_cause=ExpectedRootCause(
+            summary=rc_summary,
+            canonical_entities=tuple(rc_entities),
+        ),
+        expected_runbook_step=runbook,
+        expected_blast_radius=tuple(blast),
+        notes=notes_value,
+        source_files=tuple(source_files_raw),
+    )

--- a/bench/scorers.py
+++ b/bench/scorers.py
@@ -1,0 +1,181 @@
+"""Scoring functions for the MCP retrieval-quality benchmark (issue #241).
+
+All scorers are pure functions on already-collected results — they do
+not call the MCP server.  The runner collects raw per-fixture outputs
+and then hands them to the scorers in bulk so that aggregate metrics
+(MRR, Brier, latency percentiles) can be reported.
+
+Metric definitions
+==================
+
+top-1 accuracy
+    Fraction of fixtures where the MCP server's top-ranked retrieved
+    entity equals the golden ``canonical_entities[0]``.  Strict string
+    equality on the canonical name.
+
+MRR (Mean Reciprocal Rank)
+    Standard IR metric.  For each fixture, find the rank ``r`` of the
+    first retrieved entity that matches *any* of the golden
+    ``canonical_entities``; contribute ``1/r`` if found, ``0`` if not.
+    MRR is the mean across the corpus.
+
+    Formula::
+
+        MRR = (1/N) * sum_i ( 1 / rank_i  if hit else 0 )
+
+    where ``rank_i`` is 1-indexed.
+
+calibrated-confidence Brier score
+    Measures calibration of ``confidence_score`` against binary
+    correctness (top-1 hit).  Lower is better; range [0, 1].
+
+    Formula::
+
+        Brier = (1/N) * sum_i ( confidence_i - correct_i )^2
+
+    where ``correct_i ∈ {0, 1}`` is whether the fixture's top-1 was hit.
+
+p50 / p99 latency
+    Wall-clock seconds from "send request" to "receive parsed bundle",
+    measured per fixture.  Percentiles computed with the
+    nearest-rank method (no interpolation) — small corpora make
+    interpolation noise dominate the signal.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureResult:
+    """Raw per-fixture run output, fed to the aggregate scorers."""
+
+    fixture_id: str
+    category: str
+    retrieved_entities: tuple[str, ...]  # ranked, top first
+    confidence: float  # MCP server's self-reported [0, 1]
+    latency_seconds: float
+    golden_top1: str
+    golden_all: tuple[str, ...]
+    error: str | None = None  # set if the call failed
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusMetrics:
+    n: int
+    n_errors: int
+    top1_accuracy: float
+    mrr: float
+    brier: float
+    p50_latency_seconds: float
+    p99_latency_seconds: float
+    per_category: dict[str, CategoryMetrics]
+
+
+@dataclass(frozen=True, slots=True)
+class CategoryMetrics:
+    n: int
+    top1_accuracy: float
+    mrr: float
+
+
+def _is_top1_hit(result: FixtureResult) -> bool:
+    if result.error is not None or not result.retrieved_entities:
+        return False
+    return result.retrieved_entities[0] == result.golden_top1
+
+
+def _reciprocal_rank(result: FixtureResult) -> float:
+    """Reciprocal rank of the first golden match in ``retrieved_entities``.
+
+    Returns 0.0 if the call errored or no golden entity was retrieved.
+    Ranks are 1-indexed.
+    """
+    if result.error is not None:
+        return 0.0
+    golden = set(result.golden_all)
+    for idx, entity in enumerate(result.retrieved_entities, start=1):
+        if entity in golden:
+            return 1.0 / idx
+    return 0.0
+
+
+def top1_accuracy(results: Sequence[FixtureResult]) -> float:
+    """Fraction of results where the top-ranked entity matches the golden top-1."""
+    if not results:
+        return 0.0
+    hits = sum(1 for r in results if _is_top1_hit(r))
+    return hits / len(results)
+
+
+def mean_reciprocal_rank(results: Sequence[FixtureResult]) -> float:
+    """MRR over the given results.
+
+    Errors count as RR=0 (a failed call cannot retrieve anything).
+    """
+    if not results:
+        return 0.0
+    total = sum(_reciprocal_rank(r) for r in results)
+    return total / len(results)
+
+
+def brier_score(results: Sequence[FixtureResult]) -> float:
+    """Brier score of ``confidence`` against binary top-1 correctness.
+
+    Errored calls are excluded (no confidence to score).
+    """
+    scorable = [r for r in results if r.error is None]
+    if not scorable:
+        return 0.0
+    total = 0.0
+    for r in scorable:
+        correct = 1.0 if _is_top1_hit(r) else 0.0
+        diff = r.confidence - correct
+        total += diff * diff
+    return total / len(scorable)
+
+
+def latency_percentile(results: Sequence[FixtureResult], percentile: float) -> float:
+    """Nearest-rank percentile of latencies across all (non-errored) results.
+
+    ``percentile`` is in [0, 100].  Returns 0.0 on empty input.
+    """
+    if not 0.0 <= percentile <= 100.0:
+        raise ValueError(f"percentile must be in [0, 100]; got {percentile}")
+    samples = sorted(r.latency_seconds for r in results if r.error is None)
+    if not samples:
+        return 0.0
+    # Nearest-rank: rank = ceil(p/100 * N), 1-indexed, clamped to [1, N].
+    import math
+
+    rank = max(1, min(len(samples), math.ceil(percentile / 100.0 * len(samples))))
+    return samples[rank - 1]
+
+
+def summarise(results: Sequence[FixtureResult]) -> CorpusMetrics:
+    """Compute the full :class:`CorpusMetrics` summary."""
+    by_cat: dict[str, list[FixtureResult]] = {}
+    for r in results:
+        by_cat.setdefault(r.category, []).append(r)
+
+    per_category = {
+        cat: CategoryMetrics(
+            n=len(items),
+            top1_accuracy=top1_accuracy(items),
+            mrr=mean_reciprocal_rank(items),
+        )
+        for cat, items in sorted(by_cat.items())
+    }
+
+    return CorpusMetrics(
+        n=len(results),
+        n_errors=sum(1 for r in results if r.error is not None),
+        top1_accuracy=top1_accuracy(results),
+        mrr=mean_reciprocal_rank(results),
+        brier=brier_score(results),
+        p50_latency_seconds=latency_percentile(results, 50.0),
+        p99_latency_seconds=latency_percentile(results, 99.0),
+        per_category=per_category,
+    )

--- a/packages/parsers/src/omniscience_parsers/infra/kubernetes.py
+++ b/packages/parsers/src/omniscience_parsers/infra/kubernetes.py
@@ -19,7 +19,7 @@ import re
 from typing import Any
 
 import structlog
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from omniscience_parsers.base import ParsedDocument, Section
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "rich>=13.7.0",
     "moto>=5.1.22",
     "boto3-stubs[s3]>=1.42.91",
+    "types-PyYAML>=6.0.0",  # mypy stubs for bench/runner.py (issue #241 scaffolding)
     "testcontainers[neo4j,qdrant]>=4.8.0",
     "hypothesis>=6.108.0",
 ]
@@ -86,6 +87,9 @@ ignore = [
 ]
 "scripts/*" = [
     "T201",  # print is the standard CLI output mechanism for one-shot scripts
+]
+"bench/runner.py" = [
+    "T201",  # print is the standard CLI output mechanism for the bench runner
 ]
 "helm/**/tests/**" = [
     "S101",  # assert is the standard pytest assertion mechanism

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,0 +1,374 @@
+"""Unit tests for the benchmark runner skeleton (issue #241, scaffolding subset).
+
+Scope:
+
+* Schema validator catches the common ways a fixture goes wrong.
+* Scorers compute the documented formulas on hand-built inputs.
+* Runner round-trips a small in-memory client through ``run_corpus`` and
+  ``summarise``.
+* The corpus on disk validates and the dry-run mode goes green.
+
+Live-network tests against a real Omniscience server are out of scope
+for this PR and will land alongside the cross-vendor adapter matrix.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bench import scorers
+from bench.runner import (
+    DEFAULT_CORPUS_DIR,
+    DryRunClient,
+    _bundle_to_response,
+    build_arg_parser,
+    format_report,
+    load_corpus,
+    main,
+    metrics_to_json,
+    run_corpus,
+)
+from bench.schema import (
+    CATEGORIES,
+    ExpectedRootCause,
+    IncidentFixture,
+    InvalidIncidentError,
+    parse_incident,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _valid_raw(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": "bench-test-0001",
+        "category": "oom",
+        "description": "x",
+        "alert_payload": {"k": "v"},
+        "expected_root_cause": {
+            "summary": "s",
+            "canonical_entities": ["https://example/pr/1", "pod/x"],
+        },
+        "expected_runbook_step": "do the thing",
+        "expected_blast_radius": ["service/x"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _fixture(
+    fid: str = "f",
+    category: str = "oom",
+    canonical: tuple[str, ...] = ("ent-1", "ent-2"),
+) -> IncidentFixture:
+    return IncidentFixture(
+        id=fid,
+        category=category,
+        description="d",
+        alert_payload={"id": fid},
+        expected_root_cause=ExpectedRootCause(summary="s", canonical_entities=canonical),
+        expected_runbook_step="r",
+        expected_blast_radius=("service/x",),
+    )
+
+
+def _result(
+    fid: str = "f",
+    retrieved: tuple[str, ...] = ("ent-1",),
+    confidence: float = 1.0,
+    latency: float = 0.05,
+    golden_top1: str = "ent-1",
+    golden_all: tuple[str, ...] = ("ent-1", "ent-2"),
+    category: str = "oom",
+    error: str | None = None,
+) -> scorers.FixtureResult:
+    return scorers.FixtureResult(
+        fixture_id=fid,
+        category=category,
+        retrieved_entities=retrieved,
+        confidence=confidence,
+        latency_seconds=latency,
+        golden_top1=golden_top1,
+        golden_all=golden_all,
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema validator
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidator:
+    def test_valid_fixture_parses(self) -> None:
+        fixture = parse_incident(_valid_raw(), path_hint="t")
+        assert fixture.id == "bench-test-0001"
+        assert fixture.category == "oom"
+        assert fixture.expected_root_cause.canonical_entities[0] == "https://example/pr/1"
+        assert fixture.expected_blast_radius == ("service/x",)
+        assert fixture.notes == ""
+
+    def test_missing_required_field_raises(self) -> None:
+        raw = _valid_raw()
+        del raw["id"]
+        with pytest.raises(InvalidIncidentError, match="missing required field 'id'"):
+            parse_incident(raw, path_hint="t")
+
+    def test_unknown_category_raises(self) -> None:
+        raw = _valid_raw(category="not-a-category")
+        with pytest.raises(InvalidIncidentError, match="category"):
+            parse_incident(raw, path_hint="t")
+
+    def test_empty_canonical_entities_raises(self) -> None:
+        raw = _valid_raw(
+            expected_root_cause={"summary": "s", "canonical_entities": []},
+        )
+        with pytest.raises(InvalidIncidentError, match="canonical_entities"):
+            parse_incident(raw, path_hint="t")
+
+    def test_non_string_blast_radius_raises(self) -> None:
+        raw = _valid_raw(expected_blast_radius=["service/x", 42])
+        with pytest.raises(InvalidIncidentError, match="expected_blast_radius"):
+            parse_incident(raw, path_hint="t")
+
+    def test_empty_runbook_step_raises(self) -> None:
+        raw = _valid_raw(expected_runbook_step="")
+        with pytest.raises(InvalidIncidentError, match="expected_runbook_step"):
+            parse_incident(raw, path_hint="t")
+
+    def test_categories_constant_is_non_empty(self) -> None:
+        assert len(CATEGORIES) >= 6
+
+
+# ---------------------------------------------------------------------------
+# Scorer formulas
+# ---------------------------------------------------------------------------
+
+
+class TestScorerFormulas:
+    def test_top1_accuracy_on_mixed_hits(self) -> None:
+        results = [
+            _result(fid="a", retrieved=("ent-1",)),  # hit
+            _result(fid="b", retrieved=("ent-2",)),  # miss (top is ent-2)
+            _result(fid="c", retrieved=("ent-1", "ent-2")),  # hit
+            _result(fid="d", retrieved=()),  # miss (empty)
+        ]
+        assert scorers.top1_accuracy(results) == pytest.approx(2 / 4)
+
+    def test_mrr_uses_first_golden_match_rank(self) -> None:
+        results = [
+            # rank 1 (ent-1)
+            _result(fid="a", retrieved=("ent-1", "ent-2"), golden_all=("ent-1", "ent-2")),
+            # rank 2 (ent-2 is in goldens)
+            _result(fid="b", retrieved=("other", "ent-2"), golden_all=("ent-1", "ent-2")),
+            # no hit
+            _result(fid="c", retrieved=("x", "y"), golden_all=("ent-1",)),
+        ]
+        # RR: 1.0, 0.5, 0.0  -> mean 0.5
+        assert scorers.mean_reciprocal_rank(results) == pytest.approx(0.5)
+
+    def test_brier_score_perfect_calibration_is_zero(self) -> None:
+        results = [
+            _result(retrieved=("ent-1",), confidence=1.0),  # correct, conf 1.0
+            _result(retrieved=("zzz",), confidence=0.0),  # wrong, conf 0.0
+        ]
+        assert scorers.brier_score(results) == pytest.approx(0.0)
+
+    def test_brier_score_overconfident_wrong(self) -> None:
+        results = [
+            _result(retrieved=("zzz",), confidence=1.0),  # wrong, conf 1.0 -> (1-0)^2 = 1
+            _result(retrieved=("zzz",), confidence=1.0),  # wrong, conf 1.0 -> 1
+        ]
+        assert scorers.brier_score(results) == pytest.approx(1.0)
+
+    def test_brier_excludes_errored_calls(self) -> None:
+        results = [
+            _result(retrieved=("ent-1",), confidence=1.0),  # correct -> 0
+            _result(retrieved=(), confidence=0.5, error="HTTPError"),  # excluded
+        ]
+        assert scorers.brier_score(results) == pytest.approx(0.0)
+
+    def test_errored_call_counts_as_top1_miss_and_rr_zero(self) -> None:
+        results = [
+            _result(retrieved=(), confidence=0.0, error="boom", golden_top1="ent-1"),
+        ]
+        assert scorers.top1_accuracy(results) == 0.0
+        assert scorers.mean_reciprocal_rank(results) == 0.0
+
+    def test_latency_percentiles_nearest_rank(self) -> None:
+        # samples sorted: [0.01, 0.02, 0.05, 0.10, 1.00]
+        results = [
+            _result(fid=str(i), latency=lat)
+            for i, lat in enumerate([0.10, 0.01, 1.00, 0.02, 0.05])
+        ]
+        assert scorers.latency_percentile(results, 50.0) == pytest.approx(0.05)
+        # p99 of 5 samples by nearest-rank = ceil(0.99*5)=5 -> samples[4] = 1.00
+        assert scorers.latency_percentile(results, 99.0) == pytest.approx(1.00)
+        # p=0 clamps to rank 1 (the minimum sample), not 0; documents the contract.
+        assert scorers.latency_percentile(results, 0.0) == pytest.approx(0.01)
+        # Empty input returns 0.0 (no samples to report).
+        assert scorers.latency_percentile([], 50.0) == pytest.approx(0.0)
+
+    def test_latency_percentile_rejects_bad_input(self) -> None:
+        with pytest.raises(ValueError):
+            scorers.latency_percentile([_result()], 150.0)
+
+    def test_summarise_breaks_down_by_category(self) -> None:
+        results = [
+            _result(fid="a", category="oom", retrieved=("ent-1",)),
+            _result(fid="b", category="oom", retrieved=("zzz",)),
+            _result(fid="c", category="dns", retrieved=("ent-1",)),
+        ]
+        metrics = scorers.summarise(results)
+        assert metrics.n == 3
+        assert metrics.n_errors == 0
+        assert "oom" in metrics.per_category
+        assert metrics.per_category["oom"].n == 2
+        assert metrics.per_category["oom"].top1_accuracy == pytest.approx(0.5)
+        assert metrics.per_category["dns"].top1_accuracy == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Bundle adapter
+# ---------------------------------------------------------------------------
+
+
+class TestBundleToResponse:
+    def test_orders_target_then_pr_then_threads(self) -> None:
+        bundle = {
+            "target_resource": {"name": "pod/x"},
+            "responsible_pr": {"name": "https://github.com/a/b/pull/1"},
+            "slack_threads": [
+                {"name": "slack://t1"},
+                {"name": "slack://t2"},
+            ],
+            "confidence_score": 0.9,
+        }
+        resp = _bundle_to_response(bundle)
+        assert resp.retrieved_entities == (
+            "pod/x",
+            "https://github.com/a/b/pull/1",
+            "slack://t1",
+            "slack://t2",
+        )
+        assert resp.confidence == pytest.approx(0.9)
+
+    def test_missing_fields_are_skipped(self) -> None:
+        # Only target_resource present; PR + threads absent.
+        resp = _bundle_to_response({"target_resource": {"name": "pod/x"}})
+        assert resp.retrieved_entities == ("pod/x",)
+        assert resp.confidence == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Corpus loading + dry-run round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusLoading:
+    def test_scaffolding_corpus_loads_and_covers_min_categories(self) -> None:
+        fixtures = load_corpus(DEFAULT_CORPUS_DIR)
+        assert 10 <= len(fixtures) <= 20, (
+            "scaffolding PR ships 10-15 fixtures; follow-up grows to 50"
+        )
+        # All ids unique.
+        ids = [f.id for f in fixtures]
+        assert len(set(ids)) == len(ids)
+        # At least 6 distinct categories represented (out of 8 declared).
+        cats = {f.category for f in fixtures}
+        assert len(cats) >= 6, f"too few categories covered: {cats}"
+
+    def test_load_corpus_rejects_duplicate_ids(self, tmp_path: Path) -> None:
+        for name in ("a.yaml", "b.yaml"):
+            (tmp_path / name).write_text(
+                "id: dup\ncategory: oom\ndescription: x\nalert_payload: {}\n"
+                "expected_root_cause:\n  summary: s\n  canonical_entities: [e]\n"
+                "expected_runbook_step: r\nexpected_blast_radius: [b]\n"
+            )
+        with pytest.raises(InvalidIncidentError, match="duplicate fixture id"):
+            load_corpus(tmp_path)
+
+    def test_load_corpus_rejects_non_mapping_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.yaml").write_text("- just\n- a\n- list\n")
+        with pytest.raises(InvalidIncidentError, match="top-level YAML must be a mapping"):
+            load_corpus(tmp_path)
+
+
+class TestDryRunRoundTrip:
+    def test_dry_run_client_returns_perfect_results(self) -> None:
+        fixtures = load_corpus(DEFAULT_CORPUS_DIR)
+        client = DryRunClient({json.dumps(f.alert_payload, sort_keys=True): f for f in fixtures})
+        results = run_corpus(fixtures, client)
+        metrics = scorers.summarise(results)
+        assert metrics.n == len(fixtures)
+        assert metrics.n_errors == 0
+        assert metrics.top1_accuracy == pytest.approx(1.0)
+        assert metrics.mrr == pytest.approx(1.0)
+        # Brier on perfect calibration (conf=1.0, correct=1) is 0.
+        assert metrics.brier == pytest.approx(0.0)
+        # Latency on an in-memory stub must be small (< 100ms).
+        assert metrics.p99_latency_seconds < 0.1
+
+    def test_run_corpus_records_errors_without_crashing(self) -> None:
+        class BoomClient:
+            def resolve_incident(self, alert_payload: dict[str, Any], *, timeout: float) -> Any:
+                raise RuntimeError("boom")
+
+        fixture = _fixture()
+        results = run_corpus([fixture], BoomClient())
+        assert len(results) == 1
+        assert results[0].error is not None
+        assert "RuntimeError" in results[0].error
+        # Top-1 / MRR are 0 on errors; latency was still recorded.
+        assert scorers.top1_accuracy(results) == 0.0
+        assert math.isfinite(results[0].latency_seconds)
+
+
+# ---------------------------------------------------------------------------
+# Reporting + CLI
+# ---------------------------------------------------------------------------
+
+
+class TestReporting:
+    def test_format_report_mentions_every_metric(self) -> None:
+        results = [_result(retrieved=("ent-1",), confidence=1.0)]
+        report = format_report(scorers.summarise(results))
+        for needle in ("top-1", "MRR", "Brier", "p50", "p99", "per-category"):
+            assert needle in report
+
+    def test_metrics_to_json_is_valid_json(self) -> None:
+        results = [_result(retrieved=("ent-1",), confidence=1.0)]
+        payload = metrics_to_json(scorers.summarise(results))
+        parsed = json.loads(payload)
+        assert parsed["n"] == 1
+        assert "per_category" in parsed
+
+
+class TestCLI:
+    def test_arg_parser_help_does_not_crash(self) -> None:
+        parser = build_arg_parser()
+        # No assert beyond "doesn't raise" — argparse stays sane.
+        assert parser.prog == "bench/runner.py"
+
+    def test_validate_corpus_exits_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["--validate-corpus"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "validated" in out
+
+    def test_main_requires_endpoint_unless_validate(self) -> None:
+        with pytest.raises(SystemExit):
+            main([])  # no args at all -> parser.error -> SystemExit
+
+    def test_dry_run_via_main(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["--mcp-endpoint", "http://unused", "--dry-run", "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["top1_accuracy"] == pytest.approx(1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1277,6 +1277,7 @@ dev = [
     { name = "tenacity" },
     { name = "testcontainers", extra = ["neo4j", "qdrant"] },
     { name = "typer" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -1311,6 +1312,7 @@ dev = [
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "testcontainers", extras = ["neo4j", "qdrant"], specifier = ">=4.8.0" },
     { name = "typer", specifier = ">=0.12.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.0" },
 ]
 
 [[package]]
@@ -2641,6 +2643,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/26/0aa563e229c269c528a3b8c709fc671ac2a5c564732fab0852ac6ee006cf/types_awscrt-0.31.3.tar.gz", hash = "sha256:09d3eaf00231e0f47e101bd9867e430873bc57040050e2a3bd8305cb4fc30865", size = 18178, upload-time = "2026-03-08T02:31:14.569Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/e5/47a573bbbd0a790f8f9fe452f7188ea72b212d21c9be57d5fc0cbc442075/types_awscrt-0.31.3-py3-none-any.whl", hash = "sha256:e5ce65a00a2ab4f35eacc1e3d700d792338d56e4823ee7b4dbe017f94cfc4458", size = 43340, upload-time = "2026-03-08T02:31:13.38Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lands the scaffolding subset of issue #241 (public MCP retrieval-quality benchmark — Wave 1 Track 4 of the benchmark + compliance epic).

- New top-level `bench/` tree: `schema.py`, `scorers.py`, `runner.py`, `README.md`, and 12 golden-labelled incident YAML fixtures
- 8 topical categories represented: 2 oom, 2 cert-expiry, 2 dns, 2 deploy-rollback, 1 config-drift, 1 dependency-outage, 1 noisy-neighbor, 1 data-corruption
- Runner skeleton works as a CLI: `--validate-corpus`, `--dry-run`, `--mcp-endpoint`, `--json`
- 29 unit tests in `tests/test_benchmark_runner.py` covering the schema validator, scorer formulas, corpus loader, and the dry-run round-trip
- `mypy --strict` clean for `bench/`; added `types-PyYAML` dev dep
- One-line `Benchmarks` pointer added to top-level `README.md`

## Metrics

| metric | formula | direction |
| ------ | ------- | --------- |
| top-1 accuracy | `mean(retrieved[0] == golden_top1)` | higher |
| MRR | `mean(1/rank_of_first_golden_match or 0)` | higher |
| Brier | `mean((confidence - 1{top-1 hit})^2)` | lower |
| p50/p99 latency | nearest-rank percentile over per-fixture wall-clock | lower |

Errored calls count as RR=0 / top-1 miss; excluded from Brier and latency percentiles.

## Test plan

- [x] `uv run ruff check bench/ tests/test_benchmark_runner.py` — clean
- [x] `uv run ruff format --check bench/ tests/test_benchmark_runner.py` — clean
- [x] `uv run mypy --strict bench/ tests/test_benchmark_runner.py` — clean
- [x] `uv run pytest tests/test_benchmark_runner.py -v` — 29/29 passed
- [x] `python bench/runner.py --help` — usage banner renders
- [x] `python bench/runner.py --validate-corpus` — 12/12 fixtures validate
- [x] `python bench/runner.py --mcp-endpoint http://localhost:8000 --dry-run` — perfect dry-run pass
- [x] `python bench/runner.py --mcp-endpoint http://localhost:8000` — degrades gracefully when no live server (12 errored calls reported, exit 0)

## Toward #241 (scaffolding subset)

Follow-up PR will add:

1. ~38 more fixtures to reach the 50-incident target (oom 8, cert-expiry 6, dns 6, deploy-rollback 8, config-drift 6, dependency-outage 6, noisy-neighbor 5, data-corruption 5)
2. Cross-vendor adapters: `bench/vendors/{holmesgpt,sourcegraph,github}.py` implementing the same `MCPClient` Protocol
3. Published results: `bench/results/2026-Q2.md` + a leaderboard table in the top-level README
4. CI: `.github/workflows/benchmark.yml` — per-PR regression gate against Omniscience, nightly full vendor matrix
5. Pinned vendor versions in `bench/vendors/versions.json` for reproducibility