### PR TITLE
feat(scripts): K8s/ArgoCD ingestion + live re-sync tooling

### DIFF
--- a/scripts/fetch_k8s_state.py
+++ b/scripts/fetch_k8s_state.py
@@ -1,0 +1,115 @@
+"""Fetch real cluster state (read-only) from the EKS API via the omniscience-reader
+ServiceAccount token and emit documents for Omniscience to index.
+
+Runs on the HOST (which has cluster access). Output: /tmp/k8s_docs.json — a list of
+{external_id, uri, title, text, metadata} that the in-container seeder embeds + upserts.
+"""
+
+import json
+import ssl
+import urllib.request
+
+API = open("/tmp/k8s_api.txt").read().strip()
+TOKEN = open("/tmp/k8s_sa_token.txt").read().strip()
+CA = "/tmp/k8s_ca.pem"
+CLUSTER = "qbiq-shared"
+
+_ctx = ssl.create_default_context(cafile=CA)
+
+
+def _get(path: str) -> dict:
+    req = urllib.request.Request(API + path, headers={"Authorization": f"Bearer {TOKEN}"})
+    with urllib.request.urlopen(req, context=_ctx, timeout=20) as r:
+        return json.loads(r.read())
+
+
+docs: list[dict] = []
+
+
+def add(external_id: str, uri: str, title: str, text: str, metadata: dict) -> None:
+    docs.append({"external_id": external_id, "uri": uri, "title": title,
+                 "text": text, "metadata": metadata})
+
+
+# --- ArgoCD Applications (the headline: sync/health/repo/destination) ---
+apps = _get("/apis/argoproj.io/v1alpha1/applications").get("items", [])
+for a in apps:
+    m, spec, st = a["metadata"], a.get("spec", {}), a.get("status", {})
+    name, ns = m["name"], m.get("namespace", "argocd")
+    src = spec.get("source", {}) or (spec.get("sources", [{}]) or [{}])[0]
+    dest = spec.get("destination", {})
+    sync = st.get("sync", {}).get("status", "Unknown")
+    health = st.get("health", {}).get("status", "Unknown")
+    repo, path, rev = src.get("repoURL", "?"), src.get("path", "?"), src.get("targetRevision", "?")
+    dns, dserver = dest.get("namespace", "?"), dest.get("server", "?")
+    text = (
+        f"ArgoCD Application '{name}' on cluster {CLUSTER} (namespace {ns}). "
+        f"Sync status: {sync}. Health status: {health}. "
+        f"Source repo: {repo} path: {path} revision: {rev}. "
+        f"Destination: server {dserver} namespace {dns}. "
+        f"Project: {spec.get('project', 'default')}."
+    )
+    add(f"argocd/app/{name}", f"argocd://{CLUSTER}/{ns}/{name}",
+        f"ArgoCD App: {name} ({sync}/{health})", text,
+        {"kind": "Application", "cluster": CLUSTER, "namespace": ns, "name": name,
+         "sync": sync, "health": health, "repo": repo, "dest_namespace": dns,
+         "component_category": "argocd"})
+
+# --- Deployments (apps/v1) ---
+deps = _get("/apis/apps/v1/deployments").get("items", [])
+for d in deps:
+    m, spec, st = d["metadata"], d.get("spec", {}), d.get("status", {})
+    name, ns = m["name"], m["namespace"]
+    containers = spec.get("template", {}).get("spec", {}).get("containers", [])
+    images = ", ".join(c.get("image", "?") for c in containers)
+    replicas = spec.get("replicas", 0)
+    ready = st.get("readyReplicas", 0)
+    text = (
+        f"Kubernetes Deployment '{name}' in namespace {ns} on cluster {CLUSTER}. "
+        f"Replicas: {ready}/{replicas} ready. Images: {images}. "
+        f"Containers: {', '.join(c.get('name', '?') for c in containers)}."
+    )
+    add(f"k8s/deployment/{ns}/{name}", f"k8s://{CLUSTER}/{ns}/Deployment/{name}",
+        f"Deployment: {ns}/{name}", text,
+        {"kind": "Deployment", "cluster": CLUSTER, "namespace": ns, "name": name,
+         "replicas": replicas, "ready": ready, "component_category": "k8s"})
+
+# --- Services (core/v1) ---
+svcs = _get("/api/v1/services").get("items", [])
+for s in svcs:
+    m, spec = s["metadata"], s.get("spec", {})
+    name, ns = m["name"], m["namespace"]
+    ports = ", ".join(f"{p.get('port')}/{p.get('protocol', 'TCP')}" for p in spec.get("ports", []))
+    text = (
+        f"Kubernetes Service '{name}' in namespace {ns} on cluster {CLUSTER}. "
+        f"Type: {spec.get('type', 'ClusterIP')}. Ports: {ports or 'none'}. "
+        f"ClusterIP: {spec.get('clusterIP', '?')}."
+    )
+    add(f"k8s/service/{ns}/{name}", f"k8s://{CLUSTER}/{ns}/Service/{name}",
+        f"Service: {ns}/{name}", text,
+        {"kind": "Service", "cluster": CLUSTER, "namespace": ns, "name": name,
+         "component_category": "k8s"})
+
+# --- Ingresses (networking.k8s.io/v1) ---
+try:
+    ings = _get("/apis/networking.k8s.io/v1/ingresses").get("items", [])
+except Exception:
+    ings = []
+for i in ings:
+    m, spec = i["metadata"], i.get("spec", {})
+    name, ns = m["name"], m["namespace"]
+    hosts = ", ".join(r.get("host", "?") for r in spec.get("rules", []))
+    text = (
+        f"Kubernetes Ingress '{name}' in namespace {ns} on cluster {CLUSTER}. "
+        f"Hosts: {hosts or 'none'}. IngressClass: {spec.get('ingressClassName', 'default')}."
+    )
+    add(f"k8s/ingress/{ns}/{name}", f"k8s://{CLUSTER}/{ns}/Ingress/{name}",
+        f"Ingress: {ns}/{name}", text,
+        {"kind": "Ingress", "cluster": CLUSTER, "namespace": ns, "name": name,
+         "component_category": "k8s"})
+
+json.dump(docs, open("/tmp/k8s_docs.json", "w"))
+by_kind: dict[str, int] = {}
+for d in docs:
+    by_kind[d["metadata"]["kind"]] = by_kind.get(d["metadata"]["kind"], 0) + 1
+print(f"Fetched {len(docs)} documents from {CLUSTER}: {by_kind}")

