### PR TITLE
feat(release): GHCR pre-built images + fix install.sh (closes #261)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+# Release workflow — builds and publishes the Omniscience app + admin
+# container images to GitHub Container Registry (ghcr.io) on every `v*`
+# tag push, and on demand via `workflow_dispatch`.
+#
+# Image references (consumed by docker-compose.prod.yml):
+#   ghcr.io/100rd/omniscience-app:<tag>
+#   ghcr.io/100rd/omniscience-admin:<tag>
+#
+# Tag formula (docker/metadata-action@v5):
+#   - `v1.2.3` -> :1.2.3, :1.2, :latest
+#   - `v1.2.3-rc.1` -> :1.2.3-rc.1   (pre-release; :latest NOT applied)
+#   - workflow_dispatch (no tag context) -> :sha-<short>
+#
+# Multi-arch: linux/amd64,linux/arm64. linux/arm64 is required for
+# macOS Apple Silicon users running the one-line installer; amd64 is
+# the standard Linux server target. Both are emulated via QEMU on the
+# default Ubuntu runner, then merged into a single manifest list.
+
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag or sha) to publish images from"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-app:
+    name: Build & push app image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/100rd/omniscience-app
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=sha,format=short,prefix=sha-,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,mode=max,scope=app
+
+  build-admin:
+    name: Build & push admin image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/100rd/omniscience-admin
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=sha,format=short,prefix=sha-,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./apps/admin
+          file: ./apps/admin/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=admin
+          cache-to: type=gha,mode=max,scope=admin

--- a/.mcp/install.sh
+++ b/.mcp/install.sh
@@ -8,11 +8,23 @@
 #   1. Checks prerequisites (docker, docker compose).
 #   2. Creates ./omniscience/ working directory if missing.
 #   3. Writes a .env with generated secrets (idempotent — never overwrites).
-#   4. Fetches docker-compose.yml from the repo at the pinned ref.
+#   4. Fetches docker-compose.prod.yml from the repo at the pinned ref.
+#      The prod variant references pre-built GHCR images
+#      (ghcr.io/100rd/omniscience-app, ghcr.io/100rd/omniscience-admin)
+#      so no source checkout / local build is required.
 #   5. Starts the stack with `docker compose up -d`.
-#   6. Waits for /health to return 200 (up to 120s).
+#   6. Waits for /health to return 200 (up to 300s — first run must
+#      pull ~4 images and Neo4j start_period alone is ~30s).
 #   7. Prints next-step instructions: how to mint a token and run
 #      `omniscience init --client <ide>`.
+#
+# Environment overrides:
+#   OMNISCIENCE_REF       git ref of the published compose file. default: main
+#   OMNISCIENCE_VERSION   GHCR image tag to pin. default: latest
+#                         (set to e.g. v0.5.0 for reproducibility)
+#   OMNISCIENCE_DIR       working dir. default: $PWD/omniscience
+#   OMNISCIENCE_REPO      raw.githubusercontent.com base URL
+#   OMNISCIENCE_HEALTH_URL  app /health URL. default: http://localhost:8000/health
 #
 # Supported: macOS (Intel + Apple Silicon), Linux (x86_64, arm64).
 # Re-runnable: safe to invoke repeatedly; never destroys existing data.
@@ -20,9 +32,11 @@
 set -euo pipefail
 
 OMNISCIENCE_REF="${OMNISCIENCE_REF:-main}"
+OMNISCIENCE_VERSION="${OMNISCIENCE_VERSION:-latest}"
 OMNISCIENCE_DIR="${OMNISCIENCE_DIR:-$PWD/omniscience}"
 OMNISCIENCE_REPO="${OMNISCIENCE_REPO:-https://raw.githubusercontent.com/100rd/Omniscience}"
 HEALTH_URL="${OMNISCIENCE_HEALTH_URL:-http://localhost:8000/health}"
+COMPOSE_FILE="docker-compose.prod.yml"
 
 c_red() { printf '\033[31m%s\033[0m\n' "$*"; }
 c_grn() { printf '\033[32m%s\033[0m\n' "$*"; }
