### PR TITLE
chore(qdrant): align client & server versions (1.17)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,7 +269,7 @@ services:
   # API key:          QDRANT__SERVICE__API_KEY env (unset in dev)
   # ==========================================================================
   qdrant:
-    image: qdrant/qdrant:v1.12.4
+    image: qdrant/qdrant:v1.17.1
     ports:
       - "127.0.0.1:16333:6333"
       - "127.0.0.1:16334:6334"

--- a/packages/index/pyproject.toml
+++ b/packages/index/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.30",
     "asyncpg>=0.29.0",
     "neo4j>=5.19.0",
-    "qdrant-client>=1.12.0",
+    "qdrant-client>=1.17,<1.18",
     "structlog>=24.1.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1434,7 +1434,7 @@ requires-dist = [
     { name = "neo4j", specifier = ">=5.19.0" },
     { name = "omniscience-core", editable = "packages/core" },
     { name = "omniscience-embeddings", editable = "packages/embeddings" },
-    { name = "qdrant-client", specifier = ">=1.12.0" },
+    { name = "qdrant-client", specifier = ">=1.17,<1.18" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.30" },
     { name = "structlog", specifier = ">=24.1.0" },
 ]


### PR DESCRIPTION
Qdrant client 1.17.1 vs server v1.12.4 (5 minors apart) → incompatibility warning. Bumped server image to `qdrant/qdrant:v1.17.1` and pinned `qdrant-client>=1.17,<1.18` (lock unchanged at 1.17.1). Qdrant v1 storage is forward-compatible across minors → no volume recreate needed. compose config valid, uv sync clean, store imports.