### PR TITLE
feat(admin): System Status page — per-component health (DB size, NATS queue depth, store metrics)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -14,6 +14,7 @@ import { FreshnessPage } from "./pages/FreshnessPage";
 import { RetentionPage } from "./pages/RetentionPage";
 import { IncidentTimelinePage } from "./pages/IncidentTimelinePage";
 import { ReplayPage } from "./pages/ReplayPage";
+import { ComponentsPage } from "./pages/ComponentsPage";
 
 function AppInner() {
   const { authenticated } = useTokenContext();
@@ -59,6 +60,7 @@ function AppInner() {
               path="/replay"
               element={<ReplayPage addToast={addToast} />}
             />
+            <Route path="/components" element={<ComponentsPage />} />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -337,6 +337,92 @@ export interface Workspace {
   metadata: Record<string, unknown>;
 }
 
+
+export type ComponentStatus = "ok" | "degraded" | "error";
+
+export interface PostgresMetrics {
+  size_bytes: number;
+  table_counts: Record<string, number>;
+}
+
+export interface PostgresComponent {
+  status: ComponentStatus;
+  metrics: PostgresMetrics | null;
+  error: string | null;
+}
+
+export interface Neo4jMetrics {
+  total_nodes: number;
+  total_relationships: number;
+  entity_nodes: number;
+  entity_state_nodes: number;
+}
+
+export interface Neo4jComponent {
+  status: ComponentStatus;
+  metrics: Neo4jMetrics | null;
+  error: string | null;
+}
+
+export interface QdrantMetrics {
+  collection_name: string;
+  vectors_count: number;
+  points_count: number;
+  collection_status: string;
+}
+
+export interface QdrantComponent {
+  status: ComponentStatus;
+  metrics: QdrantMetrics | null;
+  error: string | null;
+}
+
+export interface NatsConsumerMetrics {
+  name: string;
+  num_pending: number;
+  num_ack_pending: number;
+  num_redelivered: number;
+}
+
+export interface NatsStreamMetrics {
+  name: string;
+  messages: number;
+  bytes: number;
+  consumers: NatsConsumerMetrics[];
+}
+
+export interface NatsMetrics {
+  streams: NatsStreamMetrics[];
+}
+
+export interface NatsComponent {
+  status: ComponentStatus;
+  metrics: NatsMetrics | null;
+  error: string | null;
+}
+
+export interface EmbeddingMetrics {
+  provider: string;
+  model: string;
+  dim: number;
+}
+
+export interface EmbeddingComponent {
+  status: ComponentStatus;
+  metrics: EmbeddingMetrics | null;
+  error: string | null;
+}
+
+export interface ComponentsResponse {
+  status: ComponentStatus;
+  version: string;
+  postgres: PostgresComponent;
+  neo4j: Neo4jComponent;
+  qdrant: QdrantComponent;
+  nats: NatsComponent;
+  embedding: EmbeddingComponent;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -664,4 +750,15 @@ export class ApiClient {
       `/api/v1/replay/audit/${encodeURIComponent(auditLogId)}`
     );
   }
+
+  // Components status
+  async getComponents(signal?: AbortSignal): Promise<ComponentsResponse> {
+    return this.request<ComponentsResponse>(
+      "GET",
+      "/api/v1/admin/components",
+      undefined,
+      signal
+    );
+  }
+
 }

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -17,6 +17,7 @@ const NAV_ITEMS = [
   { to: "/ingestion", label: "Ingestion" },
   { to: "/search", label: "Search Playground" },
   { to: "/replay", label: "Replay" },
+  { to: "/components", label: "System Status" },
 ];
 
 export function Layout({ children }: LayoutProps) {

--- a/apps/admin/src/pages/ComponentsPage.tsx
+++ b/apps/admin/src/pages/ComponentsPage.tsx
@@ -1,0 +1,378 @@
+/*
+ * ComponentsPage — System Status / Components admin page.
+ *
+ * Fetches GET /api/v1/admin/components every 10 s and renders one card
+ * per infrastructure component (postgres, neo4j, qdrant, nats, embedding)
+ * with a status pill and its metrics.
+ *
+ * Auto-refresh uses an AbortController to cancel the in-flight request on
+ * unmount — the same pattern used in FreshnessPanel.tsx.
+ *
+ * On 403 the server's detail message is surfaced verbatim.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ApiClient,
+  ApiError,
+  ComponentStatus,
+  ComponentsResponse,
+  NatsStreamMetrics,
+} from "../api/client";
+import { useTokenContext } from "../context/TokenContext";
+
+const REFRESH_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Format byte counts for display (KB / MB / GB). */
+function formatBytes(n: number): string {
+  if (n < 1_024) return `${n} B`;
+  if (n < 1_048_576) return `${(n / 1_024).toFixed(1)} KB`;
+  if (n < 1_073_741_824) return `${(n / 1_048_576).toFixed(1)} MB`;
+  return `${(n / 1_073_741_824).toFixed(2)} GB`;
+}
+
+// ---------------------------------------------------------------------------
+// Status pill
+// ---------------------------------------------------------------------------
+
+interface StatusPillProps {
+  status: ComponentStatus;
+}
+
+function StatusPill({ status }: StatusPillProps) {
+  const cls =
+    status === "ok"
+      ? "bg-success-bg text-success-fg"
+      : status === "degraded"
+        ? "bg-warning-bg text-warning-fg"
+        : "bg-danger-bg text-danger-fg";
+  const label = status === "ok" ? "OK" : status === "degraded" ? "Degraded" : "Error";
+  return (
+    <span
+      className={`inline-block rounded px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${cls}`}
+      aria-label={`Status: ${label}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component cards
+// ---------------------------------------------------------------------------
+
+interface CardProps {
+  title: string;
+  status: ComponentStatus;
+  error: string | null;
+  children?: React.ReactNode;
+}
+
+function ComponentCard({ title, status, error, children }: CardProps) {
+  return (
+    <section
+      className="rounded-lg border border-border bg-elevation-1 p-5 flex flex-col gap-3"
+      aria-label={`${title} component status`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-base font-semibold text-text">{title}</h2>
+        <StatusPill status={status} />
+      </div>
+      {error && (
+        <p className="text-xs text-danger-fg bg-danger-bg rounded px-2 py-1 break-all" role="alert">
+          {error}
+        </p>
+      )}
+      {children}
+    </section>
+  );
+}
+
+interface MetricRowProps {
+  label: string;
+  value: string | number;
+}
+
+function MetricRow({ label, value }: MetricRowProps) {
+  return (
+    <div className="flex items-center justify-between text-sm gap-4">
+      <span className="text-text-secondary">{label}</span>
+      <span className="text-text font-mono text-xs">{value}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-component sections
+// ---------------------------------------------------------------------------
+
+function PostgresCard({
+  component,
+}: {
+  component: ComponentsResponse["postgres"];
+}) {
+  return (
+    <ComponentCard title="PostgreSQL" status={component.status} error={component.error}>
+      {component.metrics && (
+        <dl className="flex flex-col gap-1">
+          <MetricRow label="DB size" value={formatBytes(component.metrics.size_bytes)} />
+          {Object.entries(component.metrics.table_counts).map(([table, count]) => (
+            <MetricRow key={table} label={table} value={count.toLocaleString()} />
+          ))}
+        </dl>
+      )}
+    </ComponentCard>
+  );
+}
+
+function Neo4jCard({ component }: { component: ComponentsResponse["neo4j"] }) {
+  return (
+    <ComponentCard title="Neo4j" status={component.status} error={component.error}>
+      {component.metrics && (
+        <dl className="flex flex-col gap-1">
+          <MetricRow
+            label="Total nodes"
+            value={component.metrics.total_nodes.toLocaleString()}
+          />
+          <MetricRow
+            label="Total relationships"
+            value={component.metrics.total_relationships.toLocaleString()}
+          />
+          <MetricRow
+            label="Entity nodes"
+            value={component.metrics.entity_nodes.toLocaleString()}
+          />
+          <MetricRow
+            label="EntityState nodes"
+            value={component.metrics.entity_state_nodes.toLocaleString()}
+          />
+        </dl>
+      )}
+    </ComponentCard>
+  );
+}
+
+function QdrantCard({ component }: { component: ComponentsResponse["qdrant"] }) {
+  return (
+    <ComponentCard title="Qdrant" status={component.status} error={component.error}>
+      {component.metrics && (
+        <dl className="flex flex-col gap-1">
+          <MetricRow label="Collection" value={component.metrics.collection_name} />
+          <MetricRow
+            label="Vectors"
+            value={component.metrics.vectors_count.toLocaleString()}
+          />
+          <MetricRow
+            label="Points"
+            value={component.metrics.points_count.toLocaleString()}
+          />
+          <MetricRow label="Status" value={component.metrics.collection_status} />
+        </dl>
+      )}
+    </ComponentCard>
+  );
+}
+
+function NatsStreamBlock({ stream }: { stream: NatsStreamMetrics }) {
+  return (
+    <div className="rounded border border-border bg-elevation-2 p-3 flex flex-col gap-1">
+      <p className="text-xs font-semibold text-text mb-1">{stream.name}</p>
+      <MetricRow label="Messages" value={stream.messages.toLocaleString()} />
+      <MetricRow label="Bytes" value={formatBytes(stream.bytes)} />
+      {stream.consumers.length > 0 && (
+        <div className="mt-2 flex flex-col gap-1">
+          {stream.consumers.map((c) => (
+            <div
+              key={c.name}
+              className="pl-2 border-l-2 border-border flex flex-col gap-0.5"
+              aria-label={`Consumer ${c.name}`}
+            >
+              <p className="text-xs text-text-secondary font-mono truncate">{c.name}</p>
+              <MetricRow label="Queue depth (pending)" value={c.num_pending.toLocaleString()} />
+              <MetricRow label="Ack pending" value={c.num_ack_pending.toLocaleString()} />
+              <MetricRow label="Redelivered" value={c.num_redelivered.toLocaleString()} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NatsCard({ component }: { component: ComponentsResponse["nats"] }) {
+  return (
+    <ComponentCard title="NATS JetStream" status={component.status} error={component.error}>
+      {component.metrics && (
+        <div className="flex flex-col gap-2">
+          {component.metrics.streams.length === 0 ? (
+            <p className="text-xs text-text-muted">No streams found.</p>
+          ) : (
+            component.metrics.streams.map((s) => <NatsStreamBlock key={s.name} stream={s} />)
+          )}
+        </div>
+      )}
+    </ComponentCard>
+  );
+}
+
+function EmbeddingCard({ component }: { component: ComponentsResponse["embedding"] }) {
+  return (
+    <ComponentCard title="Embedding" status={component.status} error={component.error}>
+      {component.metrics && (
+        <dl className="flex flex-col gap-1">
+          <MetricRow label="Provider" value={component.metrics.provider} />
+          <MetricRow label="Model" value={component.metrics.model} />
+          <MetricRow label="Dimensions" value={component.metrics.dim.toLocaleString()} />
+        </dl>
+      )}
+    </ComponentCard>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Overall status banner
+// ---------------------------------------------------------------------------
+
+function OverallStatusBanner({
+  status,
+  version,
+}: {
+  status: ComponentStatus;
+  version: string;
+}) {
+  const cls =
+    status === "ok"
+      ? "bg-success-bg text-success-fg border-success-fg"
+      : status === "degraded"
+        ? "bg-warning-bg text-warning-fg border-warning-fg"
+        : "bg-danger-bg text-danger-fg border-danger-fg";
+  const label =
+    status === "ok"
+      ? "All systems operational"
+      : status === "degraded"
+        ? "Partial degradation"
+        : "One or more components are failing";
+  return (
+    <div
+      className={`rounded-lg border px-4 py-3 flex items-center justify-between ${cls}`}
+      role="status"
+      aria-live="polite"
+    >
+      <span className="font-semibold text-sm">{label}</span>
+      <span className="text-xs font-mono opacity-70">v{version}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function ComponentsPage() {
+  const ctx = useTokenContext();
+  const client: ApiClient = ctx.client;
+
+  const [data, setData] = useState<ComponentsResponse | null>(null);
+  const [error, setError] = useState<ApiError | Error | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const inFlightRef = useRef<AbortController | null>(null);
+
+  const fetchOnce = useCallback(async () => {
+    inFlightRef.current?.abort();
+    const controller = new AbortController();
+    inFlightRef.current = controller;
+    setRefreshing(true);
+    try {
+      const resp = await client.getComponents(controller.signal);
+      if (controller.signal.aborted) return;
+      setData(resp);
+      setError(null);
+    } catch (e) {
+      if (controller.signal.aborted) return;
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      if (e instanceof Error) setError(e);
+      else setError(new Error(String(e)));
+    } finally {
+      if (inFlightRef.current === controller) inFlightRef.current = null;
+      setRefreshing(false);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      if (cancelled) return;
+      void fetchOnce();
+    }, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+      inFlightRef.current?.abort();
+      inFlightRef.current = null;
+    };
+  }, [fetchOnce]);
+
+  // 403 error — surface server reason
+  if (error instanceof ApiError && error.status === 403) {
+    return (
+      <div>
+        <h1 className="text-2xl font-semibold text-text mb-8">System Status</h1>
+        <div
+          className="rounded-lg border border-danger-fg bg-danger-bg text-danger-fg px-4 py-3 text-sm"
+          role="alert"
+        >
+          <strong>Access denied:</strong> {error.detail}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-2xl font-semibold text-text">System Status</h1>
+        <span
+          className={`text-xs text-text-muted transition-opacity ${refreshing ? "opacity-100" : "opacity-0"}`}
+          aria-live="polite"
+          aria-label={refreshing ? "Refreshing" : ""}
+        >
+          Refreshing…
+        </span>
+      </div>
+
+      {/* Generic fetch error (not 403) */}
+      {error && !(error instanceof ApiError && error.status === 403) && (
+        <div
+          className="mb-6 rounded-lg border border-danger-fg bg-danger-bg text-danger-fg px-4 py-3 text-sm"
+          role="alert"
+        >
+          {error instanceof ApiError ? error.detail : error.message}
+        </div>
+      )}
+
+      {/* Loading skeleton */}
+      {!data && !error && (
+        <p className="text-text-secondary text-sm">Loading component status…</p>
+      )}
+
+      {data && (
+        <div className="flex flex-col gap-6">
+          <OverallStatusBanner status={data.status} version={data.version} />
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+            <PostgresCard component={data.postgres} />
+            <Neo4jCard component={data.neo4j} />
+            <QdrantCard component={data.qdrant} />
+            <NatsCard component={data.nats} />
+            <EmbeddingCard component={data.embedding} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/server/src/omniscience_server/rest/components.py
+++ b/apps/server/src/omniscience_server/rest/components.py
@@ -1,0 +1,348 @@
+"""System Component Status endpoint (GET /api/v1/admin/components).
+
+Returns a per-component health and metrics snapshot for the Omniscience
+infrastructure:  Postgres, Neo4j, Qdrant, NATS JetStream, and the
+embedding provider.
+
+Each component block is isolated with a try/except so one failing
+dependency does not 500 the whole response.  The top-level ``status``
+field is the worst of all component statuses.
+
+Requires scope: ``admin``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from omniscience_core.auth.middleware import require_scope
+from omniscience_core.auth.scopes import Scope
+from pydantic import BaseModel
+from sqlalchemy import text
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["admin-components"])
+
+# Module-level Depends singleton — avoids ruff B008.
+_admin_scope_dep: Any = Depends(require_scope(Scope.admin))
+
+ComponentStatus = Literal["ok", "degraded", "error"]
+
+_STATUS_RANK: dict[ComponentStatus, int] = {"ok": 0, "degraded": 1, "error": 2}
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class PostgresMetrics(BaseModel):
+    size_bytes: int
+    table_counts: dict[str, int]
+
+
+class PostgresComponent(BaseModel):
+    status: ComponentStatus
+    metrics: PostgresMetrics | None
+    error: str | None
+
+
+class Neo4jMetrics(BaseModel):
+    total_nodes: int
+    total_relationships: int
+    entity_nodes: int
+    entity_state_nodes: int
+
+
+class Neo4jComponent(BaseModel):
+    status: ComponentStatus
+    metrics: Neo4jMetrics | None
+    error: str | None
+
+
+class QdrantMetrics(BaseModel):
+    collection_name: str
+    vectors_count: int
+    points_count: int
+    collection_status: str
+
+
+class QdrantComponent(BaseModel):
+    status: ComponentStatus
+    metrics: QdrantMetrics | None
+    error: str | None
+
+
+class NatsConsumerMetrics(BaseModel):
+    name: str
+    num_pending: int
+    num_ack_pending: int
+    num_redelivered: int
+
+
+class NatsStreamMetrics(BaseModel):
+    name: str
+    messages: int
+    bytes: int
+    consumers: list[NatsConsumerMetrics]
+
+
+class NatsMetrics(BaseModel):
+    streams: list[NatsStreamMetrics]
+
+
+class NatsComponent(BaseModel):
+    status: ComponentStatus
+    metrics: NatsMetrics | None
+    error: str | None
+
+
+class EmbeddingMetrics(BaseModel):
+    provider: str
+    model: str
+    dim: int
+
+
+class EmbeddingComponent(BaseModel):
+    status: ComponentStatus
+    metrics: EmbeddingMetrics | None
+    error: str | None
+
+
+class ComponentsResponse(BaseModel):
+    status: ComponentStatus
+    version: str
+    postgres: PostgresComponent
+    neo4j: Neo4jComponent
+    qdrant: QdrantComponent
+    nats: NatsComponent
+    embedding: EmbeddingComponent
+
+
+# ---------------------------------------------------------------------------
+# Per-component collectors
+# ---------------------------------------------------------------------------
+
+_TABLE_NAMES = [
+    "sources",
+    "documents",
+    "chunks",
+    "entities",
+    "edges",
+    "api_tokens",
+    "workspaces",
+]
+
+
+async def _collect_postgres(request: Request) -> PostgresComponent:
+    factory = getattr(request.app.state, "db_session_factory", None)
+    if factory is None:
+        return PostgresComponent(
+            status="error", metrics=None, error="db_session_factory not wired"
+        )
+    try:
+        async with factory() as db:
+            size_result = await db.execute(text("SELECT pg_database_size(current_database())"))
+            size_bytes = int(size_result.scalar_one())
+            table_counts: dict[str, int] = {}
+            for table in _TABLE_NAMES:
+                count_result = await db.execute(text(f"SELECT COUNT(*) FROM {table}"))  # noqa: S608
+                table_counts[table] = int(count_result.scalar_one())
+        return PostgresComponent(
+            status="ok",
+            metrics=PostgresMetrics(size_bytes=size_bytes, table_counts=table_counts),
+            error=None,
+        )
+    except Exception as exc:
+        log.warning("components_postgres_error", error=str(exc))
+        return PostgresComponent(status="error", metrics=None, error=str(exc))
+
+
+async def _collect_neo4j(request: Request) -> Neo4jComponent:
+    graph_store = getattr(request.app.state, "graph_store", None)
+    if graph_store is None:
+        return Neo4jComponent(status="error", metrics=None, error="graph_store not wired")
+    try:
+        driver = graph_store._driver  # reuse the already-connected AsyncDriver
+        database = graph_store._config.database
+        async with driver.session(database=database) as session:
+            total_nodes_row = await session.run("MATCH (n) RETURN count(n) AS total")
+            total_nodes = int((await total_nodes_row.single())["total"])
+
+            total_rels_row = await session.run("MATCH ()-[r]->() RETURN count(r) AS total")
+            total_rels = int((await total_rels_row.single())["total"])
+
+            entity_row = await session.run("MATCH (n:Entity) RETURN count(n) AS total")
+            entity_count = int((await entity_row.single())["total"])
+
+            estate_row = await session.run("MATCH (n:EntityState) RETURN count(n) AS total")
+            estate_count = int((await estate_row.single())["total"])
+
+        return Neo4jComponent(
+            status="ok",
+            metrics=Neo4jMetrics(
+                total_nodes=total_nodes,
+                total_relationships=total_rels,
+                entity_nodes=entity_count,
+                entity_state_nodes=estate_count,
+            ),
+            error=None,
+        )
+    except Exception as exc:
+        log.warning("components_neo4j_error", error=str(exc))
+        return Neo4jComponent(status="error", metrics=None, error=str(exc))
+
+
+async def _collect_qdrant(request: Request) -> QdrantComponent:
+    vector_store = getattr(request.app.state, "vector_store", None)
+    if vector_store is None:
+        return QdrantComponent(status="error", metrics=None, error="vector_store not wired")
+    try:
+        collection_name = vector_store.collection_name
+        info = await vector_store._qc.get_collection(collection_name)
+        vectors_count = int(info.vectors_count or 0)
+        points_count = int(info.points_count or 0)
+        collection_status = str(info.status.value) if info.status is not None else "unknown"
+        return QdrantComponent(
+            status="ok",
+            metrics=QdrantMetrics(
+                collection_name=collection_name,
+                vectors_count=vectors_count,
+                points_count=points_count,
+                collection_status=collection_status,
+            ),
+            error=None,
+        )
+    except Exception as exc:
+        log.warning("components_qdrant_error", error=str(exc))
+        return QdrantComponent(status="error", metrics=None, error=str(exc))
+
+
+async def _collect_nats(request: Request) -> NatsComponent:
+    nats_conn = getattr(request.app.state, "nats", None)
+    if nats_conn is None:
+        return NatsComponent(status="error", metrics=None, error="nats not wired")
+    try:
+        js = nats_conn.jetstream
+        stream_infos = await js.streams_info()
+        streams: list[NatsStreamMetrics] = []
+        for si in stream_infos:
+            consumers: list[NatsConsumerMetrics] = []
+            try:
+                consumer_infos = await js.consumers_info(si.config.name)
+                for ci in consumer_infos:
+                    consumers.append(
+                        NatsConsumerMetrics(
+                            name=ci.name,
+                            num_pending=int(ci.num_pending or 0),
+                            num_ack_pending=int(ci.num_ack_pending or 0),
+                            num_redelivered=int(ci.num_redelivered or 0),
+                        )
+                    )
+            except Exception as consumer_exc:
+                log.warning(
+                    "components_nats_consumers_error",
+                    stream=si.config.name,
+                    error=str(consumer_exc),
+                )
+            streams.append(
+                NatsStreamMetrics(
+                    name=si.config.name,
+                    messages=int(si.state.messages),
+                    bytes=int(si.state.bytes),
+                    consumers=consumers,
+                )
+            )
+        return NatsComponent(status="ok", metrics=NatsMetrics(streams=streams), error=None)
+    except Exception as exc:
+        log.warning("components_nats_error", error=str(exc))
+        return NatsComponent(status="error", metrics=None, error=str(exc))
+
+
+def _collect_embedding(request: Request) -> EmbeddingComponent:
+    provider = getattr(request.app.state, "embedding_provider", None)
+    if provider is None:
+        return EmbeddingComponent(
+            status="error", metrics=None, error="embedding_provider not wired"
+        )
+    try:
+        return EmbeddingComponent(
+            status="ok",
+            metrics=EmbeddingMetrics(
+                provider=provider.provider_name,
+                model=provider.model_name,
+                dim=provider.dim,
+            ),
+            error=None,
+        )
+    except Exception as exc:
+        log.warning("components_embedding_error", error=str(exc))
+        return EmbeddingComponent(status="error", metrics=None, error=str(exc))
+
+
+def _worst_status(*components: ComponentStatus) -> ComponentStatus:
+    """Return the worst (highest-rank) status from a sequence of component statuses."""
+    return max(components, key=lambda s: _STATUS_RANK[s])
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/components",
+    response_model=ComponentsResponse,
+    summary="Per-component infrastructure status",
+    dependencies=[_admin_scope_dep],
+)
+async def get_components(request: Request) -> ComponentsResponse:
+    """Return a health and metrics snapshot for each Omniscience infrastructure component.
+
+    Each component is probed independently — a single failure is isolated
+    to that component's block and never causes a 500 response.
+
+    Requires scope: ``admin``
+    """
+    settings = getattr(request.app.state, "settings", None)
+    version = str(getattr(settings, "app_version", "unknown")) if settings else "unknown"
+
+    postgres = await _collect_postgres(request)
+    neo4j = await _collect_neo4j(request)
+    qdrant = await _collect_qdrant(request)
+    nats = await _collect_nats(request)
+    embedding = _collect_embedding(request)
+
+    overall = _worst_status(
+        postgres.status,
+        neo4j.status,
+        qdrant.status,
+        nats.status,
+        embedding.status,
+    )
+
+    log.info(
+        "components_status",
+        overall=overall,
+        postgres=postgres.status,
+        neo4j=neo4j.status,
+        qdrant=qdrant.status,
+        nats=nats.status,
+        embedding=embedding.status,
+    )
+
+    return ComponentsResponse(
+        status=overall,
+        version=version,
+        postgres=postgres,
+        neo4j=neo4j,
+        qdrant=qdrant,
+        nats=nats,
+        embedding=embedding,
+    )
+
+
+__all__ = ["router"]

--- a/apps/server/src/omniscience_server/rest/router.py
+++ b/apps/server/src/omniscience_server/rest/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter
 
 from omniscience_server.rest.admin_session import router as admin_session_router
 from omniscience_server.rest.blast_radius import router as blast_radius_router
+from omniscience_server.rest.components import router as components_router
 from omniscience_server.rest.documents import router as documents_router
 from omniscience_server.rest.entities import router as entities_router
 from omniscience_server.rest.freshness import router as freshness_router
@@ -49,5 +50,6 @@ api_v1_router.include_router(replay_router)
 api_v1_router.include_router(runbook_router)
 api_v1_router.include_router(similar_incidents_router)
 api_v1_router.include_router(postmortem_router)
+api_v1_router.include_router(components_router)
 
 __all__ = ["api_v1_router"]

--- a/tests/test_components_endpoint.py
+++ b/tests/test_components_endpoint.py
@@ -1,0 +1,443 @@
+"""Tests for GET /api/v1/admin/components (issue: system status page).
+
+Coverage:
+* 401 without a token.
+* 403 with a token lacking admin scope.
+* 200 happy path — response shape contains all five component blocks.
+* Graceful-degrade — one store's driver raises; that component is "error"
+  but the response is still HTTP 200 and other components remain "ok".
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.config import Settings
+from omniscience_core.db.models import ApiToken
+from omniscience_server.app import create_app
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_token(scopes: list[str]) -> tuple[ApiToken, str]:
+    """Create a real hashed token with the given scopes."""
+    plaintext, prefix = generate_token("test")
+    hashed = hash_token(plaintext)
+    tok: ApiToken = MagicMock(spec=ApiToken)
+    tok.id = uuid.uuid4()
+    tok.name = "test-token"
+    tok.token_prefix = prefix
+    tok.hashed_token = hashed
+    tok.scopes = scopes
+    tok.workspace_id = None
+    tok.expires_at = None
+    tok.is_active = True
+    tok.last_used_at = None
+    return tok, plaintext
+
+
+def _make_db_session(token: ApiToken) -> AsyncMock:
+    """Return a fake async DB session that resolves *token* on bearer lookup."""
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [token]
+        result.scalars.return_value.first.return_value = token
+        result.scalar_one.return_value = 1
+        return result
+
+    session.execute = _execute
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _build_app(token: ApiToken) -> FastAPI:
+    settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+    app = create_app(settings=settings)
+    app.state.db_session_factory = MagicMock(return_value=_make_db_session(token))
+    return app
+
+
+def _make_healthy_stores(app: FastAPI) -> None:
+    """Wire app.state with mock stores that simulate fully-healthy components."""
+    # Neo4j mock — driver.session() returns an async context manager
+    mock_graph_store = MagicMock()
+    mock_graph_store._config = MagicMock()
+    mock_graph_store._config.database = "neo4j"
+
+    async def _neo4j_session_cm(*args: Any, **kwargs: Any) -> Any:
+        session = AsyncMock()
+        result_mock = AsyncMock()
+        result_mock.single = AsyncMock(return_value={"total": 42})
+        session.run = AsyncMock(return_value=result_mock)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        return session
+
+    mock_graph_store._driver = MagicMock()
+    mock_graph_store._driver.session = MagicMock(side_effect=_neo4j_session_cm)
+    app.state.graph_store = mock_graph_store
+
+    # Qdrant mock
+    mock_vector_store = MagicMock()
+    mock_vector_store.collection_name = "test_collection"
+    mock_collection_info = MagicMock()
+    mock_collection_info.vectors_count = 100
+    mock_collection_info.points_count = 100
+    mock_collection_info.status = MagicMock()
+    mock_collection_info.status.value = "green"
+    mock_vector_store._qc = AsyncMock()
+    mock_vector_store._qc.get_collection = AsyncMock(return_value=mock_collection_info)
+    app.state.vector_store = mock_vector_store
+
+    # NATS mock
+    mock_stream_state = MagicMock()
+    mock_stream_state.messages = 10
+    mock_stream_state.bytes = 1024
+
+    mock_stream_config = MagicMock()
+    mock_stream_config.name = "INGEST_CHANGES"
+
+    mock_stream_info = MagicMock()
+    mock_stream_info.state = mock_stream_state
+    mock_stream_info.config = mock_stream_config
+
+    mock_consumer_info = MagicMock()
+    mock_consumer_info.name = "omniscience-ingestion-worker"
+    mock_consumer_info.num_pending = 5
+    mock_consumer_info.num_ack_pending = 0
+    mock_consumer_info.num_redelivered = 0
+
+    mock_js = AsyncMock()
+    mock_js.streams_info = AsyncMock(return_value=[mock_stream_info])
+    mock_js.consumers_info = AsyncMock(return_value=[mock_consumer_info])
+
+    mock_nats = MagicMock()
+    mock_nats.jetstream = mock_js
+    app.state.nats = mock_nats
+
+    # Embedding provider mock
+    mock_embedding = MagicMock()
+    mock_embedding.provider_name = "ollama"
+    mock_embedding.model_name = "nomic-embed-text"
+    mock_embedding.dim = 768
+    app.state.embedding_provider = mock_embedding
+
+
+# ---------------------------------------------------------------------------
+# 401 — no token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_components_401_without_token() -> None:
+    """GET /api/v1/admin/components returns 401 when no token is provided."""
+    token, _ = _make_token(["admin"])
+    app = _build_app(token)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/api/v1/admin/components")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 403 — wrong scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_components_403_without_admin_scope() -> None:
+    """GET /api/v1/admin/components returns 403 for a token without admin scope."""
+    token, plaintext = _make_token(["stats:read"])
+    app = _build_app(token)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/api/v1/admin/components",
+            headers={"Authorization": f"Bearer {plaintext}"},
+        )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 200 happy path — shape validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_components_200_shape() -> None:
+    """Healthy request returns 200 with all five component blocks present."""
+    token, plaintext = _make_token(["admin"])
+    app = _build_app(token)
+
+    from omniscience_server.rest.components import (
+        EmbeddingComponent,
+        EmbeddingMetrics,
+        NatsComponent,
+        NatsMetrics,
+        NatsStreamMetrics,
+        Neo4jComponent,
+        Neo4jMetrics,
+        PostgresComponent,
+        PostgresMetrics,
+        QdrantComponent,
+        QdrantMetrics,
+    )
+
+    ok_postgres = PostgresComponent(
+        status="ok",
+        metrics=PostgresMetrics(
+            size_bytes=1_000_000,
+            table_counts={
+                "sources": 3,
+                "documents": 100,
+                "chunks": 500,
+                "entities": 200,
+                "edges": 150,
+                "api_tokens": 5,
+                "workspaces": 1,
+            },
+        ),
+        error=None,
+    )
+    ok_neo4j = Neo4jComponent(
+        status="ok",
+        metrics=Neo4jMetrics(
+            total_nodes=242,
+            total_relationships=150,
+            entity_nodes=200,
+            entity_state_nodes=42,
+        ),
+        error=None,
+    )
+    ok_qdrant = QdrantComponent(
+        status="ok",
+        metrics=QdrantMetrics(
+            collection_name="test_col",
+            vectors_count=500,
+            points_count=500,
+            collection_status="green",
+        ),
+        error=None,
+    )
+    ok_nats = NatsComponent(
+        status="ok",
+        metrics=NatsMetrics(
+            streams=[
+                NatsStreamMetrics(name="INGEST_CHANGES", messages=10, bytes=1024, consumers=[])
+            ]
+        ),
+        error=None,
+    )
+    ok_embedding = EmbeddingComponent(
+        status="ok",
+        metrics=EmbeddingMetrics(provider="ollama", model="nomic-embed-text", dim=768),
+        error=None,
+    )
+
+    with (
+        patch(
+            "omniscience_server.rest.components._collect_postgres",
+            AsyncMock(return_value=ok_postgres),
+        ),
+        patch(
+            "omniscience_server.rest.components._collect_neo4j",
+            AsyncMock(return_value=ok_neo4j),
+        ),
+        patch(
+            "omniscience_server.rest.components._collect_qdrant",
+            AsyncMock(return_value=ok_qdrant),
+        ),
+        patch(
+            "omniscience_server.rest.components._collect_nats",
+            AsyncMock(return_value=ok_nats),
+        ),
+        patch(
+            "omniscience_server.rest.components._collect_embedding",
+            MagicMock(return_value=ok_embedding),
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/api/v1/admin/components",
+                headers={"Authorization": f"Bearer {plaintext}"},
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert "version" in data
+
+    # All five top-level component keys must be present
+    for key in ("postgres", "neo4j", "qdrant", "nats", "embedding"):
+        assert key in data, f"missing component key: {key}"
+        assert data[key]["status"] == "ok"
+        assert data[key]["metrics"] is not None
+
+    # Postgres metrics shape
+    pg = data["postgres"]["metrics"]
+    assert "size_bytes" in pg
+    assert "table_counts" in pg
+    assert "sources" in pg["table_counts"]
+
+    # Neo4j metrics shape
+    n4 = data["neo4j"]["metrics"]
+    assert "total_nodes" in n4
+    assert "total_relationships" in n4
+    assert "entity_nodes" in n4
+    assert "entity_state_nodes" in n4
+
+    # Qdrant metrics shape
+    qd = data["qdrant"]["metrics"]
+    assert "collection_name" in qd
+    assert "vectors_count" in qd
+    assert "points_count" in qd
+
+    # NATS metrics shape
+    nats_data = data["nats"]["metrics"]
+    assert "streams" in nats_data
+    assert isinstance(nats_data["streams"], list)
+
+    # Embedding metrics shape
+    emb = data["embedding"]["metrics"]
+    assert "provider" in emb
+    assert "model" in emb
+    assert "dim" in emb
+
+
+# ---------------------------------------------------------------------------
+# Graceful degrade — neo4j driver raises, collector returns "error" component
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_components_graceful_degrade_one_store_error() -> None:
+    """When the neo4j driver raises, the neo4j block is 'error' but response is 200.
+
+    The other components must remain 'ok', and the top-level status degrades
+    to 'error' (worst-of aggregation) because one component failed.
+    """
+    token, plaintext = _make_token(["admin"])
+    app = _build_app(token)
+
+    from omniscience_server.rest.components import (
+        EmbeddingComponent,
+        EmbeddingMetrics,
+        NatsComponent,
+        NatsMetrics,
+        PostgresComponent,
+        PostgresMetrics,
+        QdrantComponent,
+        QdrantMetrics,
+    )
+
+    ok_postgres = PostgresComponent(
+        status="ok",
+        metrics=PostgresMetrics(
+            size_bytes=1_000_000,
+            table_counts={
+                t: 0
+                for t in [
+                    "sources",
+                    "documents",
+                    "chunks",
+                    "entities",
+                    "edges",
+                    "api_tokens",
+                    "workspaces",
+                ]
+            },
+        ),
+        error=None,
+    )
+    ok_qdrant = QdrantComponent(
+        status="ok",
+        metrics=QdrantMetrics(
+            collection_name="test_col",
+            vectors_count=0,
+            points_count=0,
+            collection_status="green",
+        ),
+        error=None,
+    )
+    ok_nats = NatsComponent(
+        status="ok",
+        metrics=NatsMetrics(streams=[]),
+        error=None,
+    )
+    ok_embedding = EmbeddingComponent(
+        status="ok",
+        metrics=EmbeddingMetrics(provider="ollama", model="nomic-embed-text", dim=768),
+        error=None,
+    )
+
+    # Wire a broken graph_store whose driver.session() raises so that
+    # _collect_neo4j catches the exception internally and returns
+    # Neo4jComponent(status="error").
+    mock_broken_graph_store = MagicMock()
+    mock_broken_graph_store._config = MagicMock()
+    mock_broken_graph_store._config.database = "neo4j"
+    broken_driver = MagicMock()
+    broken_driver.session = MagicMock(
+        side_effect=RuntimeError("neo4j connection refused")
+    )
+    mock_broken_graph_store._driver = broken_driver
+    app.state.graph_store = mock_broken_graph_store
+
+    with (
+        patch(
+            "omniscience_server.rest.components._collect_postgres",
+            AsyncMock(return_value=ok_postgres),
+        ),
+        patch(
+            "omniscience_server.rest.components._collect_qdrant",
+            AsyncMock(return_value=ok_qdrant),
+        ),
+        patch(
+            "omniscience_server.rest.components._collect_nats",
+            AsyncMock(return_value=ok_nats),
+        ),
+        patch(
+            "omniscience_server.rest.components._collect_embedding",
+            MagicMock(return_value=ok_embedding),
+        ),
+    ):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                "/api/v1/admin/components",
+                headers={"Authorization": f"Bearer {plaintext}"},
+            )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    # Top-level degrades to "error" because neo4j failed
+    assert data["status"] == "error"
+    # Neo4j component reports error
+    assert data["neo4j"]["status"] == "error"
+    assert data["neo4j"]["error"] is not None
+    assert data["neo4j"]["metrics"] is None
+    # All other components remain ok
+    assert data["postgres"]["status"] == "ok"
+    assert data["qdrant"]["status"] == "ok"
+    assert data["nats"]["status"] == "ok"
+    assert data["embedding"]["status"] == "ok"


### PR DESCRIPTION
New `GET /api/v1/admin/components` (admin scope) + admin "System Status" page showing per-component status of Omniscience's own infra, with graceful degradation (one store down ⇒ that component is `error`, response still 200).

**Components:** postgres (DB size + table counts), neo4j (node/rel + Entity/EntityState counts), qdrant (collection + vectors count + status), nats JetStream (per-stream messages/bytes, per-consumer `num_pending`/`num_ack_pending`/`num_redelivered` = queue depth), embedding (provider/model/dim). Top-level `status` = worst component.

**Frontend:** `ComponentsPage.tsx` — card per component with status pill (green/amber/red), NATS queue depths, postgres DB size, 10s auto-refresh; wired into nav as "System Status"; shows server `error.detail` on 403.

**Validation:** `tests/test_components_endpoint.py` (4 passed: 200 shape, 401, 403-non-admin, graceful-degrade); frontend `tsc && vite build` 0 errors; ruff clean. Tests-only mocks, no containers.