### PR TITLE
fix(mcp): start FastMCP session manager in lifespan (HTTP transport was 500)

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -50,6 +50,7 @@ from omniscience_server.freshness_worker import FreshnessWorker
 from omniscience_server.ingestion.events import DocumentChangeEvent
 from omniscience_server.ingestion.worker import IngestionWorker
 from omniscience_server.mcp.mount import create_mcp_asgi_app
+from omniscience_server.mcp.server import mcp_server
 from omniscience_server.middleware import TelemetryMiddleware, TracingMiddleware
 from omniscience_server.rest import api_v1_router, register_error_handlers
 from omniscience_server.rest.otlp_ingester import OtlpIngester
@@ -331,7 +332,13 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.scheduler = None
         log.info("scheduler_worker_disabled")
 
-    yield
+    # --- MCP streamable-http session manager (FastMCP) ---
+    # The MCP ASGI sub-app is mounted at /mcp, so its own lifespan never runs
+    # under the parent app. We must start the session-manager task group here,
+    # otherwise every MCP request 500s with "Task group is not initialized".
+    async with mcp_server.session_manager.run():
+        log.info("mcp_session_manager_started")
+        yield
 
     # --- Shutdown ---
     log.info("shutdown", app=settings.app_name)


### PR DESCRIPTION
The MCP streamable-http endpoint was **completely non-functional** over HTTP: every request to the mounted `/mcp` app returned 500 with `RuntimeError: Task group is not initialized. Make sure to use run().`

**Cause:** FastMCP's `streamable_http_app()` creates its `StreamableHTTPSessionManager` task group inside the sub-app's *own* lifespan. When the app is `app.mount("/mcp", ...)`-ed into the parent FastAPI app, that sub-lifespan never runs, so the session manager is never started. The unit tests call the MCP tool functions directly and never exercised the HTTP transport, so this slipped through.

**Fix:** run `mcp_server.session_manager.run()` inside the parent app's `_lifespan` so the task group is live for the mounted ASGI app.

**Verified live:** `POST /mcp/mcp` initialize → **200**, `mcp-session-id` header, `serverInfo {name: omniscience}`, tools/prompts/resources capabilities. Startup logs `mcp_session_manager_started`.

Follow-up (not in this PR): the endpoint sits at `/mcp/mcp` (FastMCP's default `streamable_http_path=/mcp` under the `/mcp` mount); could be flattened to `/mcp` by setting the path — cosmetic, left as-is to avoid changing the public URL in a bug-fix PR.