### PR TITLE
test(config): isolate default assertions from env leakage

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,10 +5,33 @@ from __future__ import annotations
 import pytest
 from omniscience_core.config import Settings
 
+# Environment variables that pydantic-settings would pick up and that could
+# cause these default-assertion tests to read a real deployment value instead
+# of the code default.  We clear them for every default-testing function so
+# the assertions are deterministic regardless of the shell / CI environment.
+_DEFAULT_TEST_ENV_VARS = (
+    "LOG_LEVEL",
+    "DATABASE_URL",
+    "NATS_URL",
+    "OLLAMA_URL",
+    "OTLP_ENDPOINT",
+    "APP_NAME",
+    "APP_VERSION",
+    "ENVIRONMENT",
+    "EMBEDDING_PROVIDER",
+)
 
-def test_defaults_load() -> None:
+
+@pytest.fixture()
+def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove env vars that shadow Settings defaults."""
+    for var in _DEFAULT_TEST_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_defaults_load(clean_env: None) -> None:
     """Settings can be instantiated without any environment overrides."""
-    s = Settings()
+    s = Settings(_env_file=None)
     assert s.app_name == "omniscience"
     assert s.app_version == "0.2.0"
     assert s.environment == "development"
@@ -17,22 +40,22 @@ def test_defaults_load() -> None:
     assert s.otlp_endpoint is None
 
 
-def test_default_database_url() -> None:
+def test_default_database_url(clean_env: None) -> None:
     """Default DATABASE_URL points to the local Docker Compose Postgres."""
-    s = Settings()
+    s = Settings(_env_file=None)
     assert "localhost" in s.database_url
     assert "omniscience" in s.database_url
 
 
-def test_default_nats_url() -> None:
+def test_default_nats_url(clean_env: None) -> None:
     """Default NATS_URL points to local NATS."""
-    s = Settings()
+    s = Settings(_env_file=None)
     assert s.nats_url == "nats://localhost:4222"
 
 
-def test_default_ollama_url() -> None:
+def test_default_ollama_url(clean_env: None) -> None:
     """Default OLLAMA_URL points to local Ollama."""
-    s = Settings()
+    s = Settings(_env_file=None)
     assert s.ollama_url == "http://localhost:11434"
 
 
@@ -48,12 +71,12 @@ def test_override_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Settings values are loaded from environment variables."""
     monkeypatch.setenv("LOG_LEVEL", "ERROR")
     monkeypatch.setenv("APP_NAME", "test-svc")
-    s = Settings()
+    s = Settings(_env_file=None)
     assert s.log_level == "ERROR"
     assert s.app_name == "test-svc"
 
 
-def test_otlp_endpoint_none_by_default() -> None:
+def test_otlp_endpoint_none_by_default(clean_env: None) -> None:
     """OTLP endpoint is None unless explicitly set (keeps telemetry as no-op in dev)."""
-    s = Settings()
+    s = Settings(_env_file=None)
     assert s.otlp_endpoint is None


### PR DESCRIPTION
Fixes 5 `test_config.py` failures. Root cause was **env leakage**, not stale assertions — bare `Settings()` reads `.env` + shell env, so a dev/CI `LOG_LEVEL=info` (etc.) overrode code defaults. Config defaults are all correct. Fix: `Settings(_env_file=None)` + monkeypatch-clear relevant env so default assertions are deterministic. **Test-only.** 7 passed, 0 failed.