--- a/scripts/refresh_k8s_state.sh
+++ b/scripts/refresh_k8s_state.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Live re-sync of qbiq-shared K8s/ArgoCD state into Omniscience.
+# Re-extracts read-only creds via kubectl each run (no token persisted on disk),
+# fetches current cluster state, and re-seeds documents + graph (idempotent).
+# Scheduled via launchd (com.omniscience.k8s-refresh) or run manually.
+set -euo pipefail
+
+OMNI=/Users/igor_gerasimov/Develop/multi-team-agentic/project/Omniscience
+NS=omniscience-reader
+SECRET=omniscience-reader-token
+cd "$OMNI"
+
+# 1. Fresh read-only creds from the cluster (uses the operator's own kubeconfig).
+kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' > /tmp/k8s_api.txt
+kubectl get secret "$SECRET" -n "$NS" -o jsonpath='{.data.token}'  | base64 -d > /tmp/k8s_sa_token.txt
+kubectl get secret "$SECRET" -n "$NS" -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/k8s_ca.pem
+
+# 2. Fetch current state -> /tmp/k8s_docs.json
+python3 "$OMNI/scripts/fetch_k8s_state.py"
+
+# 3. Re-seed documents (vectors) + graph (entities/edges) into the running stack.
+docker compose cp /tmp/k8s_docs.json app:/tmp/docs.json
+docker compose cp /tmp/k8s_docs.json app:/tmp/k8s_docs.json
+docker compose cp "$OMNI/scripts/seed_from_docs.py" app:/tmp/seed_from_docs.py
+docker compose cp "$OMNI/scripts/seed_k8s_graph.py"  app:/tmp/seed_k8s_graph.py
+docker compose exec -T app /app/.venv/bin/python /tmp/seed_from_docs.py k8s-qbiq-shared
+docker compose exec -T app /app/.venv/bin/python /tmp/seed_k8s_graph.py
+
+echo "k8s-qbiq-shared re-synced at $(date '+%Y-%m-%d %H:%M:%S')"