@@ -64,29 +78,85 @@ main() {
 
   if [ ! -f .env ]; then
     step "Generating .env (with fresh secrets)"
-    pw="$(gen_secret)"
+    pg_pw="$(gen_secret)"
+    neo4j_pw="$(gen_secret)"
+    qdrant_key="$(gen_secret)"
     sk="$(gen_secret)"
     umask 077
+    # All ${VAR:?...} hard-validated entries from docker-compose.prod.yml
+    # are written here (POSTGRES_PASSWORD, NEO4J_PASSWORD), plus the
+    # service-discovery hostnames the app needs to reach each backing
+    # service inside the compose network. OMNISCIENCE_VERSION pins the
+    # GHCR image tag (ghcr.io/100rd/omniscience-*:${OMNISCIENCE_VERSION}).
     cat > .env <<EOF
 # Omniscience environment — generated $(date -u +%Y-%m-%dT%H:%M:%SZ)
-POSTGRES_PASSWORD=${pw}
+
+# === Image pin ===
+# Override to e.g. v0.5.0 for reproducible installs (default: latest).
+OMNISCIENCE_VERSION=${OMNISCIENCE_VERSION}
+
+# === Required secrets (hard-validated by docker-compose.prod.yml) ===
+POSTGRES_PASSWORD=${pg_pw}
+NEO4J_PASSWORD=${neo4j_pw}
 OMNISCIENCE_SECRET_KEY=${sk}
+
+# === Postgres (operational metadata) ===
+DATABASE_URL=postgresql+asyncpg://omniscience:${pg_pw}@postgres:5432/omniscience
+
+# === NATS ===
+NATS_URL=nats://nats:4222
+
+# === Neo4j (graph store) ===
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USERNAME=neo4j
+NEO4J_DATABASE=neo4j
+
+# === Qdrant (vector store) ===
+QDRANT_HOST=qdrant
+QDRANT_GRPC_PORT=6334
+QDRANT_HTTP_PORT=6333
+QDRANT_API_KEY=${qdrant_key}
+QDRANT_HTTPS=false
+QDRANT_PREFER_GRPC=true
+
+# === Storage backend selection (v0.2+: only neo4j + qdrant supported) ===
+STORAGE_GRAPH_BACKEND=neo4j
+STORAGE_VECTOR_BACKEND=qdrant
+
+# === Application ===
+ENVIRONMENT=production
+APP_NAME=omniscience
+LOG_LEVEL=info
 EOF
     ok "wrote $OMNISCIENCE_DIR/.env (chmod 600)"
   else
     ok ".env already present — leaving untouched"
+    # Ensure OMNISCIENCE_VERSION is present in older .env files (back-compat).
+    if ! grep -q '^OMNISCIENCE_VERSION=' .env; then
+      umask 077
+      printf '\nOMNISCIENCE_VERSION=%s\n' "$OMNISCIENCE_VERSION" >> .env
+      ok "appended OMNISCIENCE_VERSION=$OMNISCIENCE_VERSION to existing .env"
+    fi
+    # Backfill NEO4J_PASSWORD on .env files written by older installer versions.
+    if ! grep -q '^NEO4J_PASSWORD=' .env; then
+      neo4j_pw="$(gen_secret)"
+      umask 077
+      printf 'NEO4J_PASSWORD=%s\n' "$neo4j_pw" >> .env
+      ok "appended NEO4J_PASSWORD to existing .env (was missing — pre-#261 install)"
+    fi
   fi
 
-  step "Fetching docker-compose.yml @ ${OMNISCIENCE_REF}"
-  curl -fsSL "${OMNISCIENCE_REPO}/${OMNISCIENCE_REF}/docker-compose.yml" -o docker-compose.yml
-  ok "wrote docker-compose.yml"
+  step "Fetching $COMPOSE_FILE @ ${OMNISCIENCE_REF}"
+  curl -fsSL "${OMNISCIENCE_REPO}/${OMNISCIENCE_REF}/${COMPOSE_FILE}" -o "$COMPOSE_FILE"
+  ok "wrote $COMPOSE_FILE"
 
-  step "Starting stack (docker compose up -d)"
-  docker compose up -d
+  step "Starting stack (docker compose -f $COMPOSE_FILE up -d) — image pull may take a few minutes on first run"
+  docker compose -f "$COMPOSE_FILE" up -d
   ok "containers started"
 
-  step "Waiting for $HEALTH_URL"
-  deadline=$(( $(date +%s) + 120 ))
+  step "Waiting for $HEALTH_URL (up to 300s)"
+  set +o pipefail
+  deadline=$(( $(date +%s) + 300 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
     if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
       ok "/health is responding"
@@ -94,8 +164,9 @@ EOF
     fi
     sleep 2
   done
+  set -o pipefail
   if ! curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
-    warn "/health did not respond within 120s — check 'docker compose logs app'"
+    warn "/health did not respond within 300s — check 'docker compose -f $COMPOSE_FILE logs app'"
   fi
 
   cat <<EOF
@@ -107,7 +178,7 @@ Next steps:
   1) Mint an API token:
 
      cd "$OMNISCIENCE_DIR"
-     docker compose exec app omniscience tokens create \\
+     docker compose -f $COMPOSE_FILE exec app omniscience tokens create \\
        --name my-client --scopes search,sources:read
 
   2) Wire it into your IDE in one shot:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,280 @@
+# Production / public-install variant. Source: docker-compose.yml.
+services:
+  app:
+    image: ghcr.io/100rd/omniscience-app:${OMNISCIENCE_VERSION:-latest}
+    ports:
+      - "8000:8000"
+    env_file: .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Air-gapped variant of the application service.
+  #
+  # Activates with:  docker compose --profile air-gapped up
+  #
+  # Differences from the default `app` service:
+  #   - EMBEDDING_PROVIDER=local  — sentence-transformers runs in-process
+  #   - LOCAL_MODEL_NAME          — model ID or path to pre-downloaded files
+  #   - LOCAL_MODEL_DEVICE        — cpu / cuda / mps
+  #   - No Ollama container is started
+  #   - No external API keys are required
+  #
+  # Pre-downloading the model for a fully disconnected environment:
+  #   python -c "from sentence_transformers import SentenceTransformer; \
+  #              SentenceTransformer('all-MiniLM-L6-v2')"
+  # Then bind-mount the HuggingFace cache into the container and set
+  # LOCAL_MODEL_NAME to the local path (e.g. /models/all-MiniLM-L6-v2).
+  # ---------------------------------------------------------------------------
+  app-air-gapped:
+    image: ghcr.io/100rd/omniscience-app:${OMNISCIENCE_VERSION:-latest}
+    profiles:
+      - air-gapped
+    ports:
+      - "8000:8000"
+    env_file: .env
+    environment:
+      EMBEDDING_PROVIDER: local
+      LOCAL_MODEL_NAME: ${LOCAL_MODEL_NAME:-all-MiniLM-L6-v2}
+      LOCAL_MODEL_DEVICE: ${LOCAL_MODEL_DEVICE:-cpu}
+      QUERY_REWRITING_ENABLED: ${QUERY_REWRITING_ENABLED:-false}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      nats:
+        condition: service_healthy
+      neo4j:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  admin:
+    image: ghcr.io/100rd/omniscience-admin:${OMNISCIENCE_VERSION:-latest}
+    ports:
+      - "3001:80"
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # postgres — operational metadata only (sources, documents row-level,
+  # ingestion_runs, api_tokens, workspaces, chunks text/lineage, entities,
+  # edges).  Vectors live in Qdrant and the symbol graph lives in Neo4j as
+  # of v0.2 (#105 cutover); the pgvector extension is no longer required.
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      POSTGRES_DB: omniscience
+      POSTGRES_USER: omniscience
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U omniscience -d omniscience"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    restart: unless-stopped
+
+  pgbackup:
+    image: postgres:16-alpine
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
+    volumes:
+      - pgbackups:/backups
+    entrypoint: >
+      sh -c "
+        while true; do
+          TIMESTAMP=$$(date +%Y%m%d_%H%M%S);
+          pg_dump -h postgres -U omniscience -d omniscience -Fc -f /backups/omniscience_$${TIMESTAMP}.dump;
+          echo \"Backup created: omniscience_$${TIMESTAMP}.dump\";
+          find /backups -name '*.dump' -mtime +7 -delete;
+          echo 'Old backups pruned (>7 days)';
+          sleep 86400;
+        done
+      "
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  nats:
+    image: nats:2.10-alpine
+    command: --jetstream --store_dir /data --http_port 8222
+    ports:
+      - "127.0.0.1:4222:4222"
+      - "127.0.0.1:8222:8222"
+    volumes:
+      - natsdata:/data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:8222/healthz || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:0.6.2
+    profiles:
+      - dev
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    profiles:
+      - monitoring
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheusdata:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    profiles:
+      - monitoring
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2-alpine
+    profiles:
+      - tls
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      CADDY_DOMAIN: ${CADDY_DOMAIN:-localhost}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ===========================================================================
+  # neo4j — graph store (ADR-0005).  As of v0.2 this is a default-on
+  # dependency of the ``app`` service (Epic #96 cutover, #105); pre-v0.2
+  # this lived behind the ``graph`` profile.
+  #
+  # Single-node Neo4j Community Edition.  Bolt on 7687, HTTP on 7474.
+  # Bolt TLS MUST be enabled in non-dev environments (not set here — this
+  # compose file is dev-only).  Credentials are read from .env via
+  # ${NEO4J_PASSWORD}; the default below is intentionally a placeholder
+  # that fails if POSTGRES_PASSWORD-style validation is applied downstream.
+  # ===========================================================================
+  neo4j:
+    image: neo4j:5.19-community
+    ports:
+      - "127.0.0.1:7474:7474"
+      - "127.0.0.1:7687:7687"
+    environment:
+      NEO4J_AUTH: ${NEO4J_USERNAME:-neo4j}/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set in .env}
+      NEO4J_server_memory_heap_initial__size: ${NEO4J_HEAP_INITIAL:-1G}
+      NEO4J_server_memory_heap_max__size: ${NEO4J_HEAP_MAX:-2G}
+      NEO4J_server_memory_pagecache_size: ${NEO4J_PAGECACHE:-1G}
+      NEO4J_PLUGINS: '["apoc"]'
+    volumes:
+      - neo4jdata:/data
+      - neo4jlogs:/logs
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "wget -q -O - http://localhost:7474 > /dev/null || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  # ==========================================================================
+  # qdrant — Vector store (Epic #96, ADR-0006, issue #106).  As of v0.2
+  # this is a default-on dependency of the ``app`` service (#105 cutover);
+  # pre-v0.2 this lived behind the ``graph`` profile.
+  # --------------------------------------------------------------------------
+  # gRPC primary:     6334  (ADR-0006 §Transport)
+  # HTTP fallback:    6333
+  # Storage volume:   /qdrant/storage  (bind-mounted for persistence)
+  # API key:          QDRANT__SERVICE__API_KEY env (unset in dev)
+  # ==========================================================================
+  qdrant:
+    image: qdrant/qdrant:v1.12.4
+    ports:
+      - "127.0.0.1:6333:6333"
+      - "127.0.0.1:6334:6334"
+    environment:
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
+      QDRANT__SERVICE__GRPC_PORT: "6334"
+      QDRANT__SERVICE__HTTP_PORT: "6333"
+      QDRANT__LOG_LEVEL: ${QDRANT_LOG_LEVEL:-INFO}
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/6333' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    restart: unless-stopped
+  # ==========================================================================
+  # /qdrant
+  # ==========================================================================
+
+volumes:
+  pgdata:
+  pgbackups:
+  natsdata:
+  ollama_data:
+  prometheusdata:
+  grafanadata:
+  caddy_data:
+  neo4jdata:
+  neo4jlogs:
+  qdrant_data:

