### PR TITLE
fix(parsers): restore Python symbol-graph extraction (green test_symbol_graph)

### DIFF
--- a/packages/parsers/src/omniscience_parsers/code/graph.py
+++ b/packages/parsers/src/omniscience_parsers/code/graph.py
@@ -1,7 +1,10 @@
 """Symbol graph extractor (v0.3 Cross-File Resolution).
 
-Transforms a ParsedDocument into entities and edges.
-Now supports basic import-tracking to resolve cross-file calls.
+Transforms a ParsedDocument into entities and edges, with import-tracking to
+resolve cross-file calls and class-inheritance edges.
+
+Supported language: Python (``parsed.language == "python"``). Other languages
+return empty lists so the ingestion pipeline degrades gracefully.
 """
 
 from __future__ import annotations
@@ -43,6 +46,23 @@ _PY_FROM_RE = re.compile(
     r"^\s*from\s+([\w.]+)\s+import\s+([\w*]+)(?:\s+as\s+(\w+))?",
     re.MULTILINE,
 )
+# `class Name(Base, Mixin, ...)` — captures the base-class list for inheritance.
+_CLASS_DEF_RE = re.compile(r"class\s+\w+\s*\(([^)]*)\)")
+
+
+def _parse_base_classes(text: str) -> list[str]:
+    """Extract base-class names from a class definition's source text."""
+    m = _CLASS_DEF_RE.search(text)
+    if not m:
+        return []
+    bases: list[str] = []
+    for raw in m.group(1).split(","):
+        base = raw.strip()
+        # skip empties, keyword args (metaclass=…), and the implicit `object` base
+        if not base or "=" in base or base == "object":
+            continue
+        bases.append(base)
+    return bases
 
 
 def _extract_python(
@@ -67,17 +87,15 @@ def _extract_python(
         import_map[alias] = fqn
         edges.append(ExtractedEdge(module_id, fqn, "imports"))
 
-    # from X import Y as Z
+    # from X import Y as Z — the import edge targets the module (base_fqn);
+    # the alias map still records the full symbol path for call resolution.
     for m in _PY_FROM_RE.finditer(full_text):
         base_fqn = m.group(1)
         symbol = m.group(2)
         alias = m.group(3) or symbol
         if symbol != "*":
-            fqn = f"{base_fqn}.{symbol}"
-            import_map[alias] = fqn
-            edges.append(ExtractedEdge(module_id, fqn, "imports"))
-        else:
-            edges.append(ExtractedEdge(module_id, base_fqn, "imports"))
+            import_map[alias] = f"{base_fqn}.{symbol}"
+        edges.append(ExtractedEdge(module_id, base_fqn, "imports"))
 
     # 2. Extract Definitions
     symbol_to_id: dict[str, uuid.UUID] = {}
@@ -92,10 +110,19 @@ def _extract_python(
             name=sec.symbol,
             display_name=sec.symbol.split(".")[-1],
             symbol=sec.symbol,
-            metadata={"line_start": sec.line_start}
+            metadata={
+                "line_start": sec.line_start,
+                "line_end": sec.line_end,
+                "language": parsed.language,
+            },
         ))
         symbol_to_id[sec.symbol] = ent_id
         edges.append(ExtractedEdge(module_id, sec.symbol, "defines"))
+
+        # Inheritance edges: parse `class Name(Base, ...)` from the section text.
+        if etype == "class":
+            for base in _parse_base_classes(sec.text):
+                edges.append(ExtractedEdge(ent_id, base, "inherits"))
 
     # 3. Extract Calls with Resolution
     for sec in parsed.sections:
@@ -127,56 +154,6 @@ def _extract_python(
     return entities, edges
 
 # ---------------------------------------------------------------------------
-# TypeScript Logic (ESM-aware)
-# ---------------------------------------------------------------------------
-
-# Module-level compiled pattern — the character class [\'"] contains both quote
-# chars, so a raw string with single-quote delimiters avoids a SyntaxError
-# under Python 3.12 when the outer string is double-quoted.
-_JS_IMPORT_RE = re.compile(r'import\s+.*\{?([\w\s,]+)\}?\s+from\s+[\'"](.*)[\'"]')
-
-
-def _extract_typescript(
-    parsed: ParsedDocument,
-    source_text: bytes,
-) -> tuple[list[ExtractedEntity], list[ExtractedEdge]]:
-    entities: list[ExtractedEntity] = []
-    edges: list[ExtractedEdge] = []
-
-    full_text = source_text.decode(errors="replace") if source_text else ""
-    module_name = parsed.sections[0].heading_path[0] if parsed.sections else "unknown"
-    module_id = uuid.uuid4()
-    entities.append(ExtractedEntity(module_id, "module", module_name, module_name, module_name))
-
-    # 1. Import Map (simplified for ESM)
-    # import { X as Y } from './path'
-    for m in _JS_IMPORT_RE.finditer(full_text):
-        path = m.group(2)
-        # For now, we use path as the module FQN
-        edges.append(ExtractedEdge(module_id, path, "imports"))
-
-    # 2. Definitions & Calls (similar to Python logic)
-    for sec in parsed.sections:
-        if not sec.symbol:
-            continue
-        ent_id = uuid.uuid4()
-        entities.append(ExtractedEntity(
-            id=ent_id,
-            entity_type="function" if "(" in sec.text else "class",
-            name=sec.symbol,
-            display_name=sec.symbol.split(".")[-1],
-            symbol=sec.symbol
-        ))
-        edges.append(ExtractedEdge(module_id, sec.symbol, "defines"))
-        # Simplified calls for TS v0.3
-        for cm in re.finditer(r"([\w.]+)\s*\(", sec.text):
-            target = cm.group(1)
-            if target != sec.symbol:
-                edges.append(ExtractedEdge(ent_id, target, "calls"))
-
-    return entities, edges
-
-# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -184,10 +161,14 @@ def extract_symbol_graph(
     parsed: ParsedDocument,
     source_text: bytes = b"",
 ) -> tuple[list[ExtractedEntity], list[ExtractedEdge]]:
-    if parsed.language == "python":
-        return _extract_python(parsed, source_text)
-    elif parsed.language in ("typescript", "javascript"):
-        return _extract_typescript(parsed, source_text)
-    return [], []
+    """Extract entities and edges from a parsed document.
+
+    Symbol-graph extraction is Python-only; for any other language (or when
+    ``parsed.language`` is ``None``) the function returns two empty lists so the
+    ingestion pipeline degrades gracefully.
+    """
+    if parsed.language != "python":
+        return [], []
+    return _extract_python(parsed, source_text)
 
 __all__ = ["ExtractedEdge", "ExtractedEntity", "extract_symbol_graph"]


### PR DESCRIPTION
Stacked on top of #263. Fixes the 6 `test_symbol_graph.py` regressions left by the in-progress graph.py rewrite, making the parser suite fully green (**40/40** symbol-graph, **275/275** parser tests).

## Root cause
The graph.py rewrite (in the WIP snapshot) regressed the Python symbol-graph extractor and added an incomplete, untested TypeScript extractor that violated the documented Python-only contract. The syntax fix in #263 unblocked test collection, surfacing these latent failures.

## Restored behaviors (matched to the existing tests + pre-rewrite `main`)
- **from-imports** — the `imports` edge targets the **module** (`from pathlib import Path` → `pathlib`); the alias map still records the full symbol path for call resolution.
- **inheritance** — emit `inherits` edges from `class Name(Base, ...)`, excluding the implicit `object` base and keyword args (`metaclass=`).
- **metadata** — entity metadata includes `line_end` and `language` alongside `line_start`.
- **language gating** — `extract_symbol_graph` is Python-only again; non-Python returns `([], [])`. Removed the incomplete TypeScript extractor (`_extract_typescript` / `_JS_IMPORT_RE`) that contradicted `test_non_python_returns_empty`. No consumer referenced it.

## Validation
- `tests/test_symbol_graph.py` → 40 passed
- full parser suite (treesitter, chunking, parsers, infra, tfstate, symbol_graph) → 275 passed
- ruff clean, compiles, no dangling references to the removed TS code.

## Note
If first-class TypeScript symbol-graph support is actually wanted, it should be reintroduced as a deliberate feature **with** updated tests (the current `test_non_python_returns_empty` encodes Python-only). One-file diff: `+45 / -64` in `graph.py`.