### PR TITLE
fix(nats): JetStream streams never created (max_age units + swallowed error)

### DIFF
--- a/packages/core/src/omniscience_core/queue/streams.py
+++ b/packages/core/src/omniscience_core/queue/streams.py
@@ -18,7 +18,14 @@ log = structlog.get_logger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-_SEVEN_DAYS_NS: int = 7 * 24 * 60 * 60 * 10**9  # nanoseconds
+# nats-py's StreamConfig.max_age is expressed in SECONDS — as_dict() converts it
+# to nanoseconds for the server. Passing nanoseconds here double-converts to a
+# 24-digit value that the server rejects with err_code 10025 "invalid JSON".
+_SEVEN_DAYS_SECONDS: float = 7 * 24 * 60 * 60
+
+# JetStream API error code for "stream name already in use" — the only
+# BadRequestError we treat as benign on re-create.
+_STREAM_ALREADY_EXISTS_CODE = 10058
 
 INGEST_CHANGES_STREAM = "INGEST_CHANGES"
 INGEST_DLQ_STREAM = "INGEST_DLQ"
@@ -28,7 +35,7 @@ _STREAM_CONFIGS: list[nats.js.api.StreamConfig] = [
         name=INGEST_CHANGES_STREAM,
         subjects=["ingest.changes.*"],
         retention=nats.js.api.RetentionPolicy.LIMITS,
-        max_age=_SEVEN_DAYS_NS,
+        max_age=_SEVEN_DAYS_SECONDS,
         storage=nats.js.api.StorageType.FILE,
         num_replicas=1,
     ),
@@ -36,7 +43,7 @@ _STREAM_CONFIGS: list[nats.js.api.StreamConfig] = [
         name=INGEST_DLQ_STREAM,
         subjects=["ingest.dlq.*"],
         retention=nats.js.api.RetentionPolicy.LIMITS,
-        max_age=_SEVEN_DAYS_NS,
+        max_age=_SEVEN_DAYS_SECONDS,
         storage=nats.js.api.StorageType.FILE,
         num_replicas=1,
     ),
@@ -65,10 +72,18 @@ async def _ensure_stream(
     js: nats.js.JetStreamContext,
     cfg: nats.js.api.StreamConfig,
 ) -> None:
-    """Create a single stream, or skip if it already exists."""
+    """Create a single stream, or skip if it already exists.
+
+    Only "stream name already in use" (err_code 10058) is treated as a benign
+    no-op; any other BadRequestError (e.g. 10025 "invalid JSON" from a bad
+    config) is re-raised so a misconfiguration fails loudly instead of being
+    silently swallowed as "already exists".
+    """
     try:
         await js.add_stream(config=cfg)
         log.info("nats_stream_created", stream=cfg.name, subjects=cfg.subjects)
-    except BadRequestError:
-        # Stream already exists — this is expected on restart.
+    except BadRequestError as exc:
+        if getattr(exc, "err_code", None) != _STREAM_ALREADY_EXISTS_CODE:
+            log.error("nats_stream_create_failed", stream=cfg.name, error=str(exc))
+            raise
         log.debug("nats_stream_exists", stream=cfg.name)

--- a/tests/test_nats_streams.py
+++ b/tests/test_nats_streams.py
@@ -1,0 +1,53 @@
+"""Regression tests for JetStream stream setup (issue: streams never created).
+
+Two bugs are covered:
+1. ``max_age`` was passed in nanoseconds; nats-py expects SECONDS and converts
+   to ns in ``as_dict()`` — the old value double-converted to a 24-digit number
+   the server rejected with err_code 10025 "invalid JSON".
+2. ``_ensure_stream`` swallowed *every* BadRequestError as "already exists",
+   masking the invalid-config failure so no stream was ever created.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from nats.js.errors import BadRequestError
+from omniscience_core.queue.streams import (
+    _STREAM_ALREADY_EXISTS_CODE,
+    _STREAM_CONFIGS,
+    _ensure_stream,
+)
+
+_SEVEN_DAYS_NS = 7 * 24 * 60 * 60 * 10**9
+
+
+def test_stream_config_max_age_serialises_to_seven_days_ns() -> None:
+    """as_dict() must yield exactly 7 days in nanoseconds (not a 24-digit value)."""
+    assert _STREAM_CONFIGS, "expected at least one stream config"
+    for cfg in _STREAM_CONFIGS:
+        assert cfg.as_dict()["max_age"] == _SEVEN_DAYS_NS
+
+
+def _bad_request(err_code: int) -> BadRequestError:
+    exc = BadRequestError.__new__(BadRequestError)
+    exc.err_code = err_code
+    exc.code = 400
+    exc.description = "test"
+    return exc
+
+
+@pytest.mark.asyncio
+async def test_ensure_stream_swallows_only_already_exists() -> None:
+    """err_code 10058 (already in use) is benign; nothing is raised."""
+    js = AsyncMock()
+    js.add_stream = AsyncMock(side_effect=_bad_request(_STREAM_ALREADY_EXISTS_CODE))
+    await _ensure_stream(js, _STREAM_CONFIGS[0])  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_ensure_stream_reraises_invalid_config() -> None:
+    """A non-exists BadRequestError (e.g. 10025 invalid JSON) must propagate."""
+    js = AsyncMock()
+    js.add_stream = AsyncMock(side_effect=_bad_request(10025))
+    with pytest.raises(BadRequestError):
+        await _ensure_stream(js, _STREAM_CONFIGS[0])


### PR DESCRIPTION
NATS JetStream had **0 streams** — `ensure_streams` never created INGEST_CHANGES/INGEST_DLQ, so the scheduler logged `nats: no response from stream` and NATS-driven ingestion was dead. Surfaced by the new System Status page.

**Root cause (two bugs):**
1. `StreamConfig.max_age` was set in **nanoseconds**, but nats-py expects **seconds** and `as_dict()` converts to ns — the ns value double-converted to a 24-digit number → server rejects with err_code 10025 "invalid JSON".
2. `_ensure_stream` caught **every** BadRequestError as "already exists", silently swallowing the 10025 error → no stream, no log.

**Fix:** max_age in seconds; only err_code 10058 ("name already in use") is benign, everything else is logged + re-raised. Regression tests added (3 passed). Verified live after rebuild: streams created, scheduler publishes ok.