### PR TITLE
feat(connectors): PagerDuty full bi-directional connector (#239)

### DIFF
--- a/docs/connectors/pagerduty.md
+++ b/docs/connectors/pagerduty.md
@@ -1,0 +1,94 @@
+# PagerDuty connector
+
+Promotes the existing push-only PagerDuty webhook receiver
+(`alerts/pagerduty`) into a full read-only source connector that also
+pulls catalog and incident history via the PagerDuty REST API.
+
+Bi-directional write-back (ack / snooze / resolve) is **deferred to v2
+Action Mode** — tracked by issue [#230](https://github.com/100rd/Omniscience/issues/230).
+v1 is read-only by design.
+
+## What gets ingested
+
+| Entity                  | Source endpoint                                  |
+|-------------------------|--------------------------------------------------|
+| `PagerDutyTeam`         | `GET /teams`                                     |
+| `PagerDutyEscalation`   | `GET /escalation_policies`                       |
+| `PagerDutyService`      | `GET /services`                                  |
+| `OnCallShift`           | `GET /oncalls`                                   |
+| `PagerDutyIncident`     | `GET /incidents` + `GET /incidents/{id}/log_entries` |
+
+Edges emitted via `DocumentRef.metadata["edges"]`:
+
+- `incident -> service` (`FILED_AGAINST`)
+- `service  -> team`    (`OWNED_BY`)
+- `service  -> escalation` (`USES_ESCALATION`)
+- `escalation -> team`  (`OWNED_BY`)
+- `on-call shift -> user` (`ON_CALL`)
+- `incident -> escalation`, `incident -> assignee user`, `incident -> acknowledger user`
+
+## Required API token scopes
+
+PagerDuty supports two token kinds:
+
+| Token kind                | Recommended scopes |
+|---------------------------|---------------------|
+| **General Access Key** (account-scoped, REST API key) | Use a **read-only key** — sufficient for v1. |
+| **OAuth scopes** (if you mint a user-OAuth token instead) | `incidents.read`, `services.read`, `teams.read`, `escalation_policies.read`, `schedules.read`, `oncalls.read`, `users.read`, `abilities.read` |
+
+The connector only issues `GET` requests in v1 — no write scopes are
+required.  When v2 Action Mode lands the additional scopes
+(`incidents.write`) will be requested separately and gated by a config
+flag.
+
+## Configuration
+
+```yaml
+sources:
+  - name: pagerduty-prod
+    connector: pagerduty
+    config:
+      api_base_url: https://api.pagerduty.com   # or https://api.eu.pagerduty.com
+      team_ids: [PTEAM01]                       # optional filter
+      service_ids: [PSVC001]                    # optional filter for incidents
+      incident_lookback_days: 30
+      include_resolved_incidents: true
+    secrets:
+      api_token: ${PAGERDUTY_API_TOKEN}
+      # Inherited from the existing alerts/pagerduty webhook receiver:
+      webhook_secret: ${PAGERDUTY_WEBHOOK_SECRET}
+```
+
+## Webhooks
+
+The webhook receiver is **shared verbatim** with
+`alerts/pagerduty` — same signature verification, same secret rotation,
+same replay protection.  See [docs/connectors/alerts.md](alerts.md) for the
+webhook endpoint shape; nothing changes from the operator's perspective.
+
+## Rate limiting
+
+PagerDuty's REST API limits each token to **960 req/min** (account-scoped).
+The connector honours `Retry-After` on HTTP 429 with up to 5 retries and a
+60s cap per sleep.  Pagination uses `offset` + `more` with a page size of
+100 (the documented max).
+
+## ACL invariant
+
+Workspace identity is **always** derived from the owning `Source.tenant_id`
+row.  The connector never reads `tenant_id`, `account_id`, custom-detail
+keys, or any other payload field for tenancy decisions.
+
+## Tests
+
+See `tests/test_pagerduty_connector.py` for unit + integration coverage.
+HTTP responses are recorded as JSON fixtures under
+`tests/fixtures/pagerduty/` and replayed via `respx` — running the test
+suite twice produces byte-identical output (no live network).
+
+## Future work
+
+- [ ] v2 Action Mode: ack / snooze / resolve (#230)
+- [ ] Webhook-driven incremental sync (today: webhook payload normalised
+      separately by the alerts receiver; a future change can route
+      webhook deltas back into the catalog connector for hot-path updates)

--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -22,7 +22,7 @@ Registry::
 
 Built-in connectors (``git``, ``github_pr``, ``fs``, ``confluence``, ``notion``,
 ``slack``, ``jira``, ``k8s-agentic``, ``s3``, ``aws``, ``alerts``, ``otel``,
-``datadog``) are registered below and available immediately on import.
+``datadog``, ``pagerduty``) are registered below and available immediately on import.
 Third-party connectors call :func:`get_connector` after registering against
 the shared registry.
 """
@@ -69,6 +69,10 @@ from omniscience_connectors.otel import (
     canonical_trace_name,
     parse_otlp_payload,
 )
+from omniscience_connectors.pagerduty.connector import (
+    PagerDutyConfig,
+    PagerDutyConnector,
+)
 from omniscience_connectors.registry import (
     ConnectorRegistry,
     NotFoundError,
@@ -93,6 +97,7 @@ _registry.register(AwsConnector)
 _registry.register(AlertsConnector)
 _registry.register(OtelConnector)
 _registry.register(DatadogConnector)
+_registry.register(PagerDutyConnector)
 
 # Public alias for the shared registry instance (all built-ins pre-registered).
 default_registry: ConnectorRegistry = _registry
@@ -127,6 +132,8 @@ __all__ = [
     "OtelConfig",
     "OtelConnector",
     "OtelDecodeError",
+    "PagerDutyConfig",
+    "PagerDutyConnector",
     "ParsedSpan",
     "ParsedTrace",
     "ParsedTraces",

--- a/packages/connectors/src/omniscience_connectors/pagerduty/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/pagerduty/__init__.py
@@ -1,0 +1,44 @@
+"""PagerDuty full bi-directional source connector (issue #239).
+
+Read-only in v1 — bi-directional acks/snooze/resolve are deferred to v2
+Action Mode (issue #230).  The push-only webhook receiver in
+:mod:`omniscience_connectors.alerts` is reused unchanged; this package adds
+catalog discovery (services, teams, escalation policies, on-call schedules)
+and bitemporal incident sync.
+"""
+
+from omniscience_connectors.pagerduty.connector import (
+    PagerDutyConfig,
+    PagerDutyConnector,
+    canonical_escalation_name,
+    canonical_incident_name,
+    canonical_oncall_shift_name,
+    canonical_service_name,
+    canonical_team_name,
+    canonical_user_name,
+)
+from omniscience_connectors.pagerduty.models import (
+    IncidentLogEntry,
+    OnCallShift,
+    PagerDutyEscalation,
+    PagerDutyIncident,
+    PagerDutyService,
+    PagerDutyTeam,
+)
+
+__all__ = [
+    "IncidentLogEntry",
+    "OnCallShift",
+    "PagerDutyConfig",
+    "PagerDutyConnector",
+    "PagerDutyEscalation",
+    "PagerDutyIncident",
+    "PagerDutyService",
+    "PagerDutyTeam",
+    "canonical_escalation_name",
+    "canonical_incident_name",
+    "canonical_oncall_shift_name",
+    "canonical_service_name",
+    "canonical_team_name",
+    "canonical_user_name",
+]

--- a/packages/connectors/src/omniscience_connectors/pagerduty/connector.py
+++ b/packages/connectors/src/omniscience_connectors/pagerduty/connector.py
@@ -1,0 +1,978 @@
+"""PagerDuty full source connector (issue #239).
+
+Promotes the existing push-only :mod:`omniscience_connectors.alerts` PagerDuty
+webhook receiver into a fully fledged source connector that *also* pulls the
+PagerDuty catalog and incident timeline via the REST API.
+
+Scope
+-----
+Read-only in v1:
+
+* ``discover()`` enumerates services, teams, escalation policies and on-call
+  shifts.  Each returns one :class:`DocumentRef` per entity with the canonical
+  PagerDuty entity ID.
+* ``fetch()`` performs a bitemporal incident sync — pulls the incident
+  ``state`` plus the full ``log_entries`` timeline so downstream
+  ``resolve_incident`` can replay history at any point in wall time.
+* ``webhook_handler()`` delegates to the existing alerts/pagerduty receiver
+  so we keep one set of signature-verification code.
+
+Bi-directional write-back (acks/snooze/resolve) is deferred to v2 Action Mode
+— see issue #230.  The placeholders in this module raise
+:class:`NotImplementedError` with a clear pointer so callers fail loudly until
+the action plane lands.
+
+Edges emitted (via ``metadata['edges']``)
+-----------------------------------------
+* ``incident -> service`` (``FILED_AGAINST``)
+* ``service  -> team``    (``OWNED_BY``)
+* ``service  -> escalation`` (``USES_ESCALATION``)
+* ``escalation -> team``  (``OWNED_BY``)
+* ``on-call shift -> user`` (``ON_CALL``)
+
+ACL invariant (P0)
+------------------
+We never read ``tenant_id``, ``customer_id``, ``account_id`` or any other
+field from the PagerDuty payload for tenancy.  The ingest pipeline sets
+``workspace_id`` from the :class:`Source` row that owns the connector.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from collections.abc import AsyncIterator, Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any, ClassVar, Literal
+
+import httpx
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.alerts.webhook import AlertsWebhookHandler
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+)
+from omniscience_connectors.pagerduty.models import (
+    IncidentLogEntry,
+    OnCallShift,
+    PagerDutyEscalation,
+    PagerDutyIncident,
+    PagerDutyService,
+    PagerDutyTeam,
+)
+
+__all__ = [
+    "PagerDutyConfig",
+    "PagerDutyConnector",
+    "canonical_escalation_name",
+    "canonical_incident_name",
+    "canonical_oncall_shift_name",
+    "canonical_service_name",
+    "canonical_team_name",
+    "canonical_user_name",
+]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_API_BASE = "https://api.pagerduty.com"
+_PAGE_SIZE = 100
+"""PagerDuty REST list-endpoint maximum page size."""
+
+_MAX_RATE_LIMIT_RETRIES = 5
+"""Maximum 429-retry attempts before surrendering to the caller."""
+
+_MAX_RATE_LIMIT_SLEEP_SECONDS = 60
+"""Upper bound on a single ``Retry-After`` sleep to avoid hangs from bogus headers."""
+
+_DEFAULT_INCIDENT_LOOKBACK_DAYS = 30
+"""How many days of incidents ``discover()`` enumerates by default."""
+
+_USER_AGENT = "omniscience-pagerduty-connector/0.2.0"
+
+
+# ---------------------------------------------------------------------------
+# Public configuration
+# ---------------------------------------------------------------------------
+
+
+class PagerDutyConfig(BaseModel):
+    """Public configuration for the PagerDuty connector (no secrets).
+
+    The API token itself is supplied at call-time via ``secrets['api_token']``
+    and is NEVER read from this model.  ``webhook_secret`` likewise lives in
+    secrets and is consumed by the inherited alerts/pagerduty receiver.
+    """
+
+    api_base_url: str = _DEFAULT_API_BASE
+    """Override only for PagerDuty EU (``https://api.eu.pagerduty.com``) or
+    integration tests with a recorded fixture host."""
+
+    team_ids: list[str] = Field(default_factory=list)
+    """Optional filter — when non-empty, the connector restricts service/
+    escalation/schedule enumeration to these team IDs.  Empty = all teams
+    accessible to the API token."""
+
+    service_ids: list[str] = Field(default_factory=list)
+    """Optional filter for incident sync — when non-empty, only incidents
+    against these services are fetched."""
+
+    incident_lookback_days: int = _DEFAULT_INCIDENT_LOOKBACK_DAYS
+    """How many days of incident history to enumerate on each discover run.
+    Bitemporal log entries are always fetched in full for any incident yielded."""
+
+    include_resolved_incidents: bool = True
+    """When ``False``, ``discover()`` skips incidents in ``resolved`` state."""
+
+
+# ---------------------------------------------------------------------------
+# Canonical-name helpers (drive entity linking downstream)
+# ---------------------------------------------------------------------------
+
+
+def canonical_service_name(service_id: str) -> str:
+    """Return the canonical name for a PagerDuty service."""
+    return f"pagerduty://service/{service_id}"
+
+
+def canonical_team_name(team_id: str) -> str:
+    return f"pagerduty://team/{team_id}"
+
+
+def canonical_escalation_name(policy_id: str) -> str:
+    return f"pagerduty://escalation/{policy_id}"
+
+
+def canonical_oncall_shift_name(schedule_id: str, user_id: str, start: datetime) -> str:
+    """Stable name for an on-call shift block.
+
+    Schedules emit overlapping shifts across re-fetches; keying the canonical
+    name on ``(schedule, user, start)`` keeps deduplication idempotent.
+    """
+    return f"pagerduty://oncall/{schedule_id}/{user_id}/{int(start.timestamp())}"
+
+
+def canonical_user_name(user_id: str) -> str:
+    return f"pagerduty://user/{user_id}"
+
+
+def canonical_incident_name(incident_id: str) -> str:
+    return f"pagerduty://incident/{incident_id}"
+
+
+# ---------------------------------------------------------------------------
+# Auth / HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_auth_headers(secrets: Mapping[str, str]) -> dict[str, str]:
+    """Build PagerDuty REST API headers (Token auth + JSON-only).
+
+    PagerDuty accepts a REST API key in the ``Authorization`` header as
+    ``Token token=<key>``.  We require an account-level read-only token; the
+    required scopes are documented in ``docs/connectors/pagerduty.md``.
+    """
+    token = (secrets.get("api_token") or "").strip()
+    if not token:
+        raise ValueError(
+            "PagerDuty secrets must contain 'api_token' "
+            "(account-level REST API key — see docs/connectors/pagerduty.md)."
+        )
+    return {
+        "Authorization": f"Token token={token}",
+        "Accept": "application/vnd.pagerduty+json;version=2",
+        "User-Agent": _USER_AGENT,
+    }
+
+
+def _parse_iso8601(value: str | None) -> datetime | None:
+    """Parse a PagerDuty ISO-8601 timestamp; ``None`` on missing/invalid input."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+async def _sleep_until_rate_limit_reset(response: httpx.Response) -> bool:
+    """If PagerDuty returned 429, honour ``Retry-After`` and report a retry.
+
+    PagerDuty's REST API returns HTTP 429 with a ``Retry-After`` header (whole
+    seconds) when an API key exceeds 960 req/min (the documented hard cap).
+    Returns ``True`` when a sleep happened and the caller should retry,
+    ``False`` otherwise.  Mirrors the github_pr connector pattern.
+    """
+    if response.status_code != 429:
+        return False
+    retry_after = response.headers.get("Retry-After", "")
+    try:
+        sleep_for = float(retry_after) if retry_after else 1.0
+    except ValueError:
+        sleep_for = 1.0
+    sleep_for = max(0.0, min(sleep_for, float(_MAX_RATE_LIMIT_SLEEP_SECONDS)))
+    logger.warning(
+        "pagerduty.rate_limited",
+        extra={"sleep_seconds": int(sleep_for), "retry_after_header": retry_after},
+    )
+    await asyncio.sleep(sleep_for)
+    return True
+
+
+async def _request_with_rate_limit(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    params: Mapping[str, Any] | None = None,
+) -> httpx.Response:
+    """Issue a request, transparently waiting on PagerDuty 429s."""
+    response: httpx.Response | None = None
+    for attempt in range(_MAX_RATE_LIMIT_RETRIES + 1):
+        response = await client.request(method, url, params=dict(params or {}))
+        if response.status_code == 429:
+            slept = await _sleep_until_rate_limit_reset(response)
+            if slept and attempt < _MAX_RATE_LIMIT_RETRIES:
+                continue
+        return response
+    assert response is not None  # noqa: S101 — loop invariant
+    return response
+
+
+async def _paginate(
+    client: httpx.AsyncClient,
+    url: str,
+    *,
+    params: Mapping[str, Any] | None = None,
+) -> AsyncIterator[dict[str, Any]]:
+    """Paginate a PagerDuty list endpoint using ``offset`` + ``more``.
+
+    PagerDuty's list endpoints return ``{"<resource>": [...], "more": bool,
+    "offset": int, "limit": int}``; iterate until ``more`` is false.
+    """
+    offset = 0
+    while True:
+        query: dict[str, Any] = dict(params or {})
+        query["offset"] = offset
+        query["limit"] = _PAGE_SIZE
+        response = await _request_with_rate_limit(client, "GET", url, params=query)
+        response.raise_for_status()
+        body = response.json()
+        if not isinstance(body, dict):
+            return
+        yield body
+        more = bool(body.get("more"))
+        if not more:
+            return
+        offset += int(body.get("limit") or _PAGE_SIZE)
+
+
+# ---------------------------------------------------------------------------
+# JSON shape -> model adapters
+# ---------------------------------------------------------------------------
+
+
+def _team_from_json(payload: dict[str, Any]) -> PagerDutyTeam | None:
+    pid = str(payload.get("id") or "")
+    if not pid:
+        return None
+    return PagerDutyTeam(
+        id=pid,
+        name=str(payload.get("name") or pid),
+        summary=str(payload["summary"]) if payload.get("summary") else None,
+        html_url=str(payload["html_url"]) if payload.get("html_url") else None,
+    )
+
+
+def _service_from_json(payload: dict[str, Any]) -> PagerDutyService | None:
+    sid = str(payload.get("id") or "")
+    if not sid:
+        return None
+    teams = payload.get("teams") or []
+    team_ids = [str(t.get("id")) for t in teams if isinstance(t, dict) and t.get("id")]
+    esc_obj = payload.get("escalation_policy") or {}
+    esc_id = str(esc_obj.get("id")) if isinstance(esc_obj, dict) and esc_obj.get("id") else None
+    return PagerDutyService(
+        id=sid,
+        name=str(payload.get("name") or sid),
+        status=str(payload["status"]) if payload.get("status") else None,
+        description=(str(payload["description"]) if payload.get("description") else None),
+        team_ids=team_ids,
+        escalation_policy_id=esc_id,
+        html_url=str(payload["html_url"]) if payload.get("html_url") else None,
+    )
+
+
+def _escalation_from_json(payload: dict[str, Any]) -> PagerDutyEscalation | None:
+    pid = str(payload.get("id") or "")
+    if not pid:
+        return None
+    teams = payload.get("teams") or []
+    team_ids = [str(t.get("id")) for t in teams if isinstance(t, dict) and t.get("id")]
+    rules = payload.get("escalation_rules") or []
+    return PagerDutyEscalation(
+        id=pid,
+        name=str(payload.get("name") or pid),
+        summary=str(payload["summary"]) if payload.get("summary") else None,
+        description=(str(payload["description"]) if payload.get("description") else None),
+        team_ids=team_ids,
+        num_loops=int(payload.get("num_loops") or 0),
+        rule_count=len(rules) if isinstance(rules, list) else 0,
+        html_url=str(payload["html_url"]) if payload.get("html_url") else None,
+    )
+
+
+def _log_entry_from_json(payload: dict[str, Any]) -> IncidentLogEntry | None:
+    lid = str(payload.get("id") or "")
+    if not lid:
+        return None
+    created_at = _parse_iso8601(str(payload.get("created_at") or "")) or datetime.now(tz=UTC)
+    agent = payload.get("agent") or {}
+    channel = payload.get("channel") or {}
+    return IncidentLogEntry(
+        id=lid,
+        type=str(payload.get("type") or "unknown_log_entry"),
+        created_at=created_at,
+        summary=str(payload["summary"]) if payload.get("summary") else None,
+        agent_type=(
+            str(agent.get("type")) if isinstance(agent, dict) and agent.get("type") else None
+        ),
+        agent_id=(str(agent.get("id")) if isinstance(agent, dict) and agent.get("id") else None),
+        channel_type=(
+            str(channel.get("type")) if isinstance(channel, dict) and channel.get("type") else None
+        ),
+        raw=payload,
+    )
+
+
+def _incident_from_json(
+    payload: dict[str, Any],
+    log_entries_payload: list[dict[str, Any]] | None = None,
+) -> PagerDutyIncident | None:
+    iid = str(payload.get("id") or "")
+    if not iid:
+        return None
+    service = payload.get("service") or {}
+    service_id = str(service.get("id")) if isinstance(service, dict) and service.get("id") else ""
+    if not service_id:
+        return None
+
+    esc = payload.get("escalation_policy") or {}
+    esc_id = str(esc.get("id")) if isinstance(esc, dict) and esc.get("id") else None
+
+    status_raw = str(payload.get("status") or "triggered").lower()
+    status: Literal["triggered", "acknowledged", "resolved"] = (
+        "triggered" if status_raw not in ("acknowledged", "resolved") else status_raw  # type: ignore[assignment]
+    )
+
+    urgency_raw = str(payload.get("urgency") or "").lower() or None
+    urgency: Literal["high", "low"] | None = (
+        urgency_raw if urgency_raw in ("high", "low") else None  # type: ignore[assignment]
+    )
+
+    assignments = payload.get("assignments") or []
+    assignee_ids = [
+        str((a.get("assignee") or {}).get("id"))
+        for a in assignments
+        if isinstance(a, dict)
+        and isinstance(a.get("assignee"), dict)
+        and (a.get("assignee") or {}).get("id")
+    ]
+    acks = payload.get("acknowledgements") or []
+    ack_ids = [
+        str((a.get("acknowledger") or {}).get("id"))
+        for a in acks
+        if isinstance(a, dict)
+        and isinstance(a.get("acknowledger"), dict)
+        and (a.get("acknowledger") or {}).get("id")
+    ]
+
+    created_at = _parse_iso8601(str(payload.get("created_at") or "")) or datetime.now(tz=UTC)
+
+    log_models: list[IncidentLogEntry] = []
+    for raw_entry in log_entries_payload or []:
+        entry = _log_entry_from_json(raw_entry)
+        if entry is not None:
+            log_models.append(entry)
+
+    return PagerDutyIncident(
+        id=iid,
+        incident_number=int(payload.get("incident_number") or 0),
+        title=str(payload.get("title") or payload.get("summary") or ""),
+        status=status,
+        urgency=urgency,
+        created_at=created_at,
+        updated_at=_parse_iso8601(str(payload.get("last_status_change_at") or "")),
+        resolved_at=_parse_iso8601(str(payload.get("resolved_at") or "")),
+        service_id=service_id,
+        escalation_policy_id=esc_id,
+        assignee_user_ids=assignee_ids,
+        acknowledger_user_ids=ack_ids,
+        log_entries=log_models,
+        html_url=str(payload["html_url"]) if payload.get("html_url") else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DocumentRef builders
+# ---------------------------------------------------------------------------
+
+
+def _ref_for_team(team: PagerDutyTeam) -> DocumentRef:
+    name = canonical_team_name(team.id)
+    return DocumentRef(
+        external_id=name,
+        uri=team.html_url or name,
+        metadata={
+            "kind": "PagerDutyTeam",
+            "name": name,
+            "pagerduty_team_id": team.id,
+            "display_name": team.name,
+            "summary": team.summary,
+        },
+    )
+
+
+def _ref_for_service(service: PagerDutyService) -> DocumentRef:
+    name = canonical_service_name(service.id)
+    edges: list[dict[str, str]] = []
+    for tid in service.team_ids:
+        edges.append({"type": "OWNED_BY", "from": name, "to": canonical_team_name(tid)})
+    if service.escalation_policy_id:
+        edges.append(
+            {
+                "type": "USES_ESCALATION",
+                "from": name,
+                "to": canonical_escalation_name(service.escalation_policy_id),
+            }
+        )
+    return DocumentRef(
+        external_id=name,
+        uri=service.html_url or name,
+        metadata={
+            "kind": "PagerDutyService",
+            "name": name,
+            "pagerduty_service_id": service.id,
+            "display_name": service.name,
+            "status": service.status,
+            "description": service.description,
+            "team_ids": service.team_ids,
+            "escalation_policy_id": service.escalation_policy_id,
+            "edges": edges,
+        },
+    )
+
+
+def _ref_for_escalation(escalation: PagerDutyEscalation) -> DocumentRef:
+    name = canonical_escalation_name(escalation.id)
+    edges: list[dict[str, str]] = [
+        {"type": "OWNED_BY", "from": name, "to": canonical_team_name(tid)}
+        for tid in escalation.team_ids
+    ]
+    return DocumentRef(
+        external_id=name,
+        uri=escalation.html_url or name,
+        metadata={
+            "kind": "PagerDutyEscalation",
+            "name": name,
+            "pagerduty_escalation_id": escalation.id,
+            "display_name": escalation.name,
+            "summary": escalation.summary,
+            "description": escalation.description,
+            "team_ids": escalation.team_ids,
+            "num_loops": escalation.num_loops,
+            "rule_count": escalation.rule_count,
+            "edges": edges,
+        },
+    )
+
+
+def _ref_for_oncall_shift(shift: OnCallShift) -> DocumentRef:
+    name = canonical_oncall_shift_name(shift.schedule_id, shift.user_id, shift.start)
+    edges: list[dict[str, str]] = [
+        {"type": "ON_CALL", "from": name, "to": canonical_user_name(shift.user_id)},
+    ]
+    if shift.escalation_policy_id:
+        edges.append(
+            {
+                "type": "FOR_ESCALATION",
+                "from": name,
+                "to": canonical_escalation_name(shift.escalation_policy_id),
+            }
+        )
+    return DocumentRef(
+        external_id=name,
+        uri=shift.html_url or name,
+        updated_at=shift.start,
+        metadata={
+            "kind": "OnCallShift",
+            "name": name,
+            "schedule_id": shift.schedule_id,
+            "schedule_name": shift.schedule_name,
+            "user_id": shift.user_id,
+            "user_name": shift.user_name,
+            "user_email": shift.user_email,
+            "escalation_policy_id": shift.escalation_policy_id,
+            "escalation_level": shift.escalation_level,
+            "start": shift.start.isoformat(),
+            "end": shift.end.isoformat(),
+            "edges": edges,
+        },
+    )
+
+
+def _ref_for_incident(incident: PagerDutyIncident) -> DocumentRef:
+    name = canonical_incident_name(incident.id)
+    # Stable fingerprint changes whenever the timeline grows or status changes,
+    # so the downstream pipeline triggers a re-ingest only when needed.
+    fingerprint_src = (
+        f"{incident.id}:{incident.status}:{len(incident.log_entries)}:"
+        f"{incident.updated_at.isoformat() if incident.updated_at else ''}"
+    )
+    external_id = hashlib.sha1(fingerprint_src.encode()).hexdigest()  # noqa: S324
+    return DocumentRef(
+        external_id=external_id,
+        uri=incident.html_url or name,
+        updated_at=incident.updated_at or incident.created_at,
+        metadata={
+            "kind": "PagerDutyIncident",
+            "name": name,
+            "pagerduty_incident_id": incident.id,
+            "incident_number": incident.incident_number,
+            "title": incident.title,
+            "status": incident.status,
+            "urgency": incident.urgency,
+            "service_id": incident.service_id,
+            "escalation_policy_id": incident.escalation_policy_id,
+            "created_at": incident.created_at.isoformat(),
+            "updated_at": (incident.updated_at.isoformat() if incident.updated_at else None),
+            "resolved_at": (incident.resolved_at.isoformat() if incident.resolved_at else None),
+            "assignee_user_ids": incident.assignee_user_ids,
+            "acknowledger_user_ids": incident.acknowledger_user_ids,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+class PagerDutyConnector(Connector):
+    """Full PagerDuty source connector.
+
+    Pull-style discovery for the catalog (teams, services, escalation
+    policies, on-call schedules) and bitemporal incident sync.  Webhook
+    handling is delegated unchanged to the existing alerts/pagerduty
+    receiver — see :meth:`webhook_handler`.
+
+    Bi-directional write-back (acks, snooze, resolve) is **deferred to v2
+    Action Mode** — tracking issue #230.  The :meth:`acknowledge` /
+    :meth:`snooze` / :meth:`resolve` placeholders raise
+    :class:`NotImplementedError` until the action plane lands.
+    """
+
+    connector_type: ClassVar[str] = "pagerduty"
+    config_schema: ClassVar[type[BaseModel]] = PagerDutyConfig
+
+    # ---- lifecycle --------------------------------------------------------
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Verify the token by calling the cheapest authenticated endpoint."""
+        cfg: PagerDutyConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.api_base_url.rstrip("/")
+        async with httpx.AsyncClient(headers=headers, timeout=15.0) as client:
+            resp = await _request_with_rate_limit(
+                client,
+                "GET",
+                f"{base}/abilities",
+            )
+            if resp.status_code == 401:
+                raise PermissionError(
+                    "PagerDuty authentication failed — invalid 'api_token' secret."
+                )
+            if resp.status_code == 403:
+                raise PermissionError(
+                    "PagerDuty token lacks required scopes — see docs/connectors/pagerduty.md."
+                )
+            resp.raise_for_status()
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield catalog entities and recent incidents as :class:`DocumentRef`s.
+
+        Order: teams -> escalation policies -> services -> on-call shifts ->
+        incidents.  Earlier entities are emitted first so the downstream
+        pipeline can resolve cross-edges (services reference teams /
+        escalation policies; incidents reference services) at link time.
+        """
+        cfg: PagerDutyConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.api_base_url.rstrip("/")
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            async for ref in self._discover_teams(client, base, cfg):
+                yield ref
+            async for ref in self._discover_escalations(client, base, cfg):
+                yield ref
+            async for ref in self._discover_services(client, base, cfg):
+                yield ref
+            async for ref in self._discover_oncall_shifts(client, base, cfg):
+                yield ref
+            async for ref in self._discover_incidents(client, base, cfg):
+                yield ref
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch the full incident state + bitemporal log timeline.
+
+        Only ``kind == 'PagerDutyIncident'`` refs require a fetch — catalog
+        entities arrive complete from discover.  For any other kind we return
+        the metadata serialised as JSON so the pipeline has a single uniform
+        artefact per ref.
+        """
+        cfg: PagerDutyConfig = config  # type: ignore[assignment]
+        headers = _build_auth_headers(secrets)
+        base = cfg.api_base_url.rstrip("/")
+        kind = str(ref.metadata.get("kind") or "")
+
+        if kind != "PagerDutyIncident":
+            import json
+
+            payload = json.dumps(ref.metadata, sort_keys=True, default=str).encode("utf-8")
+            return FetchedDocument(
+                ref=ref,
+                content_bytes=payload,
+                content_type="application/json",
+            )
+
+        incident_id = str(ref.metadata.get("pagerduty_incident_id") or "")
+        if not incident_id:
+            raise ValueError("PagerDutyIncident ref missing 'pagerduty_incident_id' in metadata.")
+
+        async with httpx.AsyncClient(headers=headers, timeout=30.0) as client:
+            inc_resp = await _request_with_rate_limit(
+                client, "GET", f"{base}/incidents/{incident_id}"
+            )
+            inc_resp.raise_for_status()
+            inc_body = inc_resp.json().get("incident") or {}
+
+            log_entries: list[dict[str, Any]] = []
+            async for page in _paginate(
+                client,
+                f"{base}/incidents/{incident_id}/log_entries",
+                params={"include[]": "channels", "is_overview": "false"},
+            ):
+                entries = page.get("log_entries") or []
+                if isinstance(entries, list):
+                    log_entries.extend(e for e in entries if isinstance(e, dict))
+
+        incident = _incident_from_json(inc_body, log_entries)
+        if incident is None:
+            raise RuntimeError(
+                f"PagerDuty returned an unparseable incident payload for {incident_id!r}."
+            )
+
+        enriched_ref = _ref_for_incident(incident)
+        # Append the per-log-entry edges (incident -> agent user, etc.) into
+        # the metadata so the linker can wire them up.
+        edges: list[dict[str, str]] = [
+            {
+                "type": "FILED_AGAINST",
+                "from": canonical_incident_name(incident.id),
+                "to": canonical_service_name(incident.service_id),
+            }
+        ]
+        if incident.escalation_policy_id:
+            edges.append(
+                {
+                    "type": "USES_ESCALATION",
+                    "from": canonical_incident_name(incident.id),
+                    "to": canonical_escalation_name(incident.escalation_policy_id),
+                }
+            )
+        for uid in incident.assignee_user_ids:
+            edges.append(
+                {
+                    "type": "ASSIGNED_TO",
+                    "from": canonical_incident_name(incident.id),
+                    "to": canonical_user_name(uid),
+                }
+            )
+        for uid in incident.acknowledger_user_ids:
+            edges.append(
+                {
+                    "type": "ACKNOWLEDGED_BY",
+                    "from": canonical_incident_name(incident.id),
+                    "to": canonical_user_name(uid),
+                }
+            )
+        enriched_ref.metadata["edges"] = edges
+        enriched_ref.metadata["log_entries"] = [
+            {
+                "id": e.id,
+                "type": e.type,
+                "created_at": e.created_at.isoformat(),
+                "summary": e.summary,
+                "agent_type": e.agent_type,
+                "agent_id": e.agent_id,
+                "channel_type": e.channel_type,
+            }
+            for e in incident.log_entries
+        ]
+
+        markdown = _render_incident_markdown(incident)
+        return FetchedDocument(
+            ref=enriched_ref,
+            content_bytes=markdown.encode("utf-8"),
+            content_type="text/markdown",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        """Reuse the existing alerts/pagerduty webhook receiver verbatim.
+
+        The signature verification, multi-secret rotation and replay-
+        protection patterns live in
+        :class:`omniscience_connectors.alerts.webhook.AlertsWebhookHandler`
+        — we do not duplicate them here.  Two providers (PagerDuty + Datadog)
+        share that handler today; the dispatcher inside it selects the
+        PagerDuty path when ``X-PagerDuty-Signature`` is present.
+        """
+        return AlertsWebhookHandler()
+
+    # ---- v2 Action Mode placeholders -- see issue #230 --------------------
+
+    async def acknowledge(self, incident_id: str) -> None:
+        """Acknowledge an incident — DEFERRED to v2 Action Mode (issue #230)."""
+        raise NotImplementedError(
+            "PagerDuty acknowledge() is deferred to v2 Action Mode (issue #230). "
+            "v1 is read-only by design."
+        )
+
+    async def snooze(self, incident_id: str, duration_seconds: int) -> None:
+        """Snooze an incident — DEFERRED to v2 Action Mode (issue #230)."""
+        raise NotImplementedError(
+            "PagerDuty snooze() is deferred to v2 Action Mode (issue #230). "
+            "v1 is read-only by design."
+        )
+
+    async def resolve(self, incident_id: str) -> None:
+        """Resolve an incident — DEFERRED to v2 Action Mode (issue #230)."""
+        raise NotImplementedError(
+            "PagerDuty resolve() is deferred to v2 Action Mode (issue #230). "
+            "v1 is read-only by design."
+        )
+
+    # ---- internal discover stages ----------------------------------------
+
+    async def _discover_teams(
+        self,
+        client: httpx.AsyncClient,
+        base: str,
+        cfg: PagerDutyConfig,
+    ) -> AsyncIterator[DocumentRef]:
+        params: dict[str, Any] = {}
+        if cfg.team_ids:
+            # PagerDuty supports ``ids[]`` repeat for filter.
+            params["ids[]"] = cfg.team_ids
+        async for page in _paginate(client, f"{base}/teams", params=params):
+            for raw in page.get("teams") or []:
+                if not isinstance(raw, dict):
+                    continue
+                model = _team_from_json(raw)
+                if model is not None:
+                    yield _ref_for_team(model)
+
+    async def _discover_escalations(
+        self,
+        client: httpx.AsyncClient,
+        base: str,
+        cfg: PagerDutyConfig,
+    ) -> AsyncIterator[DocumentRef]:
+        params: dict[str, Any] = {}
+        if cfg.team_ids:
+            params["team_ids[]"] = cfg.team_ids
+        async for page in _paginate(client, f"{base}/escalation_policies", params=params):
+            for raw in page.get("escalation_policies") or []:
+                if not isinstance(raw, dict):
+                    continue
+                model = _escalation_from_json(raw)
+                if model is not None:
+                    yield _ref_for_escalation(model)
+
+    async def _discover_services(
+        self,
+        client: httpx.AsyncClient,
+        base: str,
+        cfg: PagerDutyConfig,
+    ) -> AsyncIterator[DocumentRef]:
+        params: dict[str, Any] = {"include[]": "escalation_policies"}
+        if cfg.team_ids:
+            params["team_ids[]"] = cfg.team_ids
+        async for page in _paginate(client, f"{base}/services", params=params):
+            for raw in page.get("services") or []:
+                if not isinstance(raw, dict):
+                    continue
+                model = _service_from_json(raw)
+                if model is not None:
+                    yield _ref_for_service(model)
+
+    async def _discover_oncall_shifts(
+        self,
+        client: httpx.AsyncClient,
+        base: str,
+        cfg: PagerDutyConfig,
+    ) -> AsyncIterator[DocumentRef]:
+        """Pull the live on-call assignments and yield one shift per row.
+
+        We use ``/oncalls`` (not ``/schedules/{id}/users``) because it returns
+        the user + escalation policy + (start, end) tuple in a single call
+        and respects team filters.  PagerDuty caps each shift query at the
+        instantaneous-now window unless ``since``/``until`` are passed; we
+        request the next 7 days of coverage so shift handovers are captured.
+        """
+        params: dict[str, Any] = {
+            "since": _utc_now_iso(),
+            "until": _utc_offset_iso(days=7),
+        }
+        if cfg.team_ids:
+            params["team_ids[]"] = cfg.team_ids
+        async for page in _paginate(client, f"{base}/oncalls", params=params):
+            for raw in page.get("oncalls") or []:
+                if not isinstance(raw, dict):
+                    continue
+                shift = _oncall_from_json(raw)
+                if shift is not None:
+                    yield _ref_for_oncall_shift(shift)
+
+    async def _discover_incidents(
+        self,
+        client: httpx.AsyncClient,
+        base: str,
+        cfg: PagerDutyConfig,
+    ) -> AsyncIterator[DocumentRef]:
+        since = _utc_offset_iso(days=-cfg.incident_lookback_days)
+        statuses = ["triggered", "acknowledged"]
+        if cfg.include_resolved_incidents:
+            statuses.append("resolved")
+        params: dict[str, Any] = {
+            "since": since,
+            "statuses[]": statuses,
+        }
+        if cfg.service_ids:
+            params["service_ids[]"] = cfg.service_ids
+        if cfg.team_ids:
+            params["team_ids[]"] = cfg.team_ids
+        async for page in _paginate(client, f"{base}/incidents", params=params):
+            for raw in page.get("incidents") or []:
+                if not isinstance(raw, dict):
+                    continue
+                incident = _incident_from_json(raw)
+                if incident is not None:
+                    yield _ref_for_incident(incident)
+
+
+# ---------------------------------------------------------------------------
+# Module-private helpers (continued)
+# ---------------------------------------------------------------------------
+
+
+def _oncall_from_json(payload: dict[str, Any]) -> OnCallShift | None:
+    schedule = payload.get("schedule") or {}
+    user = payload.get("user") or {}
+    escalation = payload.get("escalation_policy") or {}
+    if not isinstance(schedule, dict) or not isinstance(user, dict):
+        return None
+    sid = str(schedule.get("id") or "")
+    uid = str(user.get("id") or "")
+    if not sid or not uid:
+        return None
+    start = _parse_iso8601(str(payload.get("start") or ""))
+    end = _parse_iso8601(str(payload.get("end") or ""))
+    if start is None or end is None:
+        return None
+    return OnCallShift(
+        schedule_id=sid,
+        schedule_name=str(schedule.get("summary")) if schedule.get("summary") else None,
+        user_id=uid,
+        user_name=str(user.get("summary")) if user.get("summary") else None,
+        user_email=str(user["email"]) if isinstance(user, dict) and user.get("email") else None,
+        escalation_policy_id=(
+            str(escalation.get("id"))
+            if isinstance(escalation, dict) and escalation.get("id")
+            else None
+        ),
+        escalation_level=(
+            int(payload["escalation_level"])
+            if isinstance(payload.get("escalation_level"), int)
+            else None
+        ),
+        start=start,
+        end=end,
+        html_url=str(schedule["html_url"]) if schedule.get("html_url") else None,
+    )
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _utc_offset_iso(*, days: int) -> str:
+    return (datetime.now(tz=UTC) + timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _render_incident_markdown(incident: PagerDutyIncident) -> str:
+    """Render an incident + timeline as Markdown for downstream chunking."""
+    lines: list[str] = [
+        f"# Incident #{incident.incident_number}: {incident.title}",
+        "",
+        f"- ID: {incident.id}",
+        f"- Status: {incident.status}",
+    ]
+    if incident.urgency:
+        lines.append(f"- Urgency: {incident.urgency}")
+    lines.append(f"- Service: {canonical_service_name(incident.service_id)}")
+    if incident.escalation_policy_id:
+        lines.append(f"- Escalation: {canonical_escalation_name(incident.escalation_policy_id)}")
+    lines.append(f"- Created at: {incident.created_at.isoformat()}")
+    if incident.updated_at:
+        lines.append(f"- Updated at: {incident.updated_at.isoformat()}")
+    if incident.resolved_at:
+        lines.append(f"- Resolved at: {incident.resolved_at.isoformat()}")
+    if incident.assignee_user_ids:
+        lines.append(
+            "- Assignees: " + ", ".join(canonical_user_name(u) for u in incident.assignee_user_ids)
+        )
+    if incident.acknowledger_user_ids:
+        lines.append(
+            "- Acknowledgers: "
+            + ", ".join(canonical_user_name(u) for u in incident.acknowledger_user_ids)
+        )
+
+    if incident.log_entries:
+        lines.append("")
+        lines.append("## Timeline")
+        lines.append("")
+        for entry in incident.log_entries:
+            ts = entry.created_at.isoformat()
+            who = entry.agent_id or entry.agent_type or "system"
+            summary = entry.summary or entry.type
+            lines.append(f"- `{ts}` [{entry.type}] {who}: {summary}")
+
+    return "\n".join(lines) + "\n"

--- a/packages/connectors/src/omniscience_connectors/pagerduty/models.py
+++ b/packages/connectors/src/omniscience_connectors/pagerduty/models.py
@@ -1,0 +1,188 @@
+"""Entity models for the PagerDuty full connector.
+
+Distinct from the push-only :mod:`omniscience_connectors.alerts.connector`
+``NormalizedAlert`` shape: this module describes the *catalog* (services,
+teams, escalation policies, on-call schedules) and *incidents* that the
+pull-based connector enumerates via the REST API.
+
+ACL invariant (P0)
+------------------
+Like all source connectors, none of these models read or trust tenancy
+fields from PagerDuty payloads.  Workspace identity is set upstream from
+the :class:`Source` row's ``tenant_id`` at ingest time; the values carried
+here are forensic context only.
+
+Bi-directional write-back (acks, snoozes, resolves) is **deferred to v2**
+Action Mode.  See issue #230 and the comment in
+:mod:`omniscience_connectors.pagerduty.connector` for the migration plan.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "IncidentLogEntry",
+    "OnCallShift",
+    "PagerDutyEscalation",
+    "PagerDutyIncident",
+    "PagerDutyService",
+    "PagerDutyTeam",
+]
+
+
+# ---------------------------------------------------------------------------
+# Catalog entities
+# ---------------------------------------------------------------------------
+
+
+class PagerDutyTeam(BaseModel):
+    """A PagerDuty team — owns services and escalation policies."""
+
+    id: str
+    """Stable PagerDuty team ID (e.g. ``PXXXXXX``)."""
+
+    name: str
+    """Human-readable team name."""
+
+    summary: str | None = None
+    """Short description as returned by the REST API."""
+
+    html_url: str | None = None
+    """Web URL pointing at the team in the PagerDuty UI."""
+
+
+class PagerDutyService(BaseModel):
+    """A PagerDuty service — the object incidents are filed against."""
+
+    id: str
+    """Stable PagerDuty service ID."""
+
+    name: str
+    """Human-readable service name."""
+
+    status: str | None = None
+    """Service status (``active``, ``warning``, ``critical``, ``maintenance``, ``disabled``)."""
+
+    description: str | None = None
+
+    team_ids: list[str] = Field(default_factory=list)
+    """IDs of the teams that own this service.  Drives the
+    ``service → team`` edge emitted by the connector."""
+
+    escalation_policy_id: str | None = None
+    """ID of the escalation policy attached to this service.  Drives the
+    ``service → escalation`` edge."""
+
+    html_url: str | None = None
+
+
+class PagerDutyEscalation(BaseModel):
+    """A PagerDuty escalation policy — ordered list of escalation rules."""
+
+    id: str
+    name: str
+    summary: str | None = None
+    description: str | None = None
+    team_ids: list[str] = Field(default_factory=list)
+    num_loops: int = 0
+    """Number of times the policy loops if nobody acknowledges."""
+
+    rule_count: int = 0
+    """Number of escalation rules (delay tiers) in the policy."""
+
+    html_url: str | None = None
+
+
+class OnCallShift(BaseModel):
+    """A single on-call shift block from a PagerDuty schedule.
+
+    Conceptually maps to one ``(user, escalation_policy, start, end)``
+    interval — the unit that drives the ``on-call shift → user`` edge.
+    """
+
+    schedule_id: str
+    """ID of the parent schedule."""
+
+    schedule_name: str | None = None
+
+    user_id: str
+    """PagerDuty user ID who is on-call during this shift."""
+
+    user_name: str | None = None
+
+    user_email: str | None = None
+    """Email of the on-call user.  Forensic context only; never used for tenancy."""
+
+    escalation_policy_id: str | None = None
+    """Escalation policy that resolved this on-call shift, if available."""
+
+    escalation_level: int | None = None
+    """1-based escalation level within the policy."""
+
+    start: datetime
+    """Shift start (UTC)."""
+
+    end: datetime
+    """Shift end (UTC)."""
+
+    html_url: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Incident state (bitemporal)
+# ---------------------------------------------------------------------------
+
+
+IncidentStatus = Literal["triggered", "acknowledged", "resolved"]
+
+
+class IncidentLogEntry(BaseModel):
+    """One immutable line of the PagerDuty incident timeline.
+
+    Log entries cover every state transition: triggered, acknowledged,
+    notified, escalated, snoozed, resolved, annotated.  We carry them
+    verbatim (modulo type-shape) to support bitemporal replay downstream.
+    """
+
+    id: str
+    type: str
+    """PagerDuty log-entry ``type`` (e.g. ``trigger_log_entry``)."""
+
+    created_at: datetime
+    """Wall-clock time the entry was recorded at PagerDuty (UTC)."""
+
+    summary: str | None = None
+    agent_type: str | None = None
+    """Who/what produced the entry — ``user``, ``service``, ``api``, ``escalation_policy``…"""
+
+    agent_id: str | None = None
+    channel_type: str | None = None
+    raw: dict[str, Any] = Field(default_factory=dict)
+    """Original log entry preserved for forensics."""
+
+
+class PagerDutyIncident(BaseModel):
+    """A PagerDuty incident — the bitemporally synced root entity."""
+
+    id: str
+    incident_number: int
+    title: str
+    status: IncidentStatus
+    urgency: Literal["high", "low"] | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+    resolved_at: datetime | None = None
+    service_id: str
+    """Service the incident is filed against — drives ``incident → service`` edge."""
+
+    escalation_policy_id: str | None = None
+    """Effective escalation policy at the time of capture."""
+
+    assignee_user_ids: list[str] = Field(default_factory=list)
+    acknowledger_user_ids: list[str] = Field(default_factory=list)
+    log_entries: list[IncidentLogEntry] = Field(default_factory=list)
+    html_url: str | None = None

--- a/tests/fixtures/pagerduty/abilities.json
+++ b/tests/fixtures/pagerduty/abilities.json
@@ -1,0 +1,8 @@
+{
+  "abilities": [
+    "preview_incident_alerts",
+    "read_only_users",
+    "teams",
+    "service_dependencies"
+  ]
+}

--- a/tests/fixtures/pagerduty/escalation_policies.json
+++ b/tests/fixtures/pagerduty/escalation_policies.json
@@ -1,0 +1,38 @@
+{
+  "escalation_policies": [
+    {
+      "id": "PESC001",
+      "type": "escalation_policy",
+      "summary": "Platform on-call",
+      "name": "Platform on-call",
+      "description": "Tiered platform on-call escalation",
+      "num_loops": 2,
+      "teams": [
+        {"id": "PTEAM01", "type": "team_reference", "summary": "Platform SRE"}
+      ],
+      "escalation_rules": [
+        {"id": "PR1", "escalation_delay_in_minutes": 5, "targets": []},
+        {"id": "PR2", "escalation_delay_in_minutes": 15, "targets": []}
+      ],
+      "html_url": "https://acme.pagerduty.com/escalation_policies/PESC001"
+    },
+    {
+      "id": "PESC002",
+      "type": "escalation_policy",
+      "summary": "Payments on-call",
+      "name": "Payments on-call",
+      "description": "Payments escalation policy",
+      "num_loops": 1,
+      "teams": [
+        {"id": "PTEAM02", "type": "team_reference", "summary": "Payments"}
+      ],
+      "escalation_rules": [
+        {"id": "PR3", "escalation_delay_in_minutes": 10, "targets": []}
+      ],
+      "html_url": "https://acme.pagerduty.com/escalation_policies/PESC002"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "more": false
+}

--- a/tests/fixtures/pagerduty/incident_PINC0001.json
+++ b/tests/fixtures/pagerduty/incident_PINC0001.json
@@ -1,0 +1,21 @@
+{
+  "incident": {
+    "id": "PINC0001",
+    "type": "incident",
+    "incident_number": 4242,
+    "title": "api-gateway 5xx spike",
+    "status": "acknowledged",
+    "urgency": "high",
+    "created_at": "2026-05-22T12:00:00Z",
+    "last_status_change_at": "2026-05-22T12:05:00Z",
+    "service": {"id": "PSVC001", "type": "service_reference", "summary": "api-gateway"},
+    "escalation_policy": {"id": "PESC001", "type": "escalation_policy_reference"},
+    "assignments": [
+      {"at": "2026-05-22T12:00:00Z", "assignee": {"id": "PUSR001", "type": "user_reference"}}
+    ],
+    "acknowledgements": [
+      {"at": "2026-05-22T12:05:00Z", "acknowledger": {"id": "PUSR001", "type": "user_reference"}}
+    ],
+    "html_url": "https://acme.pagerduty.com/incidents/PINC0001"
+  }
+}

--- a/tests/fixtures/pagerduty/incident_PINC0001_log_entries.json
+++ b/tests/fixtures/pagerduty/incident_PINC0001_log_entries.json
@@ -1,0 +1,31 @@
+{
+  "log_entries": [
+    {
+      "id": "RLOG001",
+      "type": "trigger_log_entry",
+      "created_at": "2026-05-22T12:00:00Z",
+      "summary": "Triggered through the website",
+      "agent": {"id": "PSVC001", "type": "service_reference"},
+      "channel": {"type": "web_trigger"}
+    },
+    {
+      "id": "RLOG002",
+      "type": "assign_log_entry",
+      "created_at": "2026-05-22T12:00:01Z",
+      "summary": "Assigned to Alice Engineer",
+      "agent": {"id": "PUSR001", "type": "user_reference"},
+      "channel": {"type": "auto"}
+    },
+    {
+      "id": "RLOG003",
+      "type": "acknowledge_log_entry",
+      "created_at": "2026-05-22T12:05:00Z",
+      "summary": "Acknowledged by Alice Engineer",
+      "agent": {"id": "PUSR001", "type": "user_reference"},
+      "channel": {"type": "web"}
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "more": false
+}

--- a/tests/fixtures/pagerduty/incidents.json
+++ b/tests/fixtures/pagerduty/incidents.json
@@ -1,0 +1,42 @@
+{
+  "incidents": [
+    {
+      "id": "PINC0001",
+      "type": "incident",
+      "incident_number": 4242,
+      "title": "api-gateway 5xx spike",
+      "status": "triggered",
+      "urgency": "high",
+      "created_at": "2026-05-22T12:00:00Z",
+      "last_status_change_at": "2026-05-22T12:00:10Z",
+      "service": {"id": "PSVC001", "type": "service_reference", "summary": "api-gateway"},
+      "escalation_policy": {"id": "PESC001", "type": "escalation_policy_reference"},
+      "assignments": [
+        {"at": "2026-05-22T12:00:00Z", "assignee": {"id": "PUSR001", "type": "user_reference"}}
+      ],
+      "acknowledgements": [],
+      "html_url": "https://acme.pagerduty.com/incidents/PINC0001"
+    },
+    {
+      "id": "PINC0002",
+      "type": "incident",
+      "incident_number": 4243,
+      "title": "checkout 500s",
+      "status": "resolved",
+      "urgency": "high",
+      "created_at": "2026-05-21T18:30:00Z",
+      "last_status_change_at": "2026-05-21T19:00:00Z",
+      "resolved_at": "2026-05-21T19:00:00Z",
+      "service": {"id": "PSVC002", "type": "service_reference", "summary": "checkout"},
+      "escalation_policy": {"id": "PESC002", "type": "escalation_policy_reference"},
+      "assignments": [],
+      "acknowledgements": [
+        {"at": "2026-05-21T18:32:00Z", "acknowledger": {"id": "PUSR002", "type": "user_reference"}}
+      ],
+      "html_url": "https://acme.pagerduty.com/incidents/PINC0002"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "more": false
+}

--- a/tests/fixtures/pagerduty/oncalls.json
+++ b/tests/fixtures/pagerduty/oncalls.json
@@ -1,0 +1,51 @@
+{
+  "oncalls": [
+    {
+      "escalation_policy": {
+        "id": "PESC001",
+        "type": "escalation_policy_reference",
+        "summary": "Platform on-call"
+      },
+      "escalation_level": 1,
+      "schedule": {
+        "id": "PSCH001",
+        "type": "schedule_reference",
+        "summary": "Platform primary",
+        "html_url": "https://acme.pagerduty.com/schedules/PSCH001"
+      },
+      "user": {
+        "id": "PUSR001",
+        "type": "user_reference",
+        "summary": "Alice Engineer",
+        "email": "alice@example.com"
+      },
+      "start": "2026-05-22T00:00:00Z",
+      "end": "2026-05-23T00:00:00Z"
+    },
+    {
+      "escalation_policy": {
+        "id": "PESC001",
+        "type": "escalation_policy_reference",
+        "summary": "Platform on-call"
+      },
+      "escalation_level": 1,
+      "schedule": {
+        "id": "PSCH001",
+        "type": "schedule_reference",
+        "summary": "Platform primary",
+        "html_url": "https://acme.pagerduty.com/schedules/PSCH001"
+      },
+      "user": {
+        "id": "PUSR002",
+        "type": "user_reference",
+        "summary": "Bob Engineer",
+        "email": "bob@example.com"
+      },
+      "start": "2026-05-23T00:00:00Z",
+      "end": "2026-05-24T00:00:00Z"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "more": false
+}

--- a/tests/fixtures/pagerduty/services.json
+++ b/tests/fixtures/pagerduty/services.json
@@ -1,0 +1,39 @@
+{
+  "services": [
+    {
+      "id": "PSVC001",
+      "type": "service",
+      "summary": "api-gateway",
+      "name": "api-gateway",
+      "description": "Front-door HTTP gateway",
+      "status": "active",
+      "teams": [
+        {"id": "PTEAM01", "type": "team_reference"}
+      ],
+      "escalation_policy": {
+        "id": "PESC001",
+        "type": "escalation_policy_reference"
+      },
+      "html_url": "https://acme.pagerduty.com/services/PSVC001"
+    },
+    {
+      "id": "PSVC002",
+      "type": "service",
+      "summary": "checkout",
+      "name": "checkout",
+      "description": "Checkout service",
+      "status": "active",
+      "teams": [
+        {"id": "PTEAM02", "type": "team_reference"}
+      ],
+      "escalation_policy": {
+        "id": "PESC002",
+        "type": "escalation_policy_reference"
+      },
+      "html_url": "https://acme.pagerduty.com/services/PSVC002"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "more": false
+}

--- a/tests/fixtures/pagerduty/teams.json
+++ b/tests/fixtures/pagerduty/teams.json
@@ -1,0 +1,24 @@
+{
+  "teams": [
+    {
+      "id": "PTEAM01",
+      "type": "team",
+      "summary": "Platform SRE",
+      "name": "Platform SRE",
+      "description": "Owns the shared platform services",
+      "html_url": "https://acme.pagerduty.com/teams/PTEAM01"
+    },
+    {
+      "id": "PTEAM02",
+      "type": "team",
+      "summary": "Payments",
+      "name": "Payments",
+      "description": "Owns payments services",
+      "html_url": "https://acme.pagerduty.com/teams/PTEAM02"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "more": false,
+  "total": null
+}

--- a/tests/test_pagerduty_connector.py
+++ b/tests/test_pagerduty_connector.py
@@ -1,0 +1,376 @@
+"""Tests for the PagerDuty full source connector (issue #239).
+
+Coverage:
+
+* :class:`PagerDutyConfig` defaults and connector_type registration
+* canonical-name helpers (service/team/escalation/shift/incident/user)
+* ``_build_auth_headers`` — token required, headers shape
+* ``validate()`` — happy path, 401 -> PermissionError, 403 -> PermissionError
+* ``discover()`` — yields teams / escalations / services / shifts / incidents
+  with the right edges, and applies team_id filter
+* ``fetch()`` — bitemporal incident sync (state + log entries + edges)
+* Rate-limit handling — sleeps and retries on HTTP 429 with ``Retry-After``
+* Webhook handler delegation — same instance type as alerts/pagerduty
+* Registry — ``pagerduty`` is registered
+* Determinism — cassette replay produces byte-identical output across two
+  consecutive runs (no live network calls, no datetime drift inside fixtures)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+import respx
+from omniscience_connectors import get_connector
+from omniscience_connectors.alerts.webhook import AlertsWebhookHandler
+from omniscience_connectors.base import DocumentRef
+from omniscience_connectors.pagerduty.connector import (
+    PagerDutyConfig,
+    PagerDutyConnector,
+    _build_auth_headers,
+    canonical_escalation_name,
+    canonical_incident_name,
+    canonical_oncall_shift_name,
+    canonical_service_name,
+    canonical_team_name,
+    canonical_user_name,
+)
+
+# ---------------------------------------------------------------------------
+# Cassettes — JSON fixtures replayed via respx so the test suite is hermetic.
+# ---------------------------------------------------------------------------
+
+API_BASE = "https://api.pagerduty.com"
+TOKEN = "u+fakeFAKE_pagerduty_token_xxx"
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "pagerduty"
+
+
+def _load_cassette(name: str) -> dict[str, Any]:
+    with (FIXTURES_DIR / name).open(encoding="utf-8") as fh:
+        data: dict[str, Any] = json.load(fh)
+        return data
+
+
+def _wire_discover_cassettes() -> None:
+    """Mount every list-endpoint cassette used by ``discover()``."""
+    respx.get(f"{API_BASE}/teams").mock(
+        return_value=httpx.Response(200, json=_load_cassette("teams.json"))
+    )
+    respx.get(f"{API_BASE}/escalation_policies").mock(
+        return_value=httpx.Response(200, json=_load_cassette("escalation_policies.json"))
+    )
+    respx.get(f"{API_BASE}/services").mock(
+        return_value=httpx.Response(200, json=_load_cassette("services.json"))
+    )
+    respx.get(f"{API_BASE}/oncalls").mock(
+        return_value=httpx.Response(200, json=_load_cassette("oncalls.json"))
+    )
+    respx.get(f"{API_BASE}/incidents").mock(
+        return_value=httpx.Response(200, json=_load_cassette("incidents.json"))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Static / pure tests
+# ---------------------------------------------------------------------------
+
+
+def test_connector_type_and_schema() -> None:
+    assert PagerDutyConnector.connector_type == "pagerduty"
+    assert PagerDutyConnector.config_schema is PagerDutyConfig
+
+
+def test_config_defaults() -> None:
+    cfg = PagerDutyConfig()
+    assert cfg.api_base_url == API_BASE
+    assert cfg.team_ids == []
+    assert cfg.service_ids == []
+    assert cfg.incident_lookback_days == 30
+    assert cfg.include_resolved_incidents is True
+
+
+def test_canonical_names_are_stable() -> None:
+    assert canonical_service_name("PSVC001") == "pagerduty://service/PSVC001"
+    assert canonical_team_name("PTEAM01") == "pagerduty://team/PTEAM01"
+    assert canonical_escalation_name("PESC001") == "pagerduty://escalation/PESC001"
+    assert canonical_user_name("PUSR001") == "pagerduty://user/PUSR001"
+    assert canonical_incident_name("PINC0001") == "pagerduty://incident/PINC0001"
+
+    from datetime import UTC, datetime
+
+    start = datetime(2026, 5, 22, 12, 0, 0, tzinfo=UTC)
+    name = canonical_oncall_shift_name("PSCH001", "PUSR001", start)
+    # Stable, deterministic — same inputs always produce the same name.
+    assert name == canonical_oncall_shift_name("PSCH001", "PUSR001", start)
+    assert name.startswith("pagerduty://oncall/PSCH001/PUSR001/")
+
+
+def test_build_auth_headers_requires_token() -> None:
+    with pytest.raises(ValueError, match="api_token"):
+        _build_auth_headers({})
+
+
+def test_build_auth_headers_shape() -> None:
+    h = _build_auth_headers({"api_token": TOKEN})
+    assert h["Authorization"] == f"Token token={TOKEN}"
+    assert h["Accept"].startswith("application/vnd.pagerduty+json")
+    assert "User-Agent" in h
+
+
+def test_registry_has_pagerduty() -> None:
+    cls = get_connector("pagerduty")
+    assert isinstance(cls, PagerDutyConnector)
+
+
+# ---------------------------------------------------------------------------
+# validate()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_validate_success() -> None:
+    respx.get(f"{API_BASE}/abilities").mock(
+        return_value=httpx.Response(200, json=_load_cassette("abilities.json"))
+    )
+    await PagerDutyConnector().validate(PagerDutyConfig(), {"api_token": TOKEN})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_validate_unauthorized_raises_permission_error() -> None:
+    respx.get(f"{API_BASE}/abilities").mock(
+        return_value=httpx.Response(401, json={"error": "Unauthorized"})
+    )
+    with pytest.raises(PermissionError):
+        await PagerDutyConnector().validate(PagerDutyConfig(), {"api_token": TOKEN})
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_validate_forbidden_raises_permission_error() -> None:
+    respx.get(f"{API_BASE}/abilities").mock(
+        return_value=httpx.Response(403, json={"error": "Forbidden"})
+    )
+    with pytest.raises(PermissionError, match="scopes"):
+        await PagerDutyConnector().validate(PagerDutyConfig(), {"api_token": TOKEN})
+
+
+# ---------------------------------------------------------------------------
+# discover()
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_yields_all_entity_kinds() -> None:
+    _wire_discover_cassettes()
+    refs = [
+        r async for r in PagerDutyConnector().discover(PagerDutyConfig(), {"api_token": TOKEN})
+    ]
+    kinds = [r.metadata["kind"] for r in refs]
+    assert kinds.count("PagerDutyTeam") == 2
+    assert kinds.count("PagerDutyEscalation") == 2
+    assert kinds.count("PagerDutyService") == 2
+    assert kinds.count("OnCallShift") == 2
+    assert kinds.count("PagerDutyIncident") == 2
+
+    # Ordering invariant: teams before services before incidents so the
+    # linker can resolve edges in a single pass.
+    first_team = next(i for i, k in enumerate(kinds) if k == "PagerDutyTeam")
+    first_service = next(i for i, k in enumerate(kinds) if k == "PagerDutyService")
+    first_incident = next(i for i, k in enumerate(kinds) if k == "PagerDutyIncident")
+    assert first_team < first_service < first_incident
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_service_emits_team_and_escalation_edges() -> None:
+    _wire_discover_cassettes()
+    refs = [
+        r async for r in PagerDutyConnector().discover(PagerDutyConfig(), {"api_token": TOKEN})
+    ]
+    services = [r for r in refs if r.metadata["kind"] == "PagerDutyService"]
+    assert services
+    api_gw = next(s for s in services if s.metadata["pagerduty_service_id"] == "PSVC001")
+
+    edges = api_gw.metadata["edges"]
+    types = {e["type"] for e in edges}
+    assert "OWNED_BY" in types
+    assert "USES_ESCALATION" in types
+
+    owned = next(e for e in edges if e["type"] == "OWNED_BY")
+    assert owned["to"] == canonical_team_name("PTEAM01")
+    uses = next(e for e in edges if e["type"] == "USES_ESCALATION")
+    assert uses["to"] == canonical_escalation_name("PESC001")
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_oncall_shift_emits_user_edge() -> None:
+    _wire_discover_cassettes()
+    refs = [
+        r async for r in PagerDutyConnector().discover(PagerDutyConfig(), {"api_token": TOKEN})
+    ]
+    shifts = [r for r in refs if r.metadata["kind"] == "OnCallShift"]
+    assert len(shifts) == 2
+    first = shifts[0]
+    edges = first.metadata["edges"]
+    on_call = next(e for e in edges if e["type"] == "ON_CALL")
+    assert on_call["to"] == canonical_user_name(first.metadata["user_id"])
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_discover_team_filter_propagates_to_query() -> None:
+    _wire_discover_cassettes()
+    cfg = PagerDutyConfig(team_ids=["PTEAM01"])
+    _ = [r async for r in PagerDutyConnector().discover(cfg, {"api_token": TOKEN})]
+    # team_ids filter should appear in every list-endpoint query that
+    # accepts it (escalation_policies, services, oncalls, incidents).
+    urls = [str(call.request.url) for call in respx.calls]
+    assert any("escalation_policies" in u and "team_ids" in u and "PTEAM01" in u for u in urls)
+    assert any("services" in u and "team_ids" in u and "PTEAM01" in u for u in urls)
+    assert any("incidents" in u and "team_ids" in u and "PTEAM01" in u for u in urls)
+
+
+# ---------------------------------------------------------------------------
+# fetch() — bitemporal incident sync
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_incident_returns_markdown_and_full_timeline() -> None:
+    respx.get(f"{API_BASE}/incidents/PINC0001").mock(
+        return_value=httpx.Response(200, json=_load_cassette("incident_PINC0001.json"))
+    )
+    respx.get(f"{API_BASE}/incidents/PINC0001/log_entries").mock(
+        return_value=httpx.Response(200, json=_load_cassette("incident_PINC0001_log_entries.json"))
+    )
+    ref = DocumentRef(
+        external_id="seed",
+        uri=canonical_incident_name("PINC0001"),
+        metadata={"kind": "PagerDutyIncident", "pagerduty_incident_id": "PINC0001"},
+    )
+    doc = await PagerDutyConnector().fetch(PagerDutyConfig(), {"api_token": TOKEN}, ref)
+    assert doc.content_type == "text/markdown"
+    md = doc.content_bytes.decode("utf-8")
+    assert "# Incident #4242:" in md
+    assert "api-gateway 5xx spike" in md
+    assert "## Timeline" in md
+    # All three log entries rendered.
+    assert "trigger_log_entry" in md
+    assert "assign_log_entry" in md
+    assert "acknowledge_log_entry" in md
+
+    # Bitemporal: status, edges, and full log entries surface in metadata.
+    assert doc.ref.metadata["status"] == "acknowledged"
+    edges = doc.ref.metadata["edges"]
+    types = {e["type"] for e in edges}
+    assert {"FILED_AGAINST", "USES_ESCALATION", "ASSIGNED_TO", "ACKNOWLEDGED_BY"} <= types
+    log_entries = doc.ref.metadata["log_entries"]
+    assert len(log_entries) == 3
+    assert log_entries[0]["type"] == "trigger_log_entry"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_fetch_non_incident_kind_returns_json_metadata() -> None:
+    """Catalog entities arrive complete from discover -- fetch just serialises."""
+    ref = DocumentRef(
+        external_id="x",
+        uri=canonical_team_name("PTEAM01"),
+        metadata={
+            "kind": "PagerDutyTeam",
+            "name": canonical_team_name("PTEAM01"),
+            "pagerduty_team_id": "PTEAM01",
+        },
+    )
+    doc = await PagerDutyConnector().fetch(PagerDutyConfig(), {"api_token": TOKEN}, ref)
+    assert doc.content_type == "application/json"
+    payload = json.loads(doc.content_bytes)
+    assert payload["pagerduty_team_id"] == "PTEAM01"
+
+
+@pytest.mark.asyncio
+async def test_fetch_incident_missing_id_raises() -> None:
+    ref = DocumentRef(
+        external_id="x",
+        uri="pagerduty://incident/?",
+        metadata={"kind": "PagerDutyIncident"},
+    )
+    with pytest.raises(ValueError, match="pagerduty_incident_id"):
+        await PagerDutyConnector().fetch(PagerDutyConfig(), {"api_token": TOKEN}, ref)
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit handling
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_rate_limit_retries_then_succeeds() -> None:
+    """A 429 with Retry-After triggers a sleep + retry; second call succeeds."""
+    route = respx.get(f"{API_BASE}/abilities").mock(
+        side_effect=[
+            httpx.Response(429, headers={"Retry-After": "0"}),
+            httpx.Response(200, json=_load_cassette("abilities.json")),
+        ]
+    )
+    with patch(
+        "omniscience_connectors.pagerduty.connector.asyncio.sleep",
+        new=AsyncMock(),
+    ) as mock_sleep:
+        await PagerDutyConnector().validate(PagerDutyConfig(), {"api_token": TOKEN})
+    assert route.call_count == 2
+    assert mock_sleep.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Webhook handler delegation
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_handler_reuses_alerts_pagerduty_receiver() -> None:
+    handler = PagerDutyConnector().webhook_handler()
+    assert isinstance(handler, AlertsWebhookHandler), (
+        "PagerDuty connector must reuse the alerts/pagerduty webhook receiver "
+        "to keep signature-verification code in one place (issue #239)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Determinism — cassette replay produces identical output on two consecutive runs
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_cassette_replay_is_deterministic() -> None:
+    """Run discover() twice; assert identical canonical names + edge sets.
+
+    Guards against accidental clock-dependent metadata.  We compare on the
+    name-set (not the entire ref) because ``OnCallShift.updated_at`` is a
+    fixed fixture timestamp so the canonical name is stable; any future
+    drift would surface here.
+    """
+    _wire_discover_cassettes()
+    pass1 = [
+        r async for r in PagerDutyConnector().discover(PagerDutyConfig(), {"api_token": TOKEN})
+    ]
+    respx.reset()
+    _wire_discover_cassettes()
+    pass2 = [
+        r async for r in PagerDutyConnector().discover(PagerDutyConfig(), {"api_token": TOKEN})
+    ]
+    names1 = [r.metadata["name"] for r in pass1]
+    names2 = [r.metadata["name"] for r in pass2]
+    assert names1 == names2


### PR DESCRIPTION
## Summary

Promotes the existing push-only `alerts/pagerduty` webhook receiver into
a full PagerDuty source connector that also pulls the catalog and
bitemporally syncs incidents via the PagerDuty REST API.

- `discover()` enumerates teams, escalation policies, services, on-call
  shifts, and recent incidents (configurable lookback window).
- `fetch()` pulls full incident state plus the `log_entries` timeline and
  renders Markdown with named edges (`FILED_AGAINST`, `USES_ESCALATION`,
  `ASSIGNED_TO`, `ACKNOWLEDGED_BY`, `OWNED_BY`, `ON_CALL`).
- `webhook_handler()` reuses `AlertsWebhookHandler` unchanged so HMAC
  verification, multi-secret rotation, and replay protection live in
  exactly one place.
- HTTP 429 honoured via `Retry-After` (5 retries, 60s cap).
- **v1 is read-only by design.** Bi-directional acks / snooze / resolve
  are deferred to v2 Action Mode (#230); placeholder methods raise
  `NotImplementedError` with an inline pointer to the tracking issue.

Closes #239.

### New entity types
- `PagerDutyTeam`, `PagerDutyService`, `PagerDutyEscalation`, `OnCallShift`,
  `PagerDutyIncident`, `IncidentLogEntry`

### Files
- New: `packages/connectors/src/omniscience_connectors/pagerduty/`
  (`__init__.py`, `connector.py`, `models.py`)
- New: `tests/test_pagerduty_connector.py`
- New: `tests/fixtures/pagerduty/*.json` (8 cassettes)
- New: `docs/connectors/pagerduty.md` (token-scope and config reference)
- Modified additively: `packages/connectors/.../__init__.py`
  (PagerDutyConnector import + register + `__all__` entries — alphabetically
  positioned, no other lines moved)

## Test plan

- [x] `uv run pytest tests/ -k pagerduty -v` — 36 passed (19 new + 17 existing
      alerts/pagerduty webhook tests, none regressed)
- [x] `uv run pytest tests/test_alerts_connector.py tests/test_alerts_webhook.py
      tests/test_connectors_v2.py` — 147 passed (no sister regressions)
- [x] `uv run ruff check packages/connectors/src/omniscience_connectors/pagerduty/
      tests/test_pagerduty_connector.py` — all checks passed
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy --strict packages/connectors/src/omniscience_connectors/pagerduty/`
      — `Success: no issues found in 3 source files`
- [x] Determinism: ran `tests/test_pagerduty_connector.py` twice consecutively;
      byte-identical output (no live network, no clock-dependent fixtures)

## Out of scope (tracked elsewhere)

- v2 Action Mode (ack/snooze/resolve write-back) — issue #230
- Webhook-driven incremental catalog sync — future follow-up