### PR TITLE
fix(compose): Ollama embeddings work out of the box (no --profile dev)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
         condition: service_healthy
       qdrant:
         condition: service_healthy
+      ollama-pull:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s
@@ -139,14 +141,36 @@ services:
       start_period: 5s
     restart: unless-stopped
 
+  # Embedding backend for the default `app` service (EMBEDDING_PROVIDER=ollama).
+  # Started by default — `app` waits for the model to be pulled. Air-gapped
+  # deployments use `--profile air-gapped` (app-air-gapped, local provider) and
+  # should stop this container.
   ollama:
     image: ollama/ollama:0.6.2
-    profiles:
-      - dev
+    restart: unless-stopped
     ports:
       - "127.0.0.1:11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  # One-shot: pulls the embedding model into the shared ollama volume so the
+  # stack works out of the box. Idempotent (a no-op once the volume has it).
+  # `app` depends on this completing successfully.
+  ollama-pull:
+    image: ollama/ollama:0.6.2
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    entrypoint: ["ollama", "pull", "nomic-embed-text"]
+    restart: "no"
 
   prometheus:
     image: prom/prometheus:v2.52.0


### PR DESCRIPTION
The default `app` service uses `EMBEDDING_PROVIDER=ollama`, but the `ollama` service was gated behind the `dev` profile. A plain `docker compose up` started `app` with no embedder → every search/ingest failed with `httpx.ConnectError: Name or service not known` (a 500 in the Search Playground).

## Changes
- Remove the `dev` profile from `ollama`; add `restart: unless-stopped` and an `ollama list` healthcheck (it was silently exiting).
- Add a one-shot **`ollama-pull`** service that pulls `nomic-embed-text` into the shared `ollama_data` volume — idempotent (no-op once present).
- `app` now `depends_on: ollama-pull (service_completed_successfully)`, so the embedding model is guaranteed present before the app serves traffic.

Air-gapped deployments are unaffected (they use `--profile air-gapped` → `app-air-gapped` with the in-process `local` provider).

## Verified
`docker compose up -d` (no profile) → ollama healthy, ollama-pull `Exited(0)`, app healthy; `POST /api/v1/search` → **200**.