### PR TITLE
feat(incidents): runbook parser + suggest at incident time (#231)

### DIFF
--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -98,6 +98,21 @@ from omniscience_server.replay import (
     replay_by_audit_id,
     replay_context,
 )
+from omniscience_server.runbook import (
+    ALERT_NOT_FOUND_CODE as RUNBOOK_ALERT_NOT_FOUND_CODE,
+)
+from omniscience_server.runbook import (
+    DEFAULT_TOP_K as RUNBOOK_DEFAULT_TOP_K,
+)
+from omniscience_server.runbook import (
+    INVALID_ALERT_ID_CODE as RUNBOOK_INVALID_ALERT_ID_CODE,
+)
+from omniscience_server.runbook import (
+    MAX_TOP_K as RUNBOOK_MAX_TOP_K,
+)
+from omniscience_server.runbook import (
+    suggest_runbook as mcp_suggest_runbook,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -733,6 +748,64 @@ async def replay_context_tool(
         raise ValueError(f"audit_log_not_found:{exc}") from exc
 
     return envelope_to_dict(result)
+
+
+# ---------------------------------------------------------------------------
+# Tool: suggest_runbook (issue #231)
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    name="suggest_runbook",
+    description=(
+        "Return the top matching runbooks for an alert. "
+        "alert_id MUST be of the form 'alert://{provider}/{provider_alert_id}'. "
+        "Returns suggestions ordered by confidence DESC with citation blocks "
+        "(title, source, first step) so the responder UI can render previews "
+        "without a second round-trip. Optional `as_of` (ISO-8601 UTC datetime) "
+        "anchors the traversal to graph state at that time per ADR-0008 §5. "
+        "Requires a workspace-scoped token. Confidence-score model: v0.1 "
+        "deterministic placeholder per issue #231; calibrated model is a "
+        "follow-up."
+    ),
+)
+async def suggest_runbook(
+    alert_id: str,
+    ctx: Context[Any, Any, Any],
+    top_k: int = RUNBOOK_DEFAULT_TOP_K,
+    as_of: str | None = None,
+) -> dict[str, Any]:
+    """suggest_runbook tool requires scope 'search' AND workspace token."""
+    token = await _resolve_token(ctx)
+    _require_scope(token, Scope.search)
+    _record_tool_invocation(tool_name="suggest_runbook", token=token)
+    assert token is not None  # noqa: S101 — narrows type for mypy
+
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "mcp_suggest_runbook_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise ValueError("forbidden:Runbook suggestion requires a workspace-scoped token")
+
+    parsed_as_of = _parse_as_of(as_of)
+    clamped_top_k = max(1, min(top_k, RUNBOOK_MAX_TOP_K))
+    try:
+        return await mcp_suggest_runbook(
+            app=_get_app(),
+            alert_id=alert_id,
+            workspace_id=workspace_id,
+            as_of=parsed_as_of,
+            top_k=clamped_top_k,
+        )
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith(f"{RUNBOOK_INVALID_ALERT_ID_CODE}:"):
+            raise
+        if msg.startswith(f"{RUNBOOK_ALERT_NOT_FOUND_CODE}:"):
+            raise
+        raise
 
 
 __all__ = ["mcp_server", "set_fastapi_app"]

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -16,6 +16,7 @@ from omniscience_server.rest.operator import router as operator_router
 from omniscience_server.rest.otlp import router as otlp_router
 from omniscience_server.rest.replay import router as replay_router
 from omniscience_server.rest.retention import router as retention_router
+from omniscience_server.rest.runbook import router as runbook_router
 from omniscience_server.rest.search import router as search_router
 from omniscience_server.rest.sources import router as sources_router
 from omniscience_server.rest.stats import router as stats_router
@@ -39,5 +40,6 @@ api_v1_router.include_router(incident_timeline_router)
 api_v1_router.include_router(incidents_admin_router)
 api_v1_router.include_router(blast_radius_router)
 api_v1_router.include_router(replay_router)
+api_v1_router.include_router(runbook_router)
 
 __all__ = ["api_v1_router"]

--- a/apps/server/src/omniscience_server/rest/runbook.py
+++ b/apps/server/src/omniscience_server/rest/runbook.py
@@ -1,0 +1,340 @@
+"""Runbook REST endpoints (issue #231).
+
+Two routes under ``/api/v1``:
+
+* ``POST /api/v1/incidents/{incident_id}/runbook-step``
+  Records that a responder executed a step from a runbook against an
+  incident.  The event flows into the bitemporal audit surfaces (in-
+  memory ring buffer, structured log line, Prometheus counter).
+* ``POST /api/v1/incidents/{incident_id}/suggest-runbook``
+  Sugar over the MCP ``suggest_runbook`` tool — accepts the alert id in
+  the JSON body so the path parameter slot is consistent with the
+  step-recording endpoint.
+
+Both routes:
+
+* require scope ``incidents_write`` for the step-recording endpoint and
+  ``search`` for suggest (mirrors the resolve_incident posture);
+* require a workspace-scoped token — fail-closed 403;
+* propagate workspace_id from the token, never the body.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from omniscience_server.as_of import (
+    INVALID_TIMEZONE_CODE,
+    INVALID_TIMEZONE_MESSAGE,
+    enforce_utc,
+)
+from omniscience_server.runbook import (
+    ALERT_NOT_FOUND_CODE,
+    DEFAULT_TOP_K,
+    INVALID_ALERT_ID_CODE,
+    INVALID_ALERT_ID_MESSAGE,
+    INVALID_RUNBOOK_NAME_CODE,
+    INVALID_RUNBOOK_NAME_MESSAGE,
+    INVALID_STEP_ID_CODE,
+    MAX_TOP_K,
+    record_runbook_step,
+    suggest_runbook,
+)
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["runbook"])
+
+# Module-level Depends singletons (avoids ruff B008).
+_search_scope_dep: Any = Depends(require_scope(Scope.search))
+_incidents_write_scope_dep: Any = Depends(require_scope(Scope.incidents_write))
+_current_token_dep: Any = Depends(get_current_token)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace(token: ApiToken) -> uuid.UUID:
+    """Resolve the caller's workspace or fail 403 (no cross-workspace IDs)."""
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "runbook_request_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Runbook endpoints require a workspace-scoped token",
+            },
+        )
+    return workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Request / response bodies
+# ---------------------------------------------------------------------------
+
+
+class RunbookStepRequest(BaseModel):
+    """POST /api/v1/incidents/{incident_id}/runbook-step body."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    alert_id: str = Field(
+        description="Canonical alert URI 'alert://{provider}/{provider_alert_id}'.",
+    )
+    runbook_name: str = Field(
+        description="Canonical runbook URI 'runbook://{source_uid}/{rel_path}'.",
+    )
+    step_id: str = Field(
+        description=(
+            "Slugified heading text identifying the step.  Matches "
+            "[A-Za-z0-9._-]+ — the same shape the parser emits."
+        ),
+    )
+    outcome: str = Field(
+        default="executed",
+        description=(
+            "Free-form outcome label.  Conventional values: 'executed', "
+            "'skipped', 'failed', 'rolled_back'.  Stored verbatim."
+        ),
+        max_length=64,
+    )
+    actor: str | None = Field(
+        default=None,
+        description="Display-name or id of the responder who took the step.",
+        max_length=256,
+    )
+    note: str | None = Field(
+        default=None,
+        description="Optional free-text note from the responder.",
+        max_length=4096,
+    )
+    valid_from: datetime | None = Field(
+        default=None,
+        description=(
+            "ISO-8601 UTC datetime at which the step actually executed. "
+            "Default: server-side 'now'.  Naive datetimes are rejected "
+            "with 400 invalid_timezone."
+        ),
+    )
+
+    @field_validator("valid_from")
+    @classmethod
+    def _validate_valid_from(cls, value: datetime | None) -> datetime | None:
+        try:
+            return enforce_utc(value)
+        except ValueError as exc:
+            raise ValueError(INVALID_TIMEZONE_CODE) from exc
+
+
+class SuggestRunbookRequest(BaseModel):
+    """POST /api/v1/incidents/{incident_id}/suggest-runbook body."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    alert_id: str = Field(description="Canonical alert URI to score against.")
+    top_k: int = Field(
+        default=DEFAULT_TOP_K,
+        ge=1,
+        le=MAX_TOP_K,
+        description="Number of suggestions to return.",
+    )
+    as_of: datetime | None = Field(
+        default=None,
+        description="Optional ADR-0008 §5 bitemporal anchor.",
+    )
+
+    @field_validator("as_of")
+    @classmethod
+    def _validate_as_of(cls, value: datetime | None) -> datetime | None:
+        try:
+            return enforce_utc(value)
+        except ValueError as exc:
+            raise ValueError(INVALID_TIMEZONE_CODE) from exc
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+_IncidentIdPath = Annotated[
+    str,
+    Path(
+        min_length=1,
+        max_length=256,
+        description="Caller-supplied incident identifier (PagerDuty id, etc.).",
+    ),
+]
+
+
+@router.post(
+    "/incidents/{incident_id}/runbook-step",
+    status_code=201,
+    summary="Record a runbook step execution as a bitemporal event",
+    dependencies=[_incidents_write_scope_dep],
+)
+async def post_runbook_step(
+    incident_id: _IncidentIdPath,
+    body: RunbookStepRequest,
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> dict[str, Any]:
+    """Record the step.  Returns the event envelope plus its UUID.
+
+    Validation errors are mapped to the same envelope shape the
+    resolve_incident endpoint uses so REST clients can share their error
+    handlers.
+    """
+    workspace_id = _require_workspace(token)
+    try:
+        event = record_runbook_step(
+            app=request.app,
+            workspace_id=workspace_id,
+            incident_id=incident_id,
+            alert_id=body.alert_id,
+            runbook_name=body.runbook_name,
+            step_id=body.step_id,
+            outcome=body.outcome,
+            actor=body.actor,
+            note=body.note,
+            valid_from=body.valid_from,
+        )
+    except ValueError as exc:
+        _raise_from_validation_error(exc)
+        raise  # pragma: no cover - the helper always raises HTTPException
+
+    return event.to_payload()
+
+
+@router.post(
+    "/incidents/{incident_id}/suggest-runbook",
+    summary="Suggest matching runbooks for an alert (REST mirror of MCP tool)",
+    dependencies=[_search_scope_dep],
+)
+async def post_suggest_runbook(
+    incident_id: _IncidentIdPath,
+    body: SuggestRunbookRequest,
+    request: Request,
+    token: ApiToken = _current_token_dep,
+) -> dict[str, Any]:
+    """REST mirror of ``suggest_runbook``.
+
+    ``incident_id`` is recorded in the response envelope so the responder
+    UI can correlate the suggestion with the incident timeline.
+    """
+    workspace_id = _require_workspace(token)
+    try:
+        response = await suggest_runbook(
+            app=request.app,
+            alert_id=body.alert_id,
+            workspace_id=workspace_id,
+            as_of=body.as_of,
+            top_k=body.top_k,
+        )
+    except ValueError as exc:
+        _raise_from_validation_error(exc)
+        raise  # pragma: no cover - the helper always raises HTTPException
+    response["incident_id"] = incident_id
+    return response
+
+
+@router.get(
+    "/incidents/{incident_id}/runbook-steps",
+    summary="List recent runbook-step events recorded for any incident",
+    dependencies=[_search_scope_dep],
+)
+async def list_runbook_steps(
+    incident_id: _IncidentIdPath,
+    request: Request,
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+    token: ApiToken = _current_token_dep,
+) -> dict[str, Any]:
+    """Read back the workspace's recent runbook-step events.
+
+    Filters the in-memory recorder down to events whose ``incident_id``
+    matches the path.  Workspace ACL is enforced inside
+    :meth:`RunbookStepRecorder.recent`.
+    """
+    from omniscience_server.runbook import get_recorder
+
+    workspace_id = _require_workspace(token)
+    recorder = get_recorder(request.app)
+    events = recorder.recent(workspace_id=workspace_id, limit=limit)
+    matching = [e.to_payload() for e in events if e.incident_id == incident_id]
+    return {
+        "incident_id": incident_id,
+        "events": matching,
+        "meta": {"returned": len(matching)},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+def _raise_from_validation_error(exc: ValueError) -> None:
+    """Translate the structured ValueError envelope into an HTTPException."""
+    msg = str(exc)
+    if msg.startswith(f"{INVALID_ALERT_ID_CODE}:"):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": INVALID_ALERT_ID_CODE,
+                "message": INVALID_ALERT_ID_MESSAGE,
+            },
+        ) from exc
+    if msg.startswith(f"{INVALID_RUNBOOK_NAME_CODE}:"):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": INVALID_RUNBOOK_NAME_CODE,
+                "message": INVALID_RUNBOOK_NAME_MESSAGE,
+            },
+        ) from exc
+    if msg.startswith(f"{INVALID_STEP_ID_CODE}:"):
+        raise HTTPException(
+            status_code=400,
+            detail={"code": INVALID_STEP_ID_CODE, "message": msg.split(":", 1)[1]},
+        ) from exc
+    if msg.startswith(f"{ALERT_NOT_FOUND_CODE}:"):
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": ALERT_NOT_FOUND_CODE,
+                "message": f"Alert '{msg.split(':', 1)[1]}' not found",
+            },
+        ) from exc
+    if msg.startswith("invalid_incident_id:"):
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "invalid_incident_id", "message": msg.split(":", 1)[1]},
+        ) from exc
+    if msg == INVALID_TIMEZONE_CODE:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": INVALID_TIMEZONE_CODE, "message": INVALID_TIMEZONE_MESSAGE},
+        ) from exc
+    raise HTTPException(
+        status_code=400,
+        detail={"code": "bad_request", "message": msg},
+    ) from exc
+
+
+__all__ = ["router"]

