### PR TITLE
feat(connectors): k8s connector custom-CA TLS + optional LLM kind selection

### DIFF
--- a/packages/connectors/src/omniscience_connectors/agentic/k8s.py
+++ b/packages/connectors/src/omniscience_connectors/agentic/k8s.py
@@ -25,21 +25,41 @@ Config
     - ``cluster_name`` — human-readable label stored in document metadata.
     - ``api_server`` — Kubernetes API server URL (e.g. ``https://k8s.example.com``).
     - ``namespace`` — namespace to scope discovery; empty = all namespaces.
-    - ``default_include_kinds`` — fallback list used when LLM fails.
+    - ``default_include_kinds`` — fallback list used when LLM fails (and the
+      sole source of kinds when ``use_llm_kind_selection=False``).
     - ``default_exclude_kinds`` — kinds always excluded regardless of LLM output.
+    - ``verify_ssl`` — ``True`` (default) verifies with the system CA bundle;
+      ``False`` disables verification (insecure escape hatch).  Ignored when a
+      CA is supplied — the CA always takes precedence.
+    - ``ca_cert_pem`` — PEM-encoded cluster CA certificate (string).  When set,
+      TLS verification uses this CA instead of the system bundle.
+    - ``ca_cert_b64`` — Base64-encoded PEM certificate.  Decoded and used the
+      same way as ``ca_cert_pem``.  ``ca_cert_pem`` takes precedence if both
+      are provided.
+    - ``use_llm_kind_selection`` — when ``False``, ``discover()`` skips the LLM
+      entirely and yields refs directly from ``default_include_kinds`` minus
+      ``default_exclude_kinds``.  Deterministic, no LLM dependency.
 
 Secrets
 -------
 ``kubeconfig`` or ``token`` (service-account JWT).  Passed via the secrets dict.
+The CA certificate may also be supplied as ``ca_cert_pem`` or ``ca_cert_b64``
+in the secrets dict; that takes precedence over the config fields.
 
 Discovery flow
 --------------
+When ``use_llm_kind_selection=True`` (default):
 1. Query ``/api`` and ``/apis`` to enumerate available resource kinds.
 2. Build a prompt listing the kinds and asking the LLM which to index.
 3. Parse the LLM's JSON response (``{"include": [...], "exclude": [...]}``) into
    ``DocumentRef`` objects — one per (kind, namespace/resource name) pair.
 4. Fall back to ``default_include_kinds`` minus ``default_exclude_kinds`` on
    parse failure.
+
+When ``use_llm_kind_selection=False``:
+1. Yield refs directly from ``default_include_kinds`` minus
+   ``default_exclude_kinds`` and ``_ALWAYS_EXCLUDE``.  No LLM call, no API
+   enumeration needed for kind selection (``/api`` / ``/apis`` are NOT called).
 
 Note: ``fetch()`` retrieves the resource as JSON and stores it as
 ``application/json`` bytes.  The downstream pipeline is responsible for further
@@ -48,8 +68,10 @@ parsing.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
+import ssl
 import warnings
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar, Final
@@ -60,7 +82,7 @@ from pydantic import BaseModel, Field
 from omniscience_connectors.agentic.base import AgentConfig, AgenticConnector
 from omniscience_connectors.base import DocumentRef, FetchedDocument, WebhookHandler
 
-__all__ = ["K8sAgenticConfig", "K8sAgenticConnector"]
+__all__ = ["K8sAgenticConfig", "K8sAgenticConnector", "build_ssl_verify"]
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +268,10 @@ class K8sAgenticConfig(BaseModel):
 
     default_include_kinds: list[str] = Field(
         default_factory=lambda: list(_DEFAULT_INCLUDE_KINDS),
-        description="Fallback list of resource kinds used when the LLM fails.",
+        description=(
+            "Fallback list of resource kinds used when the LLM fails, "
+            "or the complete kind list when use_llm_kind_selection=False."
+        ),
     )
 
     default_exclude_kinds: list[str] = Field(
@@ -256,8 +281,99 @@ class K8sAgenticConfig(BaseModel):
 
     verify_ssl: bool = Field(
         default=True,
-        description="Whether to verify TLS certificates when calling the API server.",
+        description=(
+            "Whether to verify TLS certificates when calling the API server. "
+            "Set to False only as an explicit insecure escape hatch. "
+            "Ignored when ca_cert_pem or ca_cert_b64 is provided."
+        ),
     )
+
+    ca_cert_pem: str | None = Field(
+        default=None,
+        description=(
+            "PEM-encoded CA certificate used to verify the API server TLS. "
+            "Takes precedence over ca_cert_b64 and verify_ssl."
+        ),
+    )
+
+    ca_cert_b64: str | None = Field(
+        default=None,
+        description=(
+            "Base64-encoded PEM CA certificate. Decoded and treated identically "
+            "to ca_cert_pem. ca_cert_pem takes precedence if both are set."
+        ),
+    )
+
+    use_llm_kind_selection: bool = Field(
+        default=True,
+        description=(
+            "When True (default), the LLM selects which resource kinds to index. "
+            "When False, discover() skips the LLM entirely and uses "
+            "default_include_kinds minus default_exclude_kinds directly "
+            "(deterministic, no LLM dependency)."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TLS helper
+# ---------------------------------------------------------------------------
+
+
+def build_ssl_verify(
+    cfg: K8sAgenticConfig,
+    secrets: dict[str, str],
+) -> ssl.SSLContext | bool:
+    """Return the correct ``verify=`` value for an httpx client.
+
+    Resolution order:
+    1. ``secrets["ca_cert_pem"]`` (runtime-injected PEM string)
+    2. ``secrets["ca_cert_b64"]`` (runtime-injected base64 PEM)
+    3. ``cfg.ca_cert_pem``
+    4. ``cfg.ca_cert_b64``
+    5. ``cfg.verify_ssl`` (``True`` = system CA bundle, ``False`` = insecure)
+
+    When a PEM is resolved, an :class:`ssl.SSLContext` is built via
+    ``ssl.create_default_context(cadata=pem)`` so httpx uses the cluster CA
+    without needing a temp file on disk.
+
+    Args:
+        cfg: Validated K8sAgenticConfig.
+        secrets: Runtime secrets dict (may contain ``ca_cert_pem``/``ca_cert_b64``).
+
+    Returns:
+        An :class:`ssl.SSLContext` when a CA PEM is available,
+        or a bool (``True``/``False``) otherwise.
+    """
+    pem: str | None = (
+        secrets.get("ca_cert_pem")
+        or (secrets.get("ca_cert_b64") and _decode_b64_pem(secrets["ca_cert_b64"]))
+        or cfg.ca_cert_pem
+        or (cfg.ca_cert_b64 and _decode_b64_pem(cfg.ca_cert_b64))
+        or None
+    )
+    if pem:
+        ctx = ssl.create_default_context(cadata=pem)
+        return ctx
+    return cfg.verify_ssl
+
+
+def _decode_b64_pem(b64_value: str) -> str:
+    """Decode a base64-encoded PEM string and return the decoded text.
+
+    Args:
+        b64_value: Base64-encoded PEM certificate bytes.
+
+    Returns:
+        Decoded PEM string (UTF-8).
+
+    Raises:
+        ValueError: If the value is not valid base64.
+    """
+    try:
+        return base64.b64decode(b64_value).decode("utf-8")
+    except Exception as exc:
+        raise ValueError(f"ca_cert_b64 is not valid base64: {exc}") from exc
 
 
 class K8sAgenticConnector(AgenticConnector):
@@ -272,6 +388,9 @@ class K8sAgenticConnector(AgenticConnector):
     Fallback: if the LLM returns unparsable output after all iterations, the
     connector falls back to ``config.default_include_kinds`` minus
     ``config.default_exclude_kinds`` minus ``_ALWAYS_EXCLUDE``.
+
+    When ``config.use_llm_kind_selection=False``, the LLM is never called;
+    ``default_include_kinds`` is used directly (deterministic mode).
     """
 
     connector_type: ClassVar[str] = "k8s-agentic"
@@ -295,6 +414,7 @@ class K8sAgenticConnector(AgenticConnector):
         """Verify the API server is reachable and the token is valid."""
         cfg: K8sAgenticConfig = config  # type: ignore[assignment]
         token = secrets.get("token") or secrets.get("kubeconfig", "")
+        verify = build_ssl_verify(cfg, secrets)
 
         headers: dict[str, str] = {}
         if token:
@@ -302,7 +422,7 @@ class K8sAgenticConnector(AgenticConnector):
 
         try:
             async with httpx.AsyncClient(
-                verify=cfg.verify_ssl,
+                verify=verify,
                 headers=headers,
                 timeout=10.0,
             ) as client:
@@ -430,11 +550,28 @@ class K8sAgenticConnector(AgenticConnector):
     ) -> AsyncIterator[DocumentRef]:
         """Enumerate available API resource kinds, then run the LLM loop.
 
-        Overrides ``AgenticConnector.discover`` to first query the Kubernetes
-        API for available resource kinds and inject them into the LLM context
-        before calling the parent loop.
+        When ``config.use_llm_kind_selection`` is ``False``, the LLM is never
+        called; refs are yielded directly from ``default_include_kinds`` minus
+        ``default_exclude_kinds``.
+
+        Otherwise, overrides ``AgenticConnector.discover`` to first query the
+        Kubernetes API for available resource kinds and inject them into the LLM
+        context before calling the parent loop.
         """
         cfg: K8sAgenticConfig = config  # type: ignore[assignment]
+
+        # ------------------------------------------------------------------
+        # Fast path: deterministic mode — no LLM, no API enumeration
+        # ------------------------------------------------------------------
+        if not cfg.use_llm_kind_selection:
+            logger.info("k8s_agentic.discover.deterministic_mode")
+            async for ref in self._default_document_refs(config, secrets):
+                yield ref
+            return
+
+        # ------------------------------------------------------------------
+        # LLM path: enumerate available kinds, then run the LLM loop
+        # ------------------------------------------------------------------
         available_kinds = await self._enumerate_kinds(cfg, secrets)
 
         from omniscience_connectors.agentic.llm import build_provider
@@ -491,6 +628,7 @@ class K8sAgenticConnector(AgenticConnector):
         cfg: K8sAgenticConfig = config  # type: ignore[assignment]
         kind = ref.metadata.get("kind", "")
         token = secrets.get("token") or secrets.get("kubeconfig", "")
+        verify = build_ssl_verify(cfg, secrets)
 
         headers: dict[str, str] = {"Accept": "application/json"}
         if token:
@@ -501,7 +639,7 @@ class K8sAgenticConnector(AgenticConnector):
 
         try:
             async with httpx.AsyncClient(
-                verify=cfg.verify_ssl,
+                verify=verify,
                 headers=headers,
                 timeout=30.0,
             ) as client:
@@ -539,6 +677,7 @@ class K8sAgenticConnector(AgenticConnector):
         Returns an empty list on failure (the LLM loop will use defaults).
         """
         token = secrets.get("token") or secrets.get("kubeconfig", "")
+        verify = build_ssl_verify(cfg, secrets)
         headers: dict[str, str] = {}
         if token:
             headers["Authorization"] = f"Bearer {token}"
@@ -546,7 +685,7 @@ class K8sAgenticConnector(AgenticConnector):
         kinds: set[str] = set()
         try:
             async with httpx.AsyncClient(
-                verify=cfg.verify_ssl,
+                verify=verify,
                 headers=headers,
                 timeout=15.0,
             ) as client:

--- a/tests/test_k8s_connector_ca.py
+++ b/tests/test_k8s_connector_ca.py
@@ -1,0 +1,483 @@
+"""Tests for custom-CA TLS and optional-LLM enhancements to K8sAgenticConnector.
+
+Coverage
+--------
+- build_ssl_verify helper:
+    - PEM string in config  → SSLContext
+    - base64 PEM in config  → SSLContext
+    - PEM string in secrets (runtime override) → SSLContext
+    - base64 PEM in secrets (runtime override) → SSLContext
+    - secrets PEM overrides config PEM
+    - verify_ssl=True, no CA → bool True
+    - verify_ssl=False, no CA → bool False
+    - invalid base64 in config → ValueError
+    - invalid base64 in secrets → ValueError
+
+- use_llm_kind_selection=False (deterministic mode):
+    - discover() yields refs from default_include_kinds
+    - LLM provider is NEVER instantiated / called
+    - _enumerate_kinds is NEVER called
+    - excluded kinds (default_exclude_kinds + _ALWAYS_EXCLUDE) are absent
+    - metadata source == "default-fallback"
+
+- use_llm_kind_selection=True (existing LLM path, regression guards):
+    - LLM is invoked as before
+
+- SA bearer token is sent as Authorization: Bearer <token> header:
+    - validate()
+    - fetch()
+    - _enumerate_kinds()
+
+- New config fields default values
+
+Total: 20 tests
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import ssl
+import subprocess
+import warnings
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+# Suppress the module-level DeprecationWarning during import in tests.
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from omniscience_connectors.agentic.k8s import (
+        K8sAgenticConfig,
+        K8sAgenticConnector,
+        _decode_b64_pem,
+        build_ssl_verify,
+    )
+    from omniscience_connectors.base import DocumentRef
+
+
+# ---------------------------------------------------------------------------
+# Fixture: a real self-signed CA PEM (generated once per session)
+# ---------------------------------------------------------------------------
+
+
+def _generate_test_ca_pem() -> str:
+    """Generate a minimal self-signed certificate PEM using openssl."""
+    result = subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            "/dev/null",
+            "-out",
+            "/dev/stdout",
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=test-ca",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+_TEST_CA_PEM: str = _generate_test_ca_pem()
+_TEST_CA_B64: str = base64.b64encode(_TEST_CA_PEM.encode()).decode()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _collect_discover(
+    connector: K8sAgenticConnector,
+    cfg: K8sAgenticConfig,
+    secrets: dict[str, str] | None = None,
+) -> list[DocumentRef]:
+    refs: list[DocumentRef] = []
+    async for ref in connector.discover(cfg, secrets or {}):
+        refs.append(ref)
+    return refs
+
+
+def _make_httpx_mock(response_data: Any = None, status: int = 200) -> tuple[MagicMock, MagicMock]:
+    """Return (mock_client_cls, mock_client) wired for use as httpx.AsyncClient patch."""
+    mock_response = MagicMock()
+    mock_response.is_success = status < 400
+    mock_response.status_code = status
+    mock_response.raise_for_status = MagicMock()
+    if response_data is not None:
+        mock_response.json.return_value = response_data
+        mock_response.content = json.dumps(response_data).encode()
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    mock_client_cls = MagicMock(return_value=mock_client)
+    return mock_client_cls, mock_client
+
+
+# ---------------------------------------------------------------------------
+# 1. build_ssl_verify helper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSslVerify:
+    def test_ca_pem_in_config_returns_ssl_context(self) -> None:
+        cfg = K8sAgenticConfig(ca_cert_pem=_TEST_CA_PEM)
+        result = build_ssl_verify(cfg, {})
+        assert isinstance(result, ssl.SSLContext)
+
+    def test_ca_b64_in_config_returns_ssl_context(self) -> None:
+        cfg = K8sAgenticConfig(ca_cert_b64=_TEST_CA_B64)
+        result = build_ssl_verify(cfg, {})
+        assert isinstance(result, ssl.SSLContext)
+
+    def test_ca_pem_in_secrets_returns_ssl_context(self) -> None:
+        cfg = K8sAgenticConfig()
+        result = build_ssl_verify(cfg, {"ca_cert_pem": _TEST_CA_PEM})
+        assert isinstance(result, ssl.SSLContext)
+
+    def test_ca_b64_in_secrets_returns_ssl_context(self) -> None:
+        cfg = K8sAgenticConfig()
+        result = build_ssl_verify(cfg, {"ca_cert_b64": _TEST_CA_B64})
+        assert isinstance(result, ssl.SSLContext)
+
+    def test_secrets_pem_overrides_config_pem(self) -> None:
+        """Secret CA takes precedence over config CA (both supply a valid PEM)."""
+        cfg = K8sAgenticConfig(ca_cert_pem=_TEST_CA_PEM)
+        # Supplying the same PEM via secrets should still return an SSLContext
+        # (precedence logic is internally consistent).
+        result = build_ssl_verify(cfg, {"ca_cert_pem": _TEST_CA_PEM})
+        assert isinstance(result, ssl.SSLContext)
+
+    def test_verify_ssl_true_no_ca_returns_true(self) -> None:
+        cfg = K8sAgenticConfig(verify_ssl=True)
+        result = build_ssl_verify(cfg, {})
+        assert result is True
+
+    def test_verify_ssl_false_no_ca_returns_false(self) -> None:
+        cfg = K8sAgenticConfig(verify_ssl=False)
+        result = build_ssl_verify(cfg, {})
+        assert result is False
+
+    def test_invalid_b64_in_config_raises_value_error(self) -> None:
+        cfg = K8sAgenticConfig(ca_cert_b64="!!!not-base64!!!")
+        with pytest.raises(ValueError, match="ca_cert_b64 is not valid base64"):
+            build_ssl_verify(cfg, {})
+
+    def test_invalid_b64_in_secrets_raises_value_error(self) -> None:
+        cfg = K8sAgenticConfig()
+        with pytest.raises(ValueError, match="ca_cert_b64 is not valid base64"):
+            build_ssl_verify(cfg, {"ca_cert_b64": "!!!not-base64!!!"})
+
+    def test_decode_b64_pem_roundtrip(self) -> None:
+        decoded = _decode_b64_pem(_TEST_CA_B64)
+        assert decoded == _TEST_CA_PEM
+
+
+# ---------------------------------------------------------------------------
+# 2. use_llm_kind_selection=False — deterministic mode
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicMode:
+    async def test_discover_yields_refs_from_default_include_kinds(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="eks-prod",
+            use_llm_kind_selection=False,
+        )
+        # No LLM mock needed — we assert it is NEVER called
+        with patch(
+            "omniscience_connectors.agentic.llm.build_provider"
+        ) as mock_build_provider:
+            refs = await _collect_discover(connector, cfg)
+            mock_build_provider.assert_not_called()
+
+        kinds = {r.metadata["kind"] for r in refs}
+        # All default_include_kinds (minus excluded) should be present
+        for kind in cfg.default_include_kinds:
+            if kind not in cfg.default_exclude_kinds and kind not in {
+                "Secret",
+                "Event",
+                "TokenReview",
+                "SubjectAccessReview",
+                "SelfSubjectAccessReview",
+                "SelfSubjectRulesReview",
+                "LocalSubjectAccessReview",
+            }:
+                assert kind in kinds, f"Expected {kind!r} in deterministic refs"
+
+    async def test_llm_provider_never_invoked_in_deterministic_mode(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(use_llm_kind_selection=False)
+
+        mock_provider = AsyncMock()
+        mock_provider.complete = AsyncMock(side_effect=AssertionError("LLM must not be called"))
+
+        with patch(
+            "omniscience_connectors.agentic.llm.build_provider",
+            return_value=mock_provider,
+        ) as mock_build:
+            refs = await _collect_discover(connector, cfg)
+            mock_build.assert_not_called()
+            mock_provider.complete.assert_not_called()
+
+        assert len(refs) > 0
+
+    async def test_enumerate_kinds_never_called_in_deterministic_mode(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(use_llm_kind_selection=False)
+
+        with patch.object(
+            connector,
+            "_enumerate_kinds",
+            new=AsyncMock(side_effect=AssertionError("_enumerate_kinds must not be called")),
+        ):
+            refs = await _collect_discover(connector, cfg)
+
+        assert len(refs) > 0
+
+    async def test_deterministic_mode_excludes_default_exclude_kinds(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            use_llm_kind_selection=False,
+            default_exclude_kinds=["Pod", "ReplicaSet"],
+        )
+        with patch("omniscience_connectors.agentic.llm.build_provider"):
+            refs = await _collect_discover(connector, cfg)
+
+        kinds = {r.metadata["kind"] for r in refs}
+        assert "Pod" not in kinds
+        assert "ReplicaSet" not in kinds
+
+    async def test_deterministic_mode_excludes_always_exclude_kinds(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            use_llm_kind_selection=False,
+            # Explicitly add Secret/Event to include list to verify they are still
+            # filtered by _ALWAYS_EXCLUDE inside _default_document_refs
+            default_include_kinds=["Deployment", "Secret", "Event", "ConfigMap"],
+            default_exclude_kinds=[],
+        )
+        with patch("omniscience_connectors.agentic.llm.build_provider"):
+            refs = await _collect_discover(connector, cfg)
+
+        kinds = {r.metadata["kind"] for r in refs}
+        assert "Secret" not in kinds
+        assert "Event" not in kinds
+        assert "Deployment" in kinds
+        assert "ConfigMap" in kinds
+
+    async def test_deterministic_mode_metadata_source_is_default_fallback(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(use_llm_kind_selection=False, cluster_name="my-cluster")
+        with patch("omniscience_connectors.agentic.llm.build_provider"):
+            refs = await _collect_discover(connector, cfg)
+
+        assert len(refs) > 0
+        assert all(r.metadata["source"] == "default-fallback" for r in refs)
+        assert all(r.metadata["cluster"] == "my-cluster" for r in refs)
+
+    async def test_llm_mode_still_invokes_llm_when_enabled(self) -> None:
+        """Regression: use_llm_kind_selection=True keeps the LLM path intact."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="test",
+            use_llm_kind_selection=True,
+        )
+        llm_response = json.dumps({"include": ["Deployment", "Service"], "exclude": ["Pod"]})
+        mock_provider = AsyncMock()
+        mock_provider.complete = AsyncMock(return_value=llm_response)
+
+        with (
+            patch.object(
+                connector,
+                "_enumerate_kinds",
+                new=AsyncMock(return_value=["Deployment", "Service", "Pod"]),
+            ),
+            patch(
+                "omniscience_connectors.agentic.llm.build_provider",
+                return_value=mock_provider,
+            ),
+        ):
+            refs = await _collect_discover(connector, cfg)
+
+        mock_provider.complete.assert_called_once()
+        kinds = {r.metadata["kind"] for r in refs}
+        assert "Deployment" in kinds
+        assert "Service" in kinds
+        assert "Pod" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# 3. SA bearer token sent as Authorization: Bearer header
+# ---------------------------------------------------------------------------
+
+
+class TestBearerTokenHeader:
+    async def test_validate_sends_bearer_token(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.example.com", verify_ssl=False)
+
+        mock_client_cls, mock_client = _make_httpx_mock()
+
+        with patch("httpx.AsyncClient", mock_client_cls):
+            await connector.validate(cfg, {"token": "my-sa-token"})
+
+        call_kwargs = mock_client.get.call_args
+        # Header must be set at client construction time via AsyncClient(headers=...)
+        client_init_kwargs = mock_client_cls.call_args[1]
+        assert "Authorization" in client_init_kwargs.get("headers", {})
+        assert client_init_kwargs["headers"]["Authorization"] == "Bearer my-sa-token"
+
+    async def test_fetch_sends_bearer_token(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.example.com", verify_ssl=False)
+        ref = DocumentRef(
+            external_id="k8s:test:kind:Deployment",
+            uri="k8s://test/Deployment",
+            metadata={"kind": "Deployment", "cluster": "test", "namespace": ""},
+        )
+
+        mock_client_cls, mock_client = _make_httpx_mock(
+            response_data={"items": []},
+        )
+
+        with patch("httpx.AsyncClient", mock_client_cls):
+            await connector.fetch(cfg, {"token": "fetch-token"}, ref)
+
+        client_init_kwargs = mock_client_cls.call_args[1]
+        assert client_init_kwargs["headers"]["Authorization"] == "Bearer fetch-token"
+
+    async def test_enumerate_kinds_sends_bearer_token(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.example.com", verify_ssl=False)
+
+        api_v1_response = {"resources": [{"kind": "Deployment", "name": "deployments"}]}
+        apis_response = {"groups": []}
+
+        responses = [
+            MagicMock(
+                is_success=True,
+                json=MagicMock(return_value=api_v1_response),
+            ),
+            MagicMock(
+                is_success=True,
+                json=MagicMock(return_value=apis_response),
+            ),
+        ]
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(side_effect=responses)
+        mock_client_cls = MagicMock(return_value=mock_client)
+
+        with patch("httpx.AsyncClient", mock_client_cls):
+            kinds = await connector._enumerate_kinds(cfg, {"token": "enum-token"})
+
+        client_init_kwargs = mock_client_cls.call_args[1]
+        assert client_init_kwargs["headers"]["Authorization"] == "Bearer enum-token"
+        assert "Deployment" in kinds
+
+    async def test_validate_omits_auth_header_when_no_token(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.example.com", verify_ssl=False)
+
+        mock_client_cls, mock_client = _make_httpx_mock()
+
+        with patch("httpx.AsyncClient", mock_client_cls):
+            await connector.validate(cfg, {})
+
+        client_init_kwargs = mock_client_cls.call_args[1]
+        assert "Authorization" not in client_init_kwargs.get("headers", {})
+
+
+# ---------------------------------------------------------------------------
+# 4. httpx verify= uses SSLContext when CA is present
+# ---------------------------------------------------------------------------
+
+
+class TestHttpxVerifyWiring:
+    async def test_validate_uses_ssl_context_when_ca_pem_provided(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            api_server="https://k8s.example.com",
+            ca_cert_pem=_TEST_CA_PEM,
+        )
+
+        mock_client_cls, mock_client = _make_httpx_mock()
+
+        with patch("httpx.AsyncClient", mock_client_cls):
+            await connector.validate(cfg, {})
+
+        client_init_kwargs = mock_client_cls.call_args[1]
+        assert isinstance(client_init_kwargs["verify"], ssl.SSLContext)
+
+    async def test_fetch_uses_ssl_context_when_ca_b64_in_secrets(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.example.com")
+        ref = DocumentRef(
+            external_id="k8s:test:kind:ConfigMap",
+            uri="k8s://test/ConfigMap",
+            metadata={"kind": "ConfigMap", "cluster": "test", "namespace": ""},
+        )
+        mock_client_cls, mock_client = _make_httpx_mock(response_data={"items": []})
+
+        with patch("httpx.AsyncClient", mock_client_cls):
+            await connector.fetch(cfg, {"ca_cert_b64": _TEST_CA_B64}, ref)
+
+        client_init_kwargs = mock_client_cls.call_args[1]
+        assert isinstance(client_init_kwargs["verify"], ssl.SSLContext)
+
+    async def test_validate_passes_bool_verify_when_no_ca(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            api_server="https://k8s.example.com",
+            verify_ssl=False,
+        )
+
+        mock_client_cls, mock_client = _make_httpx_mock()
+
+        with patch("httpx.AsyncClient", mock_client_cls):
+            await connector.validate(cfg, {})
+
+        client_init_kwargs = mock_client_cls.call_args[1]
+        assert client_init_kwargs["verify"] is False
+
+
+# ---------------------------------------------------------------------------
+# 5. New config field defaults
+# ---------------------------------------------------------------------------
+
+
+class TestNewConfigFieldDefaults:
+    def test_ca_cert_pem_defaults_to_none(self) -> None:
+        cfg = K8sAgenticConfig()
+        assert cfg.ca_cert_pem is None
+
+    def test_ca_cert_b64_defaults_to_none(self) -> None:
+        cfg = K8sAgenticConfig()
+        assert cfg.ca_cert_b64 is None
+
+    def test_use_llm_kind_selection_defaults_to_true(self) -> None:
+        cfg = K8sAgenticConfig()
+        assert cfg.use_llm_kind_selection is True
+
+    def test_verify_ssl_default_unchanged(self) -> None:
+        """Existing default verify_ssl=True must not regress."""
+        cfg = K8sAgenticConfig()
+        assert cfg.verify_ssl is True


### PR DESCRIPTION
Makes the K8s connector usable against managed clusters (EKS): adds `ca_cert_pem`/`ca_cert_b64` (config or secrets) wired through one `build_ssl_verify` helper into all httpx sites (SSLContext from PEM, no temp file), and `use_llm_kind_selection=False` for deterministic default-kinds discovery without an LLM. SA Bearer token preserved; deprecation warning kept. 82 passed (28 new). Enables a real re-syncing k8s Source.