--- a/docs/mcp-catalog-submission.md
+++ b/docs/mcp-catalog-submission.md
@@ -137,6 +137,8 @@ The `1-line install` advertised everywhere is:
 curl -fsSL https://raw.githubusercontent.com/100rd/Omniscience/main/.mcp/install.sh | bash
 ```
 
+Public installs use the GHCR-image variant **`docker-compose.prod.yml`** (no local build context required); images are published from tag `v*` by `.github/workflows/release.yml` to `ghcr.io/100rd/omniscience-{app,admin}`. Pin a specific image tag with `OMNISCIENCE_VERSION=v0.5.0 bash install.sh`; default is `:latest`. The dev compose (`docker-compose.yml`) still uses `build:` for local hot-reload and is not consumed by the installer.
+
 It must pass on **both** macOS and Linux. Validation procedure:
 
 1. **macOS** (Intel + Apple Silicon): fresh shell, fresh `$PWD`:


### PR DESCRIPTION
## Summary

Resolves [#261](https://github.com/100rd/Omniscience/issues/261) — the
advertised one-line installer aborts in ~3 s on a fresh host. Two
defects (missing `NEO4J_PASSWORD` in generated `.env`; published compose
uses `build:` with no source tree available at install time) both
removed by moving public installs onto pre-built GHCR images.

## Changes

- **`.github/workflows/release.yml`** (new) — multi-arch
  (`linux/amd64,linux/arm64`) build + push of
  `ghcr.io/100rd/omniscience-{app,admin}` on every `v*` tag.
  `workflow_dispatch` is wired for manual republishes. Tags via
  `docker/metadata-action@v5`: `:vX.Y.Z`, `:vX.Y`, `:latest` (latest
  only on stable, non-prerelease tags). GHA buildx cache scoped per
  image. `permissions: { contents: read, packages: write }`.
- **`docker-compose.prod.yml`** (new) — byte-identical to
  `docker-compose.yml` except `build: .` -> `image:
  ghcr.io/100rd/omniscience-app:${OMNISCIENCE_VERSION:-latest}` and
  same for admin. Source dev compose is **unchanged** so local
  hot-reload workflow is preserved.
- **`.mcp/install.sh`** — generates `NEO4J_PASSWORD` (plus
  `QDRANT_API_KEY`), writes the full operational env (DB URL, NATS
  URL, Neo4j/Qdrant connection vars, storage-backend selectors) so
  the app actually reaches its peers on the compose network; fetches
  `docker-compose.prod.yml`; passes through `OMNISCIENCE_VERSION`;
  bumps `/health` wait to 300 s for first-run image pulls; backfills
  missing keys on pre-#261 `.env` files for re-runs.
- **`docs/mcp-catalog-submission.md`** — one-paragraph note that the
  public installer consumes the prod compose + GHCR images, with
  `OMNISCIENCE_VERSION=v0.5.0 bash install.sh` for reproducibility.

## Local validation

Performed end-to-end (cannot publish to GHCR — that requires `v0.5.0`
to be tagged on `main`).

1. Built locally via `docker compose build app admin` from repo root.
2. Tagged as if from GHCR:
   `docker tag <local-app> ghcr.io/100rd/omniscience-app:latest`
   (same for admin).
3. Spun up a `python3 -m http.server` serving the worktree so
   `install.sh` could fetch the new prod compose file by URL.
4. Ran `bash .mcp/install.sh` in a fresh `$PWD` against the
   locally-tagged images.

**Results**:

| Check                                    | Result        |
|------------------------------------------|---------------|
| Script exits 0                           | PASS          |
| `docker compose ps` — all services       | healthy       |
| `curl http://localhost:8000/health`      | 200 `{"status":"healthy",...}` |
| `curl http://localhost:3001/` (admin)    | 200           |
| Re-run install.sh (idempotency)          | PASS (no `.env` diff, containers reused) |
| `shellcheck .mcp/install.sh`             | clean         |
| `actionlint .github/workflows/*.yml`     | clean (incl. existing workflows) |
| `docker compose -f docker-compose.prod.yml config` | valid |

## What is pending (project owner)

This PR alone does not produce a working public install — the GHCR
images don't exist yet. After merging:

1. Tag the release: `git tag -a v0.5.0 -m "Omniscience v0.5.0" && git push origin v0.5.0`
2. Watch the `release` workflow publish to `ghcr.io/100rd/*` (one-off,
   ~5-10 min for the multi-arch build).
3. After images are live, re-run `bash .mcp/install.sh` on a fresh box
   to confirm the path is unblocked.
4. Proceed with catalog submissions per `docs/mcp-catalog-submission.md`.

## Test plan

- [ ] After tag push, confirm `release` workflow produces both
      `omniscience-app` and `omniscience-admin` images with the
      `:v0.5.0`, `:v0.5`, and `:latest` tags.
- [ ] On a fresh macOS host (Apple Silicon): one-line install reaches
      healthy stack within 300 s on first run.
- [ ] On a fresh Ubuntu 22.04 host (x86_64): same.
- [ ] Re-run installer: `.env` untouched, no container churn.
- [ ] `OMNISCIENCE_VERSION=v0.5.0 bash install.sh` pins images
      correctly (verify `docker compose ps` shows `:v0.5.0` in the
      `IMAGE` column).