### PR TITLE
chore(mcp): submit to MCP catalogs (broad positioning) (#237)

### DIFF
--- a/.mcp/cline-marketplace.json
+++ b/.mcp/cline-marketplace.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/cline/mcp-marketplace/main/schema/entry.schema.json",
+  "mcpId": "omniscience",
+  "name": "Omniscience",
+  "githubUrl": "https://github.com/100rd/Omniscience",
+  "author": "100rd",
+  "description": "Self-hosted MCP retrieval over your code, docs, infra, tickets and wikis. Bitemporal storage gives you deterministic replay and audit for AI-driven incident response and SRE workflows.",
+  "codiconIcon": "search",
+  "logoUrl": "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/icon-256.png",
+  "category": "developer-tools",
+  "tags": [
+    "retrieval",
+    "rag",
+    "self-hosted",
+    "observability",
+    "audit",
+    "bitemporal",
+    "sre",
+    "k8s"
+  ],
+  "requiresApiKey": true,
+  "readmeUrl": "https://raw.githubusercontent.com/100rd/Omniscience/main/README.md",
+  "llmsInstallationContent": "Install Omniscience for Cline:\n\n1. Start the server (Docker):\n\n```bash\ncurl -fsSL https://raw.githubusercontent.com/100rd/Omniscience/main/.mcp/install.sh | bash\n```\n\n2. Mint a token:\n\n```bash\ndocker compose exec app omniscience tokens create --name cline --scopes search,sources:read\n# -> sk_live_...\n```\n\n3. Add to Cline's MCP settings (`cline_mcp_settings.json`):\n\n```json\n{\n  \"mcpServers\": {\n    \"omniscience\": {\n      \"command\": \"uvx\",\n      \"args\": [\"--from\", \"omniscience-cli\", \"omniscience\", \"mcp\", \"serve\", \"--transport\", \"stdio\"],\n      \"env\": {\n        \"OMNISCIENCE_URL\": \"http://localhost:8000\",\n        \"OMNISCIENCE_TOKEN\": \"sk_live_...\"\n      },\n      \"disabled\": false,\n      \"autoApprove\": [\"search\", \"fetch\", \"list_sources\"]\n    }\n  }\n}\n```\n\nOr run the one-shot config writer:\n\n```bash\nuvx --from omniscience-cli omniscience init --client cline\n```\n\nAfter restart, Cline will see tools: search, fetch, list_sources, describe_source, replay, blast_radius, suggest_runbook, timeline."
+}

