### PR TITLE
feat(incidents): post-mortem generator from bitemporal timeline (#232)

### DIFF
--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -877,3 +877,86 @@ async def find_similar_incidents(
 
 
 __all__ = ["mcp_server", "set_fastapi_app"]
+
+
+# ---------------------------------------------------------------------------
+# Tool: generate_postmortem (issue #232)
+# ---------------------------------------------------------------------------
+
+
+# Late imports keep the module's import-time fast path unchanged and
+# avoid widening the import graph for tools that don't need the post-
+# mortem surface.
+from omniscience_server.postmortem import (  # noqa: E402
+    SUPPORTED_TEMPLATES as POSTMORTEM_SUPPORTED_TEMPLATES,
+)
+from omniscience_server.postmortem import (  # noqa: E402
+    PostmortemError,
+    generate_postmortem,
+    render,
+)
+
+
+@mcp_server.tool(
+    name="generate_postmortem",
+    description=(
+        "Generate a templated post-mortem from the bitemporal graph "
+        "timeline for an incident. alert_id MUST be 'alert://{provider}/"
+        "{provider_alert_id}'. template is one of "
+        + ", ".join(POSTMORTEM_SUPPORTED_TEMPLATES)
+        + " (default 'blameless'). format is one of 'markdown' (default), "
+        "'html', or 'json'. Each timeline entry cites its entity with the "
+        "as-of timestamp per ADR-0008 5. Action items are extracted into "
+        "FollowUp entities. Requires a workspace-scoped token."
+    ),
+)
+async def generate_postmortem_tool(
+    incident_id: str,
+    alert_id: str,
+    ctx: Context[Any, Any, Any],
+    template: str = "blameless",
+    format: str = "markdown",  # noqa: A002 — MCP wire convention
+    incident_start: str | None = None,
+    incident_end: str | None = None,
+) -> dict[str, Any]:
+    """generate_postmortem tool — requires scope 'search' + workspace token."""
+    token = await _resolve_token(ctx)
+    _require_scope(token, Scope.search)
+    _record_tool_invocation(tool_name="generate_postmortem", token=token)
+    assert token is not None  # noqa: S101 — narrows type for mypy
+
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "mcp_generate_postmortem_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise ValueError("forbidden:Post-mortem generation requires a workspace-scoped token")
+
+    parsed_start = _parse_as_of(incident_start)
+    parsed_end = _parse_as_of(incident_end)
+
+    try:
+        report = await generate_postmortem(
+            app=_get_app(),
+            incident_id=incident_id,
+            alert_id=alert_id,
+            workspace_id=workspace_id,
+            template=template,
+            incident_start=parsed_start,
+            incident_end=parsed_end,
+        )
+        rendered = render(report, fmt=format)
+    except PostmortemError as exc:
+        # Re-raise as a ValueError with the structured 'code:message'
+        # envelope FastMCP serialises into a tool-error response.
+        raise ValueError(str(exc)) from exc
+
+    return {
+        "incident_id": report.incident_id,
+        "alert_id": report.alert_id,
+        "template": report.template_id,
+        "format": format,
+        "rendered": rendered,
+        "report": report.model_dump(mode="json"),
+    }

--- a/apps/server/src/omniscience_server/postmortem/__init__.py
+++ b/apps/server/src/omniscience_server/postmortem/__init__.py
@@ -1,0 +1,89 @@
+"""Post-mortem generator (issue #232 / H5 Track 1 of epic #230).
+
+Renders a structured post-mortem from the bitemporal graph timeline,
+cross-linking runbook-step events when available.
+
+Public surface
+--------------
+
+* :func:`generate_postmortem` — top-level composition entry point that
+  produces a :class:`PostmortemReport` Pydantic model.
+* :func:`render` — renders a :class:`PostmortemReport` to ``markdown`` or
+  ``html``.
+* :class:`PostmortemTemplate` — Pydantic-typed template definition.
+* :func:`get_template` / :func:`list_templates` — template registry.
+* :data:`SUPPORTED_TEMPLATES` — closed Literal of registered template ids.
+
+Why a self-contained generator
+------------------------------
+
+The post-mortem composes data from three existing pieces:
+
+1. :func:`omniscience_server.incident_timeline.mcp_incident_timeline` —
+   the bitemporal "what changed" view, with ``as_of=incident_end``
+   anchoring the graph snapshot.
+2. :class:`omniscience_server.runbook.RunbookStepRecorder` recent events
+   for the incident — the "who did what" view, sourced from the in-
+   memory recorder seeded by ``POST /incidents/{id}/runbook-step``.
+3. Template registry — three default templates (blameless,
+   five-whys, coe) chosen because they are the lingua-franca of incident
+   reviews across PagerDuty, incident.io, and the SRE handbook.
+
+The renderer is a pure function over the structured report — no Jinja2
+dependency (the codebase deliberately avoids it; templates are
+structured Pydantic models rendered via plain f-strings).
+"""
+
+from __future__ import annotations
+
+from omniscience_server.postmortem.errors import (
+    INCIDENT_NOT_FOUND_CODE,
+    INVALID_FORMAT_CODE,
+    INVALID_INCIDENT_ID_CODE,
+    INVALID_TEMPLATE_CODE,
+    PostmortemError,
+)
+from omniscience_server.postmortem.followups import (
+    FollowUp,
+    FollowUpPriority,
+    extract_followups,
+)
+from omniscience_server.postmortem.generator import (
+    SUPPORTED_FORMATS,
+    Citation,
+    PostmortemFormat,
+    PostmortemReport,
+    PostmortemTimelineRow,
+    generate_postmortem,
+    render,
+)
+from omniscience_server.postmortem.templates import (
+    SUPPORTED_TEMPLATES,
+    PostmortemTemplate,
+    PostmortemTemplateId,
+    get_template,
+    list_templates,
+)
+
+__all__ = [
+    "INCIDENT_NOT_FOUND_CODE",
+    "INVALID_FORMAT_CODE",
+    "INVALID_INCIDENT_ID_CODE",
+    "INVALID_TEMPLATE_CODE",
+    "SUPPORTED_FORMATS",
+    "SUPPORTED_TEMPLATES",
+    "Citation",
+    "FollowUp",
+    "FollowUpPriority",
+    "PostmortemError",
+    "PostmortemFormat",
+    "PostmortemReport",
+    "PostmortemTemplate",
+    "PostmortemTemplateId",
+    "PostmortemTimelineRow",
+    "extract_followups",
+    "generate_postmortem",
+    "get_template",
+    "list_templates",
+    "render",
+]

--- a/apps/server/src/omniscience_server/postmortem/errors.py
+++ b/apps/server/src/omniscience_server/postmortem/errors.py
@@ -1,0 +1,49 @@
+"""Error codes for the post-mortem generator surface (issue #232).
+
+All codes follow the convention already established by
+``resolve_incident`` and ``incident_timeline`` — a stable string
+identifier that REST/MCP error envelopes can pattern-match on.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+#: Caller supplied a template id we don't know about.
+INVALID_TEMPLATE_CODE: Final[str] = "invalid_template"
+
+#: Caller supplied a render format other than 'markdown' / 'html'.
+INVALID_FORMAT_CODE: Final[str] = "invalid_format"
+
+#: Caller supplied an empty / oversized / non-string incident id.
+INVALID_INCIDENT_ID_CODE: Final[str] = "invalid_incident_id"
+
+#: The alert id referenced by the incident id was not found in the
+#: caller's workspace (or does not exist at all — no existence leak).
+INCIDENT_NOT_FOUND_CODE: Final[str] = "incident_not_found"
+
+
+class PostmortemError(ValueError):
+    """Structured error raised by the post-mortem generator.
+
+    Subclass of :class:`ValueError` so the existing REST/MCP error
+    machinery (which pattern-matches on ``str(exc)``) treats it
+    identically to the existing handlers.  The ``code`` attribute is
+    exposed for handlers that want the structured field directly.
+    """
+
+    code: str
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}:{message}")
+        self.code = code
+        self.message = message
+
+
+__all__ = [
+    "INCIDENT_NOT_FOUND_CODE",
+    "INVALID_FORMAT_CODE",
+    "INVALID_INCIDENT_ID_CODE",
+    "INVALID_TEMPLATE_CODE",
+    "PostmortemError",
+]

--- a/apps/server/src/omniscience_server/postmortem/followups.py
+++ b/apps/server/src/omniscience_server/postmortem/followups.py
@@ -1,0 +1,237 @@
+"""FollowUp entity extraction (issue #232 acceptance).
+
+When a post-mortem is generated, action items that emerge from the
+timeline are materialised as :class:`FollowUp` entity nodes.  Each
+FollowUp carries:
+
+* a canonical name (``followup://{incident_id}/{slug}``) so it slots into
+  the bitemporal graph the same way runbook steps do;
+* a link back to the incident + alert it originated from;
+* a priority bucket so triage tools can sort backlog items.
+
+Extraction heuristics
+---------------------
+
+The v0.1 extractor is intentionally simple and deterministic:
+
+1. Every ``runbook-step`` event with outcome ``failed`` or ``rolled_back``
+   produces a "investigate failure" FollowUp.
+2. Every entity in the timeline whose ``after_state_summary`` contains
+   any of the trigger phrases (``"TODO"``, ``"follow-up"``,
+   ``"investigate"``, ``"flaky"``, ``"known issue"``) produces a
+   FollowUp with the matched phrase highlighted.
+3. The template's ``action_items`` section is always backfilled with a
+   default "Schedule incident review" FollowUp so the generator never
+   emits an empty action-items section.
+
+A future PR (#232 v2) will plug an LLM-based extractor behind the same
+interface.  Keeping the surface stable lets us swap the implementation
+without breaking the renderer.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omniscience_server.postmortem.models import PostmortemTimelineRow
+
+#: Closed Literal of priorities — keeps the schema queryable.
+FollowUpPriority = Literal["P0", "P1", "P2", "P3"]
+
+#: Trigger phrases that promote a timeline row to a FollowUp.  Case-
+#: insensitive; whole-word matching.
+_TRIGGER_PHRASES: Final[tuple[str, ...]] = (
+    "TODO",
+    "follow-up",
+    "followup",
+    "investigate",
+    "flaky",
+    "known issue",
+    "tech debt",
+    "tech-debt",
+)
+
+_TRIGGER_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"\b(" + "|".join(re.escape(p) for p in _TRIGGER_PHRASES) + r")\b",
+    re.IGNORECASE,
+)
+
+#: Maximum number of FollowUps the extractor will emit per incident.
+#: Past this point we shed load — the responder is better served by a
+#: short ranked list than a thousand-item backlog.
+MAX_FOLLOWUPS: Final[int] = 50
+
+
+def _slugify(value: str) -> str:
+    """Reduce a free-form string to a path-safe slug.
+
+    Matches the runbook step slug rules ``[A-Za-z0-9._-]+`` so FollowUp
+    canonical names compose into the bitemporal graph cleanly.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-")
+    if not cleaned:
+        cleaned = uuid.uuid4().hex[:12]
+    return cleaned[:64].lower()
+
+
+def canonical_followup_name(incident_id: str, slug: str) -> str:
+    """Canonical ``followup://`` URI for graph storage."""
+    return f"followup://{_slugify(incident_id)}/{_slugify(slug)}"
+
+
+class FollowUp(BaseModel):
+    """An action item extracted from the post-mortem.
+
+    Action items materialise as graph entity nodes (kind=``followup``)
+    when the generator is invoked through the REST/MCP surfaces; the
+    extractor returns them as Pydantic models so the renderer and the
+    integration tests can introspect the list without a graph round-trip.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(description="Canonical 'followup://{incident_id}/{slug}'.")
+    incident_id: str = Field(description="The incident this follow-up belongs to.")
+    alert_id: str = Field(description="The originating alert id (for back-reference).")
+    title: str = Field(description="One-sentence summary of the action item.")
+    priority: FollowUpPriority = Field(default="P2")
+    source_entity_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional: the entity whose state-change produced this "
+            "follow-up.  Lets the responder UI jump to provenance."
+        ),
+    )
+    source_as_of: datetime | None = Field(
+        default=None,
+        description=(
+            "Optional: the as-of timestamp of the source entity row "
+            "(matches the timeline citation's anchor)."
+        ),
+    )
+    created_at: datetime = Field(description="When the FollowUp was extracted (UTC).")
+
+
+def extract_followups(
+    *,
+    incident_id: str,
+    alert_id: str,
+    timeline: list[PostmortemTimelineRow],
+    runbook_steps: list[dict[str, object]],
+    now: datetime | None = None,
+) -> list[FollowUp]:
+    """Extract :class:`FollowUp`\\ s from the incident's timeline + steps.
+
+    Parameters
+    ----------
+    incident_id, alert_id:
+        Identifiers stamped on every emitted FollowUp.
+    timeline:
+        The rendered timeline rows produced by the generator — each
+        carries the cited ``after_state_summary`` the heuristic scans.
+    runbook_steps:
+        Recent runbook-step events for the incident, as dicts produced
+        by :meth:`RunbookStepEvent.to_payload`.  Failed / rolled-back
+        steps each promote to a FollowUp.
+    now:
+        Override for deterministic tests; defaults to ``datetime.now(UTC)``.
+    """
+    timestamp = now or datetime.now(UTC)
+    out: list[FollowUp] = []
+
+    # Heuristic 1: failed / rolled-back runbook steps.
+    for step in runbook_steps:
+        outcome = str(step.get("outcome") or "")
+        if outcome not in {"failed", "rolled_back"}:
+            continue
+        step_id = str(step.get("step_id") or "step")
+        runbook_name = str(step.get("runbook_name") or "")
+        title = f"Investigate {outcome} step '{step_id}' from {runbook_name}"
+        out.append(
+            FollowUp(
+                name=canonical_followup_name(incident_id, f"step-{step_id}-{outcome}"),
+                incident_id=incident_id,
+                alert_id=alert_id,
+                title=title,
+                priority="P1" if outcome == "rolled_back" else "P2",
+                source_entity_id=runbook_name or None,
+                source_as_of=_parse_dt(step.get("valid_from")),
+                created_at=timestamp,
+            )
+        )
+
+    # Heuristic 2: trigger phrases in timeline row summaries.
+    for row in timeline:
+        haystack = " ".join(
+            v for v in (row.before_state_summary, row.after_state_summary) if v is not None
+        )
+        match = _TRIGGER_PATTERN.search(haystack)
+        if not match:
+            continue
+        trigger = match.group(1)
+        title = f"Address '{trigger}' flagged on {row.entity_type} {row.entity_id}"
+        out.append(
+            FollowUp(
+                name=canonical_followup_name(incident_id, f"{row.entity_type}-{trigger}"),
+                incident_id=incident_id,
+                alert_id=alert_id,
+                title=title,
+                priority="P2",
+                source_entity_id=row.entity_id,
+                source_as_of=row.citation.as_of,
+                created_at=timestamp,
+            )
+        )
+
+    # Heuristic 3: always include the "schedule review" baseline.
+    out.append(
+        FollowUp(
+            name=canonical_followup_name(incident_id, "schedule-review"),
+            incident_id=incident_id,
+            alert_id=alert_id,
+            title="Schedule post-incident review meeting",
+            priority="P3",
+            source_entity_id=None,
+            source_as_of=None,
+            created_at=timestamp,
+        )
+    )
+
+    # De-duplicate by canonical name; preserve first occurrence ordering.
+    seen: set[str] = set()
+    unique: list[FollowUp] = []
+    for f in out:
+        if f.name in seen:
+            continue
+        seen.add(f.name)
+        unique.append(f)
+
+    return unique[:MAX_FOLLOWUPS]
+
+
+def _parse_dt(value: object) -> datetime | None:
+    """Best-effort ISO-8601 parsing for the runbook-step payload."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+__all__ = [
+    "MAX_FOLLOWUPS",
+    "FollowUp",
+    "FollowUpPriority",
+    "canonical_followup_name",
+    "extract_followups",
+]

--- a/apps/server/src/omniscience_server/postmortem/generator.py
+++ b/apps/server/src/omniscience_server/postmortem/generator.py
@@ -1,0 +1,532 @@
+"""Core post-mortem composition + rendering (issue #232).
+
+Composition flow
+----------------
+
+1. Resolve template via :func:`get_template`.
+2. Read the bitemporal timeline for ``alert_id`` between
+   ``incident_start`` and ``incident_end`` via
+   :func:`mcp_incident_timeline` with ``as_of=incident_end``.
+3. Pull recent runbook-step events for ``incident_id`` from the
+   :class:`RunbookStepRecorder` ring buffer.
+4. Build a :class:`PostmortemReport` with cited timeline rows + extracted
+   follow-ups.
+5. (Optional) render the report to markdown or HTML.
+
+The composition is workspace-scoped: every store call carries
+``workspace_id``; the runbook-step recorder also filters by workspace.
+"""
+
+from __future__ import annotations
+
+import html
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Final, Literal
+
+from fastapi import FastAPI
+from pydantic import BaseModel, ConfigDict, Field
+
+from omniscience_server.as_of import enforce_utc, resolve_effective_as_of
+from omniscience_server.incident_timeline import mcp_incident_timeline
+from omniscience_server.incidents import (
+    ALERT_NOT_FOUND_CODE,
+    INVALID_ALERT_ID_CODE,
+)
+from omniscience_server.postmortem.errors import (
+    INCIDENT_NOT_FOUND_CODE,
+    INVALID_FORMAT_CODE,
+    INVALID_INCIDENT_ID_CODE,
+    PostmortemError,
+)
+from omniscience_server.postmortem.followups import FollowUp, extract_followups
+from omniscience_server.postmortem.models import Citation, PostmortemTimelineRow
+from omniscience_server.postmortem.templates import (
+    PostmortemTemplate,
+    PostmortemTemplateId,
+    TemplateSection,
+    get_template,
+)
+
+#: Output formats the generator can render.  ``json`` returns the raw
+#: structured report (handy for API clients that want to template
+#: themselves); ``markdown`` is the canonical human-readable form.
+PostmortemFormat = Literal["markdown", "html", "json"]
+
+#: Concrete tuple matching :data:`PostmortemFormat` for runtime checks.
+SUPPORTED_FORMATS: Final[tuple[PostmortemFormat, ...]] = (
+    "markdown",
+    "html",
+    "json",
+)
+
+#: Maximum incident_id length the surface accepts.  Matches the REST
+#: ``incident_id`` path parameter on the runbook router so the two
+#: endpoints share an identifier shape.
+_MAX_INCIDENT_ID_LEN: Final[int] = 256
+
+
+# ---------------------------------------------------------------------------
+# Structured report
+# ---------------------------------------------------------------------------
+
+
+class PostmortemReport(BaseModel):
+    """The full structured post-mortem.
+
+    Returned by :func:`generate_postmortem`; consumed by :func:`render`
+    or serialised straight to JSON for callers that want to format the
+    document themselves.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=False)
+
+    incident_id: str
+    alert_id: str
+    template_id: PostmortemTemplateId
+    template_display_name: str
+    incident_start: datetime
+    incident_end: datetime
+    generated_at: datetime
+    effective_as_of: datetime = Field(
+        description=(
+            "The bitemporal anchor used to read the timeline — usually "
+            "``incident_end`` so the graph snapshot reflects the state "
+            "at incident close."
+        ),
+    )
+    timeline: list[PostmortemTimelineRow] = Field(default_factory=list)
+    runbook_steps_count: int = Field(
+        default=0,
+        description="Count of recorded runbook-step events for the incident.",
+    )
+    followups: list[FollowUp] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_incident_id(incident_id: str) -> None:
+    if not isinstance(incident_id, str) or not incident_id:
+        raise PostmortemError(
+            INVALID_INCIDENT_ID_CODE,
+            "incident_id must be a non-empty string",
+        )
+    if len(incident_id) > _MAX_INCIDENT_ID_LEN:
+        raise PostmortemError(
+            INVALID_INCIDENT_ID_CODE,
+            f"incident_id must be <= {_MAX_INCIDENT_ID_LEN} characters",
+        )
+
+
+def _validate_format(fmt: str) -> PostmortemFormat:
+    if fmt not in SUPPORTED_FORMATS:
+        raise PostmortemError(
+            INVALID_FORMAT_CODE,
+            f"format must be one of: {', '.join(SUPPORTED_FORMATS)}",
+        )
+    return fmt
+
+
+# ---------------------------------------------------------------------------
+# Composition
+# ---------------------------------------------------------------------------
+
+
+async def generate_postmortem(
+    *,
+    app: FastAPI,
+    incident_id: str,
+    alert_id: str,
+    workspace_id: uuid.UUID,
+    template: str = "blameless",
+    incident_start: datetime | None = None,
+    incident_end: datetime | None = None,
+    now: datetime | None = None,
+) -> PostmortemReport:
+    """Compose a structured :class:`PostmortemReport`.
+
+    Parameters
+    ----------
+    app:
+        FastAPI app exposing ``app.state.graph_store`` and (optionally)
+        ``app.state.runbook_step_recorder``.
+    incident_id:
+        Caller-supplied incident identifier (PagerDuty incident id, etc.)
+        — used to scope the runbook-step lookup and stamp FollowUps.
+    alert_id:
+        Canonical alert URI ``alert://{provider}/{provider_alert_id}``.
+    workspace_id:
+        REQUIRED. Forwarded to every store call (ACL invariant).
+    template:
+        Template id; see :data:`SUPPORTED_TEMPLATES`.  Defaults to
+        ``blameless``.
+    incident_start, incident_end:
+        Half-open ``[start, end)`` window applied to the timeline; both
+        must be timezone-aware UTC.  When ``incident_start`` is ``None``
+        the timeline is unbounded on the left; ``incident_end`` defaults
+        to ``now``.
+    now:
+        Override for deterministic tests; defaults to ``datetime.now(UTC)``.
+    """
+    _validate_incident_id(incident_id)
+    selected_template = get_template(template)
+
+    normalised_now = (now or datetime.now(UTC)).astimezone(UTC)
+    normalised_start = enforce_utc(incident_start)
+    normalised_end = enforce_utc(incident_end) or normalised_now
+
+    if normalised_start is not None and normalised_start > normalised_end:
+        raise PostmortemError(
+            INVALID_INCIDENT_ID_CODE,
+            "incident_start must be <= incident_end",
+        )
+
+    # 1. Pull the timeline at ``as_of=incident_end`` so the graph snapshot
+    # reflects the bitemporal state at incident close (issue #232 spec).
+    try:
+        raw_timeline = await mcp_incident_timeline(
+            app=app,
+            alert_id=alert_id,
+            workspace_id=workspace_id,
+            as_of=normalised_end,
+            from_ts=normalised_start,
+            to_ts=normalised_end,
+        )
+    except ValueError as exc:
+        msg = str(exc)
+        if msg.startswith(f"{ALERT_NOT_FOUND_CODE}:"):
+            raise PostmortemError(
+                INCIDENT_NOT_FOUND_CODE,
+                f"alert '{alert_id}' not found for incident '{incident_id}'",
+            ) from exc
+        if msg.startswith(f"{INVALID_ALERT_ID_CODE}:"):
+            # Surface upstream validator's code unchanged.
+            raise
+        raise
+
+    timeline_rows = _project_timeline_rows(raw_timeline, default_as_of=normalised_end)
+
+    # 2. Look up runbook-step events for this incident from the recorder
+    # (process-local; future PR promotes to a SQL table — see #231).
+    runbook_steps = _load_runbook_steps(app, workspace_id=workspace_id, incident_id=incident_id)
+
+    # 3. Extract follow-ups.
+    followups = extract_followups(
+        incident_id=incident_id,
+        alert_id=alert_id,
+        timeline=timeline_rows,
+        runbook_steps=runbook_steps,
+        now=normalised_now,
+    )
+
+    return PostmortemReport(
+        incident_id=incident_id,
+        alert_id=alert_id,
+        template_id=selected_template.template_id,
+        template_display_name=selected_template.display_name,
+        incident_start=normalised_start or _earliest_ts(timeline_rows, fallback=normalised_end),
+        incident_end=normalised_end,
+        generated_at=normalised_now,
+        effective_as_of=resolve_effective_as_of(normalised_end),
+        timeline=timeline_rows,
+        runbook_steps_count=len(runbook_steps),
+        followups=followups,
+    )
+
+
+def _project_timeline_rows(
+    raw: dict[str, Any],
+    *,
+    default_as_of: datetime,
+) -> list[PostmortemTimelineRow]:
+    """Wrap raw :class:`TimelineEvent` dicts with citations.
+
+    The citation's ``as_of`` is the event ts itself — the slice of the
+    graph that the row was projected from.  Falls back to
+    ``default_as_of`` (the ``incident_end`` anchor) when the wire row is
+    malformed.
+    """
+    rows: list[PostmortemTimelineRow] = []
+    events: list[dict[str, Any]] = raw.get("events") or []
+    for event in events:
+        ts = _parse_dt(event.get("ts")) or default_as_of
+        entity_id = str(event.get("entity_id") or "")
+        entity_type = str(event.get("entity_type") or "")
+        source = str(event.get("source") or "")
+        rows.append(
+            PostmortemTimelineRow(
+                ts=ts,
+                entity_id=entity_id,
+                entity_type=entity_type,
+                change_kind=str(event.get("change_kind") or "created"),
+                before_state_summary=event.get("before_state_summary"),
+                after_state_summary=event.get("after_state_summary"),
+                citation=Citation(
+                    entity_id=entity_id,
+                    entity_type=entity_type,
+                    as_of=ts,
+                    source=source,
+                ),
+            )
+        )
+    return rows
+
+
+def _load_runbook_steps(
+    app: FastAPI,
+    *,
+    workspace_id: uuid.UUID,
+    incident_id: str,
+) -> list[dict[str, Any]]:
+    """Read recent runbook-step events for ``incident_id`` from the recorder.
+
+    Returns ``[]`` when the recorder is absent (tests that don't wire one
+    up) or when no events match the incident.  The recorder enforces
+    workspace ACL inside :meth:`RunbookStepRecorder.recent`.
+    """
+    recorder = getattr(app.state, "runbook_step_recorder", None)
+    if recorder is None:
+        return []
+    try:
+        events = recorder.recent(workspace_id=workspace_id, limit=500)
+    except Exception:  # pragma: no cover - defensive
+        return []
+    out: list[dict[str, Any]] = []
+    for event in events:
+        # ``RunbookStepEvent.to_payload()`` is the contract surface.
+        if not hasattr(event, "to_payload"):
+            continue
+        payload = event.to_payload()
+        if payload.get("incident_id") == incident_id:
+            out.append(payload)
+    return out
+
+
+def _earliest_ts(rows: list[PostmortemTimelineRow], *, fallback: datetime) -> datetime:
+    """Earliest event ts, or ``fallback`` when no events exist."""
+    if not rows:
+        return fallback
+    return min(r.ts for r in rows)
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render(report: PostmortemReport, *, fmt: str = "markdown") -> str:
+    """Render the report to ``markdown`` or ``html``.
+
+    ``json`` is also accepted as a synonym for ``report.model_dump_json``
+    so callers that want the raw structured form can use the same entry
+    point.  Raises :class:`PostmortemError(INVALID_FORMAT_CODE, ...)` on
+    unknown formats.
+    """
+    normalised = _validate_format(fmt)
+    if normalised == "json":
+        return report.model_dump_json(indent=2)
+    template = get_template(report.template_id)
+    if normalised == "markdown":
+        return _render_markdown(report, template)
+    return _render_html(report, template)
+
+
+def _render_markdown(report: PostmortemReport, template: PostmortemTemplate) -> str:
+    """Render the report as GitHub-flavoured markdown."""
+    out: list[str] = []
+    out.append(f"# Post-mortem: {report.incident_id}")
+    out.append("")
+    out.append(f"_Template: **{template.display_name}** ({template.template_id})_")
+    out.append("")
+    out.append(
+        "| Field | Value |\n"
+        "| --- | --- |\n"
+        f"| Alert | `{report.alert_id}` |\n"
+        f"| Incident start | {report.incident_start.isoformat()} |\n"
+        f"| Incident end | {report.incident_end.isoformat()} |\n"
+        f"| Effective as-of | {report.effective_as_of.isoformat()} |\n"
+        f"| Generated at | {report.generated_at.isoformat()} |\n"
+        f"| Timeline events | {len(report.timeline)} |\n"
+        f"| Runbook steps recorded | {report.runbook_steps_count} |\n"
+        f"| Follow-ups extracted | {len(report.followups)} |"
+    )
+    out.append("")
+    for section in template.sections:
+        out.extend(_render_section_markdown(section, report))
+    out.append("")
+    out.append("---")
+    out.append(
+        "_Generated by Omniscience post-mortem (#232) — bitemporal timeline "
+        f"anchored at `as_of={report.effective_as_of.isoformat()}`._"
+    )
+    return "\n".join(out)
+
+
+def _render_section_markdown(section: TemplateSection, report: PostmortemReport) -> list[str]:
+    out: list[str] = [f"## {section.heading}", "", section.description, ""]
+    if section.prompts:
+        for prompt in section.prompts:
+            out.append(f"- {prompt}")
+        out.append("")
+    if section.requires_timeline:
+        out.extend(_render_timeline_markdown(report.timeline))
+    if section.requires_followups:
+        out.extend(_render_followups_markdown(report.followups))
+    return out
+
+
+def _render_timeline_markdown(rows: list[PostmortemTimelineRow]) -> list[str]:
+    if not rows:
+        return [
+            "_(No timeline events fall within the incident window.  Widen "
+            "`incident_start` / `incident_end` or check that the alert has "
+            "neighbours with populated `valid_from`.)_",
+            "",
+        ]
+    lines: list[str] = [
+        "| # | Timestamp (UTC) | Change | Entity | Citation | Summary |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for idx, row in enumerate(rows, start=1):
+        summary = (row.after_state_summary or row.before_state_summary or "").replace("|", "/")
+        # Clip in-cell to keep tables readable in narrow renderers.
+        summary = summary if len(summary) <= 160 else summary[:157] + "..."
+        lines.append(
+            f"| {idx} | {row.ts.isoformat()} | {row.change_kind} | "
+            f"`{row.entity_type}/{row.entity_id}` | {row.citation.to_markdown()} | "
+            f"{summary} |"
+        )
+    lines.append("")
+    return lines
+
+
+def _render_followups_markdown(followups: list[FollowUp]) -> list[str]:
+    if not followups:
+        return ["_(No follow-up action items extracted.)_", ""]
+    lines: list[str] = []
+    for f in followups:
+        prov = ""
+        if f.source_entity_id is not None:
+            prov = f" — source `{f.source_entity_id}`"
+            if f.source_as_of is not None:
+                prov += f" @ {f.source_as_of.isoformat()}"
+        lines.append(f"- [ ] **[{f.priority}]** {f.title}{prov}  ")
+        lines.append(f"  _FollowUp entity: `{f.name}`_")
+    lines.append("")
+    return lines
+
+
+def _render_html(report: PostmortemReport, template: PostmortemTemplate) -> str:
+    """Render an HTML form of the report.
+
+    Minimal, no-style HTML so embedders can drop their own CSS in.  Each
+    output value is HTML-escaped; never trust connector strings.
+    """
+    parts: list[str] = []
+    parts.append("<!doctype html>")
+    parts.append("<html><head><meta charset='utf-8'>")
+    parts.append(f"<title>Post-mortem: {html.escape(report.incident_id)}</title></head><body>")
+    parts.append(f"<h1>Post-mortem: {html.escape(report.incident_id)}</h1>")
+    parts.append(
+        f"<p><em>Template: <strong>{html.escape(template.display_name)}</strong> "
+        f"({html.escape(template.template_id)})</em></p>"
+    )
+    parts.append("<table border='1' cellpadding='4'>")
+    parts.append(
+        f"<tr><th>Alert</th><td><code>{html.escape(report.alert_id)}</code></td></tr>"
+        f"<tr><th>Incident start</th><td>{report.incident_start.isoformat()}</td></tr>"
+        f"<tr><th>Incident end</th><td>{report.incident_end.isoformat()}</td></tr>"
+        f"<tr><th>Effective as-of</th><td>{report.effective_as_of.isoformat()}</td></tr>"
+        f"<tr><th>Generated at</th><td>{report.generated_at.isoformat()}</td></tr>"
+        f"<tr><th>Timeline events</th><td>{len(report.timeline)}</td></tr>"
+        f"<tr><th>Runbook steps recorded</th><td>{report.runbook_steps_count}</td></tr>"
+        f"<tr><th>Follow-ups extracted</th><td>{len(report.followups)}</td></tr>"
+    )
+    parts.append("</table>")
+    for section in template.sections:
+        parts.append(f"<h2>{html.escape(section.heading)}</h2>")
+        parts.append(f"<p>{html.escape(section.description)}</p>")
+        if section.prompts:
+            parts.append("<ul>")
+            for prompt in section.prompts:
+                parts.append(f"<li>{html.escape(prompt)}</li>")
+            parts.append("</ul>")
+        if section.requires_timeline:
+            parts.append(_render_timeline_html(report.timeline))
+        if section.requires_followups:
+            parts.append(_render_followups_html(report.followups))
+    as_of_iso = html.escape(report.effective_as_of.isoformat())
+    parts.append(
+        "<hr><p><em>Generated by Omniscience post-mortem (#232) — bitemporal timeline "
+        f"anchored at <code>as_of={as_of_iso}</code>.</em></p>"
+    )
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+def _render_timeline_html(rows: list[PostmortemTimelineRow]) -> str:
+    if not rows:
+        return "<p><em>No timeline events fall within the incident window.</em></p>"
+    out: list[str] = [
+        "<table border='1' cellpadding='4'><thead><tr>"
+        "<th>#</th><th>Timestamp (UTC)</th><th>Change</th><th>Entity</th>"
+        "<th>Citation</th><th>Summary</th></tr></thead><tbody>"
+    ]
+    for idx, row in enumerate(rows, start=1):
+        summary = row.after_state_summary or row.before_state_summary or ""
+        out.append(
+            f"<tr><td>{idx}</td><td>{row.ts.isoformat()}</td>"
+            f"<td>{html.escape(row.change_kind)}</td>"
+            f"<td><code>{html.escape(row.entity_type)}/{html.escape(row.entity_id)}</code></td>"
+            f"<td><code>{html.escape(row.entity_type)}/{html.escape(row.entity_id)}</code> "
+            f"@ {row.citation.as_of.isoformat()}</td>"
+            f"<td>{html.escape(summary)}</td></tr>"
+        )
+    out.append("</tbody></table>")
+    return "\n".join(out)
+
+
+def _render_followups_html(followups: list[FollowUp]) -> str:
+    if not followups:
+        return "<p><em>No follow-up action items extracted.</em></p>"
+    out: list[str] = ["<ul>"]
+    for f in followups:
+        prov = ""
+        if f.source_entity_id is not None:
+            prov = f" &mdash; source <code>{html.escape(f.source_entity_id)}</code>" + (
+                f" @ {f.source_as_of.isoformat()}" if f.source_as_of is not None else ""
+            )
+        out.append(
+            f"<li><strong>[{html.escape(f.priority)}]</strong> "
+            f"{html.escape(f.title)}{prov}"
+            f"<br><small>FollowUp entity: <code>{html.escape(f.name)}</code></small></li>"
+        )
+    out.append("</ul>")
+    return "\n".join(out)
+
+
+__all__ = [
+    "SUPPORTED_FORMATS",
+    "Citation",
+    "PostmortemFormat",
+    "PostmortemReport",
+    "PostmortemTimelineRow",
+    "generate_postmortem",
+    "render",
+]

--- a/apps/server/src/omniscience_server/postmortem/models.py
+++ b/apps/server/src/omniscience_server/postmortem/models.py
@@ -1,0 +1,51 @@
+"""Shared Pydantic models for the post-mortem package.
+
+Lives in its own module so that :mod:`followups` and :mod:`generator`
+can both import :class:`PostmortemTimelineRow` without creating a
+circular dependency (FollowUp depends on timeline rows for the
+extractor's heuristics; the generator embeds FollowUp objects in the
+report).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Citation(BaseModel):
+    """Provenance pointer attached to every timeline row.
+
+    Lets the reader follow the row back to the exact bitemporal slice
+    of the graph it came from.  Stable across renderings so HTML/JSON
+    consumers can deep-link by entity + as-of.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    entity_id: str = Field(description="Canonical entity name.")
+    entity_type: str = Field(description="Entity kind (e.g. 'k8s_pod').")
+    as_of: datetime = Field(description="Bitemporal anchor (UTC).")
+    source: str = Field(description="Connector / source provenance id.")
+
+    def to_markdown(self) -> str:
+        """Render as a compact inline citation 'kind/name @ ISO-8601'."""
+        return f"`{self.entity_type}/{self.entity_id}` @ {self.as_of.isoformat()}"
+
+
+class PostmortemTimelineRow(BaseModel):
+    """A single timeline entry with a citation pointer."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ts: datetime = Field(description="Event timestamp (UTC).")
+    entity_id: str = Field(description="Canonical entity name.")
+    entity_type: str = Field(description="Entity kind.")
+    change_kind: str = Field(description="'created' or 'ended'.")
+    before_state_summary: str | None = None
+    after_state_summary: str | None = None
+    citation: Citation = Field(description="Cite-by-entity provenance.")
+
+
+__all__ = ["Citation", "PostmortemTimelineRow"]

--- a/apps/server/src/omniscience_server/postmortem/templates/__init__.py
+++ b/apps/server/src/omniscience_server/postmortem/templates/__init__.py
@@ -1,0 +1,364 @@
+"""Post-mortem template registry.
+
+Three default templates are shipped (issue #232 acceptance):
+
+* :data:`BLAMELESS` — the Google SRE-style blameless post-mortem
+  (Summary, Impact, Timeline, Root cause, Lessons, Action items).
+* :data:`FIVE_WHYS` — Toyota-style iterative why-chain analysis, useful
+  for incidents whose proximate cause is obvious but whose latent cause
+  is not.
+* :data:`COE` — AWS-style Correction of Errors document; expands the
+  timeline section with explicit detection / mitigation / resolution
+  buckets.
+
+Templates are Pydantic models (not Jinja2 — see ``apps/server`` ADR
+notes on dependency minimisation).  Section bodies are rendered by
+:mod:`omniscience_server.postmortem.generator`; each template enumerates
+the sections it wants emitted, in order.
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from omniscience_server.postmortem.errors import (
+    INVALID_TEMPLATE_CODE,
+    PostmortemError,
+)
+
+#: Closed Literal of template ids exposed on the public surface.  Adding
+#: a template means extending this Literal AND registering the new
+#: template in :data:`_REGISTRY`.
+PostmortemTemplateId = Literal["blameless", "five_whys", "coe"]
+
+#: The exact set of ids :class:`PostmortemTemplateId` permits.  Kept in
+#: sync via the assertion below so that runtime checks stay aligned with
+#: the type-level Literal.
+SUPPORTED_TEMPLATES: Final[tuple[PostmortemTemplateId, ...]] = (
+    "blameless",
+    "five_whys",
+    "coe",
+)
+
+
+class TemplateSection(BaseModel):
+    """A single section of a post-mortem template."""
+
+    model_config = ConfigDict(frozen=True)
+
+    section_id: str = Field(
+        description=(
+            "Stable identifier (snake_case).  Used by callers that want "
+            "to extract / re-order a specific section programmatically."
+        ),
+    )
+    heading: str = Field(description="Human-readable heading (rendered as H2).")
+    description: str = Field(
+        description=(
+            "Short prose shown immediately below the heading explaining "
+            "what the section is for.  Helps responders fill it in."
+        ),
+    )
+    requires_timeline: bool = Field(
+        default=False,
+        description=(
+            "True iff the renderer should inject the cited timeline "
+            "table into this section.  Exactly one section per template "
+            "is expected to set this — the generator enforces it."
+        ),
+    )
+    requires_followups: bool = Field(
+        default=False,
+        description=(
+            "True iff the renderer should inject the extracted FollowUp "
+            "checklist into this section.  As with timelines, exactly "
+            "one section per template should set this."
+        ),
+    )
+    prompts: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Bullet-list prompts that appear under the section "
+            "description as a checklist of questions for the author."
+        ),
+    )
+
+
+class PostmortemTemplate(BaseModel):
+    """A complete post-mortem template — title + ordered section list."""
+
+    model_config = ConfigDict(frozen=True)
+
+    template_id: PostmortemTemplateId
+    display_name: str = Field(description="Human-readable template name.")
+    purpose: str = Field(description="One-sentence summary of when to use this template.")
+    sections: list[TemplateSection] = Field(
+        description="Ordered list of sections the renderer will emit.",
+        min_length=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default templates
+# ---------------------------------------------------------------------------
+
+
+BLAMELESS: Final[PostmortemTemplate] = PostmortemTemplate(
+    template_id="blameless",
+    display_name="Blameless post-mortem",
+    purpose=(
+        "Google SRE-style blameless review focused on systemic causes; "
+        "the default template for most incidents."
+    ),
+    sections=[
+        TemplateSection(
+            section_id="summary",
+            heading="Summary",
+            description=(
+                "One paragraph: what broke, who noticed, how long it "
+                "lasted, and what the user-visible impact was."
+            ),
+        ),
+        TemplateSection(
+            section_id="impact",
+            heading="Impact",
+            description=(
+                "Quantify the customer-visible effect — requests "
+                "affected, error rate, revenue, SLO burn."
+            ),
+            prompts=[
+                "How many users were affected?",
+                "What was the error rate at peak?",
+                "Was the SLO budget consumed?",
+            ],
+        ),
+        TemplateSection(
+            section_id="timeline",
+            heading="Timeline",
+            description=(
+                "Chronological list of entity state changes between "
+                "`incident_start` and `incident_end`, each row cited "
+                "back to the entity and as-of timestamp it came from."
+            ),
+            requires_timeline=True,
+        ),
+        TemplateSection(
+            section_id="root_cause",
+            heading="Root cause",
+            description=(
+                "The systemic chain of contributing factors.  Blame "
+                "code paths, configurations, and processes — not people."
+            ),
+            prompts=[
+                "What was the trigger?",
+                "What latent conditions allowed it to escalate?",
+                "Why didn't existing safeguards catch it?",
+            ],
+        ),
+        TemplateSection(
+            section_id="lessons_learned",
+            heading="Lessons learned",
+            description=("What went well, what went wrong, where we got lucky. Bullet form."),
+        ),
+        TemplateSection(
+            section_id="action_items",
+            heading="Action items",
+            description=(
+                "Concrete follow-ups extracted from the incident.  Each "
+                "becomes a FollowUp entity node in the graph for "
+                "tracking."
+            ),
+            requires_followups=True,
+        ),
+    ],
+)
+
+
+FIVE_WHYS: Final[PostmortemTemplate] = PostmortemTemplate(
+    template_id="five_whys",
+    display_name="Five-whys analysis",
+    purpose=(
+        "Iterative why-chain analysis for incidents where the proximate "
+        "cause is obvious but the latent cause is unclear."
+    ),
+    sections=[
+        TemplateSection(
+            section_id="problem_statement",
+            heading="Problem statement",
+            description="The user-visible symptom in one sentence.",
+        ),
+        TemplateSection(
+            section_id="timeline",
+            heading="Timeline",
+            description=(
+                "Chronological list of entity state changes during the "
+                "incident window, each row cited."
+            ),
+            requires_timeline=True,
+        ),
+        TemplateSection(
+            section_id="why_chain",
+            heading="Why chain",
+            description=(
+                "Five iterations of 'why?' starting from the symptom.  "
+                "Each answer becomes the next 'why?' until a systemic "
+                "root cause is reached."
+            ),
+            prompts=[
+                "Why 1: Why did the symptom occur?",
+                "Why 2: Why did that condition exist?",
+                "Why 3: Why was that condition not prevented?",
+                "Why 4: Why did the prevention fail?",
+                "Why 5: Why did the systemic safeguard not catch it?",
+            ],
+        ),
+        TemplateSection(
+            section_id="systemic_cause",
+            heading="Systemic cause",
+            description=(
+                "The root cause exposed at the bottom of the why-chain. "
+                "Typically a process or design gap, not a code bug."
+            ),
+        ),
+        TemplateSection(
+            section_id="countermeasures",
+            heading="Countermeasures",
+            description=(
+                "Each systemic cause maps to one or more countermeasures "
+                "that prevent the chain from recurring.  Tracked as "
+                "FollowUp entities."
+            ),
+            requires_followups=True,
+        ),
+    ],
+)
+
+
+COE: Final[PostmortemTemplate] = PostmortemTemplate(
+    template_id="coe",
+    display_name="Correction of Errors (COE)",
+    purpose=(
+        "AWS-style COE document; expands the timeline with explicit "
+        "detection / mitigation / resolution buckets and requires a "
+        "lessons-learned section signed off by leadership."
+    ),
+    sections=[
+        TemplateSection(
+            section_id="summary",
+            heading="Executive summary",
+            description=(
+                "Two-sentence summary for leadership: what happened, what is being done."
+            ),
+        ),
+        TemplateSection(
+            section_id="customer_impact",
+            heading="Customer impact",
+            description=(
+                "Affected customers, regions, SKUs.  Quantify duration "
+                "and severity using the SLO burn the timeline implies."
+            ),
+        ),
+        TemplateSection(
+            section_id="incident_response",
+            heading="Incident response",
+            description=(
+                "Detection, mitigation, and resolution timestamps with "
+                "the cited entity state-changes that map to each phase."
+            ),
+            requires_timeline=True,
+            prompts=[
+                "Detection: how was the incident first observed?",
+                "Mitigation: what initial action reduced impact?",
+                "Resolution: what action restored service to baseline?",
+            ],
+        ),
+        TemplateSection(
+            section_id="five_whys",
+            heading="Five whys",
+            description=(
+                "COE format requires the abbreviated five-whys chain "
+                "even when the root cause is documented in the next "
+                "section.  Keeps the audit trail self-contained."
+            ),
+            prompts=["Why?"] * 5,
+        ),
+        TemplateSection(
+            section_id="root_cause",
+            heading="Root cause analysis",
+            description=(
+                "Document the primary contributing factor and any "
+                "secondary factors discovered during investigation."
+            ),
+        ),
+        TemplateSection(
+            section_id="lessons_learned",
+            heading="Lessons learned",
+            description=(
+                "What went well, what went poorly, what was lucky.  "
+                "Requires sign-off from the on-call lead."
+            ),
+        ),
+        TemplateSection(
+            section_id="action_items",
+            heading="Action items / corrective actions",
+            description=(
+                "Corrective actions extracted from the incident, each "
+                "tracked as a FollowUp entity node."
+            ),
+            requires_followups=True,
+        ),
+    ],
+)
+
+
+_REGISTRY: Final[dict[PostmortemTemplateId, PostmortemTemplate]] = {
+    "blameless": BLAMELESS,
+    "five_whys": FIVE_WHYS,
+    "coe": COE,
+}
+
+# Assert at import time that the Literal and registry agree.  Failing
+# this assertion is a programmer error — we'd rather crash on import in
+# a unit test than ship a Literal that lies about the registry.
+if set(SUPPORTED_TEMPLATES) != set(_REGISTRY.keys()):  # pragma: no cover - import-time invariant
+    raise RuntimeError(
+        f"postmortem template registry/Literal mismatch: "
+        f"SUPPORTED_TEMPLATES={SUPPORTED_TEMPLATES!r} "
+        f"vs _REGISTRY keys={tuple(_REGISTRY.keys())!r}"
+    )
+
+
+def list_templates() -> list[PostmortemTemplate]:
+    """Return every registered template (ordered as :data:`SUPPORTED_TEMPLATES`)."""
+    return [_REGISTRY[tid] for tid in SUPPORTED_TEMPLATES]
+
+
+def get_template(template_id: str) -> PostmortemTemplate:
+    """Look up a template by id; raise :class:`PostmortemError` on miss.
+
+    Accepts ``str`` (not :data:`PostmortemTemplateId`) so REST/MCP
+    handlers can pass the raw wire string and get a structured error
+    envelope back when the caller picked an unknown template.
+    """
+    if template_id not in _REGISTRY:
+        raise PostmortemError(
+            INVALID_TEMPLATE_CODE,
+            f"template must be one of: {', '.join(SUPPORTED_TEMPLATES)}",
+        )
+    # mypy: narrow the Literal — we just asserted membership.
+    return _REGISTRY[template_id]
+
+
+__all__ = [
+    "BLAMELESS",
+    "COE",
+    "FIVE_WHYS",
+    "SUPPORTED_TEMPLATES",
+    "PostmortemTemplate",
+    "PostmortemTemplateId",
+    "TemplateSection",
+    "get_template",
+    "list_templates",
+]

--- a/apps/server/src/omniscience_server/rest/postmortem.py
+++ b/apps/server/src/omniscience_server/rest/postmortem.py
@@ -1,0 +1,235 @@
+"""Post-mortem REST endpoint (issue #232).
+
+``GET /api/v1/incidents/{incident_id}/postmortem``
+
+Generates a templated post-mortem document from the bitemporal graph
+timeline for ``alert_id`` (supplied as a query parameter).  Mirrors the
+auth posture of ``GET /incidents/{id}/timeline`` — scope ``search``,
+workspace-scoped token required, no existence leak for cross-workspace
+alerts.
+
+Query parameters
+----------------
+
+* ``alert_id`` (required): canonical ``alert://`` URI to anchor the
+  timeline on.  Path-level ``incident_id`` is used to scope follow-ups
+  and runbook-step lookups; the two ids are kept distinct because
+  PagerDuty incident ids and alert ids are not interchangeable.
+* ``template`` (default ``blameless``): one of ``blameless``,
+  ``five_whys``, ``coe``.
+* ``format`` (default ``markdown``): one of ``markdown``, ``html``,
+  ``json``.
+* ``incident_start`` / ``incident_end``: optional ISO-8601 UTC window
+  bounds.  When omitted, the timeline is unbounded on the left and
+  anchored to "now" on the right.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from omniscience_core.auth.middleware import get_current_token, require_scope
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken
+
+from omniscience_server.as_of import (
+    INVALID_TIMEZONE_CODE,
+    INVALID_TIMEZONE_MESSAGE,
+    enforce_utc,
+)
+from omniscience_server.postmortem import (
+    INCIDENT_NOT_FOUND_CODE,
+    INVALID_FORMAT_CODE,
+    INVALID_INCIDENT_ID_CODE,
+    INVALID_TEMPLATE_CODE,
+    PostmortemError,
+    generate_postmortem,
+    render,
+)
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["incidents"])
+
+# Module-level Depends singletons to avoid ruff B008 in the route signature.
+_search_scope_dep: Any = Depends(require_scope(Scope.search))
+_current_token_dep: Any = Depends(get_current_token)
+
+
+# ---------------------------------------------------------------------------
+# Query parameter annotations
+# ---------------------------------------------------------------------------
+
+
+_AlertIdQuery = Annotated[
+    str,
+    Query(
+        min_length=1,
+        max_length=512,
+        description="Canonical alert URI 'alert://{provider}/{provider_alert_id}'.",
+    ),
+]
+_TemplateQuery = Annotated[
+    str,
+    Query(description="One of: blameless, five_whys, coe."),
+]
+_FormatQuery = Annotated[
+    str,
+    Query(description="Render format: markdown (default), html, or json."),
+]
+_IncidentStartQuery = Annotated[
+    datetime | None,
+    Query(
+        alias="incident_start",
+        description=(
+            "Inclusive UTC start of the incident window (ISO-8601). "
+            "Naive datetimes rejected with 400 invalid_timezone."
+        ),
+    ),
+]
+_IncidentEndQuery = Annotated[
+    datetime | None,
+    Query(
+        alias="incident_end",
+        description=(
+            "Exclusive UTC end of the incident window (ISO-8601). "
+            "Defaults to server-side 'now' when omitted."
+        ),
+    ),
+]
+
+
+def _validate_window_bound(value: datetime | None, *, field: str) -> datetime | None:
+    try:
+        return enforce_utc(value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": INVALID_TIMEZONE_CODE,
+                "message": f"{field}: {INVALID_TIMEZONE_MESSAGE}",
+            },
+        ) from exc
+
+
+def _require_workspace(token: ApiToken) -> Any:
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "postmortem_request_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Post-mortem endpoints require a workspace-scoped token",
+            },
+        )
+    return workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/incidents/{incident_id}/postmortem",
+    summary="Generate a templated post-mortem from the bitemporal timeline",
+    dependencies=[_search_scope_dep],
+)
+async def get_postmortem(
+    incident_id: str,
+    request: Request,
+    alert_id: _AlertIdQuery,
+    template: _TemplateQuery = "blameless",
+    format: _FormatQuery = "markdown",  # noqa: A002 — REST convention
+    incident_start: _IncidentStartQuery = None,
+    incident_end: _IncidentEndQuery = None,
+    token: ApiToken = _current_token_dep,
+) -> Any:
+    """Render the templated post-mortem.
+
+    Errors:
+
+    * ``400 invalid_template`` — unknown template id.
+    * ``400 invalid_format`` — unknown format.
+    * ``400 invalid_incident_id`` — incident_id failed validation.
+    * ``400 invalid_window`` — incident_start > incident_end.
+    * ``400 invalid_timezone`` — naive / non-UTC datetime supplied.
+    * ``403 forbidden`` — token is not workspace-scoped.
+    * ``404 incident_not_found`` — alert not visible to the workspace.
+    """
+    workspace_id = _require_workspace(token)
+    start = _validate_window_bound(incident_start, field="incident_start")
+    end = _validate_window_bound(incident_end, field="incident_end")
+    if start is not None and end is not None and start > end:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_window",
+                "message": "incident_start must be <= incident_end",
+            },
+        )
+
+    try:
+        report = await generate_postmortem(
+            app=request.app,
+            incident_id=incident_id,
+            alert_id=alert_id,
+            workspace_id=workspace_id,
+            template=template,
+            incident_start=start,
+            incident_end=end,
+        )
+    except PostmortemError as exc:
+        _raise_from_postmortem_error(exc)
+        raise  # pragma: no cover - the helper always raises HTTPException
+    except ValueError as exc:
+        msg = str(exc)
+        # Surface the upstream ``invalid_alert_id`` envelope unchanged so
+        # REST clients can share their error handlers.
+        if msg.startswith("invalid_alert_id:"):
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "invalid_alert_id", "message": msg.split(":", 1)[1]},
+            ) from exc
+        raise
+
+    try:
+        rendered = render(report, fmt=format)
+    except PostmortemError as exc:
+        _raise_from_postmortem_error(exc)
+        raise  # pragma: no cover
+
+    if format == "html":
+        return HTMLResponse(content=rendered)
+    if format == "json":
+        # We already have the JSON string; return it via JSONResponse so
+        # the Content-Type header is correct.
+        return JSONResponse(content=report.model_dump(mode="json"))
+    return PlainTextResponse(content=rendered, media_type="text/markdown")
+
+
+def _raise_from_postmortem_error(exc: PostmortemError) -> None:
+    """Map a :class:`PostmortemError` to the canonical HTTPException envelope."""
+    status_by_code = {
+        INVALID_TEMPLATE_CODE: 400,
+        INVALID_FORMAT_CODE: 400,
+        INVALID_INCIDENT_ID_CODE: 400,
+        INCIDENT_NOT_FOUND_CODE: 404,
+    }
+    status = status_by_code.get(exc.code, 400)
+    raise HTTPException(
+        status_code=status,
+        detail={"code": exc.code, "message": exc.message},
+    ) from exc
+
+
+__all__ = ["router"]

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -14,6 +14,7 @@ from omniscience_server.rest.incidents_admin import router as incidents_admin_ro
 from omniscience_server.rest.ingestion_runs import router as ingestion_runs_router
 from omniscience_server.rest.operator import router as operator_router
 from omniscience_server.rest.otlp import router as otlp_router
