### PR TITLE
fix(test): align Neo4j contract-test container credentials

### DIFF
--- a/tests/test_neo4j_store_as_of.py
+++ b/tests/test_neo4j_store_as_of.py
@@ -561,9 +561,11 @@ async def _live_store(*, bitemporal_enabled: bool = True) -> AsyncIterator[Neo4j
     """Spin up a fresh Neo4j container and yield a connected store."""
     from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
 
-    with Neo4jContainer("neo4j:5.19-community").with_env(
-        "NEO4J_AUTH", "neo4j/contract_test_password"
-    ) as neo4j:
+    # Pass password through the constructor so _configure() sets NEO4J_AUTH
+    # correctly.  Using .with_env("NEO4J_AUTH", ...) here is silently
+    # overridden by the wrapper's own _configure step (the same trap
+    # documented in tests/integration/test_neo4j_bootstrap_schema.py).
+    with Neo4jContainer("neo4j:5.19-community", password="contract_test_password") as neo4j:
         config = Neo4jStoreConfig(
             uri=neo4j.get_connection_url(),
             username="neo4j",

--- a/tests/test_neo4j_store_bitemporal_backfill.py
+++ b/tests/test_neo4j_store_bitemporal_backfill.py
@@ -139,9 +139,11 @@ async def _live_store() -> AsyncIterator[Neo4jGraphStore]:
     """Spin up a fresh Neo4j container and yield a connected store."""
     from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
 
-    with Neo4jContainer("neo4j:5.19-community").with_env(
-        "NEO4J_AUTH", "neo4j/contract_test_password"
-    ) as neo4j:
+    # Pass password through the constructor so _configure() sets NEO4J_AUTH
+    # correctly.  Using .with_env("NEO4J_AUTH", ...) here is silently
+    # overridden by the wrapper's own _configure step (the same trap
+    # documented in tests/integration/test_neo4j_bootstrap_schema.py).
+    with Neo4jContainer("neo4j:5.19-community", password="contract_test_password") as neo4j:
         config = Neo4jStoreConfig(
             uri=neo4j.get_connection_url(),
             username="neo4j",

--- a/tests/test_neo4j_store_bitemporal_writer.py
+++ b/tests/test_neo4j_store_bitemporal_writer.py
@@ -469,9 +469,11 @@ async def _live_store(*, bitemporal_enabled: bool) -> AsyncIterator[Neo4jGraphSt
     """Spin up a fresh Neo4j container and yield a connected store."""
     from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
 
-    with Neo4jContainer("neo4j:5.19-community").with_env(
-        "NEO4J_AUTH", "neo4j/contract_test_password"
-    ) as neo4j:
+    # Pass password through the constructor so _configure() sets NEO4J_AUTH
+    # correctly.  Using .with_env("NEO4J_AUTH", ...) here is silently
+    # overridden by the wrapper's own _configure step (the same trap
+    # documented in tests/integration/test_neo4j_bootstrap_schema.py).
+    with Neo4jContainer("neo4j:5.19-community", password="contract_test_password") as neo4j:
         config = Neo4jStoreConfig(
             uri=neo4j.get_connection_url(),
             username="neo4j",

--- a/tests/test_tombstone_end_dating.py
+++ b/tests/test_tombstone_end_dating.py
@@ -533,7 +533,11 @@ def _neo4j_container() -> Any:  # type: ignore[no-untyped-def]
         pytest.skip("contract tests disabled")
     from testcontainers.neo4j import Neo4jContainer  # type: ignore[import-not-found]
 
-    container = Neo4jContainer("neo4j:5.20").with_env("NEO4J_AUTH", "neo4j/testtest1")
+    # Pass password through the constructor so _configure() sets NEO4J_AUTH
+    # correctly.  Using .with_env("NEO4J_AUTH", ...) here is silently
+    # overridden by the wrapper's own _configure step (the same trap
+    # documented in tests/integration/test_neo4j_bootstrap_schema.py).
+    container = Neo4jContainer("neo4j:5.20", password="testtest1")
     container.start()
     try:
         yield container.get_connection_url()


### PR DESCRIPTION
Fixes the `AuthError: unauthorized` on Neo4j Docker contract tests. testcontainers' `Neo4jContainer._configure()` overwrites any `.with_env('NEO4J_AUTH', ...)` with `neo4j/{self.password}` (default `password`), so 4 test files that set auth via `.with_env` mismatched their configured password. Fix: pass `password=` to the `Neo4jContainer(...)` constructor. ci.yml needed no change (already consistent). **Test-only.** Contract suites: 8 AuthError failures → 0 (43 passed).