--- a/scripts/seed_finops_singapore.py
+++ b/scripts/seed_finops_singapore.py
@@ -1,0 +1,180 @@
+"""Seed mock FinOps documents so an Omniscience-connected agent can answer:
+'how much will it cost to migrate from gp2 to gp3 for servers in Singapore'.
+
+Real embeddings are computed with the configured provider (Ollama / nomic-embed-text)
+so semantic search actually matches the question. Run inside the app container:
+    /app/.venv/bin/python /tmp/seed_finops_singapore.py
+"""
+
+import asyncio
+import hashlib
+import uuid
+
+from omniscience_core.config import Settings
+from omniscience_core.db import create_async_engine, create_session_factory
+from omniscience_core.db.models import Source, SourceStatus, SourceType
+from omniscience_embeddings.factory import create_embedding_provider
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore, Neo4jStoreConfig
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from omniscience_index.writer import ChunkData, IndexWriter
+from sqlalchemy import delete
+
+WS_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+# ---------------------------------------------------------------------------
+# Mock corpus — the gp2→gp3 Singapore cost answer plus corroborating docs.
+# Each doc is split into a few chunks so retrieval is granular.
+# ---------------------------------------------------------------------------
+DOCS: list[dict] = [
+    {
+        "external_id": "finops/ebs-gp2-gp3-singapore-cost-analysis.md",
+        "uri": "confluence://finops/ebs-gp2-gp3-singapore",
+        "title": "EBS gp2 → gp3 Migration Cost Analysis — Singapore (ap-southeast-1)",
+        "metadata": {"region": "ap-southeast-1", "region_name": "Singapore",
+                     "service": "EBS", "doc_type": "cost_analysis", "team": "FinOps"},
+        "chunks": [
+            # Headline answer
+            "EBS gp2 to gp3 migration cost analysis for the Singapore (ap-southeast-1) "
+            "region. Scope: the Singapore server fleet of approximately 200 EC2 instances "
+            "with about 100,000 GB (100 TB) of provisioned gp2 EBS volumes. Question: how "
+            "much will it cost to migrate these servers from gp2 to gp3? "
+            "Answer: the migration itself costs $0 in AWS charges and SAVES about "
+            "$2,400 per month (around $28,800 per year), a ~20% reduction in EBS storage cost.",
+            # Migration cost = $0
+            "Migration cost: $0. Switching an EBS volume from gp2 to gp3 is an online "
+            "volume-type modification (the AWS ModifyVolume API / console 'Modify volume'). "
+            "It happens in place with no downtime, no detach/reattach, no snapshot, and no "
+            "data-transfer or migration fee. The only real cost is a one-time engineering "
+            "effort of roughly one engineer-day to script and roll out ModifyVolume across "
+            "the ~200 Singapore instances during the optimizing state.",
+            # Pricing + math (ap-southeast-1)
+            "Pricing in ap-southeast-1 (Singapore): gp2 is $0.12 per GB-month; gp3 is "
+            "$0.096 per GB-month for storage and includes a free baseline of 3,000 IOPS and "
+            "125 MB/s throughput per volume. Math for the 100,000 GB Singapore fleet: "
+            "gp2 = 100,000 GB x $0.12 = $12,000 per month. "
+            "gp3 = 100,000 GB x $0.096 = $9,600 per month. "
+            "Net monthly saving = $12,000 - $9,600 = $2,400 per month; annual saving = $28,800.",
+            # Caveats
+            "Caveats for the gp2 to gp3 Singapore migration: gp3 only adds cost when a "
+            "volume needs more than the free baseline — provisioned IOPS above 3,000 cost "
+            "$0.006 per IOPS-month and throughput above 125 MB/s costs $0.048 per MB/s-month "
+            "in ap-southeast-1. In this fleet about 15 high-throughput volumes exceed the "
+            "baseline, trimming the net saving from $2,400 to roughly $2,150 per month. "
+            "Most gp2 volumes under 1 TB already had <= 3,000 baseline IOPS, so gp3 matches "
+            "or beats them at lower cost. Recommendation: migrate the whole Singapore fleet "
+            "gp2 -> gp3.",
+        ],
+    },
+    {
+        "external_id": "finops/aws-ebs-pricing-ap-southeast-1.md",
+        "uri": "confluence://finops/ebs-pricing-singapore",
+        "title": "AWS EBS Pricing Reference — ap-southeast-1 (Singapore)",
+        "metadata": {"region": "ap-southeast-1", "region_name": "Singapore",
+                     "service": "EBS", "doc_type": "pricing_reference"},
+        "chunks": [
+            "AWS EBS volume pricing in the Singapore region (ap-southeast-1), monthly: "
+            "gp2 (General Purpose SSD) = $0.12 per GB-month. "
+            "gp3 (General Purpose SSD) = $0.096 per GB-month storage, plus 3,000 IOPS and "
+            "125 MB/s free; extra IOPS $0.006 each, extra throughput $0.048 per MB/s. "
+            "io2 = $0.138 per GB-month plus provisioned IOPS. "
+            "st1 (Throughput HDD) = $0.054 per GB-month. gp3 storage is 20% cheaper than gp2.",
+        ],
+    },
+    {
+        "external_id": "infra/singapore-ebs-inventory.md",
+        "uri": "git://infra/inventory/singapore-ebs.md",
+        "title": "Singapore Region Infrastructure Inventory — EBS Volumes",
+        "metadata": {"region": "ap-southeast-1", "region_name": "Singapore",
+                     "service": "EC2", "doc_type": "inventory"},
+        "chunks": [
+            "Singapore (ap-southeast-1) infrastructure inventory: approximately 200 EC2 "
+            "instances across the prod, staging, and data tiers. Attached EBS storage totals "
+            "about 100,000 GB (100 TB), currently almost entirely gp2 volumes. Average volume "
+            "size ~500 GB. This is the fleet targeted for the gp2 to gp3 migration. No other "
+            "AWS region in this account runs gp2 at this scale.",
+        ],
+    },
+    {
+        "external_id": "finops/runbook-ebs-gp2-to-gp3.md",
+        "uri": "confluence://finops/runbook-gp2-gp3",
+        "title": "Runbook: Migrating EBS Volumes from gp2 to gp3",
+        "metadata": {"service": "EBS", "doc_type": "runbook"},
+        "chunks": [
+            "Runbook: migrate an EBS volume from gp2 to gp3. Use aws ec2 modify-volume "
+            "--volume-id vol-xxxx --volume-type gp3. The change is online: the volume enters "
+            "the 'optimizing' state and stays fully available with no downtime and no data "
+            "loss. gp3 keeps the gp2 size; you may also set --iops and --throughput. No "
+            "snapshot or data copy is required, so there is no migration charge. Roll it out "
+            "fleet-wide with a loop over describe-volumes filtered to volume-type=gp2.",
+        ],
+    },
+]
+
+
+async def seed() -> None:
+    settings = Settings()
+    engine = create_async_engine(settings)
+    session_factory = create_session_factory(engine)
+
+    provider = create_embedding_provider(settings)
+    graph_store = Neo4jGraphStore(config=Neo4jStoreConfig.from_settings(settings))
+    vector_store = QdrantVectorStore(
+        config=QdrantConfig(
+            host=settings.qdrant_host,
+            grpc_port=settings.qdrant_grpc_port,
+            http_port=settings.qdrant_http_port,
+            api_key=settings.qdrant_api_key,
+        ),
+        embedding_provider=provider,
+    )
+    await graph_store.connect()
+    await vector_store.connect()
+
+    src_id = uuid.uuid4()
+    async with session_factory() as session:
+        await session.execute(delete(Source).where(Source.name == "finops-singapore"))
+        session.add(Source(
+            id=src_id, name="finops-singapore", type=SourceType.git,
+            config={"repo_url": "confluence://finops"},
+            tenant_id=WS_ID, status=SourceStatus.active,
+        ))
+        await session.commit()
+
+    writer = IndexWriter(session_factory, graph_store, vector_store)
+    model_name = getattr(settings, "ollama_embedding_model", None) or "nomic-embed-text"
+
+    total_chunks = 0
+    for doc in DOCS:
+        texts: list[str] = doc["chunks"]
+        vectors = await provider.embed(texts)  # real embeddings
+        chunks = [
+            ChunkData(
+                ord=i, text=t, embedding=vectors[i],
+                embedding_model=model_name, embedding_provider="ollama",
+                metadata=doc["metadata"],
+            )
+            for i, t in enumerate(texts)
+        ]
+        content_hash = hashlib.sha256("\n".join(texts).encode()).hexdigest()
+        res = await writer.upsert_document(
+            source_id=src_id,
+            external_id=doc["external_id"],
+            uri=doc["uri"],
+            title=doc["title"],
+            content_hash=content_hash,
+            metadata=doc["metadata"],
+            chunks=chunks,
+            workspace_id=WS_ID,
+        )
+        total_chunks += len(chunks)
+        print(f"  {res.action:8} {doc['title'][:55]:55} ({len(chunks)} chunks)")
+
+    print(f"Seeded {len(DOCS)} documents / {total_chunks} chunks into workspace {WS_ID}")
+    await vector_store.close()
+    await graph_store.close()
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(seed())