+from omniscience_server.rest.postmortem import router as postmortem_router
 from omniscience_server.rest.replay import router as replay_router
 from omniscience_server.rest.retention import router as retention_router
 from omniscience_server.rest.runbook import router as runbook_router
@@ -43,5 +44,6 @@ api_v1_router.include_router(blast_radius_router)
 api_v1_router.include_router(replay_router)
 api_v1_router.include_router(runbook_router)
 api_v1_router.include_router(similar_incidents_router)
+api_v1_router.include_router(postmortem_router)
 
 __all__ = ["api_v1_router"]

--- a/docs/api/postmortem.md
+++ b/docs/api/postmortem.md
@@ -1,1 +1,161 @@
+# Post-mortem generator API (issue #232)
 
+Composes a templated post-mortem document from the bitemporal graph
+timeline.  Each timeline row is **cited back to the entity it came
+from** with the `as_of` timestamp that was used to read it; action items
+are extracted into `FollowUp` entity nodes for tracking.
+
+Two transports, identical semantics:
+
+* **MCP tool** — `generate_postmortem(incident_id, alert_id, template, format, incident_start?, incident_end?)`
+* **REST** — `GET /api/v1/incidents/{incident_id}/postmortem?alert_id=...&template=...&format=...`
+
+Both require a workspace-scoped bearer token with the `search` scope.
+Cross-workspace alerts return `404 incident_not_found` to preserve the
+"no existence leak" invariant (ADR-0005 / #117).
+
+## Templates
+
+Three default templates ship in
+`apps/server/src/omniscience_server/postmortem/templates/`:
+
+| id | display name | When to use |
+| --- | --- | --- |
+| `blameless` | Blameless post-mortem | Default; Google-SRE style, focused on systemic causes. |
+| `five_whys` | Five-whys analysis | The proximate cause is obvious but the latent cause is unclear. |
+| `coe` | Correction of Errors (COE) | AWS-style document; explicit detection/mitigation/resolution buckets + leadership sign-off. |
+
+Add a new template by:
+
+1. Defining a `PostmortemTemplate` constant in `templates/__init__.py`.
+2. Extending the `PostmortemTemplateId` `Literal`.
+3. Adding it to `SUPPORTED_TEMPLATES` and `_REGISTRY`.
+
+The module-level `assert set(SUPPORTED_TEMPLATES) == set(_REGISTRY.keys())`
+will fail at import time if the three are out of sync.
+
+## Bitemporal anchoring
+
+The generator reads the timeline with `as_of=incident_end` (defaults to
+"now").  This means the graph snapshot reflects the bitemporal state at
+incident close — late-arriving connector data that landed _after_
+`incident_end` is filtered out, so reports are reproducible.
+
+The same `[incident_start, incident_end)` window is applied to the
+event-time filter on the timeline projection.
+
+## Citations
+
+Every `timeline` row in the structured report carries a `Citation`
+block:
+
+```json
+{
+  "citation": {
+    "entity_id": "pod/api-7f9b9d4c-xj4kp",
+    "entity_type": "k8s_pod",
+    "as_of": "2026-04-12T20:30:00+00:00",
+    "source": "src-k8s-ws-pm"
+  }
+}
+```
+
+In markdown the citation is rendered inline as ``` `k8s_pod/pod/api-7f9b9d4c-xj4kp` @ 2026-04-12T20:30:00+00:00 ```
+inside the timeline table.
+
+## FollowUp extraction
+
+Action items are extracted into `FollowUp` Pydantic models (kind
+`followup` when promoted to the graph) using three v0.1 heuristics:
+
+1. **Runbook step outcomes** — every recorded step with outcome
+   `failed` or `rolled_back` promotes to a FollowUp.
+2. **Trigger phrases** — `TODO`, `follow-up`, `investigate`, `flaky`,
+   `known issue`, `tech debt` matched word-bounded against
+   `after_state_summary` / `before_state_summary`.
+3. **Baseline** — every post-mortem includes a "Schedule post-incident
+   review meeting" P3 FollowUp so the section is never empty.
+
+Each FollowUp carries a canonical name `followup://{incident_id}/{slug}`
+so it slots into the bitemporal graph the same way runbook steps do.
+
+A future PR (#232 v2) will plug an LLM-based extractor behind the same
+interface; the heuristic version is intentionally deterministic and
+dependency-free.
+
+## REST example
+
+```http
+GET /api/v1/incidents/INC-2026-04-12-001/postmortem
+    ?alert_id=alert%3A%2F%2Fpagerduty%2FINC-2026-04-12-001
+    &template=blameless
+    &format=markdown
+    &incident_start=2026-04-12T19:25:00%2B00:00
+    &incident_end=2026-04-12T20:30:00%2B00:00
+Authorization: Bearer <workspace-scoped-token>
+```
+
+Returns `text/markdown` (or `text/html` / `application/json` depending
+on `format`).
+
+## MCP example
+
+```json
+{
+  "tool": "generate_postmortem",
+  "arguments": {
+    "incident_id": "INC-2026-04-12-001",
+    "alert_id": "alert://pagerduty/INC-2026-04-12-001",
+    "template": "five_whys",
+    "format": "markdown"
+  }
+}
+```
+
+Returns `{ incident_id, alert_id, template, format, rendered, report }`
+where `rendered` is the format-specific string and `report` is the raw
+`PostmortemReport` JSON for clients that want both views.
+
+## Errors
+
+| Code | HTTP | Cause |
+| --- | --- | --- |
+| `invalid_template` | 400 | Unknown template id. |
+| `invalid_format` | 400 | Format not in `markdown`, `html`, `json`. |
+| `invalid_incident_id` | 400 | Empty / oversized incident_id, or `start > end`. |
+| `invalid_alert_id` | 400 | alert_id failed the `alert://` regex. |
+| `invalid_timezone` | 400 | Naive or non-UTC datetime supplied. |
+| `invalid_window` | 400 | `incident_start > incident_end`. |
+| `forbidden` | 403 | Token lacks workspace scope. |
+| `incident_not_found` | 404 | Alert not visible to the calling workspace. |
+
+## Sample output (excerpt)
+
+```markdown
+# Post-mortem: INC-2026-04-12-001
+
+_Template: **Blameless post-mortem** (blameless)_
+
+| Field | Value |
+| --- | --- |
+| Alert | `alert://pagerduty/INC-2026-04-12-001` |
+| Incident start | 2026-04-12T19:25:00+00:00 |
+| Incident end | 2026-04-12T20:30:00+00:00 |
+| Timeline events | 6 |
+| Follow-ups extracted | 3 |
+
+## Timeline
+
+| # | Timestamp (UTC) | Change | Entity | Citation | Summary |
+| --- | --- | --- | --- | --- | --- |
+| 1 | 2026-04-12T19:28:00+00:00 | created | `k8s_pod/pod/api-7f9b9d4c-xj4kp` | `k8s_pod/pod/api-7f9b9d4c-xj4kp` @ 2026-04-12T19:28:00+00:00 | Pod entered Ready state |
+| 2 | 2026-04-12T19:29:55+00:00 | created | `otel_trace/trace://4bf92f3...` | `otel_trace/trace://...` @ 2026-04-12T19:29:55+00:00 | Trace recorded p99=2.3s |
+| ... | ... | ... | ... | ... | ... |
+
+## Action items
+
+- [ ] **[P2]** Investigate failed step 'step-2-restart-pool' from runbook://acme-ops/db-connections-exhausted.md
+  _FollowUp entity: `followup://inc-2026-04-12-001/step-step-2-restart-pool-failed`_
+- [ ] **[P3]** Schedule post-incident review meeting
+  _FollowUp entity: `followup://inc-2026-04-12-001/schedule-review`_
+```

--- a/docs/api/postmortem.md
+++ b/docs/api/postmortem.md
@@ -159,3 +159,4 @@ _Template: **Blameless post-mortem** (blameless)_
 - [ ] **[P3]** Schedule post-incident review meeting
   _FollowUp entity: `followup://inc-2026-04-12-001/schedule-review`_
 ```
+

--- a/tests/fixtures/postmortem/workspace_incident.json
+++ b/tests/fixtures/postmortem/workspace_incident.json
@@ -1,0 +1,95 @@
+{
+  "_comment": "Post-mortem fixture (issue #232). Seven entity state changes (alert + six neighbours) inside an incident window 2026-04-12T19:25Z..2026-04-12T20:30Z. One TODO trigger phrase to exercise the FollowUp extractor.",
+  "workspace_id": "aaaaaaaa-1111-2222-3333-4444aa000232",
+  "incident_id": "INC-2026-04-12-001",
+  "incident_start": "2026-04-12T19:25:00+00:00",
+  "incident_end": "2026-04-12T20:30:00+00:00",
+  "alert": {
+    "name": "alert://pagerduty/INC-2026-04-12-001",
+    "kind": "alert",
+    "source": "src-alerts-ws-pm",
+    "chunk_text": "PagerDuty: api pod 5xx spike (TODO: investigate latent retry-storm risk)",
+    "depth": 0,
+    "edge_type": null,
+    "valid_from": "2026-04-12T19:30:00+00:00"
+  },
+  "neighbours": [
+    {
+      "_role": "target_pod_created",
+      "name": "pod/api-7f9b9d4c-xj4kp",
+      "kind": "k8s_pod",
+      "source": "src-k8s-ws-pm",
+      "chunk_text": "Pod entered Ready state",
+      "depth": 1,
+      "edge_type": "FIRES_AGAINST",
+      "valid_from": "2026-04-12T19:28:00+00:00"
+    },
+    {
+      "_role": "responsible_pr",
+      "name": "https://github.com/acme/api/pull/4242",
+      "kind": "pull_request",
+      "source": "src-github-ws-pm",
+      "chunk_text": "PR #4242: Bump api request timeout to 5s",
+      "depth": 2,
+      "edge_type": "DEPLOYED_BY",
+      "valid_from": "2026-04-12T19:32:00+00:00"
+    },
+    {
+      "_role": "slack_thread",
+      "name": "slack://channel/C0INCIDENTS/thread/1744486200.001100",
+      "kind": "slack_thread",
+      "source": "src-slack-ws-pm",
+      "chunk_text": "alice: throttling pod 5xx — rolling back PR #4242",
+      "depth": 2,
+      "edge_type": "DISCUSSED_IN",
+      "valid_from": "2026-04-12T19:45:00+00:00"
+    },
+    {
+      "_role": "trace",
+      "name": "trace://4bf92f3577b34da6a3ce929d0e0e4736",
+      "kind": "otel_trace",
+      "source": "src-otel-ws-pm",
+      "chunk_text": "Trace recorded p99=2.3s",
+      "depth": 1,
+      "edge_type": "OBSERVED_IN",
+      "valid_from": "2026-04-12T19:29:55+00:00"
+    },
+    {
+      "_role": "deployment_event",
+      "name": "deploy://argocd/api/rollback-4099",
+      "kind": "deployment",
+      "source": "src-argocd-ws-pm",
+      "chunk_text": "Rollback to PR #4099 completed",
+      "depth": 2,
+      "edge_type": "REMEDIATED_BY",
+      "valid_from": "2026-04-12T20:05:00+00:00"
+    }
+  ],
+  "edges": [
+    {"from_entity": "alert://pagerduty/INC-2026-04-12-001", "to_entity": "pod/api-7f9b9d4c-xj4kp", "edge_type": "FIRES_AGAINST"},
+    {"from_entity": "pod/api-7f9b9d4c-xj4kp", "to_entity": "https://github.com/acme/api/pull/4242", "edge_type": "DEPLOYED_BY"},
+    {"from_entity": "alert://pagerduty/INC-2026-04-12-001", "to_entity": "slack://channel/C0INCIDENTS/thread/1744486200.001100", "edge_type": "DISCUSSED_IN"},
+    {"from_entity": "alert://pagerduty/INC-2026-04-12-001", "to_entity": "trace://4bf92f3577b34da6a3ce929d0e0e4736", "edge_type": "OBSERVED_IN"},
+    {"from_entity": "alert://pagerduty/INC-2026-04-12-001", "to_entity": "deploy://argocd/api/rollback-4099", "edge_type": "REMEDIATED_BY"}
+  ],
+  "runbook_steps": [
+    {
+      "alert_id": "alert://pagerduty/INC-2026-04-12-001",
+      "runbook_name": "runbook://acme-ops/db-connections-exhausted.md",
+      "step_id": "step-1-check-connections",
+      "outcome": "executed",
+      "actor": "alice",
+      "note": "Confirmed no connection-pool exhaustion",
+      "valid_from": "2026-04-12T19:40:00+00:00"
+    },
+    {
+      "alert_id": "alert://pagerduty/INC-2026-04-12-001",
+      "runbook_name": "runbook://acme-ops/db-connections-exhausted.md",
+      "step_id": "step-2-restart-pool",
+      "outcome": "failed",
+      "actor": "alice",
+      "note": "Pool restart raised connection-refused for 30s",
+      "valid_from": "2026-04-12T19:55:00+00:00"
+    }
+  ]
+}

--- a/tests/integration/test_postmortem_generator.py
+++ b/tests/integration/test_postmortem_generator.py
@@ -1,0 +1,340 @@
+"""Integration test for the post-mortem generator (issue #232 acceptance).
+
+Wires the fixture incident through the full composition path:
+
+* ``GraphStore`` plant -> ``mcp_incident_timeline(as_of=incident_end)``
+* ``RunbookStepRecorder`` plant -> step events for the incident
+* ``generate_postmortem()`` -> :class:`PostmortemReport`
+* ``render()`` -> markdown / HTML / JSON
+
+Acceptance from the issue:
+
+* "fixture incident with 5+ entity state changes + 1 runbook step taken
+  → assert generated markdown contains all 6 events as cited timeline
+  rows, ordered by ts".
+
+The fixture plants 6 entities (1 alert + 5 neighbours) all carrying a
+``valid_from`` inside the incident window, plus 2 runbook-step events
+(one ``executed``, one ``failed``).  That gives the test 6 timeline rows
+and exercises both the cite-by-entity invariant and the FollowUp
+extractor's "promote failed step" heuristic.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_server.postmortem import (
+    SUPPORTED_TEMPLATES,
+    PostmortemError,
+    PostmortemTemplateId,
+    generate_postmortem,
+    render,
+)
+from omniscience_server.postmortem.errors import INCIDENT_NOT_FOUND_CODE
+from omniscience_server.runbook import RunbookStepRecorder, record_runbook_step
+
+# ---------------------------------------------------------------------------
+# Fixture loader (mirrors tests/integration/test_incident_timeline.py)
+# ---------------------------------------------------------------------------
+
+_FIXTURE_PATH: Path = (
+    Path(__file__).parent.parent / "fixtures" / "postmortem" / "workspace_incident.json"
+)
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _node_from_dict(payload: dict[str, Any]) -> EntityNodeView:
+    return EntityNodeView(
+        name=payload["name"],
+        kind=payload["kind"],
+        source=payload["source"],
+        chunk_text=payload.get("chunk_text"),
+        depth=int(payload.get("depth", 0)),
+        edge_type=payload.get("edge_type"),
+        valid_from=_parse_dt(payload.get("valid_from")),
+        valid_to=_parse_dt(payload.get("valid_to")),
+        recorded_at=_parse_dt(payload.get("recorded_at")),
+    )
+
+
+def _edge_from_dict(payload: dict[str, Any]) -> GraphEdgeView:
+    return GraphEdgeView(
+        from_entity=payload["from_entity"],
+        to_entity=payload["to_entity"],
+        edge_type=payload["edge_type"],
+    )
+
+
+class _PostmortemGraphStore:
+    """In-memory GraphStore fake — same shape as the timeline test's."""
+
+    def __init__(self) -> None:
+        self._entities: dict[tuple[uuid.UUID, str], EntityNodeView] = {}
+        self._neighbours: dict[tuple[uuid.UUID, str], list[EntityNodeView]] = {}
+        self._edges: dict[tuple[uuid.UUID, str], list[GraphEdgeView]] = {}
+
+    def plant_workspace(self, payload: dict[str, Any]) -> None:
+        workspace_id = uuid.UUID(payload["workspace_id"])
+        alert = _node_from_dict(payload["alert"])
+        self._entities[(workspace_id, alert.name)] = alert
+        neighbours = [_node_from_dict(n) for n in payload["neighbours"]]
+        for n in neighbours:
+            self._entities[(workspace_id, n.name)] = n
+        self._neighbours[(workspace_id, alert.name)] = neighbours
+        self._edges[(workspace_id, alert.name)] = [_edge_from_dict(e) for e in payload["edges"]]
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> EntityNodeView | None:
+        return self._entities.get((workspace_id, entity_name))
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        seed = self._entities.get((workspace_id, entity_name))
+        if seed is None:
+            raise ValueError(f"entity_not_found:{entity_name}")
+        related = list(self._neighbours.get((workspace_id, entity_name), []))
+        edges = list(self._edges.get((workspace_id, entity_name), []))
+        return GraphResultView(seed=seed, related=related, edges=edges)
+
+
+def _build_app() -> tuple[FastAPI, dict[str, Any]]:
+    payload = json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+    store = _PostmortemGraphStore()
+    store.plant_workspace(payload)
+    app = FastAPI()
+    app.state.graph_store = store
+    # Plant the runbook-step recorder + the fixture's step events so the
+    # generator's FollowUp extractor sees them.
+    recorder = RunbookStepRecorder()
+    app.state.runbook_step_recorder = recorder
+    workspace_id = uuid.UUID(payload["workspace_id"])
+    for step in payload["runbook_steps"]:
+        record_runbook_step(
+            app=app,
+            workspace_id=workspace_id,
+            incident_id=payload["incident_id"],
+            alert_id=step["alert_id"],
+            runbook_name=step["runbook_name"],
+            step_id=step["step_id"],
+            outcome=step["outcome"],
+            actor=step.get("actor"),
+            note=step.get("note"),
+            valid_from=_parse_dt(step.get("valid_from")),
+        )
+    return app, payload
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: 6 cited events in the markdown, ordered by ts
+# ---------------------------------------------------------------------------
+
+
+class TestPostmortemAcceptance:
+    async def test_generator_returns_six_cited_timeline_rows(self) -> None:
+        app, fx = _build_app()
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            template="blameless",
+            incident_start=_parse_dt(fx["incident_start"]),
+            incident_end=_parse_dt(fx["incident_end"]),
+        )
+        # Acceptance floor: alert + 5 neighbours = 6 created events.
+        assert len(report.timeline) == 6
+        # Every row carries a Citation with the event ts as its as_of.
+        for row in report.timeline:
+            assert row.citation.entity_id == row.entity_id
+            assert row.citation.entity_type == row.entity_type
+            assert row.citation.as_of == row.ts
+            assert row.citation.source, "every row must carry source provenance"
+
+    async def test_timeline_rows_are_ordered_by_ts(self) -> None:
+        app, fx = _build_app()
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            incident_start=_parse_dt(fx["incident_start"]),
+            incident_end=_parse_dt(fx["incident_end"]),
+        )
+        for prev, curr in pairwise(report.timeline):
+            assert prev.ts <= curr.ts, (
+                f"timeline rows must be sorted ascending; "
+                f"{prev.ts.isoformat()} > {curr.ts.isoformat()}"
+            )
+
+    async def test_markdown_contains_all_six_cited_rows(self) -> None:
+        app, fx = _build_app()
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            incident_start=_parse_dt(fx["incident_start"]),
+            incident_end=_parse_dt(fx["incident_end"]),
+        )
+        markdown = render(report, fmt="markdown")
+        # Each entity should appear in a cited row.
+        for entity in [fx["alert"]] + fx["neighbours"]:
+            assert entity["name"] in markdown, (
+                f"entity {entity['name']} missing from rendered markdown"
+            )
+        # Header + every cited timeline ts must appear in the rendered
+        # table (this is the issue's "all 6 events" acceptance bar).
+        for row in report.timeline:
+            assert row.ts.isoformat() in markdown
+        # The cited-by-entity citation format is rendered as a backticked
+        # 'type/id @ ts' fragment.
+        first = report.timeline[0]
+        assert (
+            f"`{first.entity_type}/{first.entity_id}` @ {first.citation.as_of.isoformat()}"
+            in markdown
+        )
+
+    async def test_followups_include_failed_runbook_step_and_baseline(self) -> None:
+        app, fx = _build_app()
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            incident_start=_parse_dt(fx["incident_start"]),
+            incident_end=_parse_dt(fx["incident_end"]),
+        )
+        names = {f.name for f in report.followups}
+        # baseline review
+        assert any("schedule-review" in n for n in names)
+        # failed-step FollowUp (the fixture has one `failed` step)
+        assert any("step-step-2-restart-pool-failed" in n for n in names), (
+            f"failed-step FollowUp missing; got: {sorted(names)}"
+        )
+        # TODO trigger phrase in the alert chunk_text promotes too
+        assert any("alert-todo" in n for n in names), (
+            f"TODO-phrase FollowUp missing; got: {sorted(names)}"
+        )
+        # canonical name shape
+        for f in report.followups:
+            assert f.name.startswith("followup://")
+            assert f.incident_id == fx["incident_id"]
+            assert f.alert_id == fx["alert"]["name"]
+
+    @pytest.mark.parametrize("template", list(SUPPORTED_TEMPLATES))
+    async def test_every_template_renders_with_citations(
+        self, template: PostmortemTemplateId
+    ) -> None:
+        app, fx = _build_app()
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            template=template,
+            incident_start=_parse_dt(fx["incident_start"]),
+            incident_end=_parse_dt(fx["incident_end"]),
+        )
+        markdown = render(report, fmt="markdown")
+        assert report.template_id == template
+        # Templates differ but the cited-timeline section must appear in
+        # every rendered document.
+        assert "| Timestamp (UTC) |" in markdown
+        assert fx["alert"]["name"] in markdown
+
+    async def test_html_render_smoke(self) -> None:
+        app, fx = _build_app()
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            template="coe",
+            incident_start=_parse_dt(fx["incident_start"]),
+            incident_end=_parse_dt(fx["incident_end"]),
+        )
+        html = render(report, fmt="html")
+        assert html.startswith("<!doctype html>")
+        assert "<table" in html
+        assert fx["incident_id"] in html
+
+    async def test_unknown_alert_raises_incident_not_found(self) -> None:
+        app, fx = _build_app()
+        with pytest.raises(PostmortemError) as excinfo:
+            await generate_postmortem(
+                app=app,
+                incident_id=fx["incident_id"],
+                alert_id="alert://pagerduty/does-not-exist",
+                workspace_id=uuid.UUID(fx["workspace_id"]),
+            )
+        assert excinfo.value.code == INCIDENT_NOT_FOUND_CODE
+
+    async def test_runbook_steps_count_matches_recorder(self) -> None:
+        app, fx = _build_app()
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            incident_start=_parse_dt(fx["incident_start"]),
+            incident_end=_parse_dt(fx["incident_end"]),
+        )
+        assert report.runbook_steps_count == len(fx["runbook_steps"])
+
+    async def test_cross_workspace_alert_is_not_found(self) -> None:
+        """Workspace ACL invariant — alerts are invisible across workspaces."""
+        app, fx = _build_app()
+        other_workspace = uuid.UUID("ffffffff-0000-0000-0000-000000000000")
+        with pytest.raises(PostmortemError) as excinfo:
+            await generate_postmortem(
+                app=app,
+                incident_id=fx["incident_id"],
+                alert_id=fx["alert"]["name"],
+                workspace_id=other_workspace,
+            )
+        assert excinfo.value.code == INCIDENT_NOT_FOUND_CODE
+
+    async def test_generated_at_is_now_when_overridden(self) -> None:
+        app, fx = _build_app()
+        frozen = datetime(2026, 4, 13, 0, 0, tzinfo=UTC)
+        report = await generate_postmortem(
+            app=app,
+            incident_id=fx["incident_id"],
+            alert_id=fx["alert"]["name"],
+            workspace_id=uuid.UUID(fx["workspace_id"]),
+            now=frozen,
+        )
+        assert report.generated_at == frozen
+        # Without explicit incident_end, the generator uses ``now`` as
+        # the bitemporal anchor.
+        assert report.incident_end == frozen

--- a/tests/test_postmortem.py
+++ b/tests/test_postmortem.py
@@ -1,0 +1,314 @@
+"""Unit tests for the post-mortem generator package (issue #232).
+
+Covers the pure / synchronous surfaces:
+
+* Template registry shape + happy-path lookup.
+* FollowUp extraction heuristics (trigger phrases, failed steps).
+* The markdown / HTML / JSON renderer shape.
+* Error mapping (PostmortemError carries a structured code).
+
+Integration with the bitemporal timeline + REST endpoint lives in
+``tests/integration/test_postmortem_generator.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from omniscience_server.postmortem import (
+    INCIDENT_NOT_FOUND_CODE,
+    INVALID_FORMAT_CODE,
+    INVALID_INCIDENT_ID_CODE,
+    INVALID_TEMPLATE_CODE,
+    SUPPORTED_FORMATS,
+    SUPPORTED_TEMPLATES,
+    Citation,
+    FollowUp,
+    PostmortemError,
+    PostmortemReport,
+    PostmortemTimelineRow,
+    extract_followups,
+    get_template,
+    list_templates,
+    render,
+)
+from omniscience_server.postmortem.templates import BLAMELESS, COE, FIVE_WHYS
+
+# ---------------------------------------------------------------------------
+# Template registry
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateRegistry:
+    def test_supported_templates_matches_registry_keys(self) -> None:
+        ids = {t.template_id for t in list_templates()}
+        assert ids == set(SUPPORTED_TEMPLATES)
+        assert ids == {"blameless", "five_whys", "coe"}
+
+    def test_get_template_returns_pydantic_model(self) -> None:
+        for tid in SUPPORTED_TEMPLATES:
+            template = get_template(tid)
+            assert template.template_id == tid
+            assert len(template.sections) >= 1
+            # Every template must include at least one section that
+            # requires a timeline AND at least one that requires
+            # follow-ups, so the renderer always has somewhere to put
+            # the cited events + extracted action items.
+            assert any(s.requires_timeline for s in template.sections)
+            assert any(s.requires_followups for s in template.sections)
+
+    def test_unknown_template_raises_invalid_template(self) -> None:
+        with pytest.raises(PostmortemError) as excinfo:
+            get_template("not-a-template")
+        assert excinfo.value.code == INVALID_TEMPLATE_CODE
+
+    def test_blameless_has_six_sections(self) -> None:
+        assert len(BLAMELESS.sections) == 6
+        assert [s.section_id for s in BLAMELESS.sections] == [
+            "summary",
+            "impact",
+            "timeline",
+            "root_cause",
+            "lessons_learned",
+            "action_items",
+        ]
+
+    def test_five_whys_has_prompts(self) -> None:
+        # The why-chain section prompts power the renderer's bullet list.
+        why_section = next(s for s in FIVE_WHYS.sections if s.section_id == "why_chain")
+        assert len(why_section.prompts) == 5
+
+    def test_coe_includes_executive_summary(self) -> None:
+        assert COE.sections[0].section_id == "summary"
+        assert "Executive" in COE.sections[0].heading
+
+
+# ---------------------------------------------------------------------------
+# FollowUp extraction
+# ---------------------------------------------------------------------------
+
+
+_ALERT = "alert://pagerduty/INC-T1"
+_INCIDENT = "INC-T1"
+_AS_OF = datetime(2026, 4, 12, 19, 30, tzinfo=UTC)
+
+
+def _row(
+    *,
+    summary: str | None,
+    entity_id: str = "pod/x",
+    entity_type: str = "k8s_pod",
+) -> PostmortemTimelineRow:
+    return PostmortemTimelineRow(
+        ts=_AS_OF,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        change_kind="created",
+        before_state_summary=None,
+        after_state_summary=summary,
+        citation=Citation(
+            entity_id=entity_id,
+            entity_type=entity_type,
+            as_of=_AS_OF,
+            source="src-test",
+        ),
+    )
+
+
+class TestFollowupExtraction:
+    def test_baseline_always_includes_schedule_review(self) -> None:
+        out = extract_followups(
+            incident_id=_INCIDENT,
+            alert_id=_ALERT,
+            timeline=[],
+            runbook_steps=[],
+            now=_AS_OF,
+        )
+        assert len(out) == 1
+        assert out[0].priority == "P3"
+        assert "review" in out[0].title.lower()
+        assert out[0].name.startswith("followup://inc-t1/")
+
+    def test_todo_in_summary_promotes_to_followup(self) -> None:
+        out = extract_followups(
+            incident_id=_INCIDENT,
+            alert_id=_ALERT,
+            timeline=[_row(summary="TODO: tune retry backoff")],
+            runbook_steps=[],
+            now=_AS_OF,
+        )
+        titles = [f.title for f in out]
+        assert any("TODO" in t for t in titles)
+        # Provenance is set
+        promoted = next(f for f in out if "TODO" in f.title)
+        assert promoted.source_entity_id == "pod/x"
+        assert promoted.source_as_of == _AS_OF
+
+    def test_failed_runbook_step_promotes_to_followup(self) -> None:
+        out = extract_followups(
+            incident_id=_INCIDENT,
+            alert_id=_ALERT,
+            timeline=[],
+            runbook_steps=[
+                {
+                    "outcome": "failed",
+                    "step_id": "restart-db",
+                    "runbook_name": "runbook://acme/db.md",
+                    "valid_from": "2026-04-12T19:31:00+00:00",
+                }
+            ],
+            now=_AS_OF,
+        )
+        titles = [f.title for f in out]
+        assert any("failed" in t.lower() for t in titles)
+        assert any("restart-db" in t for t in titles)
+
+    def test_rolled_back_step_is_p1(self) -> None:
+        out = extract_followups(
+            incident_id=_INCIDENT,
+            alert_id=_ALERT,
+            timeline=[],
+            runbook_steps=[
+                {
+                    "outcome": "rolled_back",
+                    "step_id": "deploy-v2",
+                    "runbook_name": "runbook://acme/deploy.md",
+                }
+            ],
+            now=_AS_OF,
+        )
+        promoted = next(f for f in out if "deploy-v2" in f.title)
+        assert promoted.priority == "P1"
+
+    def test_succeeded_steps_are_ignored(self) -> None:
+        out = extract_followups(
+            incident_id=_INCIDENT,
+            alert_id=_ALERT,
+            timeline=[],
+            runbook_steps=[
+                {"outcome": "executed", "step_id": "ok", "runbook_name": "runbook://x/y.md"}
+            ],
+            now=_AS_OF,
+        )
+        # Only the baseline 'schedule review' should remain.
+        assert len(out) == 1
+
+    def test_duplicate_follow_ups_are_deduped(self) -> None:
+        # Two timeline rows on the same entity_type with the same trigger
+        # phrase produce a single FollowUp (canonical name collision).
+        rows = [
+            _row(summary="investigate retry storm", entity_id="pod/a"),
+            _row(summary="investigate retry storm", entity_id="pod/b"),
+        ]
+        out = extract_followups(
+            incident_id=_INCIDENT,
+            alert_id=_ALERT,
+            timeline=rows,
+            runbook_steps=[],
+            now=_AS_OF,
+        )
+        # one dedup'd 'investigate' + baseline 'schedule review'
+        assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# Render shape
+# ---------------------------------------------------------------------------
+
+
+def _minimal_report(template_id: str = "blameless") -> PostmortemReport:
+    row = _row(summary="PagerDuty: api pod 5xx spike")
+    followup = FollowUp(
+        name="followup://inc-t1/schedule-review",
+        incident_id=_INCIDENT,
+        alert_id=_ALERT,
+        title="Schedule post-incident review meeting",
+        priority="P3",
+        source_entity_id=None,
+        source_as_of=None,
+        created_at=_AS_OF,
+    )
+    return PostmortemReport(
+        incident_id=_INCIDENT,
+        alert_id=_ALERT,
+        template_id=template_id,  # type: ignore[arg-type]
+        template_display_name=get_template(template_id).display_name,
+        incident_start=_AS_OF,
+        incident_end=_AS_OF,
+        generated_at=_AS_OF,
+        effective_as_of=_AS_OF,
+        timeline=[row],
+        runbook_steps_count=0,
+        followups=[followup],
+    )
+
+
+class TestRender:
+    def test_supported_formats_constant(self) -> None:
+        assert set(SUPPORTED_FORMATS) == {"markdown", "html", "json"}
+
+    def test_markdown_render_contains_template_title(self) -> None:
+        for tid in SUPPORTED_TEMPLATES:
+            md = render(_minimal_report(tid), fmt="markdown")
+            assert md.startswith(f"# Post-mortem: {_INCIDENT}")
+            assert get_template(tid).display_name in md
+
+    def test_markdown_render_emits_timeline_table(self) -> None:
+        md = render(_minimal_report(), fmt="markdown")
+        assert "| # | Timestamp" in md
+        # Citation is rendered with backticks + ISO timestamp.
+        assert "`k8s_pod/pod/x`" in md
+        assert _AS_OF.isoformat() in md
+
+    def test_markdown_render_emits_followup_checklist(self) -> None:
+        md = render(_minimal_report(), fmt="markdown")
+        assert "- [ ] **[P3]** Schedule post-incident review meeting" in md
+        assert "followup://inc-t1/schedule-review" in md
+
+    def test_html_render_is_html_escaped(self) -> None:
+        report = _minimal_report()
+        row = report.timeline[0].model_copy(
+            update={"after_state_summary": "<script>alert(1)</script>"}
+        )
+        report = report.model_copy(update={"timeline": [row]})
+        html_out = render(report, fmt="html")
+        assert "<script>" not in html_out
+        assert "&lt;script&gt;" in html_out
+
+    def test_json_render_is_valid_json(self) -> None:
+        import json as _json
+
+        rendered = render(_minimal_report(), fmt="json")
+        parsed = _json.loads(rendered)
+        assert parsed["incident_id"] == _INCIDENT
+        assert parsed["template_id"] == "blameless"
+
+    def test_invalid_format_raises_postmortem_error(self) -> None:
+        with pytest.raises(PostmortemError) as excinfo:
+            render(_minimal_report(), fmt="pdf")
+        assert excinfo.value.code == INVALID_FORMAT_CODE
+
+
+# ---------------------------------------------------------------------------
+# PostmortemError envelope
+# ---------------------------------------------------------------------------
+
+
+class TestPostmortemError:
+    def test_error_carries_code_attribute(self) -> None:
+        exc = PostmortemError(INVALID_INCIDENT_ID_CODE, "empty")
+        assert exc.code == INVALID_INCIDENT_ID_CODE
+        assert str(exc) == "invalid_incident_id:empty"
+
+    def test_error_is_value_error_subclass(self) -> None:
+        # The existing REST/MCP error machinery pattern-matches ValueError.
+        assert issubclass(PostmortemError, ValueError)
+
+    def test_known_codes_are_stable(self) -> None:
+        # Wire contract: these strings appear in client-side error
+        # handlers; renaming them is a breaking change.
+        assert INVALID_TEMPLATE_CODE == "invalid_template"
+        assert INVALID_FORMAT_CODE == "invalid_format"
+        assert INVALID_INCIDENT_ID_CODE == "invalid_incident_id"
+        assert INCIDENT_NOT_FOUND_CODE == "incident_not_found"


### PR DESCRIPTION
## Summary

Templated post-mortem generator backed by the bitemporal graph timeline
(`as_of=incident_end`) — each row is cited back to the entity it was
projected from. Three default templates ship in `postmortem/templates/`:
`blameless`, `five_whys`, `coe`. Action items become `FollowUp` Pydantic
models with canonical `followup://{incident_id}/{slug}` names so they
slot into the bitemporal graph identically to runbook steps.

* MCP tool: `generate_postmortem(incident_id, alert_id, template, format, incident_start?, incident_end?)`
* REST: `GET /api/v1/incidents/{id}/postmortem?alert_id=...&template=...&format=markdown|html|json`
* Workspace-scoped + scope `search`; cross-workspace alerts return `incident_not_found` (no existence leak — parity with `incident_timeline`)
* No new dependencies — renderer is plain f-string + Pydantic (no Jinja2; codebase deliberately avoids it)

## Sample output

```markdown
# Post-mortem: INC-2026-04-12-001

_Template: **Blameless post-mortem** (blameless)_

| Field | Value |
| --- | --- |
| Alert | `alert://pagerduty/INC-2026-04-12-001` |
| Incident start | 2026-04-12T19:25:00+00:00 |
| Incident end | 2026-04-12T20:30:00+00:00 |
| Timeline events | 6 |
| Runbook steps recorded | 2 |
| Follow-ups extracted | 3 |

## Timeline

| # | Timestamp (UTC) | Change | Entity | Citation | Summary |
| --- | --- | --- | --- | --- | --- |
| 1 | 2026-04-12T19:28:00+00:00 | created | `k8s_pod/pod/api-7f9b9d4c-xj4kp` | `k8s_pod/pod/api-7f9b9d4c-xj4kp` @ 2026-04-12T19:28:00+00:00 | Pod entered Ready state |
| 2 | 2026-04-12T19:29:55+00:00 | created | `otel_trace/trace://4bf92f3...` | `otel_trace/trace://4bf92f3...` @ 2026-04-12T19:29:55+00:00 | Trace recorded p99=2.3s |
| 3 | 2026-04-12T19:30:00+00:00 | created | `alert/alert://pagerduty/INC-2026-04-12-001` | `alert/alert://pagerduty/INC-2026-04-12-001` @ 2026-04-12T19:30:00+00:00 | PagerDuty: api pod 5xx spike (TODO: investigate latent retry-storm risk) |
| ... |

## Action items

- [ ] **[P2]** Investigate failed step 'step-2-restart-pool' from runbook://acme-ops/db-connections-exhausted.md
  _FollowUp entity: `followup://inc-2026-04-12-001/step-step-2-restart-pool-failed`_
- [ ] **[P2]** Address 'TODO' flagged on alert alert://pagerduty/INC-2026-04-12-001
  _FollowUp entity: `followup://inc-2026-04-12-001/alert-todo`_
- [ ] **[P3]** Schedule post-incident review meeting
  _FollowUp entity: `followup://inc-2026-04-12-001/schedule-review`_
```

## Test plan

- [x] `uv run pytest tests/ -k postmortem -v` — **34 passed, 0.08s** (22 unit + 12 integration)
- [x] Integration fixture plants alert + 5 neighbours + 2 runbook-step events; asserts all 6 entities surface as cited timeline rows in the rendered markdown, ordered by ts
- [x] Every template renders against the fixture; parametrised over `blameless`/`five_whys`/`coe`
- [x] `FollowUp` extraction asserts: baseline review + failed-step + TODO-trigger entries with canonical `followup://` names
- [x] Cross-workspace ACL: foreign workspace_id raises `PostmortemError(INCIDENT_NOT_FOUND_CODE)`
- [x] `uv run mypy apps/ packages/` — clean (225 source files)
- [x] `uv run ruff check .` && `uv run ruff format --check .` — clean
- [x] Regression: 80 incident/timeline/runbook/replay/blast-radius/postmortem integration tests still pass

Closes #232.