### PR TITLE
fix(tests): repair EntityNodeView id-fixture drift + traversal-seed runtime bug

### DIFF
--- a/packages/index/src/omniscience_index/stores/neo4j/mappers.py
+++ b/packages/index/src/omniscience_index/stores/neo4j/mappers.py
@@ -279,6 +279,7 @@ def _edge_tuple_to_view(triplet: list[Any]) -> GraphEdgeView:
 def _rows_to_graph_result(row: dict[str, Any]) -> GraphResultView:
     """Assemble a :class:`GraphResultView` from a single traversal row."""
     seed = EntityNodeView(
+        id=uuid.UUID(str(row["id"])),
         name=str(row["seed_name"]),
         kind=str(row["seed_kind"]),
         source=str(row["seed_source_id"]),

--- a/tests/integration/test_blast_radius.py
+++ b/tests/integration/test_blast_radius.py
@@ -101,6 +101,7 @@ class _BlastGraphStore:
         recorded_at: datetime | None = None,
     ) -> None:
         self._entities[(workspace_id, name)] = EntityNodeView(
+            id=uuid.uuid4(),
             name=name,
             kind=kind,
             source="src-test",
@@ -197,6 +198,7 @@ class _BlastGraphStore:
                 continue
             related.append(
                 EntityNodeView(
+                    id=uuid.uuid4(),
                     name=base.name,
                     kind=base.kind,
                     source=base.source,

--- a/tests/integration/test_incident_demo.py
+++ b/tests/integration/test_incident_demo.py
@@ -112,6 +112,7 @@ def _node_from_dict(payload: dict[str, Any]) -> EntityNodeView:
     Drops the ``_role`` annotation (fixture-only metadata for reviewers).
     """
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=payload["name"],
         kind=payload["kind"],
         source=payload["source"],

--- a/tests/integration/test_incident_timeline.py
+++ b/tests/integration/test_incident_timeline.py
@@ -79,6 +79,7 @@ def _parse_dt(value: str | None) -> datetime | None:
 
 def _node_from_dict(payload: dict[str, Any]) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=payload["name"],
         kind=payload["kind"],
         source=payload["source"],

--- a/tests/integration/test_mcp_apps_card_render.py
+++ b/tests/integration/test_mcp_apps_card_render.py
@@ -55,6 +55,7 @@ _SLACK_THREAD = "slack://channel/C12345/thread/1716383700.000100"
 
 def _alert_node() -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=_ALERT_ID,
         kind="alert",
         source="pagerduty",
@@ -67,6 +68,7 @@ def _alert_node() -> EntityNodeView:
 
 def _pr_node() -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=_PR_URI,
         kind="pull_request",
         source="github",
@@ -79,6 +81,7 @@ def _pr_node() -> EntityNodeView:
 
 def _resource_node() -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=_RESOURCE,
         kind="k8s_deployment",
         source="kubernetes",
@@ -90,6 +93,7 @@ def _resource_node() -> EntityNodeView:
 
 def _slack_node() -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=_SLACK_THREAD,
         kind="slack_thread",
         source="slack",

--- a/tests/integration/test_postmortem_generator.py
+++ b/tests/integration/test_postmortem_generator.py
@@ -63,6 +63,7 @@ def _parse_dt(value: str | None) -> datetime | None:
 
 def _node_from_dict(payload: dict[str, Any]) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=payload["name"],
         kind=payload["kind"],
         source=payload["source"],

--- a/tests/integration/test_runbook_suggest.py
+++ b/tests/integration/test_runbook_suggest.py
@@ -77,6 +77,7 @@ class _SuggestGraphStore:
 
         chunk_text = json.dumps({"tags": tags or [], "severity": severity})
         self._entities[(workspace_id, name)] = EntityNodeView(
+            id=uuid.uuid4(),
             name=name,
             kind="alert",
             source="src-test",

--- a/tests/integration/test_similar_incidents.py
+++ b/tests/integration/test_similar_incidents.py
@@ -55,7 +55,10 @@ _DISSIMILAR_ID = "alert://datadog/past-099"
 
 _TARGET_SERVICE = "service://api"
 
-_NOW = datetime(2026, 5, 22, 12, 0, 0, tzinfo=UTC)
+# Anchored to the wall clock: the production since_days window filters against
+# the real current time, so fixture offsets must be relative to *now* (a
+# hardcoded date drifts out of any narrow window once enough days pass).
+_NOW = datetime.now(UTC)
 
 # Recency: similar #1 fired 3 days ago, similar #2 fired 14 days ago,
 # dissimilar fired 1 day ago.  Recency alone would favour the
@@ -153,6 +156,7 @@ def _alert(
     summary: str,
 ) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=name,
         kind="alert",
         source="src-datadog",
@@ -165,6 +169,7 @@ def _alert(
 
 def _service(*, name: str, depth: int = 1) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=name,
         kind="service",
         source="src-datadog",
@@ -182,6 +187,7 @@ def _peer_alert(
     depth: int = 2,
 ) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=name,
         kind="alert",
         source="src-datadog",

--- a/tests/support/graph_store_proxy.py
+++ b/tests/support/graph_store_proxy.py
@@ -44,6 +44,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 def _node_to_view(node: EntityNode) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=node.name,
         kind=node.kind,
         source=node.source,

--- a/tests/test_graph_rag.py
+++ b/tests/test_graph_rag.py
@@ -205,6 +205,7 @@ def _make_graph_result(
 ) -> GraphResultView:
     """Build a ``GraphResultView`` with given seed/related source ids."""
     seed = EntityNodeView(
+        id=uuid.uuid4(),
         name="seed-entity",
         kind="service",
         source=str(seed_source),
@@ -214,6 +215,7 @@ def _make_graph_result(
     )
     related_nodes = [
         EntityNodeView(
+            id=uuid.uuid4(),
             name=f"rel-{i}",
             kind="service",
             source=str(src),

--- a/tests/test_graphrag_regression.py
+++ b/tests/test_graphrag_regression.py
@@ -286,6 +286,7 @@ class _CorpusGraphStore:
             raise ValueError(f"entity_not_found:{entity_name}")
         related_names = self.TOPIC_CLUSTERS.get(entity_name, [])
         seed = EntityNodeView(
+            id=uuid.uuid4(),
             name=entity_name,
             kind="service",
             source=str(self._sources[entity_name]),
@@ -294,6 +295,7 @@ class _CorpusGraphStore:
         )
         related = [
             EntityNodeView(
+                id=uuid.uuid4(),
                 name=n,
                 kind="service",
                 source=str(self._sources[n]),

--- a/tests/test_graphrag_workspace_isolation.py
+++ b/tests/test_graphrag_workspace_isolation.py
@@ -179,6 +179,7 @@ def _hit(*, source_id: uuid.UUID, text: str, score: float = 0.9) -> SearchHit:
 
 def _graph_result(*, seed_source: uuid.UUID, related_sources: list[uuid.UUID]) -> GraphResultView:
     seed = EntityNodeView(
+        id=uuid.uuid4(),
         name="AuthService",
         kind="service",
         source=str(seed_source),
@@ -188,6 +189,7 @@ def _graph_result(*, seed_source: uuid.UUID, related_sources: list[uuid.UUID]) -
     )
     related = [
         EntityNodeView(
+            id=uuid.uuid4(),
             name=f"rel-{i}",
             kind="service",
             source=str(src),

--- a/tests/test_mcp_as_of.py
+++ b/tests/test_mcp_as_of.py
@@ -142,6 +142,7 @@ class _BitemporalGraphStore:
                     valid_from,
                     valid_to,
                     EntityNodeView(
+                        id=uuid.uuid4(),
                         name=name,
                         kind=kind,
                         source=f"src-{name}-v{idx}",

--- a/tests/test_mcp_resolve_incident.py
+++ b/tests/test_mcp_resolve_incident.py
@@ -184,6 +184,7 @@ class _IncidentGraphStore:
 
 def _alert_node(*, name: str = _ALERT_ID, fired_at: datetime = _ALERT_FIRED_AT) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=name,
         kind="alert",
         source="src-alerts",
@@ -202,6 +203,7 @@ def _pr_node(
     edge_type: str = "DEPLOYED_BY",
 ) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=url,
         kind="pull_request",
         source="src-github",
@@ -214,6 +216,7 @@ def _pr_node(
 
 def _slack_node(thread: str = _SLACK_THREAD, depth: int = 2) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=thread,
         kind="slack_thread",
         source="src-slack",
@@ -230,6 +233,7 @@ def _resource_node(
     edge_type: str = "FIRES_AGAINST",
 ) -> EntityNodeView:
     return EntityNodeView(
+        id=uuid.uuid4(),
         name=name,
         kind="cross_ref_target",
         source="src-alerts",

--- a/tests/test_migration_to_hybrid.py
+++ b/tests/test_migration_to_hybrid.py
@@ -660,6 +660,7 @@ class TestVerificationReport:
 class TestDiffEntityViews:
     def test_matching_views_have_no_diff(self) -> None:
         v = EntityNodeView(
+            id=uuid.uuid4(),
             name="pkg.Thing",
             kind="class",
             source="src",
@@ -668,16 +669,16 @@ class TestDiffEntityViews:
         assert _diff_entity_views(v, v) == []
 
     def test_missing_on_neo4j_detected(self) -> None:
-        v = EntityNodeView(name="n", kind="k", source="s", chunk_text=None)
+        v = EntityNodeView(id=uuid.uuid4(), name="n", kind="k", source="s", chunk_text=None)
         assert _diff_entity_views(v, None) == ["missing_on_neo4j"]
 
     def test_missing_on_pgvector_detected(self) -> None:
-        v = EntityNodeView(name="n", kind="k", source="s", chunk_text=None)
+        v = EntityNodeView(id=uuid.uuid4(), name="n", kind="k", source="s", chunk_text=None)
         assert _diff_entity_views(None, v) == ["missing_on_pgvector"]
 
     def test_field_drift_detected(self) -> None:
-        a = EntityNodeView(name="n", kind="class", source="s", chunk_text=None)
-        b = EntityNodeView(name="n", kind="function", source="s", chunk_text=None)
+        a = EntityNodeView(id=uuid.uuid4(), name="n", kind="class", source="s", chunk_text=None)
+        b = EntityNodeView(id=uuid.uuid4(), name="n", kind="function", source="s", chunk_text=None)
         assert _diff_entity_views(a, b) == ["kind"]
 
 

--- a/tests/test_neo4j_store.py
+++ b/tests/test_neo4j_store.py
@@ -272,6 +272,7 @@ async def test_get_entity_returns_view_when_row_present() -> None:
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
                 "name": "svc.auth",
                 "kind": "service",
                 "source_id": str(source_uuid),
@@ -309,6 +310,7 @@ async def test_find_related_passes_workspace_id_and_clamps_depth() -> None:
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(uuid.uuid4()),

--- a/tests/test_neo4j_store_as_of.py
+++ b/tests/test_neo4j_store_as_of.py
@@ -237,6 +237,8 @@ async def test_find_related_default_uses_latest_template() -> None:
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
+
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(uuid.uuid4()),
@@ -264,6 +266,8 @@ async def test_find_related_as_of_routes_to_bitemporal_template() -> None:
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
+
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(uuid.uuid4()),
@@ -300,6 +304,8 @@ async def test_traverse_passes_as_of_through_to_find_related() -> None:
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
+
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(uuid.uuid4()),
@@ -364,6 +370,7 @@ async def test_get_entity_view_populates_bitemporal_triple_when_present() -> Non
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
                 "name": "svc.auth",
                 "kind": "service",
                 "source_id": str(uuid.uuid4()),
@@ -390,6 +397,7 @@ async def test_get_entity_view_legacy_row_leaves_bitemporal_fields_none() -> Non
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
                 "name": "svc.legacy",
                 "kind": "service",
                 "source_id": str(uuid.uuid4()),
@@ -429,12 +437,15 @@ async def test_find_related_legacy_3_tuple_edges_still_parse() -> None:
     driver_mock._session_mock.execute_read = AsyncMock(
         return_value=[
             {
+                "id": str(uuid.uuid4()),
+
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(src),
                 "seed_chunk_text": None,
                 "neighbours": [
                     {
+                        "id": str(uuid.uuid4()),
                         "name": "svc.db",
                         "kind": "service",
                         "source_id": str(src),


### PR DESCRIPTION
A prior refactor made `EntityNodeView.id` a **required** field but didn't update the ~36 fixtures (and one production site) that construct it, raising `TypeError: missing 'id'` and masking real assertions — ~143 failures across the incident/blast/runbook/similar and neo4j-store suites.

## Changes
- **tests (16 files, 36 sites)** — add `id=uuid.uuid4()` at every `EntityNodeView(...)` construction. `id` is never asserted on (fake stores key by `name`; `_diff_entity_views` compares only `name/kind/source`), so unique uuids are safe.
- **production — `neo4j/mappers.py`** — `_rows_to_graph_result` now sets the seed entity's `id` from `row["id"]`. The traversal cypher already returns `seed.id AS id`, but the seed was built without it → `traverse`/`get_entity` raised `TypeError` **at runtime**, not only in tests. Real bug fix.
- **`test_similar_incidents.py`** — anchor `_NOW` to `datetime.now(UTC)` instead of a hardcoded `2026-05-22`. The production `since_days` window filters against the real clock, so a fixed fixture date drifts out of narrow windows as days pass. This was the single failure the `id` fix unmasked (a time-dependent test, not a logic bug — the cutoff logic is correct).

## Decision
`EntityNodeView.id` is kept **required** (matches production reality); fixtures were brought into line rather than weakening the type.

## Validation
| Suite | Before (main) | After |
|---|---|---|
| `-k "incident or blast or runbook or similar or replay"` | 81 failed / 94 passed | **0 failed / 175 passed** |
| `test_neo4j_store.py` + `test_neo4j_store_as_of.py` (unit) | 16 failed | **0 failed / 78 passed** |
| `test_graph_rag` + `test_migration_to_hybrid` + `test_mcp_as_of` + `test_aws_connector` | 8 failed | **170 passed** |

ruff clean on all changed files. `comm`-verified: zero new failures introduced.

## Out of scope (separate pre-existing debt)
The repo still has unrelated failures beyond this drift — notably the Docker Neo4j **contract** tests fail with `AuthError: unauthorized` (container auth/env setup), and other suites carry their own pre-existing failures. Those are tracked separately and are not about `EntityNodeView`.