--- a/.mcp/install.sh
+++ b/.mcp/install.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Omniscience one-line installer.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/100rd/Omniscience/main/.mcp/install.sh | bash
+#
+# What it does:
+#   1. Checks prerequisites (docker, docker compose).
+#   2. Creates ./omniscience/ working directory if missing.
+#   3. Writes a .env with generated secrets (idempotent — never overwrites).
+#   4. Fetches docker-compose.yml from the repo at the pinned ref.
+#   5. Starts the stack with `docker compose up -d`.
+#   6. Waits for /health to return 200 (up to 120s).
+#   7. Prints next-step instructions: how to mint a token and run
+#      `omniscience init --client <ide>`.
+#
+# Supported: macOS (Intel + Apple Silicon), Linux (x86_64, arm64).
+# Re-runnable: safe to invoke repeatedly; never destroys existing data.
+
+set -euo pipefail
+
+OMNISCIENCE_REF="${OMNISCIENCE_REF:-main}"
+OMNISCIENCE_DIR="${OMNISCIENCE_DIR:-$PWD/omniscience}"
+OMNISCIENCE_REPO="${OMNISCIENCE_REPO:-https://raw.githubusercontent.com/100rd/Omniscience}"
+HEALTH_URL="${OMNISCIENCE_HEALTH_URL:-http://localhost:8000/health}"
+
+c_red() { printf '\033[31m%s\033[0m\n' "$*"; }
+c_grn() { printf '\033[32m%s\033[0m\n' "$*"; }
+c_ylw() { printf '\033[33m%s\033[0m\n' "$*"; }
+c_blu() { printf '\033[34m%s\033[0m\n' "$*"; }
+
+step() { c_blu ">>> $*"; }
+ok()   { c_grn "    ok: $*"; }
+warn() { c_ylw "    warn: $*"; }
+die()  { c_red "    error: $*"; exit 1; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "missing prerequisite: $1"
+}
+
+gen_secret() {
+  # 32-byte URL-safe random — works on macOS + Linux.
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -base64 32 | tr -d '=+/\n' | cut -c1-32
+  else
+    LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32
+  fi
+}
+
+main() {
+  step "Checking prerequisites"
+  need docker
+  if ! docker compose version >/dev/null 2>&1; then
+    die "docker compose v2 plugin not available (got: $(docker --version 2>&1))"
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    die "missing prerequisite: curl"
+  fi
+  ok "docker $(docker --version | awk '{print $3}' | tr -d ,)"
+
+  step "Preparing working directory: $OMNISCIENCE_DIR"
+  mkdir -p "$OMNISCIENCE_DIR"
+  cd "$OMNISCIENCE_DIR"
+
+  if [ ! -f .env ]; then
+    step "Generating .env (with fresh secrets)"
+    pw="$(gen_secret)"
+    sk="$(gen_secret)"
+    umask 077
+    cat > .env <<EOF
+# Omniscience environment — generated $(date -u +%Y-%m-%dT%H:%M:%SZ)
+POSTGRES_PASSWORD=${pw}
+OMNISCIENCE_SECRET_KEY=${sk}
+EOF
+    ok "wrote $OMNISCIENCE_DIR/.env (chmod 600)"
+  else
+    ok ".env already present — leaving untouched"
+  fi
+
+  step "Fetching docker-compose.yml @ ${OMNISCIENCE_REF}"
+  curl -fsSL "${OMNISCIENCE_REPO}/${OMNISCIENCE_REF}/docker-compose.yml" -o docker-compose.yml
+  ok "wrote docker-compose.yml"
+
+  step "Starting stack (docker compose up -d)"
+  docker compose up -d
+  ok "containers started"
+
+  step "Waiting for $HEALTH_URL"
+  deadline=$(( $(date +%s) + 120 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+      ok "/health is responding"
+      break
+    fi
+    sleep 2
+  done
+  if ! curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+    warn "/health did not respond within 120s — check 'docker compose logs app'"
+  fi
+
+  cat <<EOF
+
+$(c_grn "Omniscience is up.")
+
+Next steps:
+
+  1) Mint an API token:
+
+     cd "$OMNISCIENCE_DIR"
+     docker compose exec app omniscience tokens create \\
+       --name my-client --scopes search,sources:read
+
+  2) Wire it into your IDE in one shot:
+
+     uvx --from omniscience-cli omniscience init --client claude-code
+     uvx --from omniscience-cli omniscience init --client cursor
+     uvx --from omniscience-cli omniscience init --client cline
+     uvx --from omniscience-cli omniscience init --client zed
+
+  Docs: https://github.com/100rd/Omniscience#integration-guides
+
+EOF
+}
+
+main "$@"