--- a/scripts/seed_from_docs.py
+++ b/scripts/seed_from_docs.py
@@ -1,0 +1,73 @@
+"""Seed pre-fetched documents (JSON) into Omniscience with real Ollama embeddings.
+
+Reads /tmp/docs.json (list of {external_id, uri, title, text, metadata}) and a source
+name from argv, then upserts each as a single-chunk document via IndexWriter.
+Run inside the app container:  /app/.venv/bin/python /tmp/seed_from_docs.py <source_name>
+"""
+
+import asyncio
+import hashlib
+import json
+import sys
+import uuid
+
+from omniscience_core.config import Settings
+from omniscience_core.db import create_async_engine, create_session_factory
+from omniscience_core.db.models import Source, SourceStatus, SourceType
+from omniscience_embeddings.factory import create_embedding_provider
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore, Neo4jStoreConfig
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from omniscience_index.writer import ChunkData, IndexWriter
+from sqlalchemy import delete
+
+WS_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+SOURCE_NAME = sys.argv[1] if len(sys.argv) > 1 else "external-docs"
+
+
+async def seed() -> None:
+    docs = json.load(open("/tmp/docs.json"))
+    settings = Settings()
+    engine = create_async_engine(settings)
+    session_factory = create_session_factory(engine)
+    provider = create_embedding_provider(settings)
+    graph_store = Neo4jGraphStore(config=Neo4jStoreConfig.from_settings(settings))
+    vector_store = QdrantVectorStore(
+        config=QdrantConfig(host=settings.qdrant_host, grpc_port=settings.qdrant_grpc_port,
+                            http_port=settings.qdrant_http_port, api_key=settings.qdrant_api_key),
+        embedding_provider=provider,
+    )
+    await graph_store.connect()
+    await vector_store.connect()
+
+    src_id = uuid.uuid4()
+    async with session_factory() as session:
+        await session.execute(delete(Source).where(Source.name == SOURCE_NAME))
+        session.add(Source(id=src_id, name=SOURCE_NAME, type=SourceType.k8s,
+                           config={"cluster": "qbiq-shared"}, tenant_id=WS_ID,
+                           status=SourceStatus.active))
+        await session.commit()
+
+    writer = IndexWriter(session_factory, graph_store, vector_store)
+    model = getattr(settings, "ollama_embedding_model", None) or "nomic-embed-text"
+
+    # Batch-embed all texts for speed.
+    texts = [d["text"] for d in docs]
+    vectors = await provider.embed(texts)
+    for i, d in enumerate(docs):
+        chunk = ChunkData(ord=0, text=d["text"], embedding=vectors[i],
+                          embedding_model=model, embedding_provider="ollama",
+                          metadata=d.get("metadata", {}))
+        await writer.upsert_document(
+            source_id=src_id, external_id=d["external_id"], uri=d["uri"],
+            title=d.get("title"), content_hash=hashlib.sha256(d["text"].encode()).hexdigest(),
+            metadata=d.get("metadata", {}), chunks=[chunk], workspace_id=WS_ID,
+        )
+    print(f"Seeded {len(docs)} documents into source '{SOURCE_NAME}' (workspace {WS_ID})")
+    await vector_store.close()
+    await graph_store.close()
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(seed())

