### PR TITLE
chore(mcp): add publish workflow + placeholder icon (toward #237 distribution)

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -1,0 +1,59 @@
+# Re-publishes the Omniscience MCP server entry to the official
+# modelcontextprotocol.io registry on every git tag (vX.Y.Z).
+#
+# Authentication: GitHub OIDC. The registry validates the OIDC token
+# against the repository slug `100rd/Omniscience`, so no long-lived
+# secrets are required for the publish call itself.
+#
+# Secrets:
+#   OMNISCIENCE_MCP_REGISTRY_ID  (optional)
+#     Server ID returned by the *first* successful publish. Once it
+#     exists, subsequent runs update the existing registry entry
+#     instead of creating duplicates. To obtain it:
+#       1. Run this workflow once (tag v0.5.0 -> first publish).
+#       2. Inspect the job log; the publisher CLI prints
+#          `published server id=<uuid>`.
+#       3. Add it as a repo secret named OMNISCIENCE_MCP_REGISTRY_ID.
+#     The workflow tolerates the secret being absent (creates new entry
+#     each run, which the registry will dedupe by repo slug + version).
+#
+# See docs/mcp-catalog-submission.md (step 8) for the rest of the
+# distribution checklist.
+
+name: MCP registry publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  # Required for OIDC authentication against modelcontextprotocol.io.
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to modelcontextprotocol.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install MCP registry publisher
+        run: npm install -g @modelcontextprotocol/registry-publisher
+
+      - name: Publish to registry
+        env:
+          # When this secret is unset GitHub Actions exposes it as an
+          # empty string, which the publisher CLI interprets as
+          # "create a new entry". Once OMNISCIENCE_MCP_REGISTRY_ID is
+          # set in repo secrets the CLI updates the existing entry.
+          OMNISCIENCE_MCP_REGISTRY_ID: ${{ secrets.OMNISCIENCE_MCP_REGISTRY_ID }}
+        run: |
+          mcp-publisher publish --file .mcp/registry.json

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,3 @@
+# Brand assets
+
+`icon-256.svg` is a placeholder OMNI mark (256x256, dark slate background, light text, cyan accent underline) used by MCP catalog listings until a designer ships a real `icon-256.png`. Track replacement in issue #237.

--- a/docs/assets/icon-256.svg
+++ b/docs/assets/icon-256.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-label="Omniscience">
+  <title>Omniscience</title>
+  <rect width="256" height="256" fill="#0f172a"/>
+  <text x="128" y="128"
+        text-anchor="middle"
+        dominant-baseline="central"
+        fill="#f8fafc"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+        font-size="64"
+        font-weight="700"
+        letter-spacing="4">OMNI</text>
+  <line x1="80" y1="172" x2="176" y2="172" stroke="#38bdf8" stroke-width="3" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Two related distribution deliverables for v0.5, both toward issue #237. **Toward #237, not closing** — manual catalog submissions to PulseMCP / Cline / mcp.directory / Awesome MCP still need a human.

### 1. `.github/workflows/mcp-publish.yml` (step 8 of `docs/mcp-catalog-submission.md`)

- Trigger: `on: push: tags: ['v*']`.
- Installs `@modelcontextprotocol/registry-publisher` globally via `npm install -g`.
- Authenticates via **GitHub OIDC** (`permissions: id-token: write`) against `100rd/Omniscience` — no long-lived API key needed.
- Runs `mcp-publisher publish --file .mcp/registry.json`.
- Documents the optional `OMNISCIENCE_MCP_REGISTRY_ID` repo secret inside the YAML: how to obtain it (first publish prints the ID in job log) and how it switches the CLI from create-mode to update-mode on subsequent runs.

### 2. `docs/assets/icon-256.svg` + `docs/assets/README.md` (step 9)

- 256x256 viewBox SVG placeholder.
- Dark slate background (`#0f172a`), white sans-serif `OMNI` text centered, thin cyan accent underline (`#38bdf8`).
- `docs/assets/README.md` flags it as placeholder pending a designer-delivered `icon-256.png`; replacement tracked in #237.
- Unblocks PulseMCP / registry listings that currently 404 on the asset path.

## Files

- NEW `.github/workflows/mcp-publish.yml`
- NEW `docs/assets/icon-256.svg`
- NEW `docs/assets/README.md`

No other files touched. `.mcp/*.json` deliberately untouched.

## Test plan

- [x] `actionlint .github/workflows/*.yml` clean (all workflows, no regressions).
- [x] `xmllint --noout docs/assets/icon-256.svg` valid XML.
- [x] SVG renders correctly at 256x256 in browser / Preview.
- [ ] Tag a release `v0.5.x` (or push a dry-run tag) to exercise the workflow once — out of scope for this PR; will be smoke-tested when v0.5.0 lands.

## Follow-ups

- After first publish, capture the server ID from the workflow run and add `OMNISCIENCE_MCP_REGISTRY_ID` as a repo secret so subsequent tags update rather than create duplicate entries.
- Designer ships real `docs/assets/icon-256.png`; update README badges that currently point at the SVG to swap to the PNG.