--- a/.mcp/pulsemcp.json
+++ b/.mcp/pulsemcp.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://www.pulsemcp.com/schemas/server-submission.schema.json",
+  "name": "Omniscience",
+  "slug": "omniscience",
+  "short_description": "Self-hosted MCP retrieval with bitemporal replay and audit.",
+  "long_description": "Omniscience is a self-hosted, MCP-first knowledge retrieval service. It indexes your sources (code, docs, infra configs, tickets, wikis, Datadog, PagerDuty, runbooks) and exposes them as MCP tools to any AI client - Claude Code, Cursor, Gemini, custom agents. Retrieval-only: returns chunks with citations, letting the calling LLM synthesize the answer. Bitemporal storage means every fact is queryable as-of any past timestamp, enabling deterministic replay for incident review and AI-action auditing. Includes blast-radius and runbook-suggestion tools tuned for SRE and platform teams.",
+  "homepage": "https://github.com/100rd/Omniscience",
+  "repository": "https://github.com/100rd/Omniscience",
+  "license": "Apache-2.0",
+  "categories": [
+    "devtools",
+    "observability",
+    "knowledge-management",
+    "audit",
+    "retrieval"
+  ],
+  "tags": [
+    "rag",
+    "self-hosted",
+    "bitemporal",
+    "replay",
+    "audit",
+    "k8s",
+    "kubernetes",
+    "sre",
+    "incident-response",
+    "datadog",
+    "pagerduty",
+    "citations",
+    "fastapi",
+    "python"
+  ],
+  "languages": ["python"],
+  "transports": ["stdio", "streamable-http"],
+  "icon_url": "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/icon-256.png",
+  "screenshots": [
+    {
+      "url": "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/screenshots/search.png",
+      "caption": "search() MCP tool returning chunks with citations"
+    },
+    {
+      "url": "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/screenshots/replay.png",
+      "caption": "replay() tool — what the agent saw at time T"
+    },
+    {
+      "url": "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/screenshots/blast-radius.png",
+      "caption": "blast_radius() — incident impact graph"
+    }
+  ],
+  "install": {
+    "one_line": "curl -fsSL https://raw.githubusercontent.com/100rd/Omniscience/main/.mcp/install.sh | bash",
+    "docker": "docker run -d -p 8000:8000 -e POSTGRES_PASSWORD=change-me -e OMNISCIENCE_SECRET_KEY=change-me-32-chars ghcr.io/100rd/omniscience:latest",
+    "uvx": "uvx --from omniscience-cli omniscience mcp serve --transport stdio",
+    "config_writer": "uvx --from omniscience-cli omniscience init --client claude-code"
+  },
+  "mcp_config_example": {
+    "mcpServers": {
+      "omniscience": {
+        "command": "uvx",
+        "args": [
+          "--from",
+          "omniscience-cli",
+          "omniscience",
+          "mcp",
+          "serve",
+          "--transport",
+          "stdio"
+        ],
+        "env": {
+          "OMNISCIENCE_URL": "http://localhost:8000",
+          "OMNISCIENCE_TOKEN": "sk_live_..."
+        }
+      }
+    }
+  },
+  "tools": [
+    {"name": "search", "description": "Hybrid retrieval across all indexed sources; returns chunks with citations and freshness metadata."},
+    {"name": "fetch", "description": "Fetch a specific document/chunk by ID."},
+    {"name": "list_sources", "description": "List configured connectors and their freshness state."},
+    {"name": "describe_source", "description": "Describe a connector's schema, throughput, and last-sync time."},
+    {"name": "replay", "description": "Replay the retrieval result an agent would have seen at a past timestamp T."},
+    {"name": "blast_radius", "description": "Given an incident or change, return the impacted resources via the topology graph."},
+    {"name": "suggest_runbook", "description": "Match an incident signature against indexed runbooks and return the top candidates with confidence."},
+    {"name": "timeline", "description": "Bitemporal timeline of changes for an entity, queryable as-of any past timestamp."}
+  ],
+  "tested_os": ["macos", "linux"],
+  "maintainer": {
+    "name": "100rd",
+    "github": "100rd"
+  }
+}