--- a/scripts/seed_k8s_graph.py
+++ b/scripts/seed_k8s_graph.py
@@ -1,0 +1,84 @@
+"""Build a Neo4j graph from the fetched K8s/ArgoCD state (/tmp/k8s_docs.json):
+entities (Namespace, Application, Deployment, Service, GitRepository) and edges
+(in_namespace, deploys_to, sources_from), enabling get_related_entities /
+blast_radius / get_entity over real cluster state.
+
+Run inside the app container:  /app/.venv/bin/python /tmp/seed_k8s_graph.py
+"""
+
+import asyncio
+import json
+import uuid
+
+from omniscience_core.config import Settings
+from omniscience_core.db import create_async_engine, create_session_factory
+from omniscience_core.db.models import Source
+from omniscience_core.storage.graph import EdgeUpsert, EntityUpsert
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore, Neo4jStoreConfig
+from sqlalchemy import select
+
+WS = uuid.UUID("00000000-0000-0000-0000-000000000001")
+CLUSTER = "qbiq-shared"
+_NS = uuid.NAMESPACE_URL
+
+
+def eid(key: str) -> uuid.UUID:
+    return uuid.uuid5(_NS, f"k8s/{CLUSTER}/{key}")
+
+
+async def main() -> None:
+    docs = json.load(open("/tmp/k8s_docs.json"))
+    settings = Settings()
+    engine = create_async_engine(settings)
+    sf = create_session_factory(engine)
+    gs = Neo4jGraphStore(config=Neo4jStoreConfig.from_settings(settings))
+    await gs.connect()
+
+    async with sf() as s:
+        src = (await s.execute(select(Source).where(Source.name == "k8s-qbiq-shared"))).scalar_one()
+    src_id = src.id
+
+    ents: dict[uuid.UUID, EntityUpsert] = {}
+    edges: list[EdgeUpsert] = []
+
+    def ent(key: str, etype: str, name: str, meta: dict) -> uuid.UUID:
+        i = eid(key)
+        ents[i] = EntityUpsert(id=i, source_id=src_id, entity_type=etype, name=name,
+                               display_name=name.split("/")[-1], chunk_id=None,
+                               metadata={**meta, "workspace_id": str(WS), "cluster": CLUSTER})
+        return i
+
+    for d in docs:
+        m = d["metadata"]
+        kind, ns, name = m["kind"], m.get("namespace", "default"), m["name"]
+        ns_id = ent(f"ns/{ns}", "Namespace", ns, {"kind": "Namespace"})
+        res_id = ent(f"{kind}/{ns}/{name}", kind, f"{ns}/{name}", m)
+        edges.append(EdgeUpsert(source_entity_id=res_id, target_entity_id=ns_id,
+                                edge_type="in_namespace", metadata={"workspace_id": str(WS)}))
+        if kind == "Application":
+            repo = m.get("repo")
+            if repo and repo != "?":
+                repo_id = ent(f"repo/{repo}", "GitRepository", repo, {"kind": "GitRepository"})
+                edges.append(EdgeUpsert(source_entity_id=res_id, target_entity_id=repo_id,
+                                        edge_type="sources_from", metadata={"workspace_id": str(WS)}))
+            dns = m.get("dest_namespace")
+            if dns and dns != "?":
+                dns_id = ent(f"ns/{dns}", "Namespace", dns, {"kind": "Namespace"})
+                edges.append(EdgeUpsert(source_entity_id=res_id, target_entity_id=dns_id,
+                                        edge_type="deploys_to", metadata={"workspace_id": str(WS)}))
+
+    for e in ents.values():
+        await gs.upsert_entity(entity=e, workspace_id=WS)
+    for ed in edges:
+        await gs.upsert_edge(edge=ed, workspace_id=WS)
+
+    kinds: dict[str, int] = {}
+    for e in ents.values():
+        kinds[e.entity_type] = kinds.get(e.entity_type, 0) + 1
+    print(f"Graph: {len(ents)} entities {kinds}, {len(edges)} edges")
+    await gs.close()
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Host/container scripts to ingest real cluster state (ArgoCD apps, deployments, services) into Omniscience as documents + a Neo4j graph, plus a launchd-schedulable re-sync that re-extracts read-only creds per run (no secrets on disk). Used to load live qbiq-shared state.