### PR TITLE
fix(admin): bump tsconfig target to ES2021 (#258)

### DIFF
--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- Bump `apps/admin/tsconfig.json` `target` and `lib` from `ES2020` → `ES2021`
- Unblocks `docker compose up -d --build app admin` from the documented quick-start

## Why
`IncidentTimelinePage.tsx:137-138` (from PR #246) uses `String.prototype.replaceAll`, which is ES2021+. Vite dev was permissive, but the production Dockerfile runs strict `tsc` which failed:

```
src/pages/IncidentTimelinePage.tsx(137,8): error TS2550:
  Property 'replaceAll' does not exist on type 'string'.
```

CI doesn't run the admin Docker build (only Python tooling) so the bug only surfaced at `docker compose up --build`.

## Test plan
- [x] Reproduce: `docker compose build admin` against `main` → fails with TS2550
- [x] Apply fix: `docker compose up -d --build app admin` → admin and app both reach Healthy
- [x] Smoke: `curl http://localhost:3001/` → 200; `curl http://localhost:8000/health` → 200; admin UI loads
- [ ] CI lint/typecheck/test green (CI was experiencing transient outage when this PR opened — will verify post-merge)

## Follow-ups (separate issues, not in scope)
- Add admin Docker build job to CI so this class of regression is caught earlier
- Audit other ES2021+ usages

Closes #258