--- a/apps/server/src/omniscience_server/runbook.py
+++ b/apps/server/src/omniscience_server/runbook.py
@@ -1,0 +1,608 @@
+"""Runbook suggest + step-recording (issue #231).
+
+Composes the two server-side primitives the runbook epic needs:
+
+1. :func:`suggest_runbook` — given an alert id, returns the top N matching
+   runbooks with their match traces.  Backed by
+   :func:`omniscience_connectors.runbook.linker.score_runbook_against_alert`.
+
+2. :func:`record_runbook_step` — records that a responder executed a
+   specific step from a specific runbook against an incident.  The event
+   is appended to the in-memory :class:`RunbookStepRecorder` (the
+   bitemporal-graph audit surface) AND a structured log line + Prometheus
+   counter are emitted so the audit trail is queryable from three
+   independent vantage points.
+
+Why an in-memory recorder (and not a DB table)
+-----------------------------------------------
+A persistent ``runbook_step_event`` SQL table would require an Alembic
+migration touching :mod:`omniscience_core.db.models` — out of scope for
+issue #231 under the file-ownership map.  The recorder is a small
+process-local ring buffer that:
+
+* Surfaces the event on ``app.state.runbook_step_recorder.recent(...)``
+  for the integration test and the admin UI.
+* Logs every event at INFO with the full bitemporal triple
+  (``valid_from``, ``recorded_at``) so log-shippers persist it.
+* Increments :data:`RUNBOOK_STEP_EVENTS_TOTAL` so Prometheus retains the
+  count even after the buffer rolls over.
+
+A future PR (tracked under epic #230 "incident workflow depth") will
+promote the recorder to a proper SQL table; the public function
+signatures defined here are deliberately stable so that migration is
+additive.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from collections import deque
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Final
+
+import structlog
+from fastapi import FastAPI
+from omniscience_connectors.runbook.linker import (
+    AlertView,
+    MatchResult,
+    score_runbook_against_alert,
+)
+from omniscience_connectors.runbook.models import (
+    RunbookDocument,
+    canonical_runbook_step_name,
+)
+from omniscience_core.storage import EntityNodeView, GraphStore
+from prometheus_client import Counter
+
+from omniscience_server.as_of import (
+    enforce_utc,
+    record_request_duration,
+    resolve_effective_as_of,
+)
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Error codes (mirrored on the MCP / REST surfaces — same envelope shape
+# the resolve_incident handlers use).
+# ---------------------------------------------------------------------------
+
+ALERT_NOT_FOUND_CODE: Final[str] = "alert_not_found"
+INVALID_ALERT_ID_CODE: Final[str] = "invalid_alert_id"
+INVALID_ALERT_ID_MESSAGE: Final[str] = (
+    "alert_id must be of the form 'alert://{provider}/{provider_alert_id}'"
+)
+RUNBOOK_NOT_FOUND_CODE: Final[str] = "runbook_not_found"
+INVALID_RUNBOOK_NAME_CODE: Final[str] = "invalid_runbook_name"
+INVALID_RUNBOOK_NAME_MESSAGE: Final[str] = (
+    "runbook_name must be of the form 'runbook://{source_uid}/{rel_path}'"
+)
+INVALID_STEP_ID_CODE: Final[str] = "invalid_step_id"
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+DEFAULT_TOP_K: Final[int] = 3
+MAX_TOP_K: Final[int] = 25
+
+# Soft cap on the in-memory event buffer.  Past this limit the oldest
+# event is dropped (FIFO); Prometheus retains the count regardless.
+DEFAULT_RECORDER_CAPACITY: Final[int] = 10_000
+
+# ---------------------------------------------------------------------------
+# Validation regexes — kept narrow so error messages are precise.
+# ---------------------------------------------------------------------------
+
+_ALERT_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^alert://[A-Za-z0-9._-]+/[A-Za-z0-9._:/+-]+$"
+)
+_RUNBOOK_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^runbook://[A-Za-z0-9._\-/]+/[A-Za-z0-9._\-/]+$"
+)
+_STEP_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+# ---------------------------------------------------------------------------
+# Prometheus surface
+# ---------------------------------------------------------------------------
+
+RUNBOOK_SUGGEST_TOTAL: Counter = Counter(
+    "omniscience_runbook_suggest_total",
+    "Number of suggest_runbook invocations, labelled by outcome.",
+    labelnames=["outcome"],
+)
+
+RUNBOOK_STEP_EVENTS_TOTAL: Counter = Counter(
+    "omniscience_runbook_step_events_total",
+    (
+        "Number of runbook-step execution events recorded.  Labelled by "
+        "workspace prefix only (first 8 hex of the workspace UUID) to "
+        "preserve tenant-cardinality bounds."
+    ),
+    labelnames=["workspace_prefix"],
+)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RunbookStepEvent:
+    """A single recorded runbook-step execution.
+
+    The triple ``(valid_from, valid_to, recorded_at)`` follows the
+    ADR-0008 bitemporal convention so the event slots into the graph
+    when a future migration promotes it to a persistent table.
+    """
+
+    event_id: uuid.UUID
+    workspace_id: uuid.UUID
+    alert_id: str
+    incident_id: str
+    runbook_name: str
+    step_id: str
+    step_name: str
+    actor: str | None
+    note: str | None
+    outcome: str
+    valid_from: datetime
+    valid_to: datetime | None
+    recorded_at: datetime
+
+    def to_payload(self) -> dict[str, Any]:
+        """Render as the JSON envelope returned by the REST endpoint."""
+        return {
+            "event_id": str(self.event_id),
+            "incident_id": self.incident_id,
+            "alert_id": self.alert_id,
+            "runbook_name": self.runbook_name,
+            "step_id": self.step_id,
+            "step_name": self.step_name,
+            "actor": self.actor,
+            "note": self.note,
+            "outcome": self.outcome,
+            "valid_from": self.valid_from.isoformat(),
+            "valid_to": self.valid_to.isoformat() if self.valid_to else None,
+            "recorded_at": self.recorded_at.isoformat(),
+        }
+
+
+@dataclass(slots=True)
+class RunbookStepRecorder:
+    """Process-local audit buffer for runbook-step events.
+
+    The buffer is bounded (FIFO) so a long-running process does not leak
+    memory.  Tests assert against :meth:`recent`; production observability
+    leans on the structured-log and Prometheus surfaces, which are
+    durable independently of this buffer.
+    """
+
+    capacity: int = DEFAULT_RECORDER_CAPACITY
+    _events: deque[RunbookStepEvent] = field(default_factory=deque)
+
+    def append(self, event: RunbookStepEvent) -> None:
+        self._events.append(event)
+        while len(self._events) > self.capacity:
+            self._events.popleft()
+
+    def recent(self, *, workspace_id: uuid.UUID, limit: int = 50) -> list[RunbookStepEvent]:
+        """Return up to ``limit`` most-recent events for ``workspace_id``.
+
+        Workspace filtering is honoured here so test assertions match the
+        ACL contract; the Prometheus counter is the only cross-workspace
+        view of the data and it's an aggregate count, not a leak.
+        """
+        out: list[RunbookStepEvent] = []
+        # Iterate from newest to oldest.
+        for event in reversed(self._events):
+            if event.workspace_id != workspace_id:
+                continue
+            out.append(event)
+            if len(out) >= limit:
+                break
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+def validate_alert_id(alert_id: str) -> None:
+    """Raise ``ValueError("invalid_alert_id:...")`` on malformed ids."""
+    if not isinstance(alert_id, str) or not _ALERT_ID_PATTERN.match(alert_id):
+        raise ValueError(f"{INVALID_ALERT_ID_CODE}:{INVALID_ALERT_ID_MESSAGE}")
+
+
+def validate_runbook_name(runbook_name: str) -> None:
+    """Raise ``ValueError("invalid_runbook_name:...")`` on malformed names."""
+    if not isinstance(runbook_name, str) or not _RUNBOOK_NAME_PATTERN.match(runbook_name):
+        raise ValueError(f"{INVALID_RUNBOOK_NAME_CODE}:{INVALID_RUNBOOK_NAME_MESSAGE}")
+
+
+def validate_step_id(step_id: str) -> None:
+    """Raise ``ValueError("invalid_step_id:...")`` on malformed ids.
+
+    Step ids are slugified heading text — alphanumerics, dot, underscore,
+    dash.  See :func:`omniscience_connectors.runbook.models._slugify`.
+    """
+    if not isinstance(step_id, str) or not _STEP_ID_PATTERN.match(step_id):
+        raise ValueError(f"{INVALID_STEP_ID_CODE}:step_id must match [A-Za-z0-9._-]+")
+
+
+# ---------------------------------------------------------------------------
+# Runbook loading
+# ---------------------------------------------------------------------------
+
+
+def runbook_from_entity_metadata(entity: EntityNodeView) -> RunbookDocument | None:
+    """Reconstruct a :class:`RunbookDocument` from an indexed entity.
+
+    The runbook connector stores the parsed JSON payload on
+    :attr:`EntityNodeView.chunk_text`.  Adapters that serialise metadata
+    differently can populate the chunk_text slot equivalently — the
+    cross-adapter contract is "chunk_text is a JSON-serialised
+    RunbookDocument".
+
+    Returns ``None`` when the entity does not carry a parseable runbook
+    payload (legacy / non-runbook entities, malformed JSON).  Callers
+    treat ``None`` as "skip" — the matcher cannot score this candidate.
+    """
+    text = entity.chunk_text or ""
+    if not text or text[0] not in "{":
+        return None
+    try:
+        return RunbookDocument.model_validate_json(text)
+    except ValueError:
+        return None
+
+
+def _alert_view_from_entity(entity: EntityNodeView) -> AlertView:
+    """Project an alert entity into the matcher's input shape.
+
+    Alert connectors store the normalised payload on ``chunk_text`` (see
+    :mod:`omniscience_connectors.alerts`); when that payload includes
+    ``tags`` / ``severity`` we surface them so the matcher can score
+    them.  Missing fields silently default to empty — a tag-less alert
+    just loses the 0.15 contribution from tag overlap.
+    """
+    tags: list[str] = []
+    severity: str | None = None
+    # The alert payload may be JSON-stringified or plain text; we read
+    # the obvious slots conservatively.  Failure here is silent — the
+    # matcher tolerates an empty AlertView.
+    text = entity.chunk_text or ""
+    if text.startswith("{"):
+        try:
+            import json as _json
+
+            blob = _json.loads(text)
+            raw_tags = blob.get("tags")
+            if isinstance(raw_tags, list):
+                tags = [str(t) for t in raw_tags if t is not None]
+            raw_sev = blob.get("severity")
+            if isinstance(raw_sev, str):
+                severity = raw_sev
+        except (ValueError, AttributeError):
+            pass
+    return AlertView(name=entity.name, tags=tags, severity=severity)
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+async def suggest_runbook(
+    *,
+    app: FastAPI,
+    alert_id: str,
+    workspace_id: uuid.UUID,
+    as_of: datetime | None = None,
+    top_k: int = DEFAULT_TOP_K,
+    candidates: Iterable[RunbookDocument] | None = None,
+) -> dict[str, Any]:
+    """Return the top ``top_k`` matching runbooks for ``alert_id``.
+
+    Parameters
+    ----------
+    app:
+        FastAPI app exposing ``app.state.graph_store``.  When ``candidates``
+        is supplied (tests, deterministic replays) the graph_store is
+        consulted only for the alert seed; otherwise the handler walks
+        ``find_related(edge_types=["MATCHES", "TARGETS"])`` to gather the
+        runbook neighbourhood.
+    alert_id:
+        Canonical alert URI ``alert://{provider}/{provider_alert_id}``.
+    workspace_id:
+        REQUIRED.  Every graph read carries it (ACL invariant).
+    as_of:
+        Optional ADR-0008 §5 bitemporal anchor.
+    top_k:
+        Number of runbooks to return.  Clamped to ``[1, MAX_TOP_K]``.
+    candidates:
+        Optional iterable of pre-loaded :class:`RunbookDocument` to score
+        against.  Used by the integration test so it does not need a
+        graph backend with runbook-entity round-trip support.
+    """
+    validate_alert_id(alert_id)
+    normalised_as_of = enforce_utc(as_of)
+    clamped_top_k = max(1, min(top_k, MAX_TOP_K))
+
+    graph_store: GraphStore | None = getattr(app.state, "graph_store", None)
+    if graph_store is None and candidates is None:
+        raise RuntimeError("graph_store not available on app.state and no candidates supplied")
+
+    with record_request_duration(surface="mcp", tool="suggest_runbook", as_of=normalised_as_of):
+        alert_view, runbooks = await _load_alert_and_candidates(
+            graph_store=graph_store,
+            alert_id=alert_id,
+            workspace_id=workspace_id,
+            as_of=normalised_as_of,
+            preloaded=candidates,
+        )
+
+    if alert_view is None:
+        RUNBOOK_SUGGEST_TOTAL.labels(outcome="alert_not_found").inc()
+        raise ValueError(f"{ALERT_NOT_FOUND_CODE}:{alert_id}")
+
+    scored: list[MatchResult] = []
+    for runbook in runbooks:
+        result = score_runbook_against_alert(runbook=runbook, alert=alert_view)
+        if result.confidence > 0.0:
+            scored.append(result)
+
+    # Stable ordering: confidence DESC, then runbook name ASC for
+    # determinism when scores tie.
+    scored.sort(key=lambda r: (-r.confidence, r.runbook_name))
+    top = scored[:clamped_top_k]
+
+    outcome = "match" if top else "no_match"
+    RUNBOOK_SUGGEST_TOTAL.labels(outcome=outcome).inc()
+
+    top_names = {r.runbook_name for r in top}
+    citations = [
+        _citation_for(runbook) for runbook in runbooks if runbook.canonical_name in top_names
+    ]
+    citations_by_name = {c["runbook_name"]: c for c in citations}
+
+    return {
+        "alert_id": alert_id,
+        "effective_as_of": resolve_effective_as_of(normalised_as_of).isoformat(),
+        "suggestions": [
+            {
+                **match.to_payload(),
+                "citation": citations_by_name.get(match.runbook_name),
+            }
+            for match in top
+        ],
+        "meta": {
+            "candidate_count": len(runbooks),
+            "scored_count": len(scored),
+            "top_k": clamped_top_k,
+            "alert_tag_count": len(alert_view.tags),
+        },
+    }
+
+
+async def _load_alert_and_candidates(
+    *,
+    graph_store: GraphStore | None,
+    alert_id: str,
+    workspace_id: uuid.UUID,
+    as_of: datetime | None,
+    preloaded: Iterable[RunbookDocument] | None,
+) -> tuple[AlertView | None, list[RunbookDocument]]:
+    """Resolve the alert seed + the runbook candidate set.
+
+    When ``preloaded`` is supplied (integration test) we still hit
+    ``get_entity`` so the ACL invariant is exercised (and the test
+    asserts the call).  When ``preloaded`` is ``None`` we walk
+    ``find_related`` and rebuild :class:`RunbookDocument` instances from
+    neighbour entities whose chunk_text is a serialised runbook payload.
+    """
+    if graph_store is None:
+        # Should never happen — the caller guards on it.  Defensive.
+        return None, list(preloaded or [])
+
+    alert_entity = await graph_store.get_entity(
+        entity_name=alert_id,
+        workspace_id=workspace_id,
+        as_of=as_of,
+    )
+    if alert_entity is None:
+        return None, []
+    alert_view = _alert_view_from_entity(alert_entity)
+
+    if preloaded is not None:
+        return alert_view, list(preloaded)
+
+    # Walk the graph for runbook neighbours.  Depth 1 covers direct
+    # ``MATCHES`` edges; depth 2 covers ``alert -> service -> runbook``
+    # patterns.  We do not request specific edge_types so the adapter
+    # surfaces every related entity; we filter by kind here.
+    related = await graph_store.find_related(
+        entity_name=alert_id,
+        workspace_id=workspace_id,
+        as_of=as_of,
+        max_depth=2,
+    )
+
+    candidates: list[RunbookDocument] = []
+    for neighbour in related.related:
+        if neighbour.kind != "runbook":
+            continue
+        rb = runbook_from_entity_metadata(neighbour)
+        if rb is not None:
+            candidates.append(rb)
+    return alert_view, candidates
+
+
+def _citation_for(runbook: RunbookDocument) -> dict[str, Any]:
+    """Build the citation block surfaced alongside each suggestion.
+
+    Pulls the runbook title + first heading body so the responder UI can
+    render a preview without a second round-trip.
+    """
+    first_step: dict[str, Any] | None = None
+    if runbook.steps:
+        first = runbook.steps[0]
+        first_step = {
+            "step_id": first.step_id,
+            "heading": first.heading,
+            "heading_level": first.heading_level,
+        }
+    return {
+        "runbook_name": runbook.canonical_name,
+        "title": runbook.title,
+        "source_uid": runbook.source_uid,
+        "rel_path": runbook.rel_path,
+        "tags": runbook.front_matter.tags,
+        "severity": runbook.front_matter.severity,
+        "first_step": first_step,
+        "parse_warnings": runbook.parse_warnings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# record_runbook_step
+# ---------------------------------------------------------------------------
+
+
+def get_recorder(app: FastAPI) -> RunbookStepRecorder:
+    """Return (lazily-creating) the process-local recorder on app.state."""
+    recorder = getattr(app.state, "runbook_step_recorder", None)
+    if recorder is None:
+        recorder = RunbookStepRecorder()
+        app.state.runbook_step_recorder = recorder
+    if not isinstance(recorder, RunbookStepRecorder):  # pragma: no cover - defensive
+        raise RuntimeError("app.state.runbook_step_recorder is not a RunbookStepRecorder")
+    return recorder
+
+
+def record_runbook_step(
+    *,
+    app: FastAPI,
+    workspace_id: uuid.UUID,
+    incident_id: str,
+    alert_id: str,
+    runbook_name: str,
+    step_id: str,
+    outcome: str = "executed",
+    actor: str | None = None,
+    note: str | None = None,
+    valid_from: datetime | None = None,
+) -> RunbookStepEvent:
+    """Record a single runbook-step execution as a bitemporal event.
+
+    Three durability surfaces (any one is sufficient to reconstruct the
+    history; we write to all three for defence-in-depth):
+
+    * The in-memory :class:`RunbookStepRecorder` ring buffer.
+    * A structured log line (event ``"runbook_step_executed"``).
+    * The :data:`RUNBOOK_STEP_EVENTS_TOTAL` Prometheus counter.
+
+    ``valid_from`` defaults to "now"; callers replaying a historical
+    execution may supply an earlier timestamp.  ``recorded_at`` is always
+    "now" — the bitemporal contract distinguishes "when it happened" from
+    "when we learned it happened".
+    """
+    validate_alert_id(alert_id)
+    validate_runbook_name(runbook_name)
+    validate_step_id(step_id)
+    if not incident_id or not isinstance(incident_id, str):
+        raise ValueError("invalid_incident_id:incident_id must be a non-empty string")
+
+    now = datetime.now(UTC)
+    valid_from_norm = enforce_utc(valid_from) or now
+
+    step_name = canonical_runbook_step_name(
+        # The recorder is downstream of the source_uid -> rel_path split
+        # encoded in the canonical name.  We pass the slugged values
+        # straight through to canonical_runbook_step_name so the result
+        # is byte-identical to the connector-emitted entity name.
+        _runbook_source_uid(runbook_name),
+        _runbook_rel_path(runbook_name),
+        step_id,
+    )
+
+    event = RunbookStepEvent(
+        event_id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        alert_id=alert_id,
+        incident_id=incident_id,
+        runbook_name=runbook_name,
+        step_id=step_id,
+        step_name=step_name,
+        actor=actor,
+        note=note,
+        outcome=outcome,
+        valid_from=valid_from_norm,
+        valid_to=None,
+        recorded_at=now,
+    )
+
+    get_recorder(app).append(event)
+    RUNBOOK_STEP_EVENTS_TOTAL.labels(workspace_prefix=str(workspace_id)[:8]).inc()
+    log.info(
+        "runbook_step_executed",
+        event_id=str(event.event_id),
+        workspace_id=str(workspace_id),
+        incident_id=incident_id,
+        alert_id=alert_id,
+        runbook_name=runbook_name,
+        step_id=step_id,
+        step_name=step_name,
+        outcome=outcome,
+        valid_from=event.valid_from.isoformat(),
+        recorded_at=event.recorded_at.isoformat(),
+    )
+    return event
+
+
+def _runbook_source_uid(runbook_name: str) -> str:
+    """Extract the ``source_uid`` segment from a canonical runbook name."""
+    # ``runbook://{source_uid}/{rel_path...}`` — split off the scheme and
+    # take everything up to the first slash.
+    tail = runbook_name[len("runbook://") :]
+    head, _, _ = tail.partition("/")
+    return head
+
+
+def _runbook_rel_path(runbook_name: str) -> str:
+    """Extract the ``rel_path`` tail from a canonical runbook name."""
+    tail = runbook_name[len("runbook://") :]
+    _, _, rest = tail.partition("/")
+    return rest
+
+
+__all__ = [
+    "ALERT_NOT_FOUND_CODE",
+    "DEFAULT_RECORDER_CAPACITY",
+    "DEFAULT_TOP_K",
+    "INVALID_ALERT_ID_CODE",
+    "INVALID_ALERT_ID_MESSAGE",
+    "INVALID_RUNBOOK_NAME_CODE",
+    "INVALID_RUNBOOK_NAME_MESSAGE",
+    "INVALID_STEP_ID_CODE",
+    "MAX_TOP_K",
+    "RUNBOOK_NOT_FOUND_CODE",
+    "RUNBOOK_STEP_EVENTS_TOTAL",
+    "RUNBOOK_SUGGEST_TOTAL",
+    "RunbookStepEvent",
+    "RunbookStepRecorder",
+    "get_recorder",
+    "record_runbook_step",
+    "runbook_from_entity_metadata",
+    "suggest_runbook",
+    "validate_alert_id",
+    "validate_runbook_name",
+    "validate_step_id",
+]

--- a/docs/runbooks/runbook-connector.md
+++ b/docs/runbooks/runbook-connector.md
@@ -1,0 +1,218 @@
+# Runbook connector
+
+> Status: shipped in v0.3 — issue [#231](https://github.com/100rd/Omniscience/issues/231).
+
+The runbook connector parses CommonMark runbooks from a filesystem tree,
+emits one bitemporal entity per file plus one per heading, and surfaces
+matching runbooks at incident time via the `suggest_runbook` MCP tool
+and the `POST /api/v1/incidents/{id}/runbook-step` REST endpoint.
+
+This page documents the **author-facing contract** — what to put in your
+runbook so it ranks highly when a matching alert fires.
+
+## Where runbooks live
+
+The connector walks any directory tree you point it at. A common pattern
+is a per-team git repo:
+
+```
+team-runbooks/
+  payments/
+    db-connections-exhausted.md
+    pagerduty-flap.md
+  search/
+    elasticsearch-yellow.md
+  README.md
+```
+
+Register the source via `omniscience-cli sources add --type runbook
+--root-path /var/runbooks --source-uid team-runbooks`. The `source_uid`
+becomes the first segment of every canonical name the connector emits
+(`runbook://team-runbooks/payments/db-connections-exhausted.md`), so
+keep it short and stable.
+
+## Front-matter
+
+The connector parses a small subset of YAML at the very top of each
+runbook, fenced with `---`. **Everything outside this block is treated
+as the runbook body and ignored by the matcher** — front-matter is the
+only signal that influences ranking.
+
+```markdown
+---
+title: "Database connections exhausted"
+alert_names:
+  - "alert://datadog/db.connections.exhausted"
+alert_patterns:
+  - "alert://datadog/db.connections.*"
+  - "alert://pagerduty/postgres-*"
+tags:
+  - "service:payments"
+  - "service:checkout"
+  - "severity:sev2"
+severity: sev2
+owners:
+  - "team:payments"
+---
+
+# Database connections exhausted
+
+This runbook fires when the payments-API connection pool is saturated.
+…
+```
+
+### Recognised keys
+
+| Key | Type | Purpose |
+|---|---|---|
+| `title` | string | Human-readable title for the responder UI. Falls back to the first `#` heading, then the filename. |
+| `alert_names` | list[string] | **Exact** canonical alert names this runbook claims. Highest-weighted signal in the matcher. |
+| `alert_patterns` | list[string] | `fnmatch`-style globs over alert names (`alert://datadog/db.*`). Cover whole alert families with one runbook. |
+| `tags` | list[string] | Free-form labels that align with the alert tag set. Jaccard overlap contributes to the score. Conventional shape is `key:value` (`service:payments`, `severity:sev2`). |
+| `severity` | string | Tie-breaker against the alert's severity. Conventional values: `sev1`, `sev2`, `sev3`, `sev4`. |
+| `owners` | list[string] | Pure metadata — surfaced in the citation block but does **not** influence ranking. |
+
+Unknown keys are kept in `raw_front_matter` and surfaced in the
+`get_document` payload so external tools can read them, but the matcher
+ignores them. We will add new structured keys here additively (no
+breaking changes).
+
+### YAML subset
+
+The connector ships its own minimal YAML parser to avoid pulling a
+200 KB dependency. The subset it accepts is deliberately small:
+
+- `key: value` scalars.
+- `key:` followed by block-style `- item` lines.
+- Inline flow lists: `key: [a, b, c]`.
+- `"` and `'` quoted strings.
+- `#` line comments.
+
+It does **not** support nested mappings, anchors, tags, JSON-flow
+mappings, or multi-line scalars. Hand-edited runbooks rarely need them.
+
+### Defensive coercion
+
+The parser is permissive on common author mistakes:
+
+- A single scalar where a list is expected is wrapped: `tags: just-one`
+  is equivalent to `tags: ["just-one"]`.
+- A missing closing `---` fence emits a `front_matter_missing_closing_fence`
+  warning, drops the would-be front-matter, and parses the file as
+  body-only — the suggest path still works, the runbook just has no
+  matching signals.
+- A duplicate heading slug emits a `duplicate_step_slug` warning and
+  disambiguates with a numeric suffix (`mitigate`, `mitigate-2`).
+
+Warnings travel with the runbook on `parse_warnings` and surface in the
+suggest response so authors can find and fix them.
+
+## Body conventions
+
+The body of the runbook is rendered verbatim by the responder UI; we do
+not require any particular structure. That said, two conventions
+maximise the responder's productivity:
+
+1. **One ATX heading per executable step.** Each `## Triage`, `## Mitigate`,
+   `## Resolve` becomes a `runbook_step` entity with its own canonical
+   name (`runbook://team-runbooks/db.md#mitigate`). When the responder
+   acks that they've executed a step, they reference it by that step id.
+2. **Put commands in fenced code blocks.** The parser extracts every
+   fenced block per step (`code_blocks`) so the responder UI can render
+   one-click "copy command" buttons.
+
+```markdown
+## Mitigate
+
+Scale the pool out by 50% — this is reversible.
+
+\`\`\`bash
+kubectl -n payments scale deploy/payments-api --replicas=8
+\`\`\`
+```
+
+## How suggestions are ranked
+
+The matcher computes a single confidence score per `(runbook, alert)`
+pair as a weighted sum of four features:
+
+```
+confidence = clamp(
+    0.55 * exact_alert_name_match    # 1.0 iff any alert_name == alert.name
+  + 0.25 * pattern_match_score       # 1.0 on first fnmatch hit
+  + 0.15 * tag_jaccard               # |runbook.tags ∩ alert.tags| / |union|
+  + 0.05 * severity_match,           # 1.0 iff runbook.severity == alert.severity
+  0.0, 1.0,
+)
+```
+
+The weights are exposed as constants in
+`omniscience_connectors.runbook.linker` so a future calibrated model
+(post-#231 follow-up) can swap them without renaming the public surface.
+
+### Monotonicity invariant
+
+Adding a matching signal to a runbook (one more exact `alert_names`
+entry, one more overlapping `tags` entry) **must not lower the
+confidence score** for an alert it was already matching. The integration
+test `tests/integration/test_runbook_suggest.py::
+test_suggest_runbook_monotonic_with_more_matching_tags` pins this in CI.
+
+### Why `confidence` and not `relevance`?
+
+The score is a v0.1 deterministic placeholder — we call it `confidence`
+to make the calibration story explicit: a 0.6 today is *not* the same
+"probability the runbook is right" as a 0.6 after #232 lands the
+calibrated model. Callers should treat the score as a stable schema slot
+that they can pin retries against, not a calibrated probability.
+
+## Recording an executed step
+
+When the responder takes an action from a runbook, the responder UI
+posts to:
+
+```http
+POST /api/v1/incidents/{incident_id}/runbook-step
+Content-Type: application/json
+Authorization: Bearer <workspace-scoped token>
+
+{
+  "alert_id":      "alert://datadog/db.connections.exhausted",
+  "runbook_name":  "runbook://team-runbooks/db-connections-exhausted.md",
+  "step_id":       "mitigate",
+  "outcome":       "executed",
+  "actor":         "alice@payments.example.com",
+  "note":          "Scaled to 8 replicas; pool gauge fell from 95% to 38%."
+}
+```
+
+The event is recorded with the full bitemporal triple (`valid_from`,
+`valid_to`, `recorded_at`) per ADR-0008 §1 and surfaced on:
+
+- `GET /api/v1/incidents/{incident_id}/runbook-steps` — the per-incident
+  step log the responder UI renders below the suggestion.
+- The `runbook_step_executed` structured-log event — picked up by any
+  log shipper for durable retention.
+- The `omniscience_runbook_step_events_total` Prometheus counter —
+  ops-team visibility on how often runbooks actually fire.
+
+The recorder is process-local in v0.3 (capacity 10 000 events, FIFO
+eviction). A follow-up (tracked under epic #230) promotes it to a
+proper SQL table so cross-replica reads do not depend on sticky
+sessions. The public function signatures are stable across that
+migration.
+
+## ACL
+
+Every endpoint is workspace-scoped via the bearer token. Cross-workspace
+alert ids return `alert_not_found` (404) — the same response a missing
+alert would produce — so workspace existence is never leaked. This
+mirrors the `resolve_incident` posture documented in
+`docs/api/resolve-incident.md`.
+
+## Sample runbooks
+
+Reference runbooks live under
+[`tests/fixtures/runbook/`](../../tests/fixtures/runbook/) and double as
+the integration-test corpus. They are a good starting point when bringing
+up a new team's runbook collection.

--- a/packages/connectors/src/omniscience_connectors/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/__init__.py
@@ -22,7 +22,7 @@ Registry::
 
 Built-in connectors (``git``, ``github_pr``, ``fs``, ``confluence``, ``notion``,
 ``slack``, ``jira``, ``k8s-agentic``, ``s3``, ``aws``, ``alerts``, ``otel``,
-``datadog``, ``pagerduty``) are registered below and available immediately on import.
+``datadog``, ``pagerduty``, ``runbook``) are registered below and available immediately on import.
 Third-party connectors call :func:`get_connector` after registering against
 the shared registry.
 """
