### PR TITLE
fix(components): qdrant collector uses points_count (real CollectionInfo has no vectors_count)

### DIFF
--- a/apps/server/src/omniscience_server/rest/components.py
+++ b/apps/server/src/omniscience_server/rest/components.py
@@ -203,8 +203,10 @@ async def _collect_qdrant(request: Request) -> QdrantComponent:
     try:
         collection_name = vector_store.collection_name
         info = await vector_store._qc.get_collection(collection_name)
-        vectors_count = int(info.vectors_count or 0)
+        # qdrant-client CollectionInfo exposes points_count + indexed_vectors_count
+        # (there is no `vectors_count`); points_count is the stored-vector total.
         points_count = int(info.points_count or 0)
+        vectors_count = int(getattr(info, "indexed_vectors_count", None) or points_count)
         collection_status = str(info.status.value) if info.status is not None else "unknown"
         return QdrantComponent(
             status="ok",


### PR DESCRIPTION
The System Status endpoint's qdrant collector used `info.vectors_count`, which doesn't exist on qdrant-client's `CollectionInfo` (only `points_count` + `indexed_vectors_count`). Against a real Qdrant it raised AttributeError → qdrant component "error" → overall "error". Fixed to use `points_count`. Verified live: qdrant → ok (84 points, green); overall → ok.

Note (separate pre-existing bug surfaced by this very page): NATS JetStream has **0 streams** — `ensure_streams` is not creating INGEST_CHANGES/INGEST_DLQ, so the scheduler logs `nats: no response from stream` and NATS-driven ingestion is broken. The nats collector correctly reports the empty state; root-causing is tracked separately.