### PR TITLE
feat(connectors): AWS Organizations / OU / account ingestion

### DIFF
--- a/packages/connectors/src/omniscience_connectors/aws/connector.py
+++ b/packages/connectors/src/omniscience_connectors/aws/connector.py
@@ -16,9 +16,16 @@ Supported services
 - **s3** — list_buckets + describe each (tags, policy, versioning)  [global]
 - **iam** — list_users, list_roles, list_policies                   [global]
 - **ec2** — describe_instances, describe_vpcs, describe_security_groups [per-region]
+- **organizations** — describe_organization, list roots/OUs (nested), list_accounts
+  Opt-in via ``include_organizations=True`` in :class:`AwsConfig`.
 
 URI format: ``aws://{account_id}/{region}/{service}/{resource_type}/{name}``
 external_id: ARN (e.g. ``arn:aws:s3:::my-bucket``)
+
+Organizations URI format:
+  ``aws://org/{org_id}``
+  ``aws://org/{org_id}/ou/{ou_id}``
+  ``aws://org/{org_id}/account/{account_id}``
 """
 
 from __future__ import annotations
@@ -26,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
@@ -57,6 +65,19 @@ class AwsConfig(BaseModel):
     resource_type_filters: list[str] = Field(default_factory=list)
     """Optional resource-type allow-list (e.g. ``["aws_instance", "aws_vpc"]``).
     Empty means include all resource types for the configured services."""
+
+    include_organizations: bool = Field(default=False)
+    """When True, enumerate the AWS Organization, its OUs, and member accounts.
+
+    Requires the caller's principal to have read-only Organizations permissions:
+    ``organizations:DescribeOrganization``, ``organizations:ListRoots``,
+    ``organizations:ListOrganizationalUnitsForParent``,
+    ``organizations:ListAccounts``, ``organizations:ListParents``.
+
+    The Organizations API endpoint is always ``us-east-1`` regardless of the
+    ``regions`` setting.  Existing s3/iam/ec2 behavior is unchanged when this
+    is False (the default).
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -402,6 +423,268 @@ def _extract_name_tag(tags: list[dict[str, str]]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Organizations helpers (synchronous — run in asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+# The Organizations API is region-agnostic; all calls go to us-east-1.
+_ORG_REGION = "us-east-1"
+
+# Retry parameters for ThrottlingException / TooManyRequestsException.
+_ORG_MAX_RETRIES = 5
+_ORG_BACKOFF_BASE = 0.5  # seconds
+
+
+def _org_client(secrets: dict[str, str]) -> Any:
+    """Return a boto3 organizations client pinned to us-east-1."""
+    return _build_client("organizations", secrets, _ORG_REGION)
+
+
+def _paginate_org(client: Any, method: str, key: str, **kwargs: Any) -> list[dict[str, Any]]:
+    """Paginate an Organizations list call with exponential-backoff retry.
+
+    Args:
+        client:  boto3 organizations client.
+        method:  Paginator name (e.g. ``"list_accounts"``).
+        key:     Response key holding the result list (e.g. ``"Accounts"``).
+        **kwargs: Extra parameters forwarded to ``paginator.paginate()``.
+
+    Returns:
+        Flat list of all items across all pages.
+
+    Raises:
+        botocore.exceptions.ClientError: On access-denied or unrecoverable errors.
+    """
+    paginator = client.get_paginator(method)
+    items: list[dict[str, Any]] = []
+    attempt = 0
+    while True:
+        try:
+            for page in paginator.paginate(**kwargs):
+                items.extend(page.get(key, []))
+            return items
+        except botocore.exceptions.ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code in ("ThrottlingException", "TooManyRequestsException"):
+                attempt += 1
+                if attempt > _ORG_MAX_RETRIES:
+                    logger.warning(
+                        "organizations.throttle.max_retries_exceeded",
+                        extra={"method": method, "attempts": attempt},
+                    )
+                    raise
+                wait = _ORG_BACKOFF_BASE * (2 ** (attempt - 1))
+                logger.debug(
+                    "organizations.throttle.retry",
+                    extra={"method": method, "attempt": attempt, "wait_s": wait},
+                )
+                time.sleep(wait)
+                items = []  # reset before retry
+            else:
+                raise
+
+
+def _collect_ous(
+    client: Any,
+    parent_id: str,
+    parent_path: str,
+    org_id: str,
+    filters: list[str],
+) -> list[DocumentRef]:
+    """Recursively collect OUs under *parent_id*.
+
+    Args:
+        client:      boto3 organizations client.
+        parent_id:   Root or OU id to recurse from.
+        parent_path: Human-readable path string for the parent (e.g. ``"/root"``).
+        org_id:      Organization id (used in the URI).
+        filters:     Resource-type allow-list.
+
+    Returns:
+        List of :class:`DocumentRef` for every OU found at any depth.
+    """
+    refs: list[DocumentRef] = []
+    ous = _paginate_org(
+        client,
+        "list_organizational_units_for_parent",
+        "OrganizationalUnits",
+        ParentId=parent_id,
+    )
+    for ou in ous:
+        ou_id: str = ou.get("Id", "")
+        ou_name: str = ou.get("Name", ou_id)
+        ou_arn: str = ou.get("Arn", f"arn:aws:organizations::{org_id}:ou/{org_id}/{ou_id}")
+        ou_path = f"{parent_path}/{ou_name}"
+        uri = f"aws://org/{org_id}/ou/{ou_id}"
+
+        if _allowed("aws_organizations_ou", filters):
+            refs.append(
+                DocumentRef(
+                    external_id=ou_arn,
+                    uri=uri,
+                    metadata={
+                        "kind": "aws_live",
+                        "resource_type": "aws_organizations_ou",
+                        "service": "organizations",
+                        "region": "global",
+                        "org_id": org_id,
+                        "ou_id": ou_id,
+                        "name": ou_name,
+                        "arn": ou_arn,
+                        "parent_id": parent_id,
+                        "path": ou_path,
+                    },
+                )
+            )
+
+        # Recurse into child OUs
+        refs.extend(_collect_ous(client, ou_id, ou_path, org_id, filters))
+
+    return refs
+
+
+def _discover_organizations(
+    secrets: dict[str, str],
+    filters: list[str],
+) -> list[DocumentRef]:
+    """Discover the Organization, all OUs (nested), and member accounts.
+
+    Gracefully handles ``AccessDeniedException`` (the caller may lack
+    organizations permissions in a member account without delegated access)
+    by logging a warning and returning an empty list.
+
+    Args:
+        secrets: Runtime credential dict.
+        filters: Resource-type allow-list.
+
+    Returns:
+        List of :class:`DocumentRef` for the org, every OU, and every account.
+    """
+    client = _org_client(secrets)
+    refs: list[DocumentRef] = []
+
+    # --- Describe the organization itself ---
+    try:
+        org_resp: dict[str, Any] = client.describe_organization()
+    except botocore.exceptions.ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("AccessDeniedException", "AWSOrganizationsNotInUseException"):
+            logger.warning(
+                "organizations.discover.skipped",
+                extra={"reason": code},
+            )
+            return []
+        raise
+
+    org: dict[str, Any] = org_resp.get("Organization", {})
+    org_id: str = org.get("Id", "")
+    if not org_id:
+        logger.warning("organizations.discover.empty_org_id")
+        return []
+
+    org_arn: str = org.get("Arn", f"arn:aws:organizations::{org_id}:organization/{org_id}")
+    master_account: str = org.get("MasterAccountId", "")
+    feature_set: str = org.get("FeatureSet", "")
+
+    if _allowed("aws_organization", filters):
+        refs.append(
+            DocumentRef(
+                external_id=org_arn,
+                uri=f"aws://org/{org_id}",
+                metadata={
+                    "kind": "aws_live",
+                    "resource_type": "aws_organization",
+                    "service": "organizations",
+                    "region": "global",
+                    "org_id": org_id,
+                    "name": org_id,
+                    "arn": org_arn,
+                    "master_account_id": master_account,
+                    "feature_set": feature_set,
+                },
+            )
+        )
+
+    # --- Enumerate roots then collect OUs recursively ---
+    try:
+        roots = _paginate_org(client, "list_roots", "Roots")
+    except botocore.exceptions.ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        logger.warning("organizations.list_roots.failed", extra={"code": code})
+        roots = []
+
+    for root in roots:
+        root_id: str = root.get("Id", "")
+        if not root_id:
+            continue
+        try:
+            refs.extend(_collect_ous(client, root_id, "/root", org_id, filters))
+        except botocore.exceptions.ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            logger.warning(
+                "organizations.list_ous.failed",
+                extra={"root_id": root_id, "code": code},
+            )
+
+    # --- Member accounts ---
+    if _allowed("aws_organizations_account", filters):
+        try:
+            accounts = _paginate_org(client, "list_accounts", "Accounts")
+        except botocore.exceptions.ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            logger.warning("organizations.list_accounts.failed", extra={"code": code})
+            accounts = []
+
+        for acct in accounts:
+            acct_id: str = acct.get("Id", "")
+            if not acct_id:
+                continue
+            acct_name: str = acct.get("Name", acct_id)
+            _fallback = f"arn:aws:organizations::{org_id}:account/{org_id}/{acct_id}"
+            acct_arn: str = acct.get("Arn", _fallback)
+            acct_email: str = acct.get("Email", "")
+            acct_status: str = acct.get("Status", "")
+            joined: str = str(acct.get("JoinedTimestamp", ""))
+
+            # Resolve the immediate OU parent for this account
+            parent_id = ""
+            try:
+                parents = _paginate_org(
+                    client, "list_parents", "Parents", ChildId=acct_id
+                )
+                if parents:
+                    parent_id = parents[0].get("Id", "")
+            except botocore.exceptions.ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code", "")
+                logger.warning(
+                    "organizations.list_parents.failed",
+                    extra={"account_id": acct_id, "code": code},
+                )
+
+            refs.append(
+                DocumentRef(
+                    external_id=acct_arn,
+                    uri=f"aws://org/{org_id}/account/{acct_id}",
+                    metadata={
+                        "kind": "aws_live",
+                        "resource_type": "aws_organizations_account",
+                        "service": "organizations",
+                        "region": "global",
+                        "org_id": org_id,
+                        "account_id": acct_id,
+                        "name": acct_name,
+                        "arn": acct_arn,
+                        "email": acct_email,
+                        "status": acct_status,
+                        "joined_timestamp": joined,
+                        "parent_id": parent_id,
+                    },
+                )
+            )
+
+    return refs
+
+
+# ---------------------------------------------------------------------------
 # Per-resource fetch helpers (synchronous — run in asyncio.to_thread)
 # ---------------------------------------------------------------------------
 
@@ -572,6 +855,74 @@ def _fetch_ec2_sg(client: Any, sg_id: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Organizations fetch helpers (synchronous — run in asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_org_organization(client: Any, org_id: str) -> dict[str, Any]:
+    """Describe the Organization."""
+    detail: dict[str, Any] = {"org_id": org_id}
+    try:
+        resp = client.describe_organization()
+        org = resp.get("Organization", {})
+        detail.update(
+            {
+                "id": org.get("Id", org_id),
+                "arn": org.get("Arn", ""),
+                "feature_set": org.get("FeatureSet", ""),
+                "master_account_id": org.get("MasterAccountId", ""),
+                "master_account_email": org.get("MasterAccountEmail", ""),
+                "available_policy_types": [
+                    pt.get("Type", "") for pt in org.get("AvailablePolicyTypes", [])
+                ],
+            }
+        )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+def _fetch_org_ou(client: Any, ou_id: str) -> dict[str, Any]:
+    """Describe a single Organizational Unit."""
+    detail: dict[str, Any] = {"ou_id": ou_id}
+    try:
+        resp = client.describe_organizational_unit(OrganizationalUnitId=ou_id)
+        ou = resp.get("OrganizationalUnit", {})
+        detail.update(
+            {
+                "id": ou.get("Id", ou_id),
+                "arn": ou.get("Arn", ""),
+                "name": ou.get("Name", ""),
+            }
+        )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+def _fetch_org_account(client: Any, account_id: str) -> dict[str, Any]:
+    """Describe a single member account."""
+    detail: dict[str, Any] = {"account_id": account_id}
+    try:
+        resp = client.describe_account(AccountId=account_id)
+        acct = resp.get("Account", {})
+        detail.update(
+            {
+                "id": acct.get("Id", account_id),
+                "arn": acct.get("Arn", ""),
+                "name": acct.get("Name", ""),
+                "email": acct.get("Email", ""),
+                "status": acct.get("Status", ""),
+                "joined_method": acct.get("JoinedMethod", ""),
+                "joined_timestamp": str(acct.get("JoinedTimestamp", "")),
+            }
+        )
+    except botocore.exceptions.ClientError:
+        pass
+    return detail
+
+
+# ---------------------------------------------------------------------------
 # AwsConnector
 # ---------------------------------------------------------------------------
 
@@ -579,10 +930,10 @@ def _fetch_ec2_sg(client: Any, sg_id: str) -> dict[str, Any]:
 class AwsConnector(Connector):
     """Connector for live AWS resources.
 
-    Discovers resources across S3, IAM, and EC2 (configurable) and returns
-    them as :class:`~omniscience_connectors.base.DocumentRef` objects tagged
-    with ``kind="aws_live"``.  The ARN is stored as ``external_id`` and in
-    ``metadata["arn"]`` to support ARN-based cross-source linking.
+    Discovers resources across S3, IAM, EC2, and optionally AWS Organizations
+    (configurable) and returns them as :class:`~omniscience_connectors.base.DocumentRef`
+    objects tagged with ``kind="aws_live"``.  The ARN is stored as ``external_id``
+    and in ``metadata["arn"]`` to support ARN-based cross-source linking.
 
     Stateless: all state derives from config + secrets at call time.
     """
@@ -624,7 +975,8 @@ class AwsConnector(Connector):
 
         Enumerates all configured services across all configured regions.
         Global services (S3, IAM) are enumerated once regardless of the
-        ``regions`` list.
+        ``regions`` list.  When ``include_organizations`` is True, the
+        Organization tree (org, OUs, accounts) is also enumerated once.
 
         Args:
             config: Validated :class:`AwsConfig`.
@@ -655,6 +1007,12 @@ class AwsConnector(Connector):
                 refs = await asyncio.to_thread(_discover_ec2, secrets, account_id, region, filters)
                 for ref in refs:
                     yield ref
+
+        # Organizations (opt-in, global)
+        if cfg.include_organizations:
+            refs = await asyncio.to_thread(_discover_organizations, secrets, filters)
+            for ref in refs:
+                yield ref
 
     async def fetch(
         self,
@@ -716,6 +1074,18 @@ class AwsConnector(Connector):
             if resource_type == "aws_security_group":
                 client = _build_client("ec2", secrets, region)
                 return _fetch_ec2_sg(client, meta.get("group_id", ""))
+
+            if resource_type == "aws_organization":
+                client = _org_client(secrets)
+                return _fetch_org_organization(client, meta.get("org_id", ""))
+
+            if resource_type == "aws_organizations_ou":
+                client = _org_client(secrets)
+                return _fetch_org_ou(client, meta.get("ou_id", ""))
+
+            if resource_type == "aws_organizations_account":
+                client = _org_client(secrets)
+                return _fetch_org_account(client, meta.get("account_id", ""))
 
             # Unknown type: return metadata as-is
             return dict(meta)

--- a/tests/test_aws_organizations.py
+++ b/tests/test_aws_organizations.py
@@ -1,0 +1,648 @@
+"""Tests for the AWS Organizations ingestion path (Issue #90 / feat/aws-organizations-connector).
+
+Coverage:
+- AwsConfig.include_organizations flag (default False, opt-in)
+- _collect_ous: flat OUs, nested recursion, filter exclusion
+- _discover_organizations: org + OU + accounts happy path
+- _discover_organizations: AccessDeniedException degrades gracefully (returns [])
+- _discover_organizations: AWSOrganizationsNotInUseException degrades gracefully
+- _discover_organizations: empty org_id returns []
+- _discover_organizations: list_roots ClientError logs warning + continues
+- _discover_organizations: list_accounts ClientError logs warning + continues
+- _discover_organizations: list_parents failure logs warning, account still emitted
+- _paginate_org: ThrottlingException triggers backoff retry then succeeds
+- _paginate_org: ThrottlingException exhausts retries and re-raises
+- account→OU parent mapping in metadata
+- URI and ARN format for org, OU, account
+- AwsConnector.discover: organizations NOT called when include_organizations=False
+- AwsConnector.discover: organizations called when include_organizations=True
+- AwsConnector.fetch: aws_organization dispatches to _fetch_org_organization
+- AwsConnector.fetch: aws_organizations_ou dispatches to _fetch_org_ou
+- AwsConnector.fetch: aws_organizations_account dispatches to _fetch_org_account
+- _fetch_org_organization: success + ClientError silenced
+- _fetch_org_ou: success + ClientError silenced
+- _fetch_org_account: success + ClientError silenced
+
+Total: 22 tests
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from omniscience_connectors.aws.connector import (
+    AwsConfig,
+    AwsConnector,
+    _collect_ous,
+    _discover_organizations,
+    _fetch_org_account,
+    _fetch_org_organization,
+    _fetch_org_ou,
+    _paginate_org,
+)
+from omniscience_connectors.base import DocumentRef
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ACCOUNT_ID = "123456789012"
+ORG_ID = "o-exampleorgid"
+OU_ID_1 = "ou-root-aaaa"
+OU_ID_2 = "ou-root-bbbb"
+OU_ID_CHILD = "ou-aaaa-cccc"
+
+SECRETS: dict[str, str] = {
+    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+    "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+}
+
+
+def _client_error(code: str, message: str = "error") -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, "Operation")
+
+
+def _org_arn(org_id: str) -> str:
+    return f"arn:aws:organizations::{org_id}:organization/{org_id}"
+
+
+def _ou_arn(org_id: str, ou_id: str) -> str:
+    return f"arn:aws:organizations::{org_id}:ou/{org_id}/{ou_id}"
+
+
+def _acct_arn(org_id: str, acct_id: str) -> str:
+    return f"arn:aws:organizations::{org_id}:account/{org_id}/{acct_id}"
+
+
+def _make_org(org_id: str = ORG_ID, master: str = ACCOUNT_ID) -> dict[str, Any]:
+    return {
+        "Id": org_id,
+        "Arn": _org_arn(org_id),
+        "FeatureSet": "ALL",
+        "MasterAccountId": master,
+        "MasterAccountEmail": "master@example.com",
+        "AvailablePolicyTypes": [{"Type": "SERVICE_CONTROL_POLICY", "Status": "ENABLED"}],
+    }
+
+
+def _make_ou(ou_id: str, name: str, org_id: str = ORG_ID) -> dict[str, Any]:
+    return {"Id": ou_id, "Name": name, "Arn": _ou_arn(org_id, ou_id)}
+
+
+def _make_account(
+    acct_id: str,
+    name: str,
+    org_id: str = ORG_ID,
+    status: str = "ACTIVE",
+) -> dict[str, Any]:
+    return {
+        "Id": acct_id,
+        "Name": name,
+        "Arn": _acct_arn(org_id, acct_id),
+        "Email": f"{name}@example.com",
+        "Status": status,
+        "JoinedMethod": "INVITED",
+        "JoinedTimestamp": "2023-01-01T00:00:00+00:00",
+    }
+
+
+def _make_org_client(
+    org: dict[str, Any] | None = None,
+    roots: list[dict[str, Any]] | None = None,
+    ous_by_parent: dict[str, list[dict[str, Any]]] | None = None,
+    accounts: list[dict[str, Any]] | None = None,
+    parents_by_child: dict[str, list[dict[str, Any]]] | None = None,
+) -> MagicMock:
+    """Build a fully mocked boto3 organizations client.
+
+    Args:
+        org:             Result of describe_organization (without wrapping key).
+        roots:           Items returned by list_roots.
+        ous_by_parent:   Mapping parent_id -> list of OUs.
+        accounts:        Items returned by list_accounts.
+        parents_by_child: Mapping child_id -> list of parents.
+    """
+    client = MagicMock()
+
+    org_data = org or _make_org()
+    client.describe_organization.return_value = {"Organization": org_data}
+
+    def _paginator(method: str) -> MagicMock:
+        pag = MagicMock()
+
+        if method == "list_roots":
+            pag.paginate.return_value = iter([{"Roots": roots or [{"Id": "r-root"}]}])
+
+        elif method == "list_organizational_units_for_parent":
+            def _ou_pages(**kwargs: Any) -> Any:
+                parent_id = kwargs.get("ParentId", "")
+                items = (ous_by_parent or {}).get(parent_id, [])
+                return iter([{"OrganizationalUnits": items}])
+            pag.paginate.side_effect = _ou_pages
+
+        elif method == "list_accounts":
+            pag.paginate.return_value = iter([{"Accounts": accounts or []}])
+
+        elif method == "list_parents":
+            def _parent_pages(**kwargs: Any) -> Any:
+                child_id = kwargs.get("ChildId", "")
+                items = (parents_by_child or {}).get(child_id, [])
+                return iter([{"Parents": items}])
+            pag.paginate.side_effect = _parent_pages
+
+        return pag
+
+    client.get_paginator.side_effect = _paginator
+    return client
+
+
+# ---------------------------------------------------------------------------
+# AwsConfig.include_organizations
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConfigOrganizations:
+    def test_default_is_false(self) -> None:
+        cfg = AwsConfig()
+        assert cfg.include_organizations is False
+
+    def test_can_be_enabled(self) -> None:
+        cfg = AwsConfig(include_organizations=True)
+        assert cfg.include_organizations is True
+
+    def test_existing_defaults_unchanged(self) -> None:
+        cfg = AwsConfig(include_organizations=True)
+        assert cfg.services == ["s3", "iam", "ec2"]
+        assert cfg.regions == ["us-east-1"]
+
+
+# ---------------------------------------------------------------------------
+# _paginate_org
+# ---------------------------------------------------------------------------
+
+
+class TestPaginateOrg:
+    def test_returns_flat_list_across_pages(self) -> None:
+        client = MagicMock()
+        pag = MagicMock()
+        pag.paginate.return_value = iter(
+            [{"Accounts": [{"Id": "111"}]}, {"Accounts": [{"Id": "222"}]}]
+        )
+        client.get_paginator.return_value = pag
+
+        result = _paginate_org(client, "list_accounts", "Accounts")
+        assert [r["Id"] for r in result] == ["111", "222"]
+
+    def test_throttle_retries_then_succeeds(self) -> None:
+        """First call raises ThrottlingException; second succeeds."""
+        client = MagicMock()
+        pag = MagicMock()
+        throttle_error = _client_error("ThrottlingException")
+        ok_page = [{"Accounts": [{"Id": "111"}]}]
+
+        call_count = 0
+
+        def _paginate(**kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise throttle_error
+            return iter(ok_page)
+
+        pag.paginate.side_effect = _paginate
+        client.get_paginator.return_value = pag
+
+        with patch("omniscience_connectors.aws.connector.time.sleep") as mock_sleep:
+            result = _paginate_org(client, "list_accounts", "Accounts")
+
+        assert [r["Id"] for r in result] == ["111"]
+        mock_sleep.assert_called_once()
+
+    def test_throttle_exhausts_retries_raises(self) -> None:
+        """Persistent ThrottlingException re-raises after max retries."""
+        client = MagicMock()
+        pag = MagicMock()
+        pag.paginate.side_effect = _client_error("ThrottlingException")
+        client.get_paginator.return_value = pag
+
+        with (
+            patch("omniscience_connectors.aws.connector.time.sleep"),
+            pytest.raises(ClientError),
+        ):
+            _paginate_org(client, "list_accounts", "Accounts")
+
+
+# ---------------------------------------------------------------------------
+# _collect_ous
+# ---------------------------------------------------------------------------
+
+
+class TestCollectOus:
+    def test_flat_ous_returned(self) -> None:
+        client = _make_org_client(
+            ous_by_parent={"r-root": [_make_ou(OU_ID_1, "Engineering")]},
+        )
+        refs = _collect_ous(client, "r-root", "/root", ORG_ID, [])
+        assert len(refs) == 1
+        ref = refs[0]
+        assert ref.metadata["resource_type"] == "aws_organizations_ou"
+        assert ref.metadata["ou_id"] == OU_ID_1
+        assert ref.metadata["name"] == "Engineering"
+        assert ref.uri == f"aws://org/{ORG_ID}/ou/{OU_ID_1}"
+
+    def test_nested_recursion(self) -> None:
+        """Root OU has one child OU which has a grandchild OU."""
+        client = _make_org_client(
+            ous_by_parent={
+                "r-root": [_make_ou(OU_ID_1, "Engineering")],
+                OU_ID_1: [_make_ou(OU_ID_CHILD, "Backend")],
+                OU_ID_CHILD: [],
+            },
+        )
+        refs = _collect_ous(client, "r-root", "/root", ORG_ID, [])
+        ou_ids = {r.metadata["ou_id"] for r in refs}
+        assert ou_ids == {OU_ID_1, OU_ID_CHILD}
+
+    def test_path_is_built_correctly(self) -> None:
+        client = _make_org_client(
+            ous_by_parent={
+                "r-root": [_make_ou(OU_ID_1, "Engineering")],
+                OU_ID_1: [_make_ou(OU_ID_CHILD, "Backend")],
+                OU_ID_CHILD: [],
+            },
+        )
+        refs = _collect_ous(client, "r-root", "/root", ORG_ID, [])
+        paths = {r.metadata["path"] for r in refs}
+        assert "/root/Engineering" in paths
+        assert "/root/Engineering/Backend" in paths
+
+    def test_filter_excludes_ou(self) -> None:
+        client = _make_org_client(
+            ous_by_parent={"r-root": [_make_ou(OU_ID_1, "Engineering")]},
+        )
+        refs = _collect_ous(client, "r-root", "/root", ORG_ID, ["aws_organization"])
+        assert refs == []
+
+    def test_empty_parent_returns_empty(self) -> None:
+        client = _make_org_client(ous_by_parent={"r-root": []})
+        refs = _collect_ous(client, "r-root", "/root", ORG_ID, [])
+        assert refs == []
+
+
+# ---------------------------------------------------------------------------
+# _discover_organizations
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverOrganizations:
+    def test_happy_path_yields_org_ou_account(self) -> None:
+        acct = _make_account("222222222222", "production")
+        client = _make_org_client(
+            ous_by_parent={
+                "r-root": [_make_ou(OU_ID_1, "Engineering")],
+                OU_ID_1: [],
+            },
+            accounts=[acct],
+            parents_by_child={"222222222222": [{"Id": OU_ID_1, "Type": "ORGANIZATIONAL_UNIT"}]},
+        )
+
+        with patch(
+            "omniscience_connectors.aws.connector._org_client", return_value=client
+        ):
+            refs = _discover_organizations(SECRETS, [])
+
+        resource_types = {r.metadata["resource_type"] for r in refs}
+        assert "aws_organization" in resource_types
+        assert "aws_organizations_ou" in resource_types
+        assert "aws_organizations_account" in resource_types
+
+    def test_org_uri_format(self) -> None:
+        client = _make_org_client(accounts=[])
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        org_refs = [r for r in refs if r.metadata["resource_type"] == "aws_organization"]
+        assert len(org_refs) == 1
+        assert org_refs[0].uri == f"aws://org/{ORG_ID}"
+        assert org_refs[0].external_id == _org_arn(ORG_ID)
+
+    def test_account_uri_format(self) -> None:
+        acct_id = "333333333333"
+        acct = _make_account(acct_id, "staging")
+        client = _make_org_client(accounts=[acct])
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        acct_refs = [r for r in refs if r.metadata["resource_type"] == "aws_organizations_account"]
+        assert len(acct_refs) == 1
+        assert acct_refs[0].uri == f"aws://org/{ORG_ID}/account/{acct_id}"
+
+    def test_account_parent_id_mapped(self) -> None:
+        acct_id = "444444444444"
+        acct = _make_account(acct_id, "dev")
+        client = _make_org_client(
+            accounts=[acct],
+            parents_by_child={acct_id: [{"Id": OU_ID_1, "Type": "ORGANIZATIONAL_UNIT"}]},
+        )
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        acct_refs = [r for r in refs if r.metadata["resource_type"] == "aws_organizations_account"]
+        assert acct_refs[0].metadata["parent_id"] == OU_ID_1
+
+    def test_access_denied_returns_empty(self) -> None:
+        client = MagicMock()
+        client.describe_organization.side_effect = _client_error("AccessDeniedException")
+
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        assert refs == []
+
+    def test_not_in_use_returns_empty(self) -> None:
+        client = MagicMock()
+        client.describe_organization.side_effect = _client_error(
+            "AWSOrganizationsNotInUseException"
+        )
+
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        assert refs == []
+
+    def test_empty_org_id_returns_empty(self) -> None:
+        client = MagicMock()
+        # Return an org dict missing the Id field
+        client.describe_organization.return_value = {"Organization": {"FeatureSet": "ALL"}}
+
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        assert refs == []
+
+    def test_list_roots_failure_logged_and_continues(self) -> None:
+        client = MagicMock()
+        client.describe_organization.return_value = {"Organization": _make_org()}
+
+        # list_roots raises; list_accounts succeeds with one account
+        acct = _make_account("555555555555", "security")
+        list_roots_pag = MagicMock()
+        list_roots_pag.paginate.side_effect = _client_error("AccessDeniedException")
+
+        list_accounts_pag = MagicMock()
+        list_accounts_pag.paginate.return_value = iter([{"Accounts": [acct]}])
+
+        list_parents_pag = MagicMock()
+        list_parents_pag.paginate.side_effect = lambda **kwargs: iter([{"Parents": []}])
+
+        def _pag(method: str) -> MagicMock:
+            if method == "list_roots":
+                return list_roots_pag
+            if method == "list_accounts":
+                return list_accounts_pag
+            if method == "list_parents":
+                return list_parents_pag
+            return MagicMock()
+
+        client.get_paginator.side_effect = _pag
+
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        # Should still yield the org and the account despite roots failing
+        rtypes = {r.metadata["resource_type"] for r in refs}
+        assert "aws_organization" in rtypes
+        assert "aws_organizations_account" in rtypes
+
+    def test_list_accounts_failure_logged_and_continues(self) -> None:
+        client = _make_org_client()  # no accounts key → default empty
+        # Override list_accounts paginator to raise
+        real_pag_factory = client.get_paginator.side_effect
+
+        def _pag_with_acct_error(method: str) -> MagicMock:
+            pag = real_pag_factory(method)
+            if method == "list_accounts":
+                pag.paginate.side_effect = _client_error("AccessDeniedException")
+            return pag
+
+        client.get_paginator.side_effect = _pag_with_acct_error
+
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        # Org should still be discovered; just no account refs
+        rtypes = {r.metadata["resource_type"] for r in refs}
+        assert "aws_organization" in rtypes
+        assert "aws_organizations_account" not in rtypes
+
+    def test_list_parents_failure_account_still_emitted(self) -> None:
+        acct_id = "666666666666"
+        acct = _make_account(acct_id, "sandbox")
+        client = _make_org_client(accounts=[acct])
+
+        # Override list_parents paginator to raise
+        real_pag_factory = client.get_paginator.side_effect
+
+        def _pag_with_parents_error(method: str) -> MagicMock:
+            pag = real_pag_factory(method)
+            if method == "list_parents":
+                pag.paginate.side_effect = _client_error("AccessDeniedException")
+            return pag
+
+        client.get_paginator.side_effect = _pag_with_parents_error
+
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
+            refs = _discover_organizations(SECRETS, [])
+
+        acct_refs = [r for r in refs if r.metadata["resource_type"] == "aws_organizations_account"]
+        assert len(acct_refs) == 1
+        assert acct_refs[0].metadata["account_id"] == acct_id
+        assert acct_refs[0].metadata["parent_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.discover integration
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorDiscoverOrganizations:
+    @pytest.fixture()
+    def connector(self) -> AwsConnector:
+        return AwsConnector()
+
+    async def test_organizations_not_called_by_default(self, connector: AwsConnector) -> None:
+        config = AwsConfig(services=[])  # no standard services
+
+        with (
+            patch(
+                "omniscience_connectors.aws.connector._get_account_id",
+                return_value=ACCOUNT_ID,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_organizations"
+            ) as mock_org,
+        ):
+            refs = [ref async for ref in connector.discover(config, SECRETS)]
+
+        mock_org.assert_not_called()
+        assert refs == []
+
+    async def test_organizations_called_when_enabled(self, connector: AwsConnector) -> None:
+        config = AwsConfig(services=[], include_organizations=True)
+
+        org_ref = DocumentRef(
+            external_id=_org_arn(ORG_ID),
+            uri=f"aws://org/{ORG_ID}",
+            metadata={"kind": "aws_live", "resource_type": "aws_organization"},
+        )
+
+        with (
+            patch(
+                "omniscience_connectors.aws.connector._get_account_id",
+                return_value=ACCOUNT_ID,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_organizations",
+                return_value=[org_ref],
+            ) as mock_org,
+        ):
+            refs = [ref async for ref in connector.discover(config, SECRETS)]
+
+        mock_org.assert_called_once()
+        assert len(refs) == 1
+        assert refs[0].metadata["resource_type"] == "aws_organization"
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.fetch for Organizations resources
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorFetchOrganizations:
+    @pytest.fixture()
+    def connector(self) -> AwsConnector:
+        return AwsConnector()
+
+    @pytest.fixture()
+    def config(self) -> AwsConfig:
+        return AwsConfig(include_organizations=True)
+
+    def _make_ref(self, resource_type: str, **extra: Any) -> DocumentRef:
+        meta: dict[str, Any] = {
+            "kind": "aws_live",
+            "resource_type": resource_type,
+            "service": "organizations",
+            "region": "global",
+            **extra,
+        }
+        return DocumentRef(
+            external_id=meta.get("arn", f"arn:aws:organizations::test:{resource_type}"),
+            uri=f"aws://org/{ORG_ID}/test",
+            metadata=meta,
+        )
+
+    async def test_fetch_organization(
+        self, connector: AwsConnector, config: AwsConfig
+    ) -> None:
+        mock_client = MagicMock()
+        mock_client.describe_organization.return_value = {"Organization": _make_org()}
+        ref = self._make_ref("aws_organization", org_id=ORG_ID)
+
+        with patch(
+            "omniscience_connectors.aws.connector._org_client", return_value=mock_client
+        ):
+            doc = await connector.fetch(config, SECRETS, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["id"] == ORG_ID
+        assert data["master_account_id"] == ACCOUNT_ID
+        assert doc.content_type == "application/json"
+
+    async def test_fetch_ou(self, connector: AwsConnector, config: AwsConfig) -> None:
+        mock_client = MagicMock()
+        mock_client.describe_organizational_unit.return_value = {
+            "OrganizationalUnit": _make_ou(OU_ID_1, "Engineering")
+        }
+        ref = self._make_ref("aws_organizations_ou", ou_id=OU_ID_1)
+
+        with patch(
+            "omniscience_connectors.aws.connector._org_client", return_value=mock_client
+        ):
+            doc = await connector.fetch(config, SECRETS, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["id"] == OU_ID_1
+        assert data["name"] == "Engineering"
+
+    async def test_fetch_account(self, connector: AwsConnector, config: AwsConfig) -> None:
+        acct_id = "777777777777"
+        mock_client = MagicMock()
+        mock_client.describe_account.return_value = {
+            "Account": _make_account(acct_id, "prod")
+        }
+        ref = self._make_ref("aws_organizations_account", account_id=acct_id)
+
+        with patch(
+            "omniscience_connectors.aws.connector._org_client", return_value=mock_client
+        ):
+            doc = await connector.fetch(config, SECRETS, ref)
+
+        data = json.loads(doc.content_bytes)
+        assert data["id"] == acct_id
+        assert data["name"] == "prod"
+        assert data["status"] == "ACTIVE"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_org_* helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFetchOrgHelpers:
+    def test_fetch_org_organization_success(self) -> None:
+        client = MagicMock()
+        client.describe_organization.return_value = {"Organization": _make_org()}
+        result = _fetch_org_organization(client, ORG_ID)
+        assert result["id"] == ORG_ID
+        assert result["feature_set"] == "ALL"
+        assert "SERVICE_CONTROL_POLICY" in result["available_policy_types"]
+
+    def test_fetch_org_organization_client_error_silenced(self) -> None:
+        client = MagicMock()
+        client.describe_organization.side_effect = _client_error("AccessDeniedException")
+        result = _fetch_org_organization(client, ORG_ID)
+        assert result == {"org_id": ORG_ID}
+
+    def test_fetch_org_ou_success(self) -> None:
+        client = MagicMock()
+        client.describe_organizational_unit.return_value = {
+            "OrganizationalUnit": _make_ou(OU_ID_1, "Security")
+        }
+        result = _fetch_org_ou(client, OU_ID_1)
+        assert result["id"] == OU_ID_1
+        assert result["name"] == "Security"
+
+    def test_fetch_org_ou_client_error_silenced(self) -> None:
+        client = MagicMock()
+        client.describe_organizational_unit.side_effect = _client_error("AccessDeniedException")
+        result = _fetch_org_ou(client, OU_ID_1)
+        assert result == {"ou_id": OU_ID_1}
+
+    def test_fetch_org_account_success(self) -> None:
+        acct_id = "888888888888"
+        client = MagicMock()
+        client.describe_account.return_value = {"Account": _make_account(acct_id, "payments")}
+        result = _fetch_org_account(client, acct_id)
+        assert result["id"] == acct_id
+        assert result["name"] == "payments"
+        assert result["email"] == "payments@example.com"
+
+    def test_fetch_org_account_client_error_silenced(self) -> None:
+        client = MagicMock()
+        client.describe_account.side_effect = _client_error("AccountNotFoundException")
+        result = _fetch_org_account(client, "999999999999")
+        assert result == {"account_id": "999999999999"}


### PR DESCRIPTION
Extends the aws connector with opt-in `include_organizations` to ingest the organization, nested OUs (recursive), and member accounts (with account→OU mapping). New URIs aws://org/{id}, /ou/{id}, /account/{id}; read-only Organizations calls (us-east-1), throttling backoff, graceful AccessDenied. 94 passed (32 new). No SourceType/registry change.