@@ -79,6 +79,10 @@ from omniscience_connectors.registry import (
     _registry,
     get_connector,
 )
+from omniscience_connectors.runbook import (
+    RunbookConfig,
+    RunbookConnector,
+)
 from omniscience_connectors.s3.connector import S3Config, S3Connector
 from omniscience_connectors.slack.connector import SlackConnector
 
@@ -98,6 +102,7 @@ _registry.register(AlertsConnector)
 _registry.register(OtelConnector)
 _registry.register(DatadogConnector)
 _registry.register(PagerDutyConnector)
+_registry.register(RunbookConnector)
 
 # Public alias for the shared registry instance (all built-ins pre-registered).
 default_registry: ConnectorRegistry = _registry
@@ -137,6 +142,8 @@ __all__ = [
     "ParsedSpan",
     "ParsedTrace",
     "ParsedTraces",
+    "RunbookConfig",
+    "RunbookConnector",
     "S3Config",
     "S3Connector",
     "SlackConnector",

--- a/packages/connectors/src/omniscience_connectors/runbook/__init__.py
+++ b/packages/connectors/src/omniscience_connectors/runbook/__init__.py
@@ -1,0 +1,86 @@
+"""Runbook source connector for Omniscience (issue #231).
+
+Parses CommonMark runbooks from filesystem trees, extracts YAML front-matter,
+headings, and fenced code blocks, and emits one bitemporal entity per runbook
+plus structured per-step bodies that downstream tooling
+(:mod:`omniscience_server.runbook`) consumes to suggest matching runbooks at
+incident time.
+
+The connector reuses the existing filesystem walking semantics but is *not*
+a subclass of :class:`FsConnector` — runbooks have a richer DocumentRef
+metadata block (parsed front-matter, step ids, alert-name globs) and a
+distinct ``runbook://`` canonical-name space so the entity linker can attach
+``MATCHES`` edges from alerts.
+
+Canonical names
+---------------
+* Runbook entity         — ``runbook://{source_uid}/{relative_path}``
+* Runbook step entity    — ``runbook://{source_uid}/{relative_path}#{step_id}``
+
+The ``relative_path`` is POSIX-normalised and stripped of leading slashes so
+runbooks discovered through git, fs, and Confluence ingest paths produce
+byte-identical names (cross_ref enabled).
+
+Front-matter schema (recognised keys; unknown keys are passed through as
+metadata but ignored by the matcher):
+
+    ---
+    title: "DB connections exhausted"
+    alert_names:                # exact-match candidates
+      - "alert://datadog/db.connections.exhausted"
+    alert_patterns:             # fnmatch-style globs
+      - "alert://datadog/db.*"
+    tags:                       # free-form, joined to alert tags
+      - "service:payments"
+      - "severity:sev2"
+    severity: sev2              # optional canonical severity slot
+    owners:
+      - "team:payments"
+    ---
+
+Public surface
+--------------
+
+>>> from omniscience_connectors.runbook import (
+...     RunbookConfig,
+...     RunbookConnector,
+...     RunbookDocument,
+...     RunbookStep,
+...     RunbookFrontMatter,
+...     parse_runbook,
+...     canonical_runbook_name,
+...     canonical_runbook_step_name,
+... )
+"""
+
+from omniscience_connectors.runbook.connector import (
+    RunbookConfig,
+    RunbookConnector,
+)
+from omniscience_connectors.runbook.models import (
+    RUNBOOK_NAME_PATTERN,
+    RUNBOOK_STEP_NAME_PATTERN,
+    RunbookDocument,
+    RunbookFrontMatter,
+    RunbookStep,
+    canonical_runbook_name,
+    canonical_runbook_step_name,
+)
+from omniscience_connectors.runbook.parser import (
+    ParseError,
+    parse_runbook,
+)
+
+__all__ = [
+    "RUNBOOK_NAME_PATTERN",
+    "RUNBOOK_STEP_NAME_PATTERN",
+    "ParseError",
+    "RunbookConfig",
+    "RunbookConnector",
+    "RunbookDocument",
+    "RunbookFrontMatter",
+    "RunbookStep",
+    "canonical_runbook_name",
+    "canonical_runbook_step_name",
+    "parse_runbook",
+]

--- a/packages/connectors/src/omniscience_connectors/runbook/connector.py
+++ b/packages/connectors/src/omniscience_connectors/runbook/connector.py
@@ -1,0 +1,276 @@
+"""Runbook source connector (issue #231).
+
+Discovers ``*.md`` / ``*.markdown`` files under a configured root, parses
+each into a :class:`RunbookDocument`, and emits one
+:class:`DocumentRef` per runbook with the parsed structure stashed in
+``metadata`` so downstream ingestion produces:
+
+* one ``runbook://`` entity per file,
+* one ``runbook://...#step`` entity per heading,
+* ``MATCHES`` edges (added by the entity linker, not here) from any alert
+  whose canonical name matches the front-matter ``alert_names`` /
+  ``alert_patterns``.
+
+This connector is **read-only** and pull-based.  Webhook-style updates
+should arrive via the existing git or fs connector and re-trigger a fetch;
+the dedicated handler is intentionally not implemented here to keep this
+connector single-purpose (parse markdown, surface structure).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import ClassVar
+
+from pydantic import BaseModel, Field, field_validator
+
+from omniscience_connectors.base import (
+    Connector,
+    DocumentRef,
+    FetchedDocument,
+    WebhookHandler,
+)
+from omniscience_connectors.runbook.models import (
+    RunbookDocument,
+    canonical_runbook_name,
+)
+from omniscience_connectors.runbook.parser import ParseError, parse_runbook
+
+__all__ = [
+    "DEFAULT_RUNBOOK_GLOBS",
+    "RunbookConfig",
+    "RunbookConnector",
+]
+
+logger = logging.getLogger(__name__)
+
+# Default file extensions a runbook author would reasonably use.  ``.mdx``
+# is intentionally included so doc-site-hosted runbooks (Docusaurus,
+# Nextra) can be ingested without renaming.
+DEFAULT_RUNBOOK_GLOBS: tuple[str, ...] = ("*.md", "*.markdown", "*.mdx")
+
+# Hard cap per file (1 MiB).  Runbooks should not realistically exceed this;
+# a larger file is almost certainly a misconfiguration.
+_MAX_FILE_SIZE_BYTES: int = 1 * 1024 * 1024
+
+
+class RunbookConfig(BaseModel):
+    """Public configuration for the runbook connector (no secrets)."""
+
+    root_path: str = Field(description="Absolute path to the runbook directory tree.")
+    source_uid: str = Field(
+        description=(
+            "Short, stable identifier for this runbook source.  Used as the "
+            "first segment of the canonical runbook name so multiple runbook "
+            "sources (one per team, one per repo) can coexist without "
+            "colliding on relative paths."
+        ),
+    )
+    include_globs: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_RUNBOOK_GLOBS),
+        description="Filename globs that count as runbooks (matched on basename).",
+    )
+    exclude_globs: list[str] = Field(
+        default_factory=list,
+        description="Path globs to exclude (matched on POSIX-relative path).",
+    )
+    follow_symlinks: bool = False
+
+    @field_validator("source_uid")
+    @classmethod
+    def _validate_source_uid(cls, value: str) -> str:
+        if not value or value.strip() != value:
+            raise ValueError("source_uid must be non-empty and not surrounded by whitespace")
+        return value
+
+
+def _path_is_within(root: Path, candidate: Path) -> bool:
+    """Containment check — same shape as the fs connector's guard."""
+    try:
+        candidate.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _basename_match(name: str, patterns: list[str]) -> bool:
+    """Filename-basename glob match."""
+    import fnmatch as _fn
+
+    return any(_fn.fnmatchcase(name, pat) for pat in patterns)
+
+
+def _path_excluded(rel_posix: str, patterns: list[str]) -> bool:
+    """POSIX-relative path glob match."""
+    import fnmatch as _fn
+
+    return any(_fn.fnmatchcase(rel_posix, pat) for pat in patterns)
+
+
+class RunbookConnector(Connector):
+    """Connector for markdown runbooks on local disk.
+
+    Stateless: all configuration is passed per call so a single instance
+    can serve many sources.  Symmetric with :class:`FsConnector`.
+    """
+
+    connector_type: ClassVar[str] = "runbook"
+    config_schema: ClassVar[type[BaseModel]] = RunbookConfig
+
+    async def validate(self, config: BaseModel, secrets: dict[str, str]) -> None:
+        """Check the root path exists, is a directory, and is readable."""
+        cfg = self._cfg(config)
+        root = Path(cfg.root_path).resolve()
+        if not root.exists():
+            raise ValueError(f"root_path {cfg.root_path!r} does not exist")
+        if not root.is_dir():
+            raise ValueError(f"root_path {cfg.root_path!r} is not a directory")
+        if not os.access(root, os.R_OK):
+            raise ValueError(f"root_path {cfg.root_path!r} is not readable")
+
+    async def discover(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Yield one DocumentRef per matching runbook file."""
+        cfg = self._cfg(config)
+        root = Path(cfg.root_path).resolve()
+
+        for file_path in _walk(root, cfg.follow_symlinks):
+            resolved = file_path.resolve()
+            if not _path_is_within(root, resolved):
+                logger.warning(
+                    "runbook.connector.traversal_attempt",
+                    extra={"path": str(file_path)},
+                )
+                continue
+
+            rel = resolved.relative_to(root)
+            rel_posix = rel.as_posix()
+
+            if not _basename_match(resolved.name, cfg.include_globs):
+                continue
+            if cfg.exclude_globs and _path_excluded(rel_posix, cfg.exclude_globs):
+                continue
+
+            try:
+                stat = resolved.stat()
+            except OSError:
+                continue
+            if stat.st_size > _MAX_FILE_SIZE_BYTES:
+                logger.debug(
+                    "runbook.connector.skip_large_file",
+                    extra={"path": rel_posix, "size": stat.st_size},
+                )
+                continue
+
+            mtime = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+            yield DocumentRef(
+                external_id=str(resolved),
+                uri=canonical_runbook_name(cfg.source_uid, rel_posix),
+                updated_at=mtime,
+                metadata={
+                    "path": rel_posix,
+                    "size": stat.st_size,
+                    "source_uid": cfg.source_uid,
+                    "content_type": "text/markdown",
+                    "edges": [],
+                },
+            )
+
+    async def fetch(
+        self,
+        config: BaseModel,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Read a runbook file, parse it, and return the parsed JSON payload.
+
+        Unlike the plain fs connector we do not return raw bytes — the
+        parsed :class:`RunbookDocument` is the canonical artefact for
+        downstream indexing.  Raw markdown is preserved on the
+        :attr:`RunbookDocument.body_markdown` slot.
+        """
+        cfg = self._cfg(config)
+        root = Path(cfg.root_path).resolve()
+        file_path = Path(ref.external_id).resolve()
+
+        if not _path_is_within(root, file_path):
+            raise ValueError(
+                f"Path {ref.external_id!r} is outside the configured root {cfg.root_path!r}"
+            )
+
+        stat = file_path.stat()
+        if stat.st_size > _MAX_FILE_SIZE_BYTES:
+            raise ValueError(
+                f"Runbook {ref.external_id!r} ({stat.st_size} bytes) exceeds "
+                f"max size {_MAX_FILE_SIZE_BYTES}"
+            )
+
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+        rel_posix_obj = ref.metadata.get("path", file_path.name)
+        rel_posix = str(rel_posix_obj)
+
+        try:
+            parsed = parse_runbook(
+                source_uid=cfg.source_uid,
+                rel_path=rel_posix,
+                text=text,
+            )
+        except ParseError:
+            logger.warning(
+                "runbook.connector.unparseable",
+                extra={"path": rel_posix},
+            )
+            # Emit a placeholder document so ingestion can record the entity
+            # but mark zero steps — the matcher will score 0 against it.
+            parsed = RunbookDocument(
+                source_uid=cfg.source_uid,
+                rel_path=rel_posix,
+                canonical_name=canonical_runbook_name(cfg.source_uid, rel_posix),
+                front_matter={},  # type: ignore[arg-type]
+                raw_front_matter={},
+                title=rel_posix.rsplit("/", 1)[-1],
+                body_markdown="",
+                steps=[],
+                parse_warnings=["empty_or_unparseable"],
+            )
+
+        payload = parsed.model_dump_json().encode("utf-8")
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=payload,
+            content_type="application/vnd.omniscience.runbook+json",
+        )
+
+    def webhook_handler(self) -> WebhookHandler | None:
+        """No webhook surface — file watcher / git pull drives re-ingest."""
+        return None
+
+    # ----- helpers -----
+
+    @staticmethod
+    def _cfg(config: BaseModel) -> RunbookConfig:
+        """Narrow ``BaseModel`` to :class:`RunbookConfig` for mypy."""
+        if not isinstance(config, RunbookConfig):
+            raise TypeError(
+                f"RunbookConnector requires RunbookConfig, got {type(config).__name__}"
+            )
+        return config
+
+
+def _walk(root: Path, follow_symlinks: bool) -> list[Path]:
+    """Return every regular file under *root* (hidden files / dirs skipped)."""
+    results: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=follow_symlinks, topdown=True):
+        dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+        for fname in filenames:
+            if fname.startswith("."):
+                continue
+            results.append(Path(dirpath) / fname)
+    return results

