### PR TITLE
feat(auth): admin session cookie + CSRF (drop localStorage token)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -16,10 +16,10 @@ import { IncidentTimelinePage } from "./pages/IncidentTimelinePage";
 import { ReplayPage } from "./pages/ReplayPage";
 
 function AppInner() {
-  const { token } = useTokenContext();
+  const { authenticated } = useTokenContext();
   const { toasts, addToast, removeToast } = useToast();
 
-  if (!token) {
+  if (!authenticated) {
     return <LoginScreen />;
   }
 

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -1,4 +1,13 @@
-// API client wrapping fetch() with Bearer token auth.
+// API client using httpOnly cookie auth + CSRF double-submit pattern.
+//
+// Auth strategy:
+//   - All requests include `credentials: 'include'` so the browser sends the
+//     httpOnly `omniscience_admin_session` cookie automatically.
+//   - For mutating methods (POST/PUT/PATCH/DELETE) the client reads the
+//     non-httpOnly `csrf_token` cookie and forwards it as `X-CSRF-Token`.
+//   - No Authorization header is sourced from localStorage or any JS storage.
+//   - The `createSession` / `deleteSession` methods are the only callers that
+//     touch session lifecycle; all other methods are auth-agnostic.
 
 export type SourceType =
   | "git"
@@ -321,7 +330,7 @@ export type ReplayRequest = ReplayInlineRequest | ReplayByAuditIdRequest;
 export interface Workspace {
   id: string;
   name: string;
-  metadata: Record<string, any>;
+  metadata: Record<string, unknown>;
 }
 
 export class ApiError extends Error {
@@ -334,23 +343,29 @@ export class ApiError extends Error {
   }
 }
 
+const _MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+/** Read the csrf_token cookie value (non-httpOnly, set by the backend). */
+function _readCsrfCookie(): string | null {
+  const match = document.cookie
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith("csrf_token="));
+  return match ? decodeURIComponent(match.slice("csrf_token=".length)) : null;
+}
+
 export class ApiClient {
-  private token: string | null;
+  constructor() {}
 
-  constructor(token: string | null = null) {
-    this.token = token;
-  }
-
-  setToken(token: string | null): void {
-    this.token = token;
-  }
-
-  private headers(): HeadersInit {
+  private headers(method: string): HeadersInit {
     const h: Record<string, string> = {
       "Content-Type": "application/json",
     };
-    if (this.token) {
-      h["Authorization"] = `Bearer ${this.token}`;
+    if (_MUTATING_METHODS.has(method.toUpperCase())) {
+      const csrf = _readCsrfCookie();
+      if (csrf) {
+        h["X-CSRF-Token"] = csrf;
+      }
     }
     return h;
   }
@@ -363,7 +378,8 @@ export class ApiClient {
   ): Promise<T> {
     const res = await fetch(path, {
       method,
-      headers: this.headers(),
+      headers: this.headers(method),
+      credentials: "include",
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal,
     });
@@ -385,6 +401,18 @@ export class ApiClient {
     }
 
     return data as T;
+  }
+
+  // Session management (admin SPA auth)
+
+  /** POST /api/v1/admin/session — validate token, receive httpOnly cookie. */
+  async createSession(token: string): Promise<void> {
+    return this.request<void>("POST", "/api/v1/admin/session", { token });
+  }
+
+  /** DELETE /api/v1/admin/session — clear session + CSRF cookies. */
+  async deleteSession(): Promise<void> {
+    return this.request<void>("DELETE", "/api/v1/admin/session");
   }
 
   // Health
@@ -478,7 +506,7 @@ export class ApiClient {
     return this.request<Workspace>("GET", "/api/v1/workspace");
   }
 
-  async updateWorkspace(metadata: Record<string, any>): Promise<Workspace> {
+  async updateWorkspace(metadata: Record<string, unknown>): Promise<Workspace> {
     return this.request<Workspace>("PATCH", "/api/v1/workspace", { metadata });
   }
 
@@ -599,9 +627,13 @@ export class ApiClient {
       for (const t of query.entity_types) qs.append("entity_types", t);
     }
     const path = `/api/v1/incidents/${encodeURIComponent(alertId)}/timeline?${qs}`;
+    const h: Record<string, string> = {};
+    const csrf = _readCsrfCookie();
+    if (csrf) h["X-CSRF-Token"] = csrf;
     const res = await fetch(path, {
       method: "GET",
-      headers: this.token ? { Authorization: `Bearer ${this.token}` } : undefined,
+      headers: Object.keys(h).length > 0 ? h : undefined,
+      credentials: "include",
       signal,
     });
     if (!res.ok) {
@@ -619,11 +651,7 @@ export class ApiClient {
 
   // Replay
   async replay(payload: ReplayRequest): Promise<ReplayEnvelope> {
-    return this.request<ReplayEnvelope>(
-      "POST",
-      "/api/v1/replay",
-      payload
-    );
+    return this.request<ReplayEnvelope>("POST", "/api/v1/replay", payload);
   }
 
   async replayByAuditId(auditLogId: string): Promise<ReplayEnvelope> {

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -54,7 +54,7 @@ export function Layout({ children }: LayoutProps) {
 
         <div className="px-4 py-4 border-t border-border">
           <button
-            onClick={logout}
+            onClick={() => void logout()}
             className="w-full text-left text-xs text-text-muted hover:text-text transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
           >
             Sign out

--- a/apps/admin/src/components/LoginScreen.tsx
+++ b/apps/admin/src/components/LoginScreen.tsx
@@ -2,11 +2,12 @@ import { useState, FormEvent } from "react";
 import { useTokenContext } from "../context/TokenContext";
 
 export function LoginScreen() {
-  const { setToken } = useTokenContext();
+  const { login } = useTokenContext();
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const trimmed = value.trim();
     if (!trimmed) {
@@ -14,7 +15,14 @@ export function LoginScreen() {
       return;
     }
     setError(null);
-    setToken(trimmed);
+    setLoading(true);
+    try {
+      await login(trimmed);
+    } catch {
+      setError("Token invalid or insufficient scope. Please try again.");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -39,20 +47,26 @@ export function LoginScreen() {
               id="token"
               type="password"
               autoComplete="current-password"
-              placeholder="omni_dev_..."
+              placeholder="sk_dev_..."
               value={value}
               onChange={(e) => setValue(e.target.value)}
-              className="w-full rounded-lg border border-border bg-elevation-2 text-text placeholder:text-text-muted px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+              disabled={loading}
+              className="w-full rounded-lg border border-border bg-elevation-2 text-text placeholder:text-text-muted px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent disabled:opacity-50"
             />
           </div>
 
-          {error && <p className="text-sm text-danger-fg">{error}</p>}
+          {error && (
+            <p role="alert" className="text-sm text-danger-fg">
+              {error}
+            </p>
+          )}
 
           <button
             type="submit"
-            className="w-full bg-accent hover:bg-accent-hover text-accent-fg font-medium rounded-lg px-4 py-2 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-elevation-1"
+            disabled={loading}
+            className="w-full bg-accent hover:bg-accent-hover text-accent-fg font-medium rounded-lg px-4 py-2 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-elevation-1 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            Sign in
+            {loading ? "Signing in…" : "Sign in"}
           </button>
         </form>
       </div>

--- a/apps/admin/src/context/TokenContext.tsx
+++ b/apps/admin/src/context/TokenContext.tsx
@@ -7,38 +7,65 @@ import {
 } from "react";
 import { ApiClient } from "../api/client";
 
-const STORAGE_KEY = "omniscience_admin_token";
+/**
+ * Auth strategy: httpOnly session cookie (set by POST /api/v1/admin/session).
+ *
+ * The plaintext API token is never stored in localStorage or any JS-readable
+ * storage after login.  On mount we probe /health to determine whether the
+ * browser already has a valid session cookie.  On login we POST the token
+ * to the session endpoint which sets the httpOnly + Secure + SameSite=Strict
+ * cookie server-side.  On logout we DELETE the session endpoint to clear both
+ * cookies.
+ *
+ * The in-memory `authenticated` flag is the only UI state kept in React; the
+ * actual credential lives exclusively in the httpOnly cookie.
+ */
 
 interface TokenContextValue {
-  token: string | null;
+  authenticated: boolean;
   client: ApiClient;
-  setToken: (t: string | null) => void;
-  logout: () => void;
+  login: (token: string) => Promise<void>;
+  logout: () => Promise<void>;
 }
 
 const TokenContext = createContext<TokenContextValue | null>(null);
 
-const client = new ApiClient(null);
+const client = new ApiClient();
 
 export function TokenProvider({ children }: { children: ReactNode }) {
-  const [token, setTokenState] = useState<string | null>(() =>
-    localStorage.getItem(STORAGE_KEY)
-  );
+  const [authenticated, setAuthenticated] = useState<boolean>(false);
+  const [probed, setProbed] = useState<boolean>(false);
 
+  // Probe on mount to restore session from existing httpOnly cookie.
   useEffect(() => {
-    client.setToken(token);
-    if (token) {
-      localStorage.setItem(STORAGE_KEY, token);
-    } else {
-      localStorage.removeItem(STORAGE_KEY);
-    }
-  }, [token]);
+    client
+      .health()
+      .then(() => setAuthenticated(true))
+      .catch(() => setAuthenticated(false))
+      .finally(() => setProbed(true));
+  }, []);
 
-  const setToken = (t: string | null) => setTokenState(t);
-  const logout = () => setTokenState(null);
+  const login = async (token: string): Promise<void> => {
+    await client.createSession(token);
+    setAuthenticated(true);
+  };
+
+  const logout = async (): Promise<void> => {
+    try {
+      await client.deleteSession();
+    } finally {
+      setAuthenticated(false);
+    }
+  };
+
+  // Don't render children until the session probe completes to avoid
+  // a flash of the login screen on page reload with a valid cookie.
+  if (!probed) {
+    return null;
+  }
 
   return (
-    <TokenContext.Provider value={{ token, client, setToken, logout }}>
+    <TokenContext.Provider value={{ authenticated, client, login, logout }}>
       {children}
     </TokenContext.Provider>
   );

--- a/apps/admin/src/pages/GraphPage.tsx
+++ b/apps/admin/src/pages/GraphPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useTokenContext } from "../context/TokenContext";
-import { ApiClient, RelatedEntitiesResponse } from "../api/client";
+import { RelatedEntitiesResponse } from "../api/client";
 import { StatusBadge } from "../components/StatusBadge";
 import { GraphCanvas } from "../components/GraphCanvas";
 
@@ -9,45 +9,49 @@ interface GraphPageProps {
 }
 
 export function GraphPage({ addToast }: GraphPageProps) {
-  const { token } = useTokenContext();
+  const { client } = useTokenContext();
   const [entityName, setEntityName] = useState("");
   const [data, setData] = useState<RelatedEntitiesResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [depth, setDepth] = useState(1);
   const [asOf, setAsOf] = useState("");
 
-  const graphNodes = data ? [
-    { id: data.seed.name, name: data.seed.name, kind: data.seed.kind },
-    ...data.related.map(r => ({ id: r.name, name: r.name, kind: r.kind }))
-  ] : [];
+  const graphNodes = data
+    ? [
+        { id: data.seed.name, name: data.seed.name, kind: data.seed.kind },
+        ...data.related.map((r) => ({ id: r.name, name: r.name, kind: r.kind })),
+      ]
+    : [];
 
-  const graphLinks = data ? data.edges.map(e => ({
-    source: e.from,
-    target: e.to,
-    type: e.type
-  })) : [];
+  const graphLinks = data
+    ? data.edges.map((e) => ({ source: e.from, target: e.to, type: e.type }))
+    : [];
 
-    const fetchGraph = async (name: string) => {
+  const fetchGraph = async (name: string) => {
     if (!name) return;
     setLoading(true);
-    const client = new ApiClient(token);
     try {
-      // FIX: Robust UTC formatting using Date object
       let formattedAsOf = asOf;
-      if (formattedAsOf && !formattedAsOf.includes('Z') && !formattedAsOf.includes('+')) {
-        // Convert local time string to UTC ISO string
+      if (
+        formattedAsOf &&
+        !formattedAsOf.includes("Z") &&
+        !formattedAsOf.includes("+")
+      ) {
         formattedAsOf = new Date(formattedAsOf).toISOString();
       }
-
-      const res = await client.getRelatedEntities(name, { 
-        depth, 
-        as_of: formattedAsOf || undefined 
+      const res = await client.getRelatedEntities(name, {
+        depth,
+        as_of: formattedAsOf || undefined,
       });
       setData(res);
-    } catch (err: any) {
-      // Show structured error message if available
-      const detail = typeof err.detail === 'object' ? JSON.stringify(err.detail) : err.detail;
-      addToast(detail || "Failed to fetch graph", "error");
+    } catch (err: unknown) {
+      const detail =
+        err instanceof Error
+          ? err.message
+          : typeof err === "object" && err !== null && "detail" in err
+            ? String((err as { detail: unknown }).detail)
+            : "Failed to fetch graph";
+      addToast(detail, "error");
       setData(null);
     } finally {
       setLoading(false);
@@ -56,23 +60,28 @@ export function GraphPage({ addToast }: GraphPageProps) {
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    fetchGraph(entityName);
+    void fetchGraph(entityName);
   };
 
   const navigateTo = (name: string) => {
     setEntityName(name);
-    fetchGraph(name);
+    void fetchGraph(name);
   };
 
   return (
     <div className="space-y-6">
       <header>
         <h1 className="text-2xl font-bold text-gray-900">Graph Explorer</h1>
-        <p className="text-gray-500">Traverse semantic relationships across sources.</p>
+        <p className="text-gray-500">
+          Traverse semantic relationships across sources.
+        </p>
       </header>
 
       <div className="bg-elevation-1 p-6 rounded-lg border border-border shadow-md">
-        <form onSubmit={handleSearch} className="flex flex-col md:flex-row gap-6 items-end">
+        <form
+          onSubmit={handleSearch}
+          className="flex flex-col md:flex-row gap-6 items-end"
+        >
           <div className="flex-1 w-full">
             <label className="block text-xs font-bold text-text-muted uppercase mb-1">
               Entity Name (FQN)
@@ -85,7 +94,7 @@ export function GraphPage({ addToast }: GraphPageProps) {
               className="w-full px-4 py-2 bg-elevation-2 border border-border text-text rounded-md focus:ring-2 focus:ring-accent outline-none transition-all"
             />
           </div>
-          
+
           <div className="w-full md:w-32">
             <label className="block text-xs font-bold text-text-muted uppercase mb-1">
               Depth
@@ -95,7 +104,11 @@ export function GraphPage({ addToast }: GraphPageProps) {
               onChange={(e) => setDepth(Number(e.target.value))}
               className="w-full px-3 py-2 bg-elevation-2 border border-border text-text rounded-md focus:ring-2 focus:ring-accent outline-none"
             >
-              {[1, 2, 3, 4, 5].map(d => <option key={d} value={d} className="bg-elevation-2 text-text">{d} hops</option>)}
+              {[1, 2, 3, 4, 5].map((d) => (
+                <option key={d} value={d} className="bg-elevation-2 text-text">
+                  {d} hops
+                </option>
+              ))}
             </select>
           </div>
 
@@ -126,38 +139,56 @@ export function GraphPage({ addToast }: GraphPageProps) {
         <div className="space-y-6">
           <div className="bg-white p-4 rounded-lg border border-gray-200 shadow-sm overflow-hidden">
             <div className="flex justify-between items-center mb-4">
-               <h2 className="text-sm font-bold text-gray-900 uppercase tracking-tighter">Visual Semantic Map</h2>
-               <div className="text-[10px] text-gray-400 font-mono">Found {graphNodes.length} nodes and {graphLinks.length} edges</div>
+              <h2 className="text-sm font-bold text-gray-900 uppercase tracking-tighter">
+                Visual Semantic Map
+              </h2>
+              <div className="text-[10px] text-gray-400 font-mono">
+                Found {graphNodes.length} nodes and {graphLinks.length} edges
+              </div>
             </div>
-            <GraphCanvas 
-              nodes={graphNodes} 
-              links={graphLinks} 
-              onNodeClick={navigateTo} 
+            <GraphCanvas
+              nodes={graphNodes}
+              links={graphLinks}
+              onNodeClick={navigateTo}
             />
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div className="lg:col-span-1 space-y-6">
               <div className="bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
-                <h2 className="text-sm font-bold text-gray-900 uppercase mb-4">Selected Entity</h2>
+                <h2 className="text-sm font-bold text-gray-900 uppercase mb-4">
+                  Selected Entity
+                </h2>
                 <div className="space-y-4">
                   <div>
-                    <div className="text-[10px] font-bold text-gray-400 uppercase">FQN</div>
-                    <div className="text-sm font-mono text-blue-800 break-all">{data.seed.name}</div>
-                  </div>
-                  <div>
-                    <div className="text-[10px] font-bold text-gray-400 uppercase">Type</div>
-                    <div className="inline-block mt-1">
-                        <StatusBadge value={data.seed.kind as any} />
+                    <div className="text-[10px] font-bold text-gray-400 uppercase">
+                      FQN
+                    </div>
+                    <div className="text-sm font-mono text-blue-800 break-all">
+                      {data.seed.name}
                     </div>
                   </div>
                   <div>
-                    <div className="text-[10px] font-bold text-gray-400 uppercase">Source Identifier</div>
-                    <div className="text-xs text-gray-500 font-mono mt-1 italic">{data.seed.source}</div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase">
+                      Type
+                    </div>
+                    <div className="inline-block mt-1">
+                      <StatusBadge value={data.seed.kind as Parameters<typeof StatusBadge>[0]["value"]} />
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-bold text-gray-400 uppercase">
+                      Source Identifier
+                    </div>
+                    <div className="text-xs text-gray-500 font-mono mt-1 italic">
+                      {data.seed.source}
+                    </div>
                   </div>
                   {data.seed.chunk_text && (
                     <div>
-                      <div className="text-[10px] font-bold text-gray-400 uppercase">AST Snippet</div>
+                      <div className="text-[10px] font-bold text-gray-400 uppercase">
+                        AST Snippet
+                      </div>
                       <pre className="mt-2 p-4 bg-gray-900 text-green-400 text-[11px] rounded-lg border border-gray-800 font-mono overflow-x-auto shadow-inner">
                         {data.seed.chunk_text}
                       </pre>
@@ -172,14 +203,23 @@ export function GraphPage({ addToast }: GraphPageProps) {
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-gray-50">
                     <tr>
-                      <th className="px-6 py-3 text-left text-[10px] font-bold text-gray-400 uppercase">Relation</th>
-                      <th className="px-6 py-3 text-left text-[10px] font-bold text-gray-400 uppercase">Target Entity</th>
-                      <th className="px-6 py-3 text-right text-[10px] font-bold text-gray-400 uppercase">Hops</th>
+                      <th className="px-6 py-3 text-left text-[10px] font-bold text-gray-400 uppercase">
+                        Relation
+                      </th>
+                      <th className="px-6 py-3 text-left text-[10px] font-bold text-gray-400 uppercase">
+                        Target Entity
+                      </th>
+                      <th className="px-6 py-3 text-right text-[10px] font-bold text-gray-400 uppercase">
+                        Hops
+                      </th>
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-100">
                     {data.related.map((rel, idx) => (
-                      <tr key={idx} className="hover:bg-blue-50/50 transition-colors group">
+                      <tr
+                        key={idx}
+                        className="hover:bg-blue-50/50 transition-colors group"
+                      >
                         <td className="px-6 py-4">
                           <span className="px-2 py-0.5 rounded text-[10px] font-bold uppercase bg-blue-100 text-blue-700 border border-blue-200">
                             {rel.edge_type}
@@ -193,7 +233,7 @@ export function GraphPage({ addToast }: GraphPageProps) {
                             {rel.name}
                           </button>
                           <div className="text-[10px] text-gray-400 font-sans mt-0.5">
-                            {rel.kind} • {rel.source.slice(0, 12)}...
+                            {rel.kind} &bull; {rel.source.slice(0, 12)}...
                           </div>
                         </td>
                         <td className="px-6 py-4 text-right text-xs text-gray-500 font-mono">
@@ -203,7 +243,10 @@ export function GraphPage({ addToast }: GraphPageProps) {
                     ))}
                     {data.related.length === 0 && (
                       <tr>
-                        <td colSpan={3} className="px-6 py-12 text-center text-sm text-gray-400 italic bg-gray-50/50">
+                        <td
+                          colSpan={3}
+                          className="px-6 py-12 text-center text-sm text-gray-400 italic bg-gray-50/50"
+                        >
                           Isolated entity. No relationships found at this depth.
                         </td>
                       </tr>

--- a/apps/server/src/omniscience_server/rest/admin_session.py
+++ b/apps/server/src/omniscience_server/rest/admin_session.py
@@ -1,0 +1,156 @@
+"""Admin session endpoints — httpOnly cookie-based auth for the admin SPA.
+
+POST   /admin/session  — validate a scoped API token, set session+CSRF cookies
+DELETE /admin/session  — clear both cookies (logout)
+
+Design decision: the session cookie carries the validated plaintext token
+directly (no server-side session store exists in this deployment).  This is
+documented explicitly below.  The CSRF token is an opaque random value stored
+in a *non*-httpOnly cookie so JavaScript can read and forward it as a header
+(double-submit cookie pattern).
+
+Decision note for reviewers
+----------------------------
+The ``omniscience_admin_session`` cookie value equals the plaintext API token.
+A server-side session store (e.g. Redis) would let us issue opaque IDs and
+revoke sessions independently of the token, but no session store is wired in
+this service.  The trade-off:
+
+  - Pro (current): zero new infrastructure; revocation is token-level (delete
+    the ApiToken row); validated on every request via argon2 (same as Bearer).
+  - Con: cookie size is ~80 chars; cannot invalidate one browser session
+    without revoking the token globally.
+
+If a session store is added later, swap ``_set_session_cookies`` to store an
+opaque ID and add a session lookup step in ``get_current_token_from_cookie``.
+"""
+
+from __future__ import annotations
+
+import secrets
+
+import structlog
+from fastapi import APIRouter, HTTPException, Request, Response
+from omniscience_core.auth.middleware import _lookup_token
+from omniscience_core.auth.scopes import Scope, check_scopes
+from pydantic import BaseModel, field_validator
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["admin-session"])
+
+_SESSION_COOKIE = "omniscience_admin_session"
+_CSRF_COOKIE = "csrf_token"
+_CSRF_BYTES = 32
+_COOKIE_MAX_AGE = 86_400 * 7  # 7 days
+
+
+class _SessionCreateRequest(BaseModel):
+    token: str
+
+    @field_validator("token")
+    @classmethod
+    def _token_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("token must not be empty")
+        return v
+
+
+def _require_db_factory(request: Request) -> object:
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if factory is None:
+        raise HTTPException(status_code=503, detail="Database not available")
+    return factory
+
+
+def _set_session_cookies(
+    response: Response,
+    plaintext: str,
+    csrf_token: str,
+    is_secure: bool,
+) -> None:
+    """Attach the session and CSRF cookies to *response*."""
+    response.set_cookie(
+        key=_SESSION_COOKIE,
+        value=plaintext,
+        httponly=True,
+        secure=is_secure,
+        samesite="strict",
+        max_age=_COOKIE_MAX_AGE,
+        path="/",
+    )
+    # CSRF cookie is intentionally NOT httpOnly — JS must read it.
+    response.set_cookie(
+        key=_CSRF_COOKIE,
+        value=csrf_token,
+        httponly=False,
+        secure=is_secure,
+        samesite="strict",
+        max_age=_COOKIE_MAX_AGE,
+        path="/",
+    )
+
+
+def _clear_session_cookies(response: Response, is_secure: bool) -> None:
+    """Expire both cookies immediately."""
+    for name in (_SESSION_COOKIE, _CSRF_COOKIE):
+        response.set_cookie(
+            key=name,
+            value="",
+            httponly=(name == _SESSION_COOKIE),
+            secure=is_secure,
+            samesite="strict",
+            max_age=0,
+            path="/",
+        )
+
+
+def _is_secure(request: Request) -> bool:
+    """Return True when the request arrived over HTTPS or in production."""
+    settings = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        env = str(getattr(settings, "environment", "")).lower()
+        if env not in ("development", "dev", "test"):
+            return True
+    return request.url.scheme == "https"
+
+
+@router.post("/session", status_code=204)
+async def create_session(
+    payload: _SessionCreateRequest,
+    request: Request,
+    response: Response,
+) -> None:
+    """Validate *token* and set httpOnly session + CSRF cookies.
+
+    Raises 401 when the token is missing, invalid, expired, or lacks
+    ``admin`` scope.
+    """
+    factory = _require_db_factory(request)
+
+    async with factory() as db:
+        api_token = await _lookup_token(db, payload.token)
+
+    if api_token is None:
+        log.warning("admin_session_create_rejected", reason="invalid_token")
+        raise HTTPException(status_code=401, detail="Token invalid or expired")
+
+    granted = {Scope(s) for s in api_token.scopes if s in Scope.__members__.values()}
+    if not check_scopes({Scope.admin}, granted):
+        log.warning(
+            "admin_session_create_rejected",
+            reason="insufficient_scope",
+            token_prefix=api_token.token_prefix,
+        )
+        raise HTTPException(status_code=403, detail="Token lacks admin scope")
+
+    csrf_token = secrets.token_urlsafe(_CSRF_BYTES)
+    _set_session_cookies(response, payload.token, csrf_token, _is_secure(request))
+    log.info("admin_session_created", token_prefix=api_token.token_prefix)
+
+
+@router.delete("/session", status_code=204)
+async def delete_session(request: Request, response: Response) -> None:
+    """Clear both session cookies, effectively logging the user out."""
+    _clear_session_cookies(response, _is_secure(request))
+    log.info("admin_session_deleted")

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from omniscience_server.rest.admin_session import router as admin_session_router
 from omniscience_server.rest.blast_radius import router as blast_radius_router
 from omniscience_server.rest.documents import router as documents_router
 from omniscience_server.rest.entities import router as entities_router
@@ -27,6 +28,7 @@ from omniscience_server.rest.workspace import router as workspace_router
 
 api_v1_router = APIRouter(prefix="/api/v1")
 
+api_v1_router.include_router(admin_session_router)
 api_v1_router.include_router(search_router)
 api_v1_router.include_router(sources_router)
 api_v1_router.include_router(workspace_router)

--- a/packages/core/src/omniscience_core/auth/middleware.py
+++ b/packages/core/src/omniscience_core/auth/middleware.py
@@ -1,7 +1,21 @@
-"""FastAPI dependencies for token-based authentication and scope enforcement."""
+"""FastAPI dependencies for token-based authentication and scope enforcement.
+
+Authentication sources (in priority order)
+------------------------------------------
+1. ``Authorization: Bearer <token>`` header  — CLI / MCP / programmatic clients.
+   No CSRF check: Bearer credentials are explicit, not ambient.
+2. ``omniscience_admin_session`` httpOnly cookie — admin SPA only.
+   State-changing methods (POST/PUT/PATCH/DELETE) additionally require the
+   ``X-CSRF-Token`` header to equal the ``csrf_token`` cookie value
+   (double-submit cookie pattern, RFC 6265 §8.2.1).
+
+Both paths share the same ``_lookup_token`` helper so token validation logic
+(argon2 verify, expiry, active flag) is identical.
+"""
 
 from __future__ import annotations
 
+import secrets
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
 from typing import Any
@@ -27,7 +41,16 @@ _AUTH_ERROR = HTTPException(
     detail={"code": "unauthorized", "message": "Token missing or invalid"},
 )
 
+_CSRF_ERROR = HTTPException(
+    status_code=403,
+    detail={"code": "csrf_invalid", "message": "CSRF token missing or invalid"},
+)
+
 _PREFIX_LEN = 8
+_SESSION_COOKIE = "omniscience_admin_session"
+_CSRF_COOKIE = "csrf_token"
+_CSRF_HEADER = "x-csrf-token"
+_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 
 def _utc_now() -> datetime:
@@ -67,22 +90,76 @@ async def _update_last_used(session: AsyncSession, token: ApiToken) -> None:
         log.warning("last_used_at_update_failed", token_prefix=token.token_prefix)
 
 
+def _verify_csrf(request: Request) -> None:
+    """Enforce double-submit CSRF for cookie-authenticated mutating requests.
+
+    Compares ``X-CSRF-Token`` header against the ``csrf_token`` cookie using
+    a constant-time comparison so timing attacks cannot distinguish missing
+    vs wrong values.
+
+    Raises HTTPException 403 when CSRF verification fails.
+    """
+    if request.method not in _MUTATING_METHODS:
+        return
+
+    cookie_val = request.cookies.get(_CSRF_COOKIE, "")
+    header_val = request.headers.get(_CSRF_HEADER, "")
+
+    # Both must be present and non-empty before we compare.
+    if not cookie_val or not header_val:
+        raise _CSRF_ERROR
+
+    # hmac.compare_digest requires equal-length bytes for a meaningful
+    # constant-time comparison; secrets.compare_digest is its alias.
+    if not secrets.compare_digest(
+        cookie_val.encode("utf-8"),
+        header_val.encode("utf-8"),
+    ):
+        raise _CSRF_ERROR
+
+
+def _extract_plaintext(
+    credentials: HTTPAuthorizationCredentials | None,
+    request: Request,
+) -> tuple[str | None, bool]:
+    """Return ``(plaintext, is_bearer)`` from whichever auth source is present.
+
+    Priority: Bearer header > session cookie.
+    Returns ``(None, False)`` when neither is present.
+    """
+    if credentials is not None and credentials.credentials:
+        return credentials.credentials, True
+
+    cookie_val = request.cookies.get(_SESSION_COOKIE)
+    if cookie_val:
+        return cookie_val, False
+
+    return None, False
+
+
 async def get_current_token(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = _bearer_dep,
 ) -> ApiToken:
-    """FastAPI dependency: extract and validate the Bearer token.
+    """FastAPI dependency: validate Bearer header or admin session cookie.
+
+    When the session cookie is used for a mutating request, CSRF is enforced
+    via the double-submit pattern before the token lookup runs.
 
     Raises:
         HTTPException 401 — token missing, invalid, or expired.
+        HTTPException 403 — CSRF token missing or invalid (cookie auth only).
 
     Returns:
         The authenticated ApiToken ORM instance.
     """
-    if credentials is None or not credentials.credentials:
+    plaintext, is_bearer = _extract_plaintext(credentials, request)
+
+    if plaintext is None:
         raise _AUTH_ERROR
 
-    plaintext = credentials.credentials
+    if not is_bearer:
+        _verify_csrf(request)
 
     factory = getattr(request.app.state, "db_session_factory", None)
     if factory is None:
@@ -134,4 +211,4 @@ def require_scope(
     return _check
 
 
-__all__ = ["get_current_token", "require_scope"]
+__all__ = ["_lookup_token", "get_current_token", "require_scope"]

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -1,0 +1,403 @@
+"""Tests for admin session endpoints and CSRF enforcement.
+
+Coverage matrix:
+  POST /admin/session
+    - valid admin token -> 204, sets session + CSRF cookies
+    - invalid/unknown token -> 401
+    - token with non-admin scope -> 403
+    - empty token body -> 422 (pydantic validation)
+
+  DELETE /admin/session
+    - always 204, clears both cookies
+
+  CSRF enforcement (via get_current_token / cookie path)
+    - GET with cookie, no CSRF header -> 200 (reads are exempt)
+    - POST with cookie + matching X-CSRF-Token -> 200
+    - POST with cookie + missing X-CSRF-Token -> 403
+    - POST with cookie + wrong X-CSRF-Token -> 403
+    - POST with Bearer header, no CSRF header -> 200 (bearer exempt)
+    - Bearer takes priority over cookie
+    - No auth -> 401
+    - Cookie with inactive token -> 401
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.middleware import get_current_token
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.db.models import ApiToken
+
+# Module-level singleton — avoids ruff B008
+_get_token_dep: Any = Depends(get_current_token)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_token(
+    plaintext: str,
+    prefix: str,
+    scopes: list[str],
+    hashed: str,
+) -> ApiToken:
+    """Build a minimal ApiToken mock for test injection."""
+    mock: ApiToken = MagicMock(spec=ApiToken)
+    mock.token_prefix = prefix
+    mock.hashed_token = hashed
+    mock.scopes = scopes
+    mock.expires_at = None
+    mock.is_active = True
+    mock.last_used_at = None
+    return mock
+
+
+def _make_fake_session(tokens: list[Any]) -> AsyncMock:
+    """Async session context-manager returning *tokens* on execute."""
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = tokens
+        return result
+
+    session.execute = _execute
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_session_app(tokens: list[Any]) -> FastAPI:
+    """Minimal app wired with the admin session router."""
+    from omniscience_server.rest.admin_session import router as session_router
+
+    app = FastAPI()
+    fake_session = _make_fake_session(tokens)
+    app.state.db_session_factory = MagicMock(return_value=fake_session)
+    settings = MagicMock()
+    settings.environment = "test"
+    app.state.settings = settings
+    app.include_router(session_router)
+    return app
+
+
+def _make_protected_app(tokens: list[Any]) -> FastAPI:
+    """Minimal app with cookie-authenticated endpoints for CSRF tests."""
+    app = FastAPI()
+    fake_session = _make_fake_session(tokens)
+    app.state.db_session_factory = MagicMock(return_value=fake_session)
+
+    @app.get("/probe")
+    async def _probe(token: ApiToken = _get_token_dep) -> dict[str, str]:  # type: ignore[assignment]
+        return {"prefix": token.token_prefix}
+
+    @app.post("/mutate")
+    async def _mutate(token: ApiToken = _get_token_dep) -> dict[str, str]:  # type: ignore[assignment]
+        return {"prefix": token.token_prefix}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/session — valid token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_session_sets_cookies_for_admin_token() -> None:
+    """Valid admin token -> 204 + both cookies present."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_session_app([mock_token])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/session", json={"token": plaintext})
+
+    assert response.status_code == 204
+    assert "omniscience_admin_session" in response.cookies
+    assert "csrf_token" in response.cookies
+
+
+@pytest.mark.asyncio
+async def test_create_session_session_cookie_is_httponly() -> None:
+    """Session cookie must carry HttpOnly flag (not readable by JS)."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_session_app([mock_token])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/session", json={"token": plaintext})
+
+    raw = "\n".join(response.headers.get_list("set-cookie")).lower()
+    assert "httponly" in raw
+
+
+@pytest.mark.asyncio
+async def test_create_session_samesite_strict() -> None:
+    """Session and CSRF cookies must have SameSite=Strict."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_session_app([mock_token])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/session", json={"token": plaintext})
+
+    raw = "\n".join(response.headers.get_list("set-cookie")).lower()
+    assert "samesite=strict" in raw
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/session — invalid / non-admin token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_unknown_token() -> None:
+    """No matching token in DB -> 401."""
+    app = _make_session_app([])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        plaintext, _ = generate_token("development")
+        response = await client.post("/admin/session", json={"token": plaintext})
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_non_admin_scope() -> None:
+    """Token with search-only scope -> 403."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["search"], hashed)
+    app = _make_session_app([mock_token])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/session", json={"token": plaintext})
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_empty_token() -> None:
+    """Empty/whitespace token string -> 422 (pydantic validation)."""
+    app = _make_session_app([])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/session", json={"token": "   "})
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# DELETE /admin/session — logout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_session_clears_cookies() -> None:
+    """DELETE /admin/session returns 204 and expires both cookies."""
+    app = _make_session_app([])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.delete("/admin/session")
+
+    assert response.status_code == 204
+    raw = "\n".join(response.headers.get_list("set-cookie")).lower()
+    assert "max-age=0" in raw
+    assert "omniscience_admin_session" in raw
+    assert "csrf_token" in raw
+
+
+# ---------------------------------------------------------------------------
+# CSRF enforcement (cookie auth path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_request_via_cookie_exempt_from_csrf() -> None:
+    """GET with session cookie but no CSRF header -> 200 (reads exempt)."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_protected_app([mock_token])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"omniscience_admin_session": plaintext},
+    ) as client:
+        response = await client.get("/probe")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_post_via_cookie_with_matching_csrf_succeeds() -> None:
+    """POST with matching X-CSRF-Token header -> 200."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_protected_app([mock_token])
+
+    csrf_value = secrets.token_urlsafe(32)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"omniscience_admin_session": plaintext, "csrf_token": csrf_value},
+    ) as client:
+        response = await client.post("/mutate", headers={"X-CSRF-Token": csrf_value})
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_post_via_cookie_missing_csrf_header_rejected() -> None:
+    """POST with cookie but no X-CSRF-Token header -> 403."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_protected_app([mock_token])
+
+    csrf_value = secrets.token_urlsafe(32)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"omniscience_admin_session": plaintext, "csrf_token": csrf_value},
+    ) as client:
+        response = await client.post("/mutate")  # no X-CSRF-Token header
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "csrf_invalid"
+
+
+@pytest.mark.asyncio
+async def test_post_via_cookie_wrong_csrf_header_rejected() -> None:
+    """POST with wrong X-CSRF-Token value -> 403."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_protected_app([mock_token])
+
+    csrf_value = secrets.token_urlsafe(32)
+    wrong_csrf = secrets.token_urlsafe(32)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"omniscience_admin_session": plaintext, "csrf_token": csrf_value},
+    ) as client:
+        response = await client.post("/mutate", headers={"X-CSRF-Token": wrong_csrf})
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["code"] == "csrf_invalid"
+
+
+@pytest.mark.asyncio
+async def test_bearer_post_exempt_from_csrf() -> None:
+    """POST with Bearer Authorization header requires no X-CSRF-Token."""
+    plaintext, prefix = generate_token("development")
+    hashed = hash_token(plaintext)
+    mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
+    app = _make_protected_app([mock_token])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/mutate", headers={"Authorization": f"Bearer {plaintext}"}
+        )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_bearer_takes_priority_over_cookie() -> None:
+    """When both Bearer header and session cookie present, Bearer wins."""
+    bearer_plaintext, bearer_prefix = generate_token("development")
+    bearer_hashed = hash_token(bearer_plaintext)
+    bearer_token = _make_mock_token(bearer_plaintext, bearer_prefix, ["admin"], bearer_hashed)
+
+    cookie_plaintext, _ = generate_token("development")
+    app = _make_protected_app([bearer_token])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"omniscience_admin_session": cookie_plaintext},
+    ) as client:
+        response = await client.get(
+            "/probe", headers={"Authorization": f"Bearer {bearer_plaintext}"}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["prefix"] == bearer_prefix
+
+
+@pytest.mark.asyncio
+async def test_no_auth_returns_401() -> None:
+    """No bearer header and no session cookie -> 401."""
+    app = _make_protected_app([])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/probe")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_session_cookie_with_inactive_token_rejected() -> None:
+    """Session cookie present but token is not in DB (deactivated) -> 401."""
+    plaintext, _ = generate_token("development")
+    app = _make_protected_app([])  # empty list simulates deactivated/missing token
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"omniscience_admin_session": plaintext},
+    ) as client:
+        response = await client.get("/probe")
+
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Import sanity
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_token_is_accessible() -> None:
+    """_lookup_token must be importable from the middleware module."""
+    from omniscience_core.auth.middleware import _lookup_token  # type: ignore[attr-defined]
+
+    assert callable(_lookup_token)


### PR DESCRIPTION
Migrates the admin SPA off an XSS-exfiltratable `localStorage` API token to an httpOnly session cookie with CSRF protection.

## Backend
- `rest/admin_session.py`: `POST /api/v1/admin/session` validates a scoped token (existing argon2 `_lookup_token`, `Scope.admin`) and sets `omniscience_admin_session` (httpOnly, Secure, SameSite=Strict) + `csrf_token` (JS-readable, double-submit). `DELETE` clears both.
- `auth/middleware.py`: `get_current_token` tries Bearer first, then the session cookie. Cookie-auth + mutating method ⇒ require `X-CSRF-Token` matching the `csrf_token` cookie (`secrets.compare_digest`). Bearer requests are CSRF-exempt. CLI/MCP Bearer flow unchanged.

## Frontend
- `TokenContext.tsx`: no localStorage; `login()` posts token to establish the cookie, `logout()` calls DELETE; token never enters JS-readable storage.
- `client.ts`: `credentials: 'include'`, `X-CSRF-Token` on mutations, no `Authorization` from storage; `any` removed.

## Validation
- `ruff` clean; `pytest test_auth.py test_admin_session.py` → **42 passed** (16 new: cookie set/clear, CSRF reject on mutation, Bearer still works).
- Frontend `tsc && vite build` → **0 type errors**; typecheck clean.

## Reviewer decision
The cookie stores the raw token (no session store exists). Revocation is token-level. Upgrade path to opaque session IDs is documented in the module. Confirm acceptable, or wire a session store first.