### PR TITLE
fix(mcp): serve MCP at /mcp (was /mcp/mcp)

### DIFF
--- a/apps/server/src/omniscience_server/mcp/mount.py
+++ b/apps/server/src/omniscience_server/mcp/mount.py
@@ -120,6 +120,10 @@ def create_mcp_asgi_app(app: FastAPI) -> ASGIApp:
         ``/mcp`` in the parent application.
     """
     set_fastapi_app(app)
+    # Serve the transport at the sub-app root so, mounted at "/mcp" in the
+    # parent, the endpoint is "/mcp" — not the default "/mcp/mcp" (FastMCP's
+    # streamable_http_path defaults to "/mcp", which doubles under the mount).
+    mcp_server.settings.streamable_http_path = "/"
     starlette_app = mcp_server.streamable_http_app()
     return McpSessionTelemetryMiddleware(starlette_app)
 


### PR DESCRIPTION
Sets FastMCP `streamable_http_path="/"` so the mounted endpoint is the expected `/mcp` instead of the doubled `/mcp/mcp`. Verified: `POST /mcp` initialize → 200 + mcp-session-id + serverInfo; old `/mcp/mcp` → 404.