--- a/packages/connectors/src/omniscience_connectors/runbook/linker.py
+++ b/packages/connectors/src/omniscience_connectors/runbook/linker.py
@@ -1,0 +1,190 @@
+"""Runbook -> alert matcher and confidence scoring (issue #231).
+
+The matcher is intentionally pure: it takes a parsed
+:class:`RunbookDocument` plus an :class:`AlertView` and returns a
+:class:`MatchResult`.  No DB / graph access — the server's
+``suggest_runbook`` handler loads candidates from the graph and feeds them
+through this function in a loop.
+
+Confidence formula (v0.1 placeholder; calibrated model is a follow-up
+tracked under issue #231's "post-merge" thread)
+================================================================
+
+Confidence ∈ [0.0, 1.0] is computed as a weighted sum of feature scores:
+
+    confidence = clamp(
+        0.55 * exact_alert_name_match    # 1.0 if any alert_name == alert.name
+      + 0.25 * pattern_match_score       # max fnmatch ratio over alert_patterns
+      + 0.15 * tag_jaccard               # |fm.tags ∩ alert.tags| / |union|
+      + 0.05 * severity_match,           # 1.0 if fm.severity == alert.severity
+      0.0, 1.0,
+    )
+
+Monotonicity invariant (asserted in the integration test): adding more
+matching tags or matching exact alert names to a runbook must produce a
+weakly higher confidence — never lower.  The integration test fixtures are
+constructed to make this trivially checkable.
+
+Why these weights:
+    - Exact match dominates because runbook authors who bother to list
+      an alert by name *intend* that runbook to fire for that alert.
+    - Pattern match is second because globs cover families
+      (``alert://datadog/db.*``) — high precision when present.
+    - Tag overlap is third — useful but noisier (tags like ``severity:sev2``
+      match many runbooks).
+    - Severity is a tie-breaker — never the primary signal.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Final
+
+from pydantic import BaseModel, Field
+
+from omniscience_connectors.runbook.models import RunbookDocument
+
+__all__ = [
+    "WEIGHT_EXACT",
+    "WEIGHT_PATTERN",
+    "WEIGHT_SEVERITY",
+    "WEIGHT_TAGS",
+    "AlertView",
+    "MatchResult",
+    "score_runbook_against_alert",
+]
+
+
+# Weights — exposed as constants for the admin telemetry surface and so the
+# monotonicity test can lean on them rather than hard-coding "0.55".
+WEIGHT_EXACT: Final[float] = 0.55
+WEIGHT_PATTERN: Final[float] = 0.25
+WEIGHT_TAGS: Final[float] = 0.15
+WEIGHT_SEVERITY: Final[float] = 0.05
+
+# A run-of-the-mill heuristic — if the runbook lists *zero* matching signals
+# of any kind we round the confidence down to 0 so it never surfaces.
+_MIN_SIGNAL_CONFIDENCE: Final[float] = 0.01
+
+
+class AlertView(BaseModel):
+    """Minimal alert projection the matcher needs.
+
+    Built by the server from the alert entity + its bitemporal facts;
+    decoupled from the full :class:`omniscience_core.storage.EntityNodeView`
+    so the matcher can be unit-tested without a graph store.
+    """
+
+    name: str = Field(description="Canonical alert name, e.g. alert://datadog/db.conn")
+    tags: list[str] = Field(default_factory=list)
+    severity: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MatchResult:
+    """Per-runbook scoring trace returned by :func:`score_runbook_against_alert`.
+
+    The handler returns the top N of these to the caller so the responder
+    can see *why* the suggestion ranked where it did.
+    """
+
+    runbook_name: str
+    confidence: float
+    exact_match: bool
+    pattern_match: str | None
+    matched_tags: tuple[str, ...]
+    severity_match: bool
+
+    def to_payload(self) -> dict[str, object]:
+        """JSON-serialisable representation for the REST/MCP wire."""
+        return {
+            "runbook_name": self.runbook_name,
+            "confidence": round(self.confidence, 4),
+            "exact_match": self.exact_match,
+            "pattern_match": self.pattern_match,
+            "matched_tags": list(self.matched_tags),
+            "severity_match": self.severity_match,
+        }
+
+
+def _pattern_score(patterns: list[str], alert_name: str) -> tuple[float, str | None]:
+    """Return the best fnmatch ratio (0/1) and the pattern that produced it.
+
+    ``fnmatch`` is binary — a glob either matches or it doesn't — so the
+    "ratio" is 1.0 on first hit, 0.0 otherwise.  We keep the float surface
+    for symmetry with the other features and so a calibrated v0.2 model
+    (e.g. cosine similarity) can drop in without changing the signature.
+    """
+    for pattern in patterns:
+        if fnmatch.fnmatchcase(alert_name, pattern):
+            return 1.0, pattern
+    return 0.0, None
+
+
+def _tag_jaccard(rb_tags: list[str], alert_tags: list[str]) -> tuple[float, tuple[str, ...]]:
+    """Return Jaccard similarity over tag sets plus the intersection.
+
+    Empty alert-tags set yields 0.0 (no signal); empty runbook-tags set
+    likewise.  Tags are matched case-sensitively — the connector authors
+    can normalise upstream if they want case-insensitive semantics.
+    """
+    if not rb_tags or not alert_tags:
+        return 0.0, ()
+    rb_set = set(rb_tags)
+    alert_set = set(alert_tags)
+    intersection = rb_set & alert_set
+    if not intersection:
+        return 0.0, ()
+    union = rb_set | alert_set
+    jaccard = len(intersection) / len(union)
+    # Stable ordering for deterministic test assertions.
+    return jaccard, tuple(sorted(intersection))
+
+
+def score_runbook_against_alert(
+    *,
+    runbook: RunbookDocument,
+    alert: AlertView,
+) -> MatchResult:
+    """Compute the v0.1 confidence score for one runbook / alert pair.
+
+    Pure function — no IO, no global state.  Idempotent; the same inputs
+    always produce the same MatchResult.  Safe to call inside a hot loop;
+    the algorithm is O(|alert_patterns| + |runbook.tags| + |alert.tags|).
+    """
+    fm = runbook.front_matter
+
+    exact_match = alert.name in set(fm.alert_names)
+    exact_score = 1.0 if exact_match else 0.0
+
+    pattern_score, pattern_hit = _pattern_score(fm.alert_patterns, alert.name)
+
+    tag_score, matched_tags = _tag_jaccard(fm.tags, alert.tags)
+
+    severity_match = (
+        fm.severity is not None and alert.severity is not None and fm.severity == alert.severity
+    )
+    severity_score = 1.0 if severity_match else 0.0
+
+    confidence = (
+        WEIGHT_EXACT * exact_score
+        + WEIGHT_PATTERN * pattern_score
+        + WEIGHT_TAGS * tag_score
+        + WEIGHT_SEVERITY * severity_score
+    )
+    # Clamp to [0, 1] defensively even though the weights sum to 1.0; a
+    # future tweak that pushes a feature above 1.0 should not silently
+    # produce a malformed confidence.
+    confidence = max(0.0, min(1.0, confidence))
+    if confidence < _MIN_SIGNAL_CONFIDENCE:
+        confidence = 0.0
+
+    return MatchResult(
+        runbook_name=runbook.canonical_name,
+        confidence=confidence,
+        exact_match=exact_match,
+        pattern_match=pattern_hit,
+        matched_tags=matched_tags,
+        severity_match=severity_match,
+    )

--- a/packages/connectors/src/omniscience_connectors/runbook/models.py
+++ b/packages/connectors/src/omniscience_connectors/runbook/models.py
@@ -1,0 +1,188 @@
+"""Runbook entity models and canonical name helpers (issue #231).
+
+Kept in a tiny module so the matcher (``linker.py``), the parser
+(``parser.py``), and the server-side handlers
+(``apps/server/.../runbook.py``) can all import the value objects without
+pulling the network-touching connector class.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from pydantic import BaseModel, Field, field_validator
+
+__all__ = [
+    "RUNBOOK_NAME_PATTERN",
+    "RUNBOOK_STEP_NAME_PATTERN",
+    "RunbookDocument",
+    "RunbookFrontMatter",
+    "RunbookStep",
+    "canonical_runbook_name",
+    "canonical_runbook_step_name",
+]
+
+
+# ---------------------------------------------------------------------------
+# Canonical name pattern.  Permissive enough to cover ``a/b/runbook.md``,
+# ``team/payments/db-conn.md``, ``my_dir/file.markdown``, but forbids the
+# fragment marker ``#`` in the base name slot — ``#`` is reserved for the
+# step suffix on :func:`canonical_runbook_step_name`.
+# ---------------------------------------------------------------------------
+_NAME_SAFE_CHARS: Final[str] = r"[A-Za-z0-9._\-/]"
+RUNBOOK_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(
+    rf"^runbook://{_NAME_SAFE_CHARS}+/{_NAME_SAFE_CHARS}+$"
+)
+RUNBOOK_STEP_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(
+    rf"^runbook://{_NAME_SAFE_CHARS}+/{_NAME_SAFE_CHARS}+#[A-Za-z0-9._\-]+$"
+)
+
+# Step ids are slugified heading text — `/` and `#` are forbidden so the
+# canonical name parser can split on them unambiguously.
+_STEP_ID_SAFE: Final[re.Pattern[str]] = re.compile(r"[^A-Za-z0-9._\-]+")
+_SOURCE_UID_SAFE: Final[re.Pattern[str]] = re.compile(r"[^A-Za-z0-9._\-]+")
+
+
+def _slugify_source_uid(source_uid: str) -> str:
+    """Return a canonical-name-safe slug from a free-form source uid.
+
+    The connector accepts arbitrary source labels (``"git://repo"``,
+    ``"team-runbooks"``, ``"fs:/var/lib/runbooks"``).  We strip the URL
+    scheme separator and replace anything outside ``[A-Za-z0-9._-]`` with
+    a single ``-`` so the canonical name shape stays deterministic.
+    """
+    cleaned = _SOURCE_UID_SAFE.sub("-", source_uid).strip("-")
+    if not cleaned:
+        raise ValueError("source_uid must contain at least one safe character")
+    return cleaned
+
+
+def _normalise_rel_path(rel_path: str) -> str:
+    """Return a POSIX-style relative path with no leading slashes or dots.
+
+    Defends against ``./foo.md`` and ``/abs/path/foo.md`` arriving from
+    different filesystems — the canonical name must be stable across
+    callers regardless of how they expressed the path.
+    """
+    rel = rel_path.replace("\\", "/").lstrip("./")
+    rel = rel.lstrip("/")
+    if not rel:
+        raise ValueError("rel_path must be non-empty")
+    if "#" in rel:
+        raise ValueError("rel_path must not contain '#' (reserved for step suffix)")
+    return rel
+
+
+def canonical_runbook_name(source_uid: str, rel_path: str) -> str:
+    """Return the canonical entity name for a runbook document.
+
+    >>> canonical_runbook_name("team-runbooks", "payments/db-conn.md")
+    'runbook://team-runbooks/payments/db-conn.md'
+    """
+    slug = _slugify_source_uid(source_uid)
+    rel = _normalise_rel_path(rel_path)
+    return f"runbook://{slug}/{rel}"
+
+
+def canonical_runbook_step_name(
+    source_uid: str,
+    rel_path: str,
+    step_id: str,
+) -> str:
+    """Return the canonical name for an individual runbook step.
+
+    >>> canonical_runbook_step_name(
+    ...     "team-runbooks", "payments/db-conn.md", "Restart-the-pool"
+    ... )
+    'runbook://team-runbooks/payments/db-conn.md#restart-the-pool'
+    """
+    base = canonical_runbook_name(source_uid, rel_path)
+    slug = _STEP_ID_SAFE.sub("-", step_id).strip("-").lower()
+    if not slug:
+        raise ValueError("step_id slugifies to empty string")
+    return f"{base}#{slug}"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic value objects.  These are pure data — no behaviour — so they
+# round-trip through JSON cleanly for storage in DocumentRef.metadata.
+# ---------------------------------------------------------------------------
+
+
+class RunbookFrontMatter(BaseModel):
+    """YAML front-matter block parsed off the head of a runbook file.
+
+    Unknown keys are silently dropped by Pydantic to keep ``mypy --strict``
+    happy with the typed surface; raw passthrough lives in
+    :attr:`RunbookDocument.raw_front_matter`.
+    """
+
+    title: str | None = None
+    alert_names: list[str] = Field(default_factory=list)
+    alert_patterns: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    severity: str | None = None
+    owners: list[str] = Field(default_factory=list)
+
+    @field_validator("alert_names", "alert_patterns", "tags", "owners", mode="before")
+    @classmethod
+    def _coerce_to_string_list(cls, value: object) -> list[str]:
+        """Front-matter is YAML — be defensive about scalar vs list.
+
+        Hand-edited runbooks frequently provide a single string where a
+        list is expected (``tags: service:payments``).  We accept either
+        shape so authors do not get stuck on YAML quirks.
+        """
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        if isinstance(value, list):
+            return [str(v) for v in value if v is not None]
+        # Numeric/bool/etc. — coerce to string for forward-compat.
+        return [str(value)]
+
+
+class RunbookStep(BaseModel):
+    """One actionable step extracted from a runbook (== one heading).
+
+    The step's ``body`` carries the markdown beneath the heading verbatim
+    so the responder UI can render code fences, lists, and links without
+    a second pass through the parser.
+    """
+
+    step_id: str = Field(description="Slug derived from heading text.")
+    heading: str = Field(description="Original heading text (CommonMark inline).")
+    heading_level: int = Field(ge=1, le=6)
+    body: str = Field(description="Verbatim markdown body beneath the heading.")
+    code_blocks: list[str] = Field(
+        default_factory=list,
+        description="Fenced-code-block contents inside ``body`` (info string stripped).",
+    )
+
+
+class RunbookDocument(BaseModel):
+    """Parsed runbook ready for indexing or matching.
+
+    Constructed by :func:`omniscience_connectors.runbook.parse_runbook`; the
+    suggest path reads this back out of the indexed entity metadata.
+    """
+
+    source_uid: str
+    rel_path: str
+    canonical_name: str
+    front_matter: RunbookFrontMatter
+    raw_front_matter: dict[str, object] = Field(default_factory=dict)
+    title: str = Field(description="Human-readable title (front-matter or first H1).")
+    body_markdown: str = Field(description="Full markdown body with front-matter stripped.")
+    steps: list[RunbookStep] = Field(default_factory=list)
+    parse_warnings: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Non-fatal warnings encountered during parsing — e.g. malformed "
+            "front-matter that was skipped, duplicate step slugs that were "
+            "disambiguated, etc.  Surfaced in suggest_runbook output so "
+            "authors can fix their runbooks."
+        ),
+    )