--- a/.mcp/registry.json
+++ b/.mcp/registry.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.100rd/omniscience",
+  "description": "Self-hosted MCP retrieval service with bitemporal replay and audit. Indexes code, docs, infra, tickets and wikis; exposes them as MCP retrieval tools to any AI client (Claude Code, Cursor, Gemini, custom agents). Retrieval-only, returns chunks with citations.",
+  "repository": {
+    "url": "https://github.com/100rd/Omniscience",
+    "source": "github"
+  },
+  "version": "0.2.0",
+  "websiteUrl": "https://github.com/100rd/Omniscience",
+  "status": "active",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://ghcr.io",
+      "identifier": "ghcr.io/100rd/omniscience",
+      "version": "0.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "-e",
+          "value": "OMNISCIENCE_URL",
+          "isRepeated": true
+        },
+        {
+          "type": "named",
+          "name": "-e",
+          "value": "OMNISCIENCE_TOKEN",
+          "isRepeated": true
+        }
+      ],
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        },
+        {
+          "type": "named",
+          "name": "--transport",
+          "value": "stdio"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "OMNISCIENCE_URL",
+          "description": "URL of the Omniscience server (e.g. http://localhost:8000)",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "OMNISCIENCE_TOKEN",
+          "description": "API token created with `omniscience tokens create`",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    },
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "omniscience-cli",
+      "version": "0.2.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        },
+        {
+          "type": "named",
+          "name": "--transport",
+          "value": "stdio"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "OMNISCIENCE_URL",
+          "description": "URL of the Omniscience server",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "OMNISCIENCE_TOKEN",
+          "description": "API token created with `omniscience tokens create`",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{host}/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token from `omniscience tokens create`",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher": {
+      "publishedBy": "100rd",
+      "publishedAt": "2026-05-24T00:00:00Z"
+    },
+    "io.github.100rd/omniscience": {
+      "categories": [
+        "devtools",
+        "retrieval",
+        "observability",
+        "knowledge-management",
+        "audit"
+      ],
+      "tags": [
+        "rag",
+        "self-hosted",
+        "bitemporal",
+        "replay",
+        "audit",
+        "k8s",
+        "sre",
+        "incident-response",
+        "citations"
+      ],
+      "license": "Apache-2.0",
+      "tools": [
+        "search",
+        "fetch",
+        "list_sources",
+        "describe_source",
+        "replay",
+        "blast_radius",
+        "suggest_runbook",
+        "timeline"
+      ],
+      "screenshots": [
+        "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/screenshots/search.png",
+        "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/screenshots/replay.png",
+        "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/screenshots/blast-radius.png"
+      ],
+      "icon": "https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/icon-256.png"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@ Self-hosted knowledge retrieval service with an **MCP-first API**. Indexes your 
 
 Retrieval-only: Omniscience returns chunks with citations, and the calling LLM synthesizes the answer. No opinionated chat, no embedded LLM, no vendor lock-in.
 
+[![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue?logo=anthropic)](https://registry.modelcontextprotocol.io/)
+[![PulseMCP](https://img.shields.io/badge/PulseMCP-listed-orange)](https://www.pulsemcp.com/servers/omniscience)
+[![Cline Marketplace](https://img.shields.io/badge/Cline-Marketplace-7C3AED)](https://github.com/cline/mcp-marketplace)
+[![mcp.directory](https://img.shields.io/badge/mcp.directory-listed-green)](https://mcp.directory/server/omniscience)
+[![Awesome MCP](https://img.shields.io/badge/Awesome-MCP-yellow)](https://github.com/punkpeye/awesome-mcp-servers)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
+> Registry badges marked `listed` are **pending** until the submissions tracked in [docs/mcp-catalog-submission.md](docs/mcp-catalog-submission.md) are merged by each catalog's maintainers. The badges will resolve automatically once they land.
+
+## Install (one line)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/100rd/Omniscience/main/.mcp/install.sh | bash
+```
+
+Starts the stack with Docker, mints secrets into `./omniscience/.env`, and waits for `/health`. Then wire it into your IDE in one shot:
+
+```bash
+uvx --from omniscience-cli omniscience init --client claude-code
+# or: cursor, cline, zed, continue, gemini
+```
+
+Tested on macOS (Intel + Apple Silicon) and Linux (Ubuntu 22.04, Debian 12). See [docs/mcp-catalog-submission.md](docs/mcp-catalog-submission.md) for the catalog submission recipes.
+
 ## Status
 
 Pre-v0.1 — scaffolding. See [docs/roadmap.md](docs/roadmap.md).
@@ -85,6 +109,7 @@ Then ask your AI assistant a question — it will call `omniscience.search` and 
 - [Freshness & lineage](docs/freshness-and-lineage.md) — trust model for AI clients
 - [Retrieval strategy (ADR 0004)](docs/decisions/0004-retrieval-strategy-staged.md) — hybrid → structural → GraphRAG-if-needed
 - [Architecture decisions](docs/decisions/)
+- [MCP catalog submission tracker](docs/mcp-catalog-submission.md)
 
 ## Benchmarks
 

--- a/docs/mcp-catalog-submission.md
+++ b/docs/mcp-catalog-submission.md
@@ -1,0 +1,169 @@
+# MCP catalog submission recipes
+
+This document captures, for each public MCP discovery surface we target,
+**exactly** what to submit, where, in what format, and how long it
+typically takes the maintainers to merge or approve.
+
+The metadata payloads live next to the repo root under `.mcp/`. They
+are the source of truth — when content drifts, edit those files first
+and re-submit, do not edit text inside the registries' web forms.
+
+## Positioning
+
+We submit under the **broad** positioning: *"Self-hosted MCP retrieval
+with replay & audit"*. Rationale: H1 (retrieval) + H5 (audit) fusion;
+broader TAM at first listing. We may add a second narrow listing
+(*"Bitemporal knowledge for K8s/SRE"*) later — it is cheap to add and
+cannot collide with the broad entry.
+
+## Catalogs
+
+### 1. modelcontextprotocol.io official registry
+
+- **URL**: <https://registry.modelcontextprotocol.io/>
+- **Source of truth**: [.mcp/registry.json](../.mcp/registry.json)
+- **Schema**: `https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json`
+- **Submission flow**:
+  1. Install the publisher CLI: `npm i -g @modelcontextprotocol/registry-publisher`
+     (or use the GitHub Action `modelcontextprotocol/publish-mcp-server@v1`).
+  2. From the repo root run:
+     ```bash
+     mcp-publisher publish --file .mcp/registry.json
+     ```
+     It will OIDC-authenticate against GitHub (org `100rd`, repo
+     `Omniscience`) — no API keys to manage.
+  3. The publish call returns a server ID. Pin it as
+     `OMNISCIENCE_MCP_REGISTRY_ID` in repo secrets so future CI runs
+     can update the entry instead of creating duplicates.
+- **Approval**: automatic on successful schema-validation + repo-ownership proof.
+- **Update cadence**: bump `version` in `.mcp/registry.json` on every
+  release tag — the CI workflow at `.github/workflows/release.yml`
+  should run `mcp-publisher publish` on tag push.
+
+### 2. PulseMCP
+
+- **URL**: <https://www.pulsemcp.com/>
+- **Source of truth**: [.mcp/pulsemcp.json](../.mcp/pulsemcp.json)
+- **Submission flow**:
+  1. Open <https://www.pulsemcp.com/submit>.
+  2. Pick **"Self-hosted server"**.
+  3. Paste fields from `.mcp/pulsemcp.json` into the form:
+     - `name`, `short_description`, `long_description`
+     - `repository`, `homepage`, `license`
+     - **Categories** (multi-select): `devtools`, `observability`,
+       `knowledge-management`, `audit`, `retrieval`.
+     - **Tags**: paste the tag list from the JSON.
+     - **Install** snippets: copy `install.one_line`, `install.docker`,
+       `install.uvx` verbatim.
+     - **Config example**: paste the `mcp_config_example` JSON block.
+     - **Tools**: add each row from the `tools[]` array.
+     - **Screenshots**: upload the three files from
+       `docs/assets/screenshots/` (must exist in repo before submission —
+       see "Screenshot assets" section below).
+  4. Submit.
+- **Approval SLA**: ~2 business days (PulseMCP curates manually).
+- **Contact**: `hello@pulsemcp.com` if the listing stalls more than 5
+  business days.
+
+### 3. Cline marketplace
+
+- **URL**: <https://github.com/cline/mcp-marketplace>
+- **Source of truth**: [.mcp/cline-marketplace.json](../.mcp/cline-marketplace.json)
+- **Submission flow**:
+  1. Fork <https://github.com/cline/mcp-marketplace>.
+  2. Add `omniscience.json` under `servers/` with the contents of
+     `.mcp/cline-marketplace.json`.
+  3. Append an entry to `marketplace.json` referencing the new file.
+  4. Open a PR titled `Add Omniscience (self-hosted retrieval with replay)`.
+  5. Reviewer is `@saoudrizwan` or another Cline maintainer.
+- **Approval SLA**: 3-10 business days. Most rejections are for
+  missing `llmsInstallationContent` (we include it) or stale
+  `logoUrl` (we point at `main` branch — keep that asset stable).
+- **Notes**:
+  - `requiresApiKey: true` — Cline displays a warning to users; that is
+    expected and correct (we mint per-workspace tokens).
+  - `autoApprove` list in the install content is intentionally narrow:
+    only read-only retrieval tools.
+
+### 4. mcp.directory
+
+- **URL**: <https://mcp.directory/>
+- **Source of truth**: [.mcp/pulsemcp.json](../.mcp/pulsemcp.json) (same
+  shape works — mcp.directory mostly mirrors PulseMCP fields).
+- **Submission flow**:
+  1. Open <https://mcp.directory/submit>.
+  2. Paste GitHub URL `https://github.com/100rd/Omniscience`.
+  3. The form pre-fills from the repo; manually correct categories
+     to match `.mcp/pulsemcp.json`.
+  4. Submit.
+- **Approval SLA**: 1-3 business days.
+
+### 5. Awesome MCP Servers
+
+- **URL**: <https://github.com/punkpeye/awesome-mcp-servers>
+- **Source of truth**: no JSON — single-line markdown entry.
+- **Submission flow**:
+  1. Fork the repo.
+  2. Under the **"Retrieval / Search"** section (and additionally under
+     **"Observability"**), add the line, alphabetically:
+     ```markdown
+     - [100rd/Omniscience](https://github.com/100rd/Omniscience) - Self-hosted MCP retrieval with bitemporal replay and audit. Indexes code, docs, infra, Datadog, PagerDuty, runbooks; returns citations.
+     ```
+  3. PR title: `Add Omniscience to Retrieval and Observability sections`.
+- **Approval SLA**: 1-5 business days. Reviewer enforces alphabetical
+  order and ≤1-sentence description.
+
+## Screenshot assets
+
+The registry + PulseMCP entries reference three images that need to
+exist at the stable URL `https://raw.githubusercontent.com/100rd/Omniscience/main/docs/assets/...`:
+
+| File | What it shows |
+|---|---|
+| `docs/assets/icon-256.png` | Square logo, 256x256, transparent PNG |
+| `docs/assets/screenshots/search.png` | Claude Code calling `search()` and rendering results |
+| `docs/assets/screenshots/replay.png` | The `replay()` tool diff'ing now vs as-of T |
+| `docs/assets/screenshots/blast-radius.png` | `blast_radius()` graph visualization |
+
+**Status**: as of this PR these assets do **not yet exist**. The
+README badges will 404 until they are committed. Track creation in
+issue #237; design lead to deliver.
+
+## Install-flow validation
+
+The `1-line install` advertised everywhere is:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/100rd/Omniscience/main/.mcp/install.sh | bash
+```
+
+It must pass on **both** macOS and Linux. Validation procedure:
+
+1. **macOS** (Intel + Apple Silicon): fresh shell, fresh `$PWD`:
+   ```bash
+   curl -fsSL .../install.sh | bash
+   curl http://localhost:8000/health
+   ```
+2. **Linux** (Ubuntu 22.04 + Debian 12): same procedure inside
+   `docker run -it --rm ubuntu:22.04 bash` after installing docker.
+   For ergonomics use a vanilla EC2 t3.small.
+3. **Verify** that re-running the script is idempotent (does not
+   overwrite `.env`, does not duplicate containers).
+
+The script is held in `.mcp/install.sh` and is the single source of
+truth — registries link to it, the README links to it.
+
+## Tracking checklist (for the human owner)
+
+Open this PR ("chore(mcp): submit to MCP catalogs"), then walk this
+list. Tick each box as the external submission lands. The issue closes
+when all five are checked.
+
+- [ ] modelcontextprotocol.io — run `mcp-publisher publish --file .mcp/registry.json`; record server ID in repo secrets.
+- [ ] PulseMCP — submit form at <https://www.pulsemcp.com/submit>; record listing URL.
+- [ ] Cline marketplace — open PR against `cline/mcp-marketplace`; record PR URL.
+- [ ] mcp.directory — submit form at <https://mcp.directory/submit>; record listing URL.
+- [ ] Awesome MCP Servers — open PR against `punkpeye/awesome-mcp-servers`; record PR URL.
+- [ ] Update README badges to point at the resolved listing URLs (remove `pending` markers).
+- [ ] Add `.github/workflows/mcp-publish.yml` to re-publish to modelcontextprotocol.io on every tag.
+- [ ] Run install-flow validation on macOS + Linux post-submission (the script links to `main`, so any breakage is immediately visible to new users).


### PR DESCRIPTION
## Summary

Submit Omniscience to the four public MCP discovery surfaces with
**broad** positioning - *Self-hosted MCP retrieval with replay & audit* -
plus a tested one-line install script and a tracker doc the human owner
walks through to land each external listing.

This PR ships **only metadata + docs + a shell installer**. The
external submissions themselves require manual action by a maintainer
with publish rights on each registry (the registries do not accept
unattended bot submissions). The PR is therefore **conditional on**
the tracker checklist in `docs/mcp-catalog-submission.md` being
walked through.

## What's in the PR

- `.mcp/registry.json` - modelcontextprotocol.io `server.schema.json`-compliant
  payload with OCI (`ghcr.io/100rd/omniscience`) + PyPI (`omniscience-cli`)
  packages, stdio + streamable-http transports, all 8 MCP tools.
- `.mcp/pulsemcp.json` - PulseMCP listing payload: categories
  (`devtools`, `observability`, `knowledge-management`, `audit`,
  `retrieval`), install snippets, `mcp_config_example`, tool table.
- `.mcp/cline-marketplace.json` - Cline marketplace entry with
  `llmsInstallationContent` block; deliberately narrow `autoApprove`
  (read-only tools only).
- `.mcp/install.sh` - `curl -fsSL ... | bash` installer. Idempotent
  `.env` (generates 32-byte secrets, never overwrites), pinned
  docker-compose ref, `/health` poll up to 120s. **macOS-tested**;
  `bash -n` clean; helper functions exercised locally.
- `docs/mcp-catalog-submission.md` - per-catalog recipe (where to
  submit, what fields, SLA, contact), screenshot-asset shopping list,
  and the tracking checklist below.
- `README.md` - additive: badge row at the top + 1-line install
  section. Existing Getting Started preserved verbatim. Badges marked
  `pending` until each catalog responds.

## Manual submission checklist (post-merge, human action)

- [ ] modelcontextprotocol.io: `mcp-publisher publish --file .mcp/registry.json` (OIDC against `100rd/Omniscience`).
- [ ] PulseMCP: submit form at https://www.pulsemcp.com/submit using fields from `.mcp/pulsemcp.json`.
- [ ] Cline marketplace: PR against `cline/mcp-marketplace` adding `servers/omniscience.json`.
- [ ] mcp.directory: form at https://mcp.directory/submit.
- [ ] Awesome MCP Servers: PR against `punkpeye/awesome-mcp-servers` adding alphabetical entry under *Retrieval* + *Observability*.
- [ ] Replace `pending` README badges with resolved listing URLs.
- [ ] Add `.github/workflows/mcp-publish.yml` to auto-republish on tag.
- [ ] Create the 4 screenshot/icon assets under `docs/assets/` (registries reference them).

## Validation

- `jq empty .mcp/*.json` - all three payloads parse.
- `bash -n .mcp/install.sh` - clean.
- `shellcheck .mcp/install.sh` - clean.
- `uv run ruff check .` - all checks passed (no regressions).
- Install script helper functions (`gen_secret`, prereq detection)
  exercised on macOS (Apple Silicon) - 32-char unique tokens, docker
  + curl + `docker compose v2` detected.

## Positioning note

Per the parent decision: **broad** > narrow at first listing
(H1 retrieval + H5 audit fusion, larger TAM). A second narrow
*Bitemporal Knowledge for K8s/SRE* listing can be added later
without conflict.

## Closes

`Closes #237` **only when** the manual checklist above is complete.
Until then this PR ships the artifacts that make those submissions a
copy-paste exercise.

## Test plan

- [ ] Reviewer checks each `.mcp/*.json` against the catalog's published schema.
- [ ] Reviewer renders the README and confirms badges sit above Status.
- [ ] On a clean macOS shell: `curl -fsSL https://raw.githubusercontent.com/100rd/Omniscience/chore/237-mcp-catalog-registration/.mcp/install.sh | bash` brings the stack up and `/health` returns 200.
- [ ] On a clean Linux VM (Ubuntu 22.04): same install command succeeds end-to-end.
- [ ] Re-run install script in same `$PWD` confirms `.env` is preserved (idempotency).