--- a/packages/connectors/src/omniscience_connectors/runbook/parser.py
+++ b/packages/connectors/src/omniscience_connectors/runbook/parser.py
@@ -1,0 +1,435 @@
+"""Markdown runbook parser (issue #231).
+
+Self-contained: no new dependencies beyond the existing pydantic/httpx/etc.
+that the connector package already pulls.  We deliberately avoid a full
+CommonMark parser — runbooks live in `.md` files that are hand-authored,
+not machine-generated, and the only structural pieces we need are:
+
+* YAML front-matter at the top of the document (between ``---`` fences).
+* ATX headings (``#`` … ``######``).
+* Fenced code blocks (```````).
+
+A full CommonMark library (e.g. ``markdown-it-py``) would add 200kB to the
+wheel for features we never use.  This parser is documented as a "best
+effort over real runbooks" — malformed inputs return a partially-populated
+:class:`RunbookDocument` with warnings rather than raising, so a single bad
+runbook does not stall the ingest pipeline.
+
+YAML subset
+-----------
+We parse a deliberately small YAML subset:
+
+* ``key: value`` scalars
+* ``key:`` followed by ``- item`` block-style lists (one item per line)
+* Inline ``key: [a, b, c]`` flow-style lists
+* ``"`` and ``'`` quoted scalars
+* ``#`` line comments
+
+Block mappings, anchors, tags, multi-line scalars, and JSON-style flow
+mappings are *not* supported.  Runbook authors who need richer YAML can
+keep using the raw passthrough in :attr:`RunbookDocument.raw_front_matter`
+but they will be ignored by the matcher.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Final
+
+from pydantic import ValidationError
+
+from omniscience_connectors.runbook.models import (
+    RunbookDocument,
+    RunbookFrontMatter,
+    RunbookStep,
+    canonical_runbook_name,
+)
+
+__all__ = ["ParseError", "parse_runbook"]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module constants — no magic numbers
+# ---------------------------------------------------------------------------
+
+# Front-matter fence — three or more dashes on a line by themselves.  Trailing
+# whitespace allowed because hand-edited runbooks frequently include it.
+_FENCE_PATTERN: Final[re.Pattern[str]] = re.compile(r"^-{3,}\s*$")
+
+# ATX heading: 1-6 ``#`` followed by space and inline text.  Closing ``#``
+# tail (per CommonMark) is stripped.
+_HEADING_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^(?P<hashes>#{1,6})\s+(?P<text>.+?)(?:\s+#+\s*)?$"
+)
+
+# Fenced-code-block start/end — three backticks or three tildes, optional info
+# string.  Mixed fence chars (start ``` end ~~~) are *not* matched.
+_CODE_FENCE_PATTERN: Final[re.Pattern[str]] = re.compile(r"^(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+# Inline list literal: ``[a, b, "c d"]``.
+_INLINE_LIST_PATTERN: Final[re.Pattern[str]] = re.compile(r"^\[(?P<inner>.*)\]$")
+
+# Slugifier — collapses any run of non-alphanum to a single dash.
+_SLUG_PATTERN: Final[re.Pattern[str]] = re.compile(r"[^A-Za-z0-9]+")
+
+# Largest accepted front-matter block (chars).  Defends against pathological
+# input where the closing fence is missing — without this we would scan the
+# entire document looking for a fence that never arrives.
+_MAX_FRONTMATTER_CHARS: Final[int] = 32 * 1024
+
+
+class ParseError(Exception):
+    """Raised only for unrecoverable parser failures (e.g. empty input).
+
+    Recoverable issues — malformed YAML, duplicate slugs, missing closing
+    code fences — are captured as :attr:`RunbookDocument.parse_warnings`.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Front-matter extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_front_matter(text: str) -> tuple[str, str | None, list[str]]:
+    """Split front-matter from the body.
+
+    Returns ``(body, raw_fm_text or None, warnings)``.  Body is the text
+    with the front-matter fences removed.  ``raw_fm_text`` is the inner
+    YAML block (without the fences); ``None`` when no front-matter was
+    detected.
+    """
+    warnings: list[str] = []
+    lines = text.splitlines()
+    if not lines:
+        return text, None, warnings
+
+    # Front-matter must start on the very first non-empty line.  Allow
+    # a UTF-8 BOM and leading blank lines to be lenient with hand-edited
+    # files saved by Windows editors.
+    idx = 0
+    while idx < len(lines) and lines[idx].strip() == "":
+        idx += 1
+    if idx >= len(lines):
+        return text, None, warnings
+
+    first = lines[idx].lstrip("﻿")
+    if not _FENCE_PATTERN.match(first):
+        return text, None, warnings
+
+    # Walk forward until the closing fence.
+    start = idx + 1
+    end: int | None = None
+    char_budget = 0
+    for j in range(start, len(lines)):
+        char_budget += len(lines[j]) + 1
+        if char_budget > _MAX_FRONTMATTER_CHARS:
+            warnings.append("front_matter_unterminated_within_budget")
+            return text, None, warnings
+        if _FENCE_PATTERN.match(lines[j]):
+            end = j
+            break
+
+    if end is None:
+        warnings.append("front_matter_missing_closing_fence")
+        return text, None, warnings
+
+    fm_text = "\n".join(lines[start:end])
+    body_lines = lines[end + 1 :]
+    return "\n".join(body_lines), fm_text, warnings
+
+
+# ---------------------------------------------------------------------------
+# Tiny YAML subset parser
+# ---------------------------------------------------------------------------
+
+
+def _strip_comment(line: str) -> str:
+    """Remove trailing ``#`` comments outside quoted strings."""
+    in_single = in_double = False
+    for i, ch in enumerate(line):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif ch == "#" and not in_single and not in_double:
+            return line[:i].rstrip()
+    return line
+
+
+def _parse_scalar(raw: str) -> str:
+    """Parse a YAML scalar, stripping matched quotes."""
+    s = raw.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in {'"', "'"}:
+        return s[1:-1]
+    return s
+
+
+def _parse_inline_list(raw: str) -> list[str]:
+    """Parse a flow-style YAML list literal — best effort split on commas.
+
+    Respects single/double quoted strings; does not handle nested lists
+    or mappings (which the matcher would ignore anyway).
+    """
+    m = _INLINE_LIST_PATTERN.match(raw.strip())
+    if m is None:
+        return []
+    inner = m.group("inner")
+    items: list[str] = []
+    buf: list[str] = []
+    in_single = in_double = False
+    for ch in inner:
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            buf.append(ch)
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+            buf.append(ch)
+        elif ch == "," and not in_single and not in_double:
+            items.append(_parse_scalar("".join(buf)))
+            buf = []
+        else:
+            buf.append(ch)
+    if buf:
+        items.append(_parse_scalar("".join(buf)))
+    return [item for item in items if item != ""]
+
+
+def _parse_yaml_subset(text: str) -> tuple[dict[str, object], list[str]]:
+    """Parse the subset of YAML that runbook front-matter is allowed to use.
+
+    Returns ``(mapping, warnings)``.  Unknown structural constructs are
+    skipped with a warning rather than raising — a malformed line should
+    not poison the rest of the front-matter.
+    """
+    warnings: list[str] = []
+    result: dict[str, object] = {}
+    current_key: str | None = None
+    current_list: list[str] | None = None
+
+    for raw_line in text.splitlines():
+        stripped = _strip_comment(raw_line)
+        if stripped.strip() == "":
+            continue
+
+        # Block-style list continuation: ``  - item``.
+        if stripped.lstrip().startswith("- "):
+            if current_key is None or current_list is None:
+                warnings.append("list_item_without_parent_key")
+                continue
+            item = _parse_scalar(stripped.lstrip()[2:])
+            current_list.append(item)
+            continue
+
+        # ``key: value`` or ``key:``.
+        if ":" not in stripped:
+            warnings.append(f"unparseable_line:{stripped[:64]}")
+            continue
+        key, _, rhs = stripped.partition(":")
+        key = key.strip()
+        rhs = rhs.strip()
+        if not key:
+            warnings.append("empty_key")
+            continue
+
+        if rhs == "":
+            # Open a list.  We don't know yet whether the next lines are
+            # list items or a nested mapping; we initialise a list and
+            # downgrade to scalar later if no items arrive.
+            current_key = key
+            current_list = []
+            result[key] = current_list
+        elif rhs.startswith("["):
+            result[key] = _parse_inline_list(rhs)
+            current_key = key
+            current_list = None
+        else:
+            result[key] = _parse_scalar(rhs)
+            current_key = key
+            current_list = None
+
+    return result, warnings
+
+
+# ---------------------------------------------------------------------------
+# Heading + code-block extraction
+# ---------------------------------------------------------------------------
+
+
+def _slugify(text: str) -> str:
+    """Slugify heading text for use as a step id."""
+    slug = _SLUG_PATTERN.sub("-", text.strip().lower()).strip("-")
+    return slug or "step"
+
+
+@dataclass(slots=True)
+class _StepBuilder:
+    """Mutable accumulator for an in-progress step, typed for mypy --strict."""
+
+    step_id: str
+    heading: str
+    heading_level: int
+
+
+def _split_steps(body: str) -> tuple[list[RunbookStep], list[str]]:
+    """Split the markdown body into one step per ATX heading.
+
+    The first heading begins step 1.  Content before the first heading is
+    discarded (the runbook entity itself carries the full body in
+    :attr:`RunbookDocument.body_markdown`, so no information is lost).
+
+    Returns ``(steps, warnings)``.
+    """
+    warnings: list[str] = []
+    steps: list[RunbookStep] = []
+    lines = body.splitlines()
+
+    current: _StepBuilder | None = None
+    buf: list[str] = []
+    in_fence = False
+    fence_char: str | None = None
+    code_buf: list[str] = []
+    current_code_blocks: list[str] = []
+
+    def _flush() -> None:
+        if current is None:
+            return
+        step_text = "\n".join(buf).rstrip()
+        steps.append(
+            RunbookStep(
+                step_id=current.step_id,
+                heading=current.heading,
+                heading_level=current.heading_level,
+                body=step_text,
+                code_blocks=list(current_code_blocks),
+            )
+        )
+
+    seen_slugs: dict[str, int] = {}
+
+    for raw in lines:
+        # Track fenced code blocks so headings inside them don't open a
+        # new step (markdown convention; CommonMark §4.5).
+        fence_match = _CODE_FENCE_PATTERN.match(raw)
+        if fence_match is not None:
+            ch = fence_match.group("fence")[0]
+            if not in_fence:
+                in_fence = True
+                fence_char = ch
+                code_buf = []
+                buf.append(raw)
+                continue
+            if fence_char == ch:
+                in_fence = False
+                fence_char = None
+                if current is not None:
+                    current_code_blocks.append("\n".join(code_buf))
+                code_buf = []
+                buf.append(raw)
+                continue
+            # Mismatched fence char — keep collecting as content.
+
+        if in_fence:
+            code_buf.append(raw)
+            buf.append(raw)
+            continue
+
+        heading_match = _HEADING_PATTERN.match(raw)
+        if heading_match is not None:
+            # Close out the previous step.
+            _flush()
+
+            heading_text = heading_match.group("text").strip()
+            level = len(heading_match.group("hashes"))
+            slug = _slugify(heading_text)
+            if slug in seen_slugs:
+                seen_slugs[slug] += 1
+                disambiguated = f"{slug}-{seen_slugs[slug]}"
+                warnings.append(f"duplicate_step_slug:{slug}->{disambiguated}")
+                slug = disambiguated
+            else:
+                seen_slugs[slug] = 1
+
+            current = _StepBuilder(
+                step_id=slug,
+                heading=heading_text,
+                heading_level=level,
+            )
+            current_code_blocks = []
+            buf = []
+            continue
+
+        if current is not None:
+            buf.append(raw)
+
+    if in_fence:
+        warnings.append("unterminated_code_fence")
+    _flush()
+    return steps, warnings
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_runbook(
+    *,
+    source_uid: str,
+    rel_path: str,
+    text: str,
+) -> RunbookDocument:
+    """Parse a markdown runbook into a :class:`RunbookDocument`.
+
+    Never raises on malformed input — all recoverable issues are accumulated
+    on :attr:`RunbookDocument.parse_warnings`.  The only raised exception is
+    :class:`ParseError` when the input is empty / non-textual, which the
+    connector treats as a hard skip (one log line, no entity emitted).
+    """
+    if text == "":
+        raise ParseError("empty runbook text")
+
+    warnings: list[str] = []
+    body, fm_text, fm_warnings = _extract_front_matter(text)
+    warnings.extend(fm_warnings)
+
+    raw_fm: dict[str, object] = {}
+    fm: RunbookFrontMatter
+    if fm_text is not None:
+        raw_fm, yaml_warnings = _parse_yaml_subset(fm_text)
+        warnings.extend(yaml_warnings)
+        try:
+            fm = RunbookFrontMatter.model_validate(raw_fm)
+        except ValidationError as exc:
+            warnings.append(f"front_matter_validation_error:{exc.error_count()}")
+            fm = RunbookFrontMatter()
+    else:
+        fm = RunbookFrontMatter()
+
+    steps, step_warnings = _split_steps(body)
+    warnings.extend(step_warnings)
+
+    # Title precedence: front-matter > first H1 in body > rel_path basename.
+    title: str
+    if fm.title:
+        title = fm.title
+    elif steps and steps[0].heading_level == 1:
+        title = steps[0].heading
+    else:
+        title = rel_path.rsplit("/", 1)[-1]
+
+    return RunbookDocument(
+        source_uid=source_uid,
+        rel_path=rel_path,
+        canonical_name=canonical_runbook_name(source_uid, rel_path),
+        front_matter=fm,
+        raw_front_matter=raw_fm,
+        title=title,
+        body_markdown=body,
+        steps=steps,
+        parse_warnings=warnings,
+    )

--- a/project/PROJECT_HISTORY.md
+++ b/project/PROJECT_HISTORY.md
@@ -17,3 +17,25 @@
 **Outcome**: 44 tests passing (0.48s). `mypy --strict` clean; `ruff` + `ruff format` clean. Existing 142 connector tests still green. Branch `feat/240-datadog-connector` opened against `main`.
 
 **Tags**: backend, connector, datadog, observability, bitemporal, issue-240, wave-3
+
+## 2026-05-23 — senior-backend-engineer — Issue #231: Runbook parser + suggest
+
+**What**: Shipped the runbook connector (markdown parser + tiny YAML front-matter parser + matcher), the `suggest_runbook` MCP tool, and `POST /api/v1/incidents/{id}/runbook-step` REST endpoint. Step events are recorded with the full bitemporal triple (`valid_from`, `valid_to`, `recorded_at`) into an in-memory ring buffer plus a structured-log event plus a Prometheus counter. Confidence scoring is a weighted sum (exact 0.55, pattern 0.25, tags 0.15, severity 0.05) — monotonicity invariant asserted by integration test.
+
+**Files added**:
+- `packages/connectors/src/omniscience_connectors/runbook/{__init__.py,models.py,parser.py,linker.py,connector.py}`
+- `apps/server/src/omniscience_server/runbook.py`
+- `apps/server/src/omniscience_server/rest/runbook.py`
+- `tests/test_runbook_connector.py`
+- `tests/integration/test_runbook_suggest.py`
+- `tests/fixtures/runbook/{db-connections-exhausted,redis-evictions,generic-5xx,malformed}.md`
+- `docs/runbooks/runbook-connector.md`
+
+**Files modified** (additive only):
+- `packages/connectors/src/omniscience_connectors/__init__.py` — registered `RunbookConnector`; exported config + connector.
+- `apps/server/src/omniscience_server/rest/router.py` — included `runbook_router`.
+- `apps/server/src/omniscience_server/mcp/server.py` — registered `suggest_runbook` MCP tool.
+
+**Outcome**: 38 new tests passing (0.09s for runbook-only run; 39 with the unrelated benchmark runbook test). `mypy --strict` clean across 218 files. `ruff` + `ruff format` clean. 142 connector regression tests + 67 incident/replay/blast-radius regression tests still green. Branch `feat/231-runbook-parser`.
+
+**Tags**: backend, connector, runbook, parser, incidents, bitemporal, mcp, rest, issue-231, wave-2

--- a/project/project_history.json
+++ b/project/project_history.json
@@ -51,6 +51,68 @@
         "issue-240",
         "wave-3"
       ]
+    },
+    {
+      "timestamp": "2026-05-23T12:00:00Z",
+      "agent": "senior-backend-engineer",
+      "issue": 231,
+      "branch": "feat/231-runbook-parser",
+      "action": {
+        "type": "feature_implementation",
+        "summary": "Runbook parser + suggest_runbook MCP tool + POST /incidents/{id}/runbook-step REST endpoint"
+      },
+      "files": {
+        "added": [
+          "packages/connectors/src/omniscience_connectors/runbook/__init__.py",
+          "packages/connectors/src/omniscience_connectors/runbook/models.py",
+          "packages/connectors/src/omniscience_connectors/runbook/parser.py",
+          "packages/connectors/src/omniscience_connectors/runbook/linker.py",
+          "packages/connectors/src/omniscience_connectors/runbook/connector.py",
+          "apps/server/src/omniscience_server/runbook.py",
+          "apps/server/src/omniscience_server/rest/runbook.py",
+          "tests/test_runbook_connector.py",
+          "tests/integration/test_runbook_suggest.py",
+          "tests/fixtures/runbook/db-connections-exhausted.md",
+          "tests/fixtures/runbook/redis-evictions.md",
+          "tests/fixtures/runbook/generic-5xx.md",
+          "tests/fixtures/runbook/malformed.md",
+          "docs/runbooks/runbook-connector.md"
+        ],
+        "modified": [
+          "packages/connectors/src/omniscience_connectors/__init__.py",
+          "apps/server/src/omniscience_server/rest/router.py",
+          "apps/server/src/omniscience_server/mcp/server.py"
+        ]
+      },
+      "tests": {
+        "added": 38,
+        "passing": 38,
+        "runtime_seconds": 0.09,
+        "regression_check": "142 connector tests + 67 incident/replay/blast-radius tests still pass"
+      },
+      "quality_gates": {
+        "ruff_check": "clean",
+        "ruff_format": "clean",
+        "mypy_strict": "clean (218 source files)"
+      },
+      "design_decisions": [
+        "v0.1 confidence scoring: weighted sum (exact 0.55, pattern 0.25, tags 0.15, severity 0.05) with monotonicity invariant",
+        "In-memory ring-buffer recorder (no Alembic migration) + structlog event + Prometheus counter for triple-durability of step events",
+        "Self-contained YAML subset parser to avoid pulling 200KB markdown-it-py / pyyaml deps",
+        "Permissive parsing: malformed runbooks return RunbookDocument with parse_warnings rather than raising"
+      ],
+      "tags": [
+        "backend",
+        "connector",
+        "runbook",
+        "parser",
+        "incidents",
+        "bitemporal",
+        "mcp",
+        "rest",
+        "issue-231",
+        "wave-2"
+      ]
     }
   ]
 }

--- a/tests/fixtures/runbook/db-connections-exhausted.md
+++ b/tests/fixtures/runbook/db-connections-exhausted.md
@@ -1,0 +1,42 @@
+---
+title: "Database connections exhausted"
+alert_names:
+  - "alert://datadog/db.connections.exhausted"
+alert_patterns:
+  - "alert://datadog/db.connections.*"
+  - "alert://pagerduty/postgres-*"
+tags:
+  - "service:payments"
+  - "service:checkout"
+  - "severity:sev2"
+severity: sev2
+owners:
+  - "team:payments"
+---
+
+# Database connections exhausted
+
+This runbook fires when the payments-API connection pool is saturated.
+Symptoms include 5xx error rate spike + Datadog monitor
+`db.connections.exhausted` firing for more than 5 minutes.
+
+## Triage
+
+1. Open the [pool dashboard](https://app.datadoghq.com/dashboard/abc).
+2. Confirm the saturation is real (some monitors flap on cold-start).
+
+```bash
+kubectl -n payments top pods --selector app=payments-api
+```
+
+## Mitigate
+
+Scale the pool out by 50% — this is reversible.
+
+```bash
+kubectl -n payments scale deploy/payments-api --replicas=8
+```
+
+## Resolve
+
+Wait for the pool gauge to drop below 70% then scale back to baseline.

--- a/tests/fixtures/runbook/generic-5xx.md
+++ b/tests/fixtures/runbook/generic-5xx.md
@@ -1,0 +1,12 @@
+# Generic 5xx spike
+
+No front-matter at all — should still parse cleanly with empty
+front-matter and produce one step per heading.
+
+## Step one
+
+Verify the alert is real.
+
+## Step two
+
+Restart the service.

--- a/tests/fixtures/runbook/malformed.md
+++ b/tests/fixtures/runbook/malformed.md
@@ -1,0 +1,10 @@
+---
+title: "Missing closing fence — front-matter is unterminated and should be skipped"
+tags:
+  - service:broken
+  this is not a list item
+weird-line-without-colon-or-dash
+
+# Real heading
+
+Body content.

--- a/tests/fixtures/runbook/redis-evictions.md
+++ b/tests/fixtures/runbook/redis-evictions.md
@@ -1,0 +1,24 @@
+---
+title: Redis evictions spiking
+alert_patterns: ["alert://datadog/redis.*"]
+tags:
+  - service:cache
+  - severity:sev3
+severity: sev3
+---
+
+# Redis evictions spiking
+
+When Redis hits maxmemory it starts evicting keys based on the policy.
+
+## Check
+
+Look at the eviction counter.
+
+```bash
+redis-cli info stats | grep evicted_keys
+```
+
+## Mitigate
+
+Bump maxmemory by 25% if the host has headroom.

--- a/tests/integration/test_runbook_suggest.py
+++ b/tests/integration/test_runbook_suggest.py
@@ -1,0 +1,389 @@
+"""Integration test for ``suggest_runbook`` + ``record_runbook_step`` (issue #231).
+
+Drives the server-side surface end-to-end against the runbook fixtures at
+``tests/fixtures/runbook/`` and an in-memory ``GraphStore`` fake so the
+test runs in the default CI lane without testcontainers.
+
+Asserted invariants
+-------------------
+
+1. Discovery -> parse -> suggest: real fixtures are walked by the
+   connector, parsed, and (after being threaded through suggest as the
+   pre-loaded candidate set) the highest-confidence runbook for the
+   planted alert is the ``db-connections-exhausted`` runbook.
+2. Top-3 contract: at most 3 suggestions returned; ordered DESC by
+   confidence.
+3. Monotonicity: when we re-score against an alert that gains a matching
+   tag, the same runbook's confidence is weakly higher — not lower.
+4. Step recording: ``record_runbook_step`` round-trips through the
+   in-memory recorder, the structured-log event fires (asserted via
+   structlog capture), and the recorder filters by workspace_id.
+5. Cross-workspace ACL: alert_id in workspace A is invisible to a
+   recorder filter for workspace B even when the same alert was used.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from omniscience_connectors.runbook import (
+    RunbookConfig,
+    RunbookConnector,
+    RunbookDocument,
+)
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphResultView,
+)
+from omniscience_server.runbook import (
+    ALERT_NOT_FOUND_CODE,
+    INVALID_ALERT_ID_CODE,
+    RunbookStepRecorder,
+    record_runbook_step,
+    suggest_runbook,
+)
+
+FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "runbook"
+
+_WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000231")
+_WS_B = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000231")
+_ALERT_DB = "alert://datadog/db.connections.exhausted"
+_ALERT_REDIS = "alert://datadog/redis.evictions"
+_ALERT_5XX = "alert://datadog/http.5xx"
+
+
+class _SuggestGraphStore:
+    """In-memory store that only needs ``get_entity``/``find_related``."""
+
+    def __init__(self) -> None:
+        self._entities: dict[tuple[uuid.UUID, str], EntityNodeView] = {}
+        self._neighbours: dict[tuple[uuid.UUID, str], list[EntityNodeView]] = {}
+        self.calls: list[dict[str, Any]] = []
+
+    def plant_alert(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        name: str,
+        tags: list[str] | None = None,
+        severity: str | None = None,
+    ) -> None:
+        import json
+
+        chunk_text = json.dumps({"tags": tags or [], "severity": severity})
+        self._entities[(workspace_id, name)] = EntityNodeView(
+            name=name,
+            kind="alert",
+            source="src-test",
+            chunk_text=chunk_text,
+            depth=0,
+            edge_type=None,
+        )
+        self._neighbours[(workspace_id, name)] = []
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> EntityNodeView | None:
+        self.calls.append(
+            {"op": "get_entity", "name": entity_name, "ws": workspace_id, "as_of": as_of}
+        )
+        return self._entities.get((workspace_id, entity_name))
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        self.calls.append({"op": "find_related", "name": entity_name, "ws": workspace_id})
+        seed = self._entities.get((workspace_id, entity_name))
+        if seed is None:
+            raise ValueError(f"entity_not_found:{entity_name}")
+        return GraphResultView(
+            seed=seed,
+            related=list(self._neighbours.get((workspace_id, entity_name), [])),
+            edges=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _load_fixture_runbooks() -> list[RunbookDocument]:
+    """Walk the fixture directory via the real connector and parse each file."""
+    cn = RunbookConnector()
+    cfg = RunbookConfig(root_path=str(FIXTURE_DIR), source_uid="team-runbooks")
+    refs = [ref async for ref in cn.discover(cfg, {})]
+    out: list[RunbookDocument] = []
+    for ref in refs:
+        fetched = await cn.fetch(cfg, {}, ref)
+        rb = RunbookDocument.model_validate_json(fetched.content_bytes.decode("utf-8"))
+        out.append(rb)
+    return out
+
+
+def _make_app(graph_store: _SuggestGraphStore) -> SimpleNamespace:
+    """Build a minimal FastAPI-app stand-in exposing ``state.graph_store``."""
+    state = SimpleNamespace(graph_store=graph_store)
+    return SimpleNamespace(state=state)
+
+
+# ---------------------------------------------------------------------------
+# Suggest path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_suggest_runbook_picks_best_match_from_fixtures() -> None:
+    candidates = await _load_fixture_runbooks()
+    # Sanity: at least three runbooks were discovered.
+    assert len(candidates) >= 3, [c.canonical_name for c in candidates]
+
+    store = _SuggestGraphStore()
+    store.plant_alert(
+        workspace_id=_WS_A,
+        name=_ALERT_DB,
+        tags=["service:payments", "severity:sev2"],
+        severity="sev2",
+    )
+    app = _make_app(store)
+
+    response = await suggest_runbook(
+        app=app,  # type: ignore[arg-type]
+        alert_id=_ALERT_DB,
+        workspace_id=_WS_A,
+        candidates=candidates,
+    )
+
+    suggestions = response["suggestions"]
+    assert 1 <= len(suggestions) <= 3
+    top = suggestions[0]
+    assert top["runbook_name"] == "runbook://team-runbooks/db-connections-exhausted.md"
+    assert top["exact_match"] is True
+    assert top["confidence"] > 0.5
+    assert top["citation"]["title"] == "Database connections exhausted"
+    assert top["citation"]["first_step"]["step_id"] == "database-connections-exhausted"
+    # Confidence is sorted DESC.
+    confidences = [s["confidence"] for s in suggestions]
+    assert confidences == sorted(confidences, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_suggest_runbook_unknown_alert_raises_not_found() -> None:
+    candidates = await _load_fixture_runbooks()
+    store = _SuggestGraphStore()  # alert is NOT planted
+    app = _make_app(store)
+
+    with pytest.raises(ValueError, match=rf"^{ALERT_NOT_FOUND_CODE}:"):
+        await suggest_runbook(
+            app=app,  # type: ignore[arg-type]
+            alert_id=_ALERT_DB,
+            workspace_id=_WS_A,
+            candidates=candidates,
+        )
+
+
+@pytest.mark.asyncio
+async def test_suggest_runbook_invalid_alert_id() -> None:
+    with pytest.raises(ValueError, match=rf"^{INVALID_ALERT_ID_CODE}:"):
+        await suggest_runbook(
+            app=_make_app(_SuggestGraphStore()),  # type: ignore[arg-type]
+            alert_id="not-a-canonical-name",
+            workspace_id=_WS_A,
+            candidates=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_suggest_runbook_monotonic_with_more_matching_tags() -> None:
+    """Adding a matching tag to the alert must not lower confidence."""
+    candidates = await _load_fixture_runbooks()
+    db_rb = next(c for c in candidates if "db-connections" in c.rel_path)
+
+    store_one = _SuggestGraphStore()
+    store_one.plant_alert(workspace_id=_WS_A, name=_ALERT_DB, tags=[], severity=None)
+    response_one = await suggest_runbook(
+        app=_make_app(store_one),  # type: ignore[arg-type]
+        alert_id=_ALERT_DB,
+        workspace_id=_WS_A,
+        candidates=[db_rb],
+    )
+    c_one = response_one["suggestions"][0]["confidence"]
+
+    store_two = _SuggestGraphStore()
+    store_two.plant_alert(
+        workspace_id=_WS_A,
+        name=_ALERT_DB,
+        tags=["service:payments"],
+        severity="sev2",
+    )
+    response_two = await suggest_runbook(
+        app=_make_app(store_two),  # type: ignore[arg-type]
+        alert_id=_ALERT_DB,
+        workspace_id=_WS_A,
+        candidates=[db_rb],
+    )
+    c_two = response_two["suggestions"][0]["confidence"]
+
+    assert c_two >= c_one
+
+
+@pytest.mark.asyncio
+async def test_suggest_runbook_top_k_bound() -> None:
+    candidates = await _load_fixture_runbooks()
+    store = _SuggestGraphStore()
+    store.plant_alert(
+        workspace_id=_WS_A,
+        name=_ALERT_REDIS,
+        tags=["service:cache"],
+        severity="sev3",
+    )
+    response = await suggest_runbook(
+        app=_make_app(store),  # type: ignore[arg-type]
+        alert_id=_ALERT_REDIS,
+        workspace_id=_WS_A,
+        candidates=candidates,
+        top_k=2,
+    )
+    assert len(response["suggestions"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_suggest_runbook_meta_block_has_counts() -> None:
+    candidates = await _load_fixture_runbooks()
+    store = _SuggestGraphStore()
+    store.plant_alert(workspace_id=_WS_A, name=_ALERT_5XX, tags=[])
+    response = await suggest_runbook(
+        app=_make_app(store),  # type: ignore[arg-type]
+        alert_id=_ALERT_5XX,
+        workspace_id=_WS_A,
+        candidates=candidates,
+    )
+    assert response["meta"]["candidate_count"] == len(candidates)
+    assert "effective_as_of" in response
+
+
+# ---------------------------------------------------------------------------
+# Record step path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_runbook_step_round_trip() -> None:
+    app = SimpleNamespace(state=SimpleNamespace())
+    event = record_runbook_step(
+        app=app,  # type: ignore[arg-type]
+        workspace_id=_WS_A,
+        incident_id="INC-123",
+        alert_id=_ALERT_DB,
+        runbook_name="runbook://team-runbooks/db-connections-exhausted.md",
+        step_id="mitigate",
+        outcome="executed",
+        actor="alice",
+        note="Scaled to 8 replicas.",
+    )
+    assert event.workspace_id == _WS_A
+    assert event.incident_id == "INC-123"
+    assert event.step_name.endswith("#mitigate")
+    assert event.recorded_at.tzinfo is not None
+    assert event.valid_from.tzinfo is not None
+
+    payload = event.to_payload()
+    assert payload["actor"] == "alice"
+    assert payload["note"] == "Scaled to 8 replicas."
+
+    recorder: RunbookStepRecorder = app.state.runbook_step_recorder
+    recent = recorder.recent(workspace_id=_WS_A)
+    assert len(recent) == 1
+    assert recent[0].event_id == event.event_id
+
+
+@pytest.mark.asyncio
+async def test_record_runbook_step_filters_by_workspace() -> None:
+    app = SimpleNamespace(state=SimpleNamespace())
+    record_runbook_step(
+        app=app,  # type: ignore[arg-type]
+        workspace_id=_WS_A,
+        incident_id="INC-A",
+        alert_id=_ALERT_DB,
+        runbook_name="runbook://team-runbooks/db-connections-exhausted.md",
+        step_id="triage",
+    )
+    record_runbook_step(
+        app=app,  # type: ignore[arg-type]
+        workspace_id=_WS_B,
+        incident_id="INC-B",
+        alert_id=_ALERT_REDIS,
+        runbook_name="runbook://team-runbooks/redis-evictions.md",
+        step_id="check",
+    )
+    recorder: RunbookStepRecorder = app.state.runbook_step_recorder
+    a_events = recorder.recent(workspace_id=_WS_A)
+    b_events = recorder.recent(workspace_id=_WS_B)
+    assert len(a_events) == 1 and a_events[0].incident_id == "INC-A"
+    assert len(b_events) == 1 and b_events[0].incident_id == "INC-B"
+
+
+@pytest.mark.asyncio
+async def test_record_runbook_step_validation_errors() -> None:
+    app = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(ValueError, match=r"^invalid_alert_id:"):
+        record_runbook_step(
+            app=app,  # type: ignore[arg-type]
+            workspace_id=_WS_A,
+            incident_id="INC-1",
+            alert_id="bogus",
+            runbook_name="runbook://team-runbooks/db.md",
+            step_id="triage",
+        )
+    with pytest.raises(ValueError, match=r"^invalid_runbook_name:"):
+        record_runbook_step(
+            app=app,  # type: ignore[arg-type]
+            workspace_id=_WS_A,
+            incident_id="INC-1",
+            alert_id=_ALERT_DB,
+            runbook_name="not-a-canonical-runbook",
+            step_id="triage",
+        )
+    with pytest.raises(ValueError, match=r"^invalid_step_id:"):
+        record_runbook_step(
+            app=app,  # type: ignore[arg-type]
+            workspace_id=_WS_A,
+            incident_id="INC-1",
+            alert_id=_ALERT_DB,
+            runbook_name="runbook://team-runbooks/db.md",
+            step_id="bad step id with spaces",
+        )
+
+
+@pytest.mark.asyncio
+async def test_record_runbook_step_honours_supplied_valid_from() -> None:
+    """A historical replay can backdate ``valid_from`` per ADR-0008 §1."""
+    app = SimpleNamespace(state=SimpleNamespace())
+    past = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    event = record_runbook_step(
+        app=app,  # type: ignore[arg-type]
+        workspace_id=_WS_A,
+        incident_id="INC-9",
+        alert_id=_ALERT_DB,
+        runbook_name="runbook://team-runbooks/db.md",
+        step_id="triage",
+        valid_from=past,
+    )
+    assert event.valid_from == past
+    # recorded_at is "now" - strictly after the backdated valid_from.
+    assert event.recorded_at > event.valid_from

--- a/tests/test_runbook_connector.py
+++ b/tests/test_runbook_connector.py
@@ -1,0 +1,385 @@
+"""Tests for the runbook connector + parser + linker (issue #231).
+
+Coverage:
+
+* :func:`parse_runbook` — well-formed runbook, missing front-matter, malformed
+  front-matter (recoverable), unterminated code fence.
+* Canonical name helpers — round-trip stability across source uids and paths.
+* :func:`score_runbook_against_alert` — exact match, pattern match, tag
+  overlap, severity, monotonicity invariant (more matching signals -> higher
+  confidence), zero-signal -> 0.0 floor.
+* :class:`RunbookConnector` — discover walks the fixture directory, fetch
+  returns the parsed payload, validate rejects bad paths, registry lookup.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from omniscience_connectors import get_connector
+from omniscience_connectors.base import DocumentRef
+from omniscience_connectors.runbook import (
+    RUNBOOK_NAME_PATTERN,
+    RUNBOOK_STEP_NAME_PATTERN,
+    ParseError,
+    RunbookConfig,
+    RunbookConnector,
+    RunbookDocument,
+    canonical_runbook_name,
+    canonical_runbook_step_name,
+    parse_runbook,
+)
+from omniscience_connectors.runbook.linker import (
+    WEIGHT_EXACT,
+    WEIGHT_PATTERN,
+    WEIGHT_SEVERITY,
+    WEIGHT_TAGS,
+    AlertView,
+    score_runbook_against_alert,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "runbook"
+
+
+# ---------------------------------------------------------------------------
+# Canonical name helpers
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_runbook_name_basic() -> None:
+    name = canonical_runbook_name("team-runbooks", "payments/db-conn.md")
+    assert name == "runbook://team-runbooks/payments/db-conn.md"
+    assert RUNBOOK_NAME_PATTERN.match(name)
+
+
+def test_canonical_runbook_name_strips_leading_slashes() -> None:
+    a = canonical_runbook_name("rb", "/sub/dir/file.md")
+    b = canonical_runbook_name("rb", "sub/dir/file.md")
+    c = canonical_runbook_name("rb", "./sub/dir/file.md")
+    assert a == b == c == "runbook://rb/sub/dir/file.md"
+
+
+def test_canonical_runbook_name_slugifies_source_uid() -> None:
+    name = canonical_runbook_name("git://repo team", "p/file.md")
+    assert name.startswith("runbook://git-repo-team/")
+
+
+def test_canonical_runbook_step_name() -> None:
+    step = canonical_runbook_step_name("rb", "p/f.md", "Restart the Pool")
+    assert step == "runbook://rb/p/f.md#restart-the-pool"
+    assert RUNBOOK_STEP_NAME_PATTERN.match(step)
+
+
+def test_canonical_runbook_name_rejects_hash_in_path() -> None:
+    with pytest.raises(ValueError, match="reserved for step suffix"):
+        canonical_runbook_name("rb", "weird#name.md")
+
+
+def test_canonical_step_name_rejects_unslugifiable() -> None:
+    with pytest.raises(ValueError, match="empty string"):
+        canonical_runbook_step_name("rb", "p/f.md", "!!!")
+
+
+# ---------------------------------------------------------------------------
+# parse_runbook — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_parse_well_formed_runbook() -> None:
+    text = (FIXTURE_DIR / "db-connections-exhausted.md").read_text()
+    doc = parse_runbook(
+        source_uid="team-runbooks",
+        rel_path="db-connections-exhausted.md",
+        text=text,
+    )
+
+    assert doc.title == "Database connections exhausted"
+    assert doc.front_matter.alert_names == ["alert://datadog/db.connections.exhausted"]
+    assert "alert://datadog/db.connections.*" in doc.front_matter.alert_patterns
+    assert "alert://pagerduty/postgres-*" in doc.front_matter.alert_patterns
+    assert "service:payments" in doc.front_matter.tags
+    assert "service:checkout" in doc.front_matter.tags
+    assert doc.front_matter.severity == "sev2"
+    assert doc.front_matter.owners == ["team:payments"]
+    assert doc.canonical_name == "runbook://team-runbooks/db-connections-exhausted.md"
+    # 4 ATX headings in the fixture
+    assert len(doc.steps) == 4
+    step_ids = [s.step_id for s in doc.steps]
+    assert step_ids == [
+        "database-connections-exhausted",
+        "triage",
+        "mitigate",
+        "resolve",
+    ]
+    # Code blocks inside steps are captured
+    mitigate = next(s for s in doc.steps if s.step_id == "mitigate")
+    assert any("kubectl" in cb for cb in mitigate.code_blocks)
+    assert doc.parse_warnings == []
+
+
+def test_parse_no_front_matter() -> None:
+    text = (FIXTURE_DIR / "generic-5xx.md").read_text()
+    doc = parse_runbook(
+        source_uid="team-runbooks",
+        rel_path="generic-5xx.md",
+        text=text,
+    )
+    assert doc.title == "Generic 5xx spike"  # from first H1
+    assert doc.front_matter.alert_names == []
+    assert doc.front_matter.alert_patterns == []
+    assert len(doc.steps) == 3
+    assert doc.parse_warnings == []
+
+
+def test_parse_malformed_front_matter_recovers() -> None:
+    text = (FIXTURE_DIR / "malformed.md").read_text()
+    doc = parse_runbook(
+        source_uid="team-runbooks",
+        rel_path="malformed.md",
+        text=text,
+    )
+    # No closing fence => warning, body kept verbatim.
+    assert any("front_matter" in w for w in doc.parse_warnings)
+    # First real heading is still found.
+    assert any(s.heading == "Real heading" for s in doc.steps)
+
+
+def test_parse_empty_text_raises_parse_error() -> None:
+    with pytest.raises(ParseError):
+        parse_runbook(source_uid="rb", rel_path="a.md", text="")
+
+
+def test_parse_unterminated_code_fence_emits_warning() -> None:
+    text = "# Heading\n\n```bash\nstart-of-code-block-no-end\n"
+    doc = parse_runbook(source_uid="rb", rel_path="x.md", text=text)
+    assert "unterminated_code_fence" in doc.parse_warnings
+
+
+def test_parse_duplicate_headings_disambiguates() -> None:
+    text = "# Same\nbody one\n\n# Same\nbody two\n"
+    doc = parse_runbook(source_uid="rb", rel_path="x.md", text=text)
+    assert [s.step_id for s in doc.steps] == ["same", "same-2"]
+    assert any("duplicate_step_slug" in w for w in doc.parse_warnings)
+
+
+def test_parse_inline_list_yaml() -> None:
+    text = '---\ntags: ["a", "b", c]\nalert_names: [alert://x/1]\n---\n\n# Hi\n'
+    doc = parse_runbook(source_uid="rb", rel_path="x.md", text=text)
+    assert doc.front_matter.tags == ["a", "b", "c"]
+    assert doc.front_matter.alert_names == ["alert://x/1"]
+
+
+def test_parse_scalar_coerces_to_list() -> None:
+    """A single string where a list is expected should be promoted."""
+    text = "---\ntags: just-one-tag\n---\n\n# Hi\n"
+    doc = parse_runbook(source_uid="rb", rel_path="x.md", text=text)
+    assert doc.front_matter.tags == ["just-one-tag"]
+
+
+# ---------------------------------------------------------------------------
+# Linker / scoring
+# ---------------------------------------------------------------------------
+
+
+def _doc_with_fm(
+    *,
+    alert_names: list[str] | None = None,
+    alert_patterns: list[str] | None = None,
+    tags: list[str] | None = None,
+    severity: str | None = None,
+) -> RunbookDocument:
+    body = "---\n"
+    if alert_names:
+        body += "alert_names:\n" + "\n".join(f"  - {n}" for n in alert_names) + "\n"
+    if alert_patterns:
+        body += "alert_patterns:\n" + "\n".join(f"  - {p}" for p in alert_patterns) + "\n"
+    if tags:
+        body += "tags:\n" + "\n".join(f"  - {t}" for t in tags) + "\n"
+    if severity:
+        body += f"severity: {severity}\n"
+    body += "---\n\n# Test\nbody\n"
+    return parse_runbook(source_uid="t", rel_path="t.md", text=body)
+
+
+def test_score_exact_match_dominates() -> None:
+    rb = _doc_with_fm(alert_names=["alert://dd/db.x"])
+    alert = AlertView(name="alert://dd/db.x")
+    result = score_runbook_against_alert(runbook=rb, alert=alert)
+    assert result.exact_match is True
+    # Exact-match alone -> weight_exact.
+    assert result.confidence == pytest.approx(WEIGHT_EXACT)
+
+
+def test_score_pattern_match() -> None:
+    rb = _doc_with_fm(alert_patterns=["alert://dd/db.*"])
+    alert = AlertView(name="alert://dd/db.connections.exhausted")
+    result = score_runbook_against_alert(runbook=rb, alert=alert)
+    assert result.pattern_match == "alert://dd/db.*"
+    assert result.confidence == pytest.approx(WEIGHT_PATTERN)
+
+
+def test_score_tag_jaccard() -> None:
+    rb = _doc_with_fm(tags=["service:payments", "severity:sev2", "team:x"])
+    alert = AlertView(
+        name="alert://dd/some.alert",
+        tags=["service:payments", "severity:sev2"],
+    )
+    result = score_runbook_against_alert(runbook=rb, alert=alert)
+    # Intersection 2, union 3 -> jaccard 2/3.
+    assert result.confidence == pytest.approx(WEIGHT_TAGS * (2 / 3))
+    assert sorted(result.matched_tags) == ["service:payments", "severity:sev2"]
+
+
+def test_score_severity_match() -> None:
+    rb = _doc_with_fm(severity="sev1")
+    alert = AlertView(name="alert://x/y", severity="sev1")
+    result = score_runbook_against_alert(runbook=rb, alert=alert)
+    assert result.severity_match is True
+    assert result.confidence == pytest.approx(WEIGHT_SEVERITY)
+
+
+def test_score_zero_signal_floors_to_zero() -> None:
+    rb = _doc_with_fm()
+    alert = AlertView(name="alert://x/y", tags=["service:other"], severity="sev3")
+    result = score_runbook_against_alert(runbook=rb, alert=alert)
+    assert result.confidence == 0.0
+
+
+def test_score_monotonic_increase_with_more_signals() -> None:
+    """The integration acceptance: more matching signals -> weakly higher confidence."""
+    alert = AlertView(
+        name="alert://dd/db.connections.exhausted",
+        tags=["service:payments", "severity:sev2"],
+        severity="sev2",
+    )
+
+    only_pattern = _doc_with_fm(alert_patterns=["alert://dd/db.*"])
+    plus_tag = _doc_with_fm(
+        alert_patterns=["alert://dd/db.*"],
+        tags=["service:payments"],
+    )
+    plus_severity = _doc_with_fm(
+        alert_patterns=["alert://dd/db.*"],
+        tags=["service:payments"],
+        severity="sev2",
+    )
+    plus_exact = _doc_with_fm(
+        alert_names=["alert://dd/db.connections.exhausted"],
+        alert_patterns=["alert://dd/db.*"],
+        tags=["service:payments"],
+        severity="sev2",
+    )
+
+    c_only = score_runbook_against_alert(runbook=only_pattern, alert=alert).confidence
+    c_tag = score_runbook_against_alert(runbook=plus_tag, alert=alert).confidence
+    c_sev = score_runbook_against_alert(runbook=plus_severity, alert=alert).confidence
+    c_full = score_runbook_against_alert(runbook=plus_exact, alert=alert).confidence
+
+    assert c_only < c_tag < c_sev < c_full
+    assert c_full <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# RunbookConnector
+# ---------------------------------------------------------------------------
+
+
+def test_connector_registry_lookup() -> None:
+    instance = get_connector("runbook")
+    assert isinstance(instance, RunbookConnector)
+    assert RunbookConnector.connector_type == "runbook"
+    assert RunbookConnector.config_schema is RunbookConfig
+
+
+@pytest.mark.asyncio
+async def test_connector_validate_rejects_missing_path(tmp_path: Path) -> None:
+    cn = RunbookConnector()
+    cfg = RunbookConfig(root_path=str(tmp_path / "does-not-exist"), source_uid="rb")
+    with pytest.raises(ValueError, match="does not exist"):
+        await cn.validate(cfg, {})
+
+
+@pytest.mark.asyncio
+async def test_connector_validate_rejects_non_directory(tmp_path: Path) -> None:
+    f = tmp_path / "a.md"
+    f.write_text("# x")
+    cn = RunbookConnector()
+    cfg = RunbookConfig(root_path=str(f), source_uid="rb")
+    with pytest.raises(ValueError, match="not a directory"):
+        await cn.validate(cfg, {})
+
+
+@pytest.mark.asyncio
+async def test_connector_discover_yields_only_markdown(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text("# A")
+    (tmp_path / "b.markdown").write_text("# B")
+    (tmp_path / "c.txt").write_text("not a runbook")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "d.md").write_text("# D")
+
+    cn = RunbookConnector()
+    cfg = RunbookConfig(root_path=str(tmp_path), source_uid="team-rb")
+    refs = [ref async for ref in cn.discover(cfg, {})]
+    paths = sorted(ref.metadata["path"] for ref in refs)
+    assert paths == ["a.md", "b.markdown", "sub/d.md"]
+    # Canonical names produced by discover() match the helper.
+    for ref in refs:
+        assert ref.uri.startswith("runbook://team-rb/")
+
+
+@pytest.mark.asyncio
+async def test_connector_fetch_returns_parsed_payload(tmp_path: Path) -> None:
+    f = tmp_path / "a.md"
+    f.write_text(
+        "---\ntitle: T\nalert_names:\n  - alert://x/1\n---\n\n# Heading\nbody\n",
+    )
+    cn = RunbookConnector()
+    cfg = RunbookConfig(root_path=str(tmp_path), source_uid="rb")
+    refs = [ref async for ref in cn.discover(cfg, {})]
+    assert len(refs) == 1
+    fetched = await cn.fetch(cfg, {}, refs[0])
+    assert fetched.content_type == "application/vnd.omniscience.runbook+json"
+    payload = json.loads(fetched.content_bytes.decode("utf-8"))
+    assert payload["title"] == "T"
+    assert payload["front_matter"]["alert_names"] == ["alert://x/1"]
+    assert payload["canonical_name"] == "runbook://rb/a.md"
+
+
+@pytest.mark.asyncio
+async def test_connector_fetch_rejects_path_outside_root(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text("# A")
+    cn = RunbookConnector()
+    cfg = RunbookConfig(root_path=str(tmp_path), source_uid="rb")
+    rogue_ref = DocumentRef(
+        external_id="/etc/passwd",
+        uri="runbook://rb/etc/passwd",
+        metadata={"path": "etc/passwd"},
+    )
+    with pytest.raises(ValueError, match="outside the configured root"):
+        await cn.fetch(cfg, {}, rogue_ref)
+
+
+@pytest.mark.asyncio
+async def test_connector_no_webhook_handler() -> None:
+    assert RunbookConnector().webhook_handler() is None
+
+
+@pytest.mark.asyncio
+async def test_connector_discover_respects_exclude_globs(tmp_path: Path) -> None:
+    (tmp_path / "keep.md").write_text("# K")
+    drafts = tmp_path / "drafts"
+    drafts.mkdir()
+    (drafts / "skip.md").write_text("# S")
+
+    cn = RunbookConnector()
+    cfg = RunbookConfig(
+        root_path=str(tmp_path),
+        source_uid="rb",
+        exclude_globs=["drafts/*"],
+    )
+    refs = [ref async for ref in cn.discover(cfg, {})]
+    paths = sorted(ref.metadata["path"] for ref in refs)
+    assert paths == ["keep.md"]


### PR DESCRIPTION
## Summary

Closes #231.

Adds the runbook source connector (parses markdown + YAML front-matter), the `suggest_runbook` MCP tool, and the `POST /api/v1/incidents/{id}/runbook-step` REST endpoint. Step executions are recorded into the bitemporal audit surfaces (in-memory ring buffer + structured-log event + Prometheus counter) with the full ADR-0008 §1 triple (`valid_from`, `valid_to`, `recorded_at`).

## What's in the box

**Connector** (`packages/connectors/src/omniscience_connectors/runbook/`)
- `parser.py` — self-contained markdown + YAML-subset parser (no new deps).
- `models.py` — `RunbookDocument`, `RunbookStep`, `RunbookFrontMatter` + canonical-name helpers.
- `linker.py` — pure `score_runbook_against_alert` (exact 0.55 + pattern 0.25 + tag-jaccard 0.15 + severity 0.05).
- `connector.py` — `RunbookConnector` implementing the standard `discover` / `fetch` / `validate` protocol.

**Server**
- `apps/server/src/omniscience_server/runbook.py` — `suggest_runbook`, `record_runbook_step`, the in-memory `RunbookStepRecorder`.
- `apps/server/src/omniscience_server/rest/runbook.py` — three REST endpoints (POST runbook-step, POST suggest-runbook, GET runbook-steps log).
- `mcp/server.py` — new `suggest_runbook` MCP tool wired in additively.

**Docs & fixtures**
- `docs/runbooks/runbook-connector.md` — author guidance for front-matter conventions, ranking explanation, ACL notes.
- `tests/fixtures/runbook/*.md` — 4 fixtures (well-formed, no-front-matter, redis sample, malformed/unterminated).

## Front-matter schema

```yaml
---
title: "Database connections exhausted"
alert_names:        # exact-match canonical alert URIs
  - "alert://datadog/db.connections.exhausted"
alert_patterns:     # fnmatch globs
  - "alert://datadog/db.*"
tags:               # free-form, joined to alert tags via Jaccard
  - "service:payments"
severity: sev2      # tie-breaker
owners:
  - "team:payments"
---
```

## Confidence formula (v0.1 placeholder)

```
confidence = clamp(
    0.55 * exact_alert_name_match
  + 0.25 * pattern_match
  + 0.15 * tag_jaccard
  + 0.05 * severity_match,
  0.0, 1.0,
)
```

Monotonicity invariant: adding more matching signals never lowers the score — asserted by `tests/integration/test_runbook_suggest.py::test_suggest_runbook_monotonic_with_more_matching_tags`.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean (336 files)
- [x] `uv run mypy apps/ packages/` — clean (218 source files)
- [x] `uv run pytest tests/ -k runbook -v` — 38 new tests + 1 unrelated benchmark test pass in 0.09s
- [x] Integration test runs against 4 fixture runbooks; confidence scoring is monotonic
- [x] Malformed front-matter does not raise (parse_warnings populated instead)
- [x] Regression: 142 existing connector tests still green
- [x] Regression: 67 existing incident / replay / blast-radius tests still green

## File boundaries respected

- No modifications to `incidents.py`, `incidents_scoring.py`, `mcp/tools.py`, `packages/index/`, or any existing connector (PagerDuty, Datadog, github_pr, slack, alerts, …).
- Only additive edits to the registration files: connector registry append, MCP tool block append, REST `include_router` append.