### PR TITLE
chore: fix repo-wide ruff lint and format violations

### DIFF
--- a/apps/server/src/omniscience_server/discovery_worker.py
+++ b/apps/server/src/omniscience_server/discovery_worker.py
@@ -1,6 +1,6 @@
 """Discovery worker — automatic source provisioning (v0.4 Preview).
 
-Periodically runs discovery connectors (GitHub, GitLab) to find new 
+Periodically runs discovery connectors (GitHub, GitLab) to find new
 repositories and register them as Sources in the database.
 """
 
@@ -12,13 +12,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
+from omniscience_connectors.github_discovery import GitHubDiscoveryConnector
 from omniscience_core.config import Settings
 from omniscience_core.db.models import Source, Workspace
-from omniscience_connectors.github_discovery import GitHubDiscoveryConnector
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 log = structlog.get_logger(__name__)
+
 
 class DiscoveryWorker:
     """Background task that discovers and provisions new sources."""
@@ -39,13 +40,13 @@ class DiscoveryWorker:
         """Run the worker loop."""
         self._running = True
         log.info("discovery_worker_started", interval=self._interval_seconds)
-        
+
         while self._running:
             try:
                 await self.run_once()
             except Exception as exc:
                 log.error("discovery_worker_error", error=str(exc))
-            
+
             await asyncio.sleep(self._interval_seconds)
 
     def stop(self) -> None:
@@ -55,12 +56,12 @@ class DiscoveryWorker:
         """Perform one discovery cycle across all enabled platforms."""
         # For v0.4 Preview, we assume discovery is mapped to workspaces via settings
         # or we just discover into a default workspace.
-        
+
         async with self._session_factory() as session:
             # 1. Load active workspaces
             result = await session.execute(select(Workspace))
             workspaces = result.scalars().all()
-            
+
             for ws in workspaces:
                 await self._discover_for_workspace(session, ws)
                 await session.commit()
@@ -69,7 +70,7 @@ class DiscoveryWorker:
         """Run discovery for a specific workspace based on its settings."""
         ws_metadata = workspace.settings or {}
         discovery_config = ws_metadata.get("discovery", {})
-        
+
         if not discovery_config:
             return
 
@@ -78,23 +79,32 @@ class DiscoveryWorker:
         if github_cfg:
             discovered = await self._github_connector.discover(
                 config=github_cfg,
-                secrets={"github_token": github_cfg.get("token")} # In production, pull from secrets manager
+                secrets={
+                    "github_token": github_cfg.get("token")
+                },  # In production, pull from secrets manager
             )
-            
+
             for ds in discovered:
                 await self._ensure_source(session, workspace.id, ds)
 
-    async def _ensure_source(self, session: AsyncSession, workspace_id: uuid.UUID, ds: Any) -> None:
+    async def _ensure_source(
+        self, session: AsyncSession, workspace_id: uuid.UUID, ds: Any
+    ) -> None:
         """Create source if it doesn't exist (keyed by URI)."""
         stmt = select(Source).where(Source.uri == ds.uri, Source.tenant_id == workspace_id)
         result = await session.execute(stmt)
         existing = result.scalar_one_or_none()
-        
+
         if existing:
             return
 
-        log.info("discovery_provisioning_new_source", name=ds.name, uri=ds.uri, workspace_id=str(workspace_id))
-        
+        log.info(
+            "discovery_provisioning_new_source",
+            name=ds.name,
+            uri=ds.uri,
+            workspace_id=str(workspace_id),
+        )
+
         new_source = Source(
             id=uuid.uuid4(),
             name=ds.name,
@@ -102,12 +112,12 @@ class DiscoveryWorker:
             uri=ds.uri,
             tenant_id=workspace_id,
             status="active",
-            freshness_sla_seconds=86400, # Default 1 day
+            freshness_sla_seconds=86400,  # Default 1 day
             last_sync_at=None,
             source_metadata={
                 **ds.metadata,
                 "provisioned_by": "discovery_worker",
-                "discovered_at": datetime.now(UTC).isoformat()
-            }
+                "discovered_at": datetime.now(UTC).isoformat(),
+            },
         )
         session.add(new_source)

--- a/apps/server/src/omniscience_server/ingestion/pipeline.py
+++ b/apps/server/src/omniscience_server/ingestion/pipeline.py
@@ -161,8 +161,8 @@ class IndexWriterProtocol(Protocol):
     ) -> None: ...
 
     async def tombstone(
-        self, 
-        source_id: UUID, 
+        self,
+        source_id: UUID,
         external_id: str,
         workspace_id: UUID | None = None,
     ) -> bool: ...
@@ -542,8 +542,8 @@ class IngestionPipeline:
             if extracted is None:
                 return
             entities, edges = extracted
-            
-            # Orchestrated write: index_writer handles the workspace-tagging 
+
+            # Orchestrated write: index_writer handles the workspace-tagging
             # and Neo4j call.
             await self._index_writer.upsert_graph(
                 source_id=event.source_id,
@@ -621,7 +621,7 @@ class IngestionPipeline:
         t0 = time.monotonic()
         try:
             found = await self._index_writer.tombstone(
-                event.source_id, 
+                event.source_id,
                 event.external_id,
                 workspace_id=workspace_id,
             )

--- a/packages/connectors/src/omniscience_connectors/aws/connector.py
+++ b/packages/connectors/src/omniscience_connectors/aws/connector.py
@@ -648,9 +648,7 @@ def _discover_organizations(
             # Resolve the immediate OU parent for this account
             parent_id = ""
             try:
-                parents = _paginate_org(
-                    client, "list_parents", "Parents", ChildId=acct_id
-                )
+                parents = _paginate_org(client, "list_parents", "Parents", ChildId=acct_id)
                 if parents:
                     parent_id = parents[0].get("Id", "")
             except botocore.exceptions.ClientError as exc:

--- a/packages/connectors/src/omniscience_connectors/discovery.py
+++ b/packages/connectors/src/omniscience_connectors/discovery.py
@@ -2,22 +2,26 @@
 
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass, field
 from typing import Any, Protocol
+
 
 @dataclass(frozen=True)
 class DiscoveredSource:
     """A source candidate found by a discovery connector."""
+
     name: str
     type: str  # e.g. "git"
     uri: str
     external_id: str  # e.g. github repo ID or full path
     metadata: dict[str, Any] = field(default_factory=dict)
 
+
 class DiscoveryConnector(Protocol):
     """Protocol for connectors that can discover new sources automatically."""
-    
-    async def discover(self, config: dict[str, Any], secrets: dict[str, str]) -> list[DiscoveredSource]:
+
+    async def discover(
+        self, config: dict[str, Any], secrets: dict[str, str]
+    ) -> list[DiscoveredSource]:
         """Scan the remote platform and return a list of discovered sources."""
         ...

--- a/packages/connectors/src/omniscience_connectors/github_discovery.py
+++ b/packages/connectors/src/omniscience_connectors/github_discovery.py
@@ -3,19 +3,24 @@
 from __future__ import annotations
 
 from typing import Any
+
 import httpx
 import structlog
+
 from omniscience_connectors.discovery import DiscoveredSource
 
 log = structlog.get_logger(__name__)
 
+
 class GitHubDiscoveryConnector:
     """Discovers repositories within a GitHub organization."""
 
-    async def discover(self, config: dict[str, Any], secrets: dict[str, str]) -> list[DiscoveredSource]:
+    async def discover(
+        self, config: dict[str, Any], secrets: dict[str, str]
+    ) -> list[DiscoveredSource]:
         org_name = config.get("org")
         token = secrets.get("github_token")
-        
+
         if not org_name or not token:
             log.error("github_discovery_missing_config", org=org_name, has_token=bool(token))
             return []
@@ -23,7 +28,7 @@ class GitHubDiscoveryConnector:
         discovered = []
         include_pattern = config.get("include_pattern")
         exclude_repos = set(config.get("exclude_repos", []))
-        
+
         import re
 
         async with httpx.AsyncClient() as client:
@@ -31,46 +36,48 @@ class GitHubDiscoveryConnector:
             url = f"https://api.github.com/orgs/{org_name}/repos"
             headers = {
                 "Authorization": f"token {token}",
-                "Accept": "application/vnd.github.v3+json"
+                "Accept": "application/vnd.github.v3+json",
             }
-            
+
             params = {"per_page": 100, "type": config.get("repo_type", "all")}
-            
+
             try:
                 response = await client.get(url, headers=headers, params=params)
                 response.raise_for_status()
                 repos = response.json()
-                
+
                 for repo in repos:
                     name = repo["name"]
-                    
+
                     # 1. Denylist check (exact name)
                     if name in exclude_repos:
                         continue
-                    
+
                     # 2. Archive check
                     if repo.get("archived"):
                         continue
-                    
+
                     # 3. Allowlist check (regex pattern)
                     if include_pattern and not re.search(include_pattern, name):
                         continue
-                        
-                    discovered.append(DiscoveredSource(
-                        name=name,
-                        type="git",
-                        uri=repo["clone_url"],
-                        external_id=str(repo["id"]),
-                        metadata={
-                            "description": repo.get("description"),
-                            "language": repo.get("language"),
-                            "stars": repo.get("stargazers_count"),
-                            "github_full_name": repo["full_name"]
-                        }
-                    ))
-                
+
+                    discovered.append(
+                        DiscoveredSource(
+                            name=name,
+                            type="git",
+                            uri=repo["clone_url"],
+                            external_id=str(repo["id"]),
+                            metadata={
+                                "description": repo.get("description"),
+                                "language": repo.get("language"),
+                                "stars": repo.get("stargazers_count"),
+                                "github_full_name": repo["full_name"],
+                            },
+                        )
+                    )
+
                 log.info("github_discovery_success", org=org_name, count=len(discovered))
             except Exception as exc:
                 log.error("github_discovery_failed", org=org_name, error=str(exc))
-                
+
         return discovered

--- a/packages/connectors/src/omniscience_connectors/slack_discovery.py
+++ b/packages/connectors/src/omniscience_connectors/slack_discovery.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 from typing import Any
+
 import httpx
 import structlog
+
 from omniscience_connectors.discovery import DiscoveredSource
 
 log = structlog.get_logger(__name__)
 
+
 class SlackDiscoveryConnector:
     """Discovers public and private channels in a Slack workspace."""
 
-    async def discover(self, config: dict[str, Any], secrets: dict[str, str]) -> list[DiscoveredSource]:
+    async def discover(
+        self, config: dict[str, Any], secrets: dict[str, str]
+    ) -> list[DiscoveredSource]:
         token = secrets.get("slack_token")
         if not token:
             log.error("slack_discovery_missing_token")
@@ -25,32 +30,34 @@ class SlackDiscoveryConnector:
             params = {
                 "types": config.get("channel_types", "public_channel,private_channel"),
                 "exclude_archived": "true",
-                "limit": 1000
+                "limit": 1000,
             }
-            
+
             try:
                 response = await client.get(url, headers=headers, params=params)
                 data = response.json()
-                
+
                 if not data.get("ok"):
                     log.error("slack_discovery_api_error", error=data.get("error"))
                     return []
 
                 for channel in data.get("channels", []):
-                    discovered.append(DiscoveredSource(
-                        name=f"slack-{channel['name']}",
-                        type="slack",
-                        uri=f"slack://{channel['id']}",
-                        external_id=channel['id'],
-                        metadata={
-                            "topic": channel.get("topic", {}).get("value"),
-                            "purpose": channel.get("purpose", {}).get("value"),
-                            "num_members": channel.get("num_members")
-                        }
-                    ))
-                
+                    discovered.append(
+                        DiscoveredSource(
+                            name=f"slack-{channel['name']}",
+                            type="slack",
+                            uri=f"slack://{channel['id']}",
+                            external_id=channel["id"],
+                            metadata={
+                                "topic": channel.get("topic", {}).get("value"),
+                                "purpose": channel.get("purpose", {}).get("value"),
+                                "num_members": channel.get("num_members"),
+                            },
+                        )
+                    )
+
                 log.info("slack_discovery_success", count=len(discovered))
             except Exception as exc:
                 log.error("slack_discovery_failed", error=str(exc))
-                
+
         return discovered

--- a/packages/core/alembic/versions/0003_workspaces.py
+++ b/packages/core/alembic/versions/0003_workspaces.py
@@ -65,7 +65,8 @@ def upgrade() -> None:
     # ------------------------------------------------------------------
     # 2. Seed the default workspace
     # ------------------------------------------------------------------
-    from datetime import datetime, UTC
+    from datetime import UTC, datetime
+
     workspaces_table = sa.table(
         "workspaces",
         sa.column("id", postgresql.UUID(as_uuid=True)),

--- a/packages/index/src/omniscience_index/linker.py
+++ b/packages/index/src/omniscience_index/linker.py
@@ -46,6 +46,7 @@ class EntityLinker:
 
     def __init__(self, graph_store: GraphStore) -> None:
         self._graph_store = graph_store
+
     async def link_entities(self, source_id: uuid.UUID, workspace_id: uuid.UUID) -> int:
         """Find and create cross-source edges for entities in *source_id*."""
         all_entities = await self._graph_store.get_all_entities(workspace_id=workspace_id)
@@ -94,7 +95,6 @@ class EntityLinker:
                 count=resolved,
             )
         return resolved
-
 
     def _compute_links(
         self,
@@ -147,5 +147,6 @@ class EntityLinker:
                 return score, "resource_name"
 
         return 0.0, ""
+
 
 __all__ = ["CROSS_REF_EDGE_TYPE", "EntityLinker"]

--- a/packages/index/src/omniscience_index/stores/neo4j/store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j/store.py
@@ -690,9 +690,7 @@ class Neo4jGraphStore:
             "limit": int(limit),
         }
         async with self._driver.session(database=self._config.database) as session:
-            rows = await session.execute_read(
-                _run_read_stmt, _LIST_WARM_TO_ARCHIVE_DATES, params
-            )
+            rows = await session.execute_read(_run_read_stmt, _LIST_WARM_TO_ARCHIVE_DATES, params)
         out: list[date] = []
         for row in rows:
             raw = row.get("snapshot_date")
@@ -769,9 +767,7 @@ class Neo4jGraphStore:
         """Return {'hot': int, 'warm': int} record counts for the workspace."""
         params: dict[str, Any] = {_WORKSPACE_PARAM: str(workspace_id)}
         async with self._driver.session(database=self._config.database) as session:
-            hot_rows = await session.execute_read(
-                _run_read_stmt, _COUNT_HOT_ENTITY_STATES, params
-            )
+            hot_rows = await session.execute_read(_run_read_stmt, _COUNT_HOT_ENTITY_STATES, params)
             warm_rows = await session.execute_read(
                 _run_read_stmt, _COUNT_WARM_ENTITY_SNAPSHOTS, params
             )

--- a/packages/index/src/omniscience_index/writer.py
+++ b/packages/index/src/omniscience_index/writer.py
@@ -103,7 +103,7 @@ class IndexWriter:
             if self._vector_store and workspace_id:
                 vector_metadata = dict(metadata)
                 vector_metadata["workspace_id"] = str(workspace_id)
-                
+
                 payloads: list[ChunkPayload] = [
                     {
                         "ord": c.ord,
@@ -118,7 +118,7 @@ class IndexWriter:
                     }
                     for c in chunks
                 ]
-                
+
                 await self._vector_store.upsert_chunks(
                     source_id=source_id,
                     external_id=external_id,
@@ -138,8 +138,8 @@ class IndexWriter:
             )
 
     async def tombstone(
-        self, 
-        source_id: uuid.UUID, 
+        self,
+        source_id: uuid.UUID,
         external_id: str,
         workspace_id: uuid.UUID | None = None,
     ) -> bool:
@@ -149,7 +149,7 @@ class IndexWriter:
             if doc is None:
                 return False
             doc.tombstoned_at = datetime.now(UTC)
-            
+
             if self._vector_store and workspace_id:
                 await self._vector_store.delete_by_document(
                     source_id=source_id,
@@ -199,7 +199,7 @@ class IndexWriter:
                 edges=edges,
                 snapshot_at=snapshot_at,
             )
-        
+
         # SQL-side graph storage is now deprecated and removed from ingestion path.
 
     # ------------------------------------------------------------------

--- a/packages/parsers/src/omniscience_parsers/code/graph.py
+++ b/packages/parsers/src/omniscience_parsers/code/graph.py
@@ -20,6 +20,7 @@ from omniscience_parsers.base import ParsedDocument
 # Data classes
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ExtractedEntity:
     id: uuid.UUID
@@ -29,12 +30,14 @@ class ExtractedEntity:
     symbol: str
     metadata: dict[str, Any] = field(default_factory=dict)
 
+
 @dataclass
 class ExtractedEdge:
     source_entity_id: uuid.UUID
     target_name: str  # FQN or alias
     edge_type: str
     metadata: dict[str, Any] = field(default_factory=dict)
+
 
 # ---------------------------------------------------------------------------
 # Python Logic (AST-aware heuristics)
@@ -104,18 +107,20 @@ def _extract_python(
             continue
         ent_id = uuid.uuid4()
         etype = "class" if "class " in sec.text else "function"
-        entities.append(ExtractedEntity(
-            id=ent_id,
-            entity_type=etype,
-            name=sec.symbol,
-            display_name=sec.symbol.split(".")[-1],
-            symbol=sec.symbol,
-            metadata={
-                "line_start": sec.line_start,
-                "line_end": sec.line_end,
-                "language": parsed.language,
-            },
-        ))
+        entities.append(
+            ExtractedEntity(
+                id=ent_id,
+                entity_type=etype,
+                name=sec.symbol,
+                display_name=sec.symbol.split(".")[-1],
+                symbol=sec.symbol,
+                metadata={
+                    "line_start": sec.line_start,
+                    "line_end": sec.line_end,
+                    "language": parsed.language,
+                },
+            )
+        )
         symbol_to_id[sec.symbol] = ent_id
         edges.append(ExtractedEdge(module_id, sec.symbol, "defines"))
 
@@ -153,9 +158,11 @@ def _extract_python(
 
     return entities, edges
 
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def extract_symbol_graph(
     parsed: ParsedDocument,
@@ -170,5 +177,6 @@ def extract_symbol_graph(
     if parsed.language != "python":
         return [], []
     return _extract_python(parsed, source_text)
+
 
 __all__ = ["ExtractedEdge", "ExtractedEntity", "extract_symbol_graph"]

--- a/packages/retrieval/src/omniscience_retrieval/incidents/resolution.py
+++ b/packages/retrieval/src/omniscience_retrieval/incidents/resolution.py
@@ -194,7 +194,7 @@ def validate_alert_id(alert_id: str) -> None:
         raise ValueError(f"{INVALID_ALERT_ID_CODE}:{INVALID_ALERT_ID_MESSAGE}")
     if not alert_id.startswith(_ALERT_PREFIX):
         raise ValueError(f"{INVALID_ALERT_ID_CODE}:{INVALID_ALERT_ID_MESSAGE}")
-    suffix = alert_id[len(_ALERT_PREFIX):]
+    suffix = alert_id[len(_ALERT_PREFIX) :]
     if "/" not in suffix:
         raise ValueError(f"{INVALID_ALERT_ID_CODE}:{INVALID_ALERT_ID_MESSAGE}")
     provider, _, provider_alert_id = suffix.partition("/")

--- a/packages/retrieval/src/omniscience_retrieval/incidents/similar.py
+++ b/packages/retrieval/src/omniscience_retrieval/incidents/similar.py
@@ -141,7 +141,7 @@ def _is_alert_name(name: str) -> bool:
     """True iff ``name`` is an ``alert://...`` canonical URI."""
     if not name.startswith(_ALERT_PREFIX):
         return False
-    suffix = name[len(_ALERT_PREFIX):]
+    suffix = name[len(_ALERT_PREFIX) :]
     return "/" in suffix
 
 

--- a/packages/retrieval/src/omniscience_retrieval/runbook.py
+++ b/packages/retrieval/src/omniscience_retrieval/runbook.py
@@ -274,14 +274,14 @@ def citation_for(runbook: RunbookDocument) -> dict[str, Any]:
 
 def runbook_source_uid(runbook_name: str) -> str:
     """Extract the ``source_uid`` segment from a canonical runbook name."""
-    tail = runbook_name[len("runbook://"):]
+    tail = runbook_name[len("runbook://") :]
     head, _, _ = tail.partition("/")
     return head
 
 
 def runbook_rel_path(runbook_name: str) -> str:
     """Extract the ``rel_path`` tail from a canonical runbook name."""
-    tail = runbook_name[len("runbook://"):]
+    tail = runbook_name[len("runbook://") :]
     _, _, rest = tail.partition("/")
     return rest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,10 @@ ignore = [
     "S101",  # assert is the standard pytest assertion mechanism
 ]
 "scripts/*" = [
-    "T201",  # print is the standard CLI output mechanism for one-shot scripts
+    "T201",    # print is the standard CLI output mechanism for one-shot scripts
+    "S108",    # /tmp paths are intentional for one-shot operational glue scripts
+    "S310",    # urlopen targets the trusted cluster API URL in fetch scripts
+    "SIM115",  # json.load(open(...)) is acceptable for short-lived one-shot scripts
 ]
 "bench/runner.py" = [
     "T201",  # print is the standard CLI output mechanism for the bench runner

--- a/scripts/debug_entities.py
+++ b/scripts/debug_entities.py
@@ -18,5 +18,6 @@ async def list_all():
 
     await graph_store.close()
 
+
 if __name__ == "__main__":
     asyncio.run(list_all())

--- a/scripts/fetch_k8s_state.py
+++ b/scripts/fetch_k8s_state.py
@@ -27,8 +27,15 @@ docs: list[dict] = []
 
 
 def add(external_id: str, uri: str, title: str, text: str, metadata: dict) -> None:
-    docs.append({"external_id": external_id, "uri": uri, "title": title,
-                 "text": text, "metadata": metadata})
+    docs.append(
+        {
+            "external_id": external_id,
+            "uri": uri,
+            "title": title,
+            "text": text,
+            "metadata": metadata,
+        }
+    )
 
 
 # --- ArgoCD Applications (the headline: sync/health/repo/destination) ---
@@ -49,11 +56,23 @@ for a in apps:
         f"Destination: server {dserver} namespace {dns}. "
         f"Project: {spec.get('project', 'default')}."
     )
-    add(f"argocd/app/{name}", f"argocd://{CLUSTER}/{ns}/{name}",
-        f"ArgoCD App: {name} ({sync}/{health})", text,
-        {"kind": "Application", "cluster": CLUSTER, "namespace": ns, "name": name,
-         "sync": sync, "health": health, "repo": repo, "dest_namespace": dns,
-         "component_category": "argocd"})
+    add(
+        f"argocd/app/{name}",
+        f"argocd://{CLUSTER}/{ns}/{name}",
+        f"ArgoCD App: {name} ({sync}/{health})",
+        text,
+        {
+            "kind": "Application",
+            "cluster": CLUSTER,
+            "namespace": ns,
+            "name": name,
+            "sync": sync,
+            "health": health,
+            "repo": repo,
+            "dest_namespace": dns,
+            "component_category": "argocd",
+        },
+    )
 
 # --- Deployments (apps/v1) ---
 deps = _get("/apis/apps/v1/deployments").get("items", [])
@@ -69,10 +88,21 @@ for d in deps:
         f"Replicas: {ready}/{replicas} ready. Images: {images}. "
         f"Containers: {', '.join(c.get('name', '?') for c in containers)}."
     )
-    add(f"k8s/deployment/{ns}/{name}", f"k8s://{CLUSTER}/{ns}/Deployment/{name}",
-        f"Deployment: {ns}/{name}", text,
-        {"kind": "Deployment", "cluster": CLUSTER, "namespace": ns, "name": name,
-         "replicas": replicas, "ready": ready, "component_category": "k8s"})
+    add(
+        f"k8s/deployment/{ns}/{name}",
+        f"k8s://{CLUSTER}/{ns}/Deployment/{name}",
+        f"Deployment: {ns}/{name}",
+        text,
+        {
+            "kind": "Deployment",
+            "cluster": CLUSTER,
+            "namespace": ns,
+            "name": name,
+            "replicas": replicas,
+            "ready": ready,
+            "component_category": "k8s",
+        },
+    )
 
 # --- Services (core/v1) ---
 svcs = _get("/api/v1/services").get("items", [])
@@ -85,10 +115,19 @@ for s in svcs:
         f"Type: {spec.get('type', 'ClusterIP')}. Ports: {ports or 'none'}. "
         f"ClusterIP: {spec.get('clusterIP', '?')}."
     )
-    add(f"k8s/service/{ns}/{name}", f"k8s://{CLUSTER}/{ns}/Service/{name}",
-        f"Service: {ns}/{name}", text,
-        {"kind": "Service", "cluster": CLUSTER, "namespace": ns, "name": name,
-         "component_category": "k8s"})
+    add(
+        f"k8s/service/{ns}/{name}",
+        f"k8s://{CLUSTER}/{ns}/Service/{name}",
+        f"Service: {ns}/{name}",
+        text,
+        {
+            "kind": "Service",
+            "cluster": CLUSTER,
+            "namespace": ns,
+            "name": name,
+            "component_category": "k8s",
+        },
+    )
 
 # --- Ingresses (networking.k8s.io/v1) ---
 try:
@@ -103,10 +142,19 @@ for i in ings:
         f"Kubernetes Ingress '{name}' in namespace {ns} on cluster {CLUSTER}. "
         f"Hosts: {hosts or 'none'}. IngressClass: {spec.get('ingressClassName', 'default')}."
     )
-    add(f"k8s/ingress/{ns}/{name}", f"k8s://{CLUSTER}/{ns}/Ingress/{name}",
-        f"Ingress: {ns}/{name}", text,
-        {"kind": "Ingress", "cluster": CLUSTER, "namespace": ns, "name": name,
-         "component_category": "k8s"})
+    add(
+        f"k8s/ingress/{ns}/{name}",
+        f"k8s://{CLUSTER}/{ns}/Ingress/{name}",
+        f"Ingress: {ns}/{name}",
+        text,
+        {
+            "kind": "Ingress",
+            "cluster": CLUSTER,
+            "namespace": ns,
+            "name": name,
+            "component_category": "k8s",
+        },
+    )
 
 json.dump(docs, open("/tmp/k8s_docs.json", "w"))
 by_kind: dict[str, int] = {}

--- a/scripts/resolve_stubs.py
+++ b/scripts/resolve_stubs.py
@@ -16,5 +16,6 @@ async def resolve():
 
     await graph_store.close()
 
+
 if __name__ == "__main__":
     asyncio.run(resolve())

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -25,7 +25,7 @@ async def seed():
             http_port=settings.qdrant_http_port,
             api_key=settings.qdrant_api_key,
         ),
-        embedding_provider=create_embedding_provider(settings)
+        embedding_provider=create_embedding_provider(settings),
     )
 
     await graph_store.connect()
@@ -42,9 +42,12 @@ async def seed():
     async with session_factory() as session:
         await session.execute(delete(Source).where(Source.name == "omniscience-demo"))
         demo_source = Source(
-            id=src_id, name="omniscience-demo", type=SourceType.git,
+            id=src_id,
+            name="omniscience-demo",
+            type=SourceType.git,
             config={"repo_url": "git://demo-repo"},
-            tenant_id=ws_id, status=SourceStatus.active
+            tenant_id=ws_id,
+            status=SourceStatus.active,
         )
         session.add(demo_source)
         await session.commit()
@@ -53,14 +56,25 @@ async def seed():
     print(f"Seeding demo data for workspace {ws_id}...")
 
     # Data for Payments
-    chunks_p = [ChunkData(ord=0, text="""def process_payment(card):
+    chunks_p = [
+        ChunkData(
+            ord=0,
+            text="""def process_payment(card):
     auth.validate_token()
-    print('Paid')""", embedding=[0.1]*768)]
+    print('Paid')""",
+            embedding=[0.1] * 768,
+        )
+    ]
 
     res_p = await writer.upsert_document(
-        source_id=src_id, external_id="payments.py", uri="git://demo/payments.py",
-        title="Payments Module", content_hash="hash_p1", metadata={"lang": "python"},
-        chunks=chunks_p, workspace_id=ws_id
+        source_id=src_id,
+        external_id="payments.py",
+        uri="git://demo/payments.py",
+        title="Payments Module",
+        content_hash="hash_p1",
+        metadata={"lang": "python"},
+        chunks=chunks_p,
+        workspace_id=ws_id,
     )
 
     # Manual graph insertion to ensure stubs are created
@@ -72,7 +86,7 @@ async def seed():
             self.id = eid
             self.entity_type = etype
             self.name = name
-            self.display_name = name.split('.')[-1]
+            self.display_name = name.split(".")[-1]
             self.metadata = {}
             self.chunk_id = None
 
@@ -85,27 +99,40 @@ async def seed():
 
     # Upsert payments.py (creates stub for auth.validate_token)
     await writer.upsert_graph(
-        source_id=src_id, document_id=res_p.document_id,
+        source_id=src_id,
+        document_id=res_p.document_id,
         entities=[MockEnt(ent_p1_id, "function", "payments.process_payment")],
         edges=[MockEdge(ent_p1_id, "auth.validate_token", "calls")],
-        workspace_id=ws_id
+        workspace_id=ws_id,
     )
 
     # Upsert auth.py (materializes the stub)
-    chunks_a = [ChunkData(ord=0, text="""def validate_token():
-    return True""", embedding=[0.3]*768)]
+    chunks_a = [
+        ChunkData(
+            ord=0,
+            text="""def validate_token():
+    return True""",
+            embedding=[0.3] * 768,
+        )
+    ]
 
     res_a = await writer.upsert_document(
-        source_id=src_id, external_id="auth.py", uri="git://demo/auth.py",
-        title="Auth Module", content_hash="hash_a1", metadata={"lang": "python"},
-        chunks=chunks_a, workspace_id=ws_id
+        source_id=src_id,
+        external_id="auth.py",
+        uri="git://demo/auth.py",
+        title="Auth Module",
+        content_hash="hash_a1",
+        metadata={"lang": "python"},
+        chunks=chunks_a,
+        workspace_id=ws_id,
     )
 
     await writer.upsert_graph(
-        source_id=src_id, document_id=res_a.document_id,
+        source_id=src_id,
+        document_id=res_a.document_id,
         entities=[MockEnt(uuid.uuid4(), "function", "auth.validate_token")],
         edges=[],
-        workspace_id=ws_id
+        workspace_id=ws_id,
     )
 
     # 3. Resolve Stubs
@@ -114,6 +141,7 @@ async def seed():
 
     await graph_store.close()
     await vector_store.close()
+
 
 if __name__ == "__main__":
     asyncio.run(seed())

--- a/scripts/seed_final.py
+++ b/scripts/seed_final.py
@@ -18,9 +18,13 @@ async def seed():
     session_factory = create_session_factory(engine)
     graph_store = Neo4jGraphStore(config=Neo4jStoreConfig.from_settings(settings))
     vector_store = QdrantVectorStore(
-        config=QdrantConfig(host=settings.qdrant_host, grpc_port=settings.qdrant_grpc_port,
-                           http_port=settings.qdrant_http_port, api_key=settings.qdrant_api_key),
-        embedding_provider=create_embedding_provider(settings)
+        config=QdrantConfig(
+            host=settings.qdrant_host,
+            grpc_port=settings.qdrant_grpc_port,
+            http_port=settings.qdrant_http_port,
+            api_key=settings.qdrant_api_key,
+        ),
+        embedding_provider=create_embedding_provider(settings),
     )
     await graph_store.connect()
     await vector_store.connect()
@@ -35,8 +39,12 @@ async def seed():
     async with session_factory() as session:
         await session.execute(delete(Source).where(Source.name == "demo"))
         src = Source(
-            id=src_id, name="demo", type=SourceType.git,
-            config={}, tenant_id=ws_id, status=SourceStatus.active,
+            id=src_id,
+            name="demo",
+            type=SourceType.git,
+            config={},
+            tenant_id=ws_id,
+            status=SourceStatus.active,
         )
         session.add(src)
         await session.commit()
@@ -59,23 +67,43 @@ async def seed():
             self.metadata = {}
 
     # 1. Auth.py
-    res_a = await writer.upsert_document(src_id, "auth.py", "git://auth.py", "Auth", "h1", {},
-                                       [ChunkData(0, "def validate(): pass", [0.1]*768)], ws_id)
+    res_a = await writer.upsert_document(
+        src_id,
+        "auth.py",
+        "git://auth.py",
+        "Auth",
+        "h1",
+        {},
+        [ChunkData(0, "def validate(): pass", [0.1] * 768)],
+        ws_id,
+    )
     await writer.upsert_graph(src_id, res_a.document_id, [E("auth.validate")], [], ws_id)
 
     # 2. Payments.py (with edge to auth.validate)
-    res_p = await writer.upsert_document(src_id, "pay.py", "git://pay.py", "Pay", "h2", {},
-                                       [ChunkData(0, "auth.validate()", [0.2]*768)], ws_id)
+    res_p = await writer.upsert_document(
+        src_id,
+        "pay.py",
+        "git://pay.py",
+        "Pay",
+        "h2",
+        {},
+        [ChunkData(0, "auth.validate()", [0.2] * 768)],
+        ws_id,
+    )
     p_ent = E("payments.process")
     await writer.upsert_graph(
-        src_id, res_p.document_id, [p_ent],
-        [Edge(p_ent.id, "auth.validate", "calls")], ws_id,
+        src_id,
+        res_p.document_id,
+        [p_ent],
+        [Edge(p_ent.id, "auth.validate", "calls")],
+        ws_id,
     )
 
     await graph_store.resolve_pending_stubs(workspace_id=ws_id)
     print("DEMO_READY")
     await graph_store.close()
     await vector_store.close()
+
 
 if __name__ == "__main__":
     asyncio.run(seed())

--- a/scripts/seed_finops_singapore.py
+++ b/scripts/seed_finops_singapore.py
@@ -31,8 +31,13 @@ DOCS: list[dict] = [
         "external_id": "finops/ebs-gp2-gp3-singapore-cost-analysis.md",
         "uri": "confluence://finops/ebs-gp2-gp3-singapore",
         "title": "EBS gp2 → gp3 Migration Cost Analysis — Singapore (ap-southeast-1)",
-        "metadata": {"region": "ap-southeast-1", "region_name": "Singapore",
-                     "service": "EBS", "doc_type": "cost_analysis", "team": "FinOps"},
+        "metadata": {
+            "region": "ap-southeast-1",
+            "region_name": "Singapore",
+            "service": "EBS",
+            "doc_type": "cost_analysis",
+            "team": "FinOps",
+        },
         "chunks": [
             # Headline answer
             "EBS gp2 to gp3 migration cost analysis for the Singapore (ap-southeast-1) "
@@ -70,8 +75,12 @@ DOCS: list[dict] = [
         "external_id": "finops/aws-ebs-pricing-ap-southeast-1.md",
         "uri": "confluence://finops/ebs-pricing-singapore",
         "title": "AWS EBS Pricing Reference — ap-southeast-1 (Singapore)",
-        "metadata": {"region": "ap-southeast-1", "region_name": "Singapore",
-                     "service": "EBS", "doc_type": "pricing_reference"},
+        "metadata": {
+            "region": "ap-southeast-1",
+            "region_name": "Singapore",
+            "service": "EBS",
+            "doc_type": "pricing_reference",
+        },
         "chunks": [
             "AWS EBS volume pricing in the Singapore region (ap-southeast-1), monthly: "
             "gp2 (General Purpose SSD) = $0.12 per GB-month. "
@@ -85,8 +94,12 @@ DOCS: list[dict] = [
         "external_id": "infra/singapore-ebs-inventory.md",
         "uri": "git://infra/inventory/singapore-ebs.md",
         "title": "Singapore Region Infrastructure Inventory — EBS Volumes",
-        "metadata": {"region": "ap-southeast-1", "region_name": "Singapore",
-                     "service": "EC2", "doc_type": "inventory"},
+        "metadata": {
+            "region": "ap-southeast-1",
+            "region_name": "Singapore",
+            "service": "EC2",
+            "doc_type": "inventory",
+        },
         "chunks": [
             "Singapore (ap-southeast-1) infrastructure inventory: approximately 200 EC2 "
             "instances across the prod, staging, and data tiers. Attached EBS storage totals "
@@ -134,11 +147,16 @@ async def seed() -> None:
     src_id = uuid.uuid4()
     async with session_factory() as session:
         await session.execute(delete(Source).where(Source.name == "finops-singapore"))
-        session.add(Source(
-            id=src_id, name="finops-singapore", type=SourceType.git,
-            config={"repo_url": "confluence://finops"},
-            tenant_id=WS_ID, status=SourceStatus.active,
-        ))
+        session.add(
+            Source(
+                id=src_id,
+                name="finops-singapore",
+                type=SourceType.git,
+                config={"repo_url": "confluence://finops"},
+                tenant_id=WS_ID,
+                status=SourceStatus.active,
+            )
+        )
         await session.commit()
 
     writer = IndexWriter(session_factory, graph_store, vector_store)
@@ -150,8 +168,11 @@ async def seed() -> None:
         vectors = await provider.embed(texts)  # real embeddings
         chunks = [
             ChunkData(
-                ord=i, text=t, embedding=vectors[i],
-                embedding_model=model_name, embedding_provider="ollama",
+                ord=i,
+                text=t,
+                embedding=vectors[i],
+                embedding_model=model_name,
+                embedding_provider="ollama",
                 metadata=doc["metadata"],
             )
             for i, t in enumerate(texts)

--- a/scripts/seed_from_docs.py
+++ b/scripts/seed_from_docs.py
@@ -33,8 +33,12 @@ async def seed() -> None:
     provider = create_embedding_provider(settings)
     graph_store = Neo4jGraphStore(config=Neo4jStoreConfig.from_settings(settings))
     vector_store = QdrantVectorStore(
-        config=QdrantConfig(host=settings.qdrant_host, grpc_port=settings.qdrant_grpc_port,
-                            http_port=settings.qdrant_http_port, api_key=settings.qdrant_api_key),
+        config=QdrantConfig(
+            host=settings.qdrant_host,
+            grpc_port=settings.qdrant_grpc_port,
+            http_port=settings.qdrant_http_port,
+            api_key=settings.qdrant_api_key,
+        ),
         embedding_provider=provider,
     )
     await graph_store.connect()
@@ -43,9 +47,16 @@ async def seed() -> None:
     src_id = uuid.uuid4()
     async with session_factory() as session:
         await session.execute(delete(Source).where(Source.name == SOURCE_NAME))
-        session.add(Source(id=src_id, name=SOURCE_NAME, type=SourceType.k8s,
-                           config={"cluster": "qbiq-shared"}, tenant_id=WS_ID,
-                           status=SourceStatus.active))
+        session.add(
+            Source(
+                id=src_id,
+                name=SOURCE_NAME,
+                type=SourceType.k8s,
+                config={"cluster": "qbiq-shared"},
+                tenant_id=WS_ID,
+                status=SourceStatus.active,
+            )
+        )
         await session.commit()
 
     writer = IndexWriter(session_factory, graph_store, vector_store)
@@ -55,13 +66,23 @@ async def seed() -> None:
     texts = [d["text"] for d in docs]
     vectors = await provider.embed(texts)
     for i, d in enumerate(docs):
-        chunk = ChunkData(ord=0, text=d["text"], embedding=vectors[i],
-                          embedding_model=model, embedding_provider="ollama",
-                          metadata=d.get("metadata", {}))
+        chunk = ChunkData(
+            ord=0,
+            text=d["text"],
+            embedding=vectors[i],
+            embedding_model=model,
+            embedding_provider="ollama",
+            metadata=d.get("metadata", {}),
+        )
         await writer.upsert_document(
-            source_id=src_id, external_id=d["external_id"], uri=d["uri"],
-            title=d.get("title"), content_hash=hashlib.sha256(d["text"].encode()).hexdigest(),
-            metadata=d.get("metadata", {}), chunks=[chunk], workspace_id=WS_ID,
+            source_id=src_id,
+            external_id=d["external_id"],
+            uri=d["uri"],
+            title=d.get("title"),
+            content_hash=hashlib.sha256(d["text"].encode()).hexdigest(),
+            metadata=d.get("metadata", {}),
+            chunks=[chunk],
+            workspace_id=WS_ID,
         )
     print(f"Seeded {len(docs)} documents into source '{SOURCE_NAME}' (workspace {WS_ID})")
     await vector_store.close()

--- a/scripts/seed_k8s_graph.py
+++ b/scripts/seed_k8s_graph.py
@@ -35,7 +35,9 @@ async def main() -> None:
     await gs.connect()
 
     async with sf() as s:
-        src = (await s.execute(select(Source).where(Source.name == "k8s-qbiq-shared"))).scalar_one()
+        src = (
+            await s.execute(select(Source).where(Source.name == "k8s-qbiq-shared"))
+        ).scalar_one()
     src_id = src.id
 
     ents: dict[uuid.UUID, EntityUpsert] = {}
@@ -43,9 +45,15 @@ async def main() -> None:
 
     def ent(key: str, etype: str, name: str, meta: dict) -> uuid.UUID:
         i = eid(key)
-        ents[i] = EntityUpsert(id=i, source_id=src_id, entity_type=etype, name=name,
-                               display_name=name.split("/")[-1], chunk_id=None,
-                               metadata={**meta, "workspace_id": str(WS), "cluster": CLUSTER})
+        ents[i] = EntityUpsert(
+            id=i,
+            source_id=src_id,
+            entity_type=etype,
+            name=name,
+            display_name=name.split("/")[-1],
+            chunk_id=None,
+            metadata={**meta, "workspace_id": str(WS), "cluster": CLUSTER},
+        )
         return i
 
     for d in docs:
@@ -53,19 +61,37 @@ async def main() -> None:
         kind, ns, name = m["kind"], m.get("namespace", "default"), m["name"]
         ns_id = ent(f"ns/{ns}", "Namespace", ns, {"kind": "Namespace"})
         res_id = ent(f"{kind}/{ns}/{name}", kind, f"{ns}/{name}", m)
-        edges.append(EdgeUpsert(source_entity_id=res_id, target_entity_id=ns_id,
-                                edge_type="in_namespace", metadata={"workspace_id": str(WS)}))
+        edges.append(
+            EdgeUpsert(
+                source_entity_id=res_id,
+                target_entity_id=ns_id,
+                edge_type="in_namespace",
+                metadata={"workspace_id": str(WS)},
+            )
+        )
         if kind == "Application":
             repo = m.get("repo")
             if repo and repo != "?":
                 repo_id = ent(f"repo/{repo}", "GitRepository", repo, {"kind": "GitRepository"})
-                edges.append(EdgeUpsert(source_entity_id=res_id, target_entity_id=repo_id,
-                                        edge_type="sources_from", metadata={"workspace_id": str(WS)}))
+                edges.append(
+                    EdgeUpsert(
+                        source_entity_id=res_id,
+                        target_entity_id=repo_id,
+                        edge_type="sources_from",
+                        metadata={"workspace_id": str(WS)},
+                    )
+                )
             dns = m.get("dest_namespace")
             if dns and dns != "?":
                 dns_id = ent(f"ns/{dns}", "Namespace", dns, {"kind": "Namespace"})
-                edges.append(EdgeUpsert(source_entity_id=res_id, target_entity_id=dns_id,
-                                        edge_type="deploys_to", metadata={"workspace_id": str(WS)}))
+                edges.append(
+                    EdgeUpsert(
+                        source_entity_id=res_id,
+                        target_entity_id=dns_id,
+                        edge_type="deploys_to",
+                        metadata={"workspace_id": str(WS)},
+                    )
+                )
 
     for e in ents.values():
         await gs.upsert_entity(entity=e, workspace_id=WS)

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -121,9 +121,7 @@ async def test_create_session_sets_cookies_for_admin_token() -> None:
     mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
     app = _make_session_app([mock_token])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/admin/session", json={"token": plaintext})
 
     assert response.status_code == 204
@@ -139,9 +137,7 @@ async def test_create_session_session_cookie_is_httponly() -> None:
     mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
     app = _make_session_app([mock_token])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/admin/session", json={"token": plaintext})
 
     raw = "\n".join(response.headers.get_list("set-cookie")).lower()
@@ -156,9 +152,7 @@ async def test_create_session_samesite_strict() -> None:
     mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
     app = _make_session_app([mock_token])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/admin/session", json={"token": plaintext})
 
     raw = "\n".join(response.headers.get_list("set-cookie")).lower()
@@ -175,9 +169,7 @@ async def test_create_session_rejects_unknown_token() -> None:
     """No matching token in DB -> 401."""
     app = _make_session_app([])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         plaintext, _ = generate_token("development")
         response = await client.post("/admin/session", json={"token": plaintext})
 
@@ -192,9 +184,7 @@ async def test_create_session_rejects_non_admin_scope() -> None:
     mock_token = _make_mock_token(plaintext, prefix, ["search"], hashed)
     app = _make_session_app([mock_token])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/admin/session", json={"token": plaintext})
 
     assert response.status_code == 403
@@ -205,9 +195,7 @@ async def test_create_session_rejects_empty_token() -> None:
     """Empty/whitespace token string -> 422 (pydantic validation)."""
     app = _make_session_app([])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.post("/admin/session", json={"token": "   "})
 
     assert response.status_code == 422
@@ -223,9 +211,7 @@ async def test_delete_session_clears_cookies() -> None:
     """DELETE /admin/session returns 204 and expires both cookies."""
     app = _make_session_app([])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.delete("/admin/session")
 
     assert response.status_code == 204
@@ -329,12 +315,8 @@ async def test_bearer_post_exempt_from_csrf() -> None:
     mock_token = _make_mock_token(plaintext, prefix, ["admin"], hashed)
     app = _make_protected_app([mock_token])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
-        response = await client.post(
-            "/mutate", headers={"Authorization": f"Bearer {plaintext}"}
-        )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/mutate", headers={"Authorization": f"Bearer {plaintext}"})
 
     assert response.status_code == 200
 
@@ -367,9 +349,7 @@ async def test_no_auth_returns_401() -> None:
     """No bearer header and no session cookie -> 401."""
     app = _make_protected_app([])
 
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
-    ) as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/probe")
 
     assert response.status_code == 401

--- a/tests/test_aws_organizations.py
+++ b/tests/test_aws_organizations.py
@@ -138,20 +138,24 @@ def _make_org_client(
             pag.paginate.return_value = iter([{"Roots": roots or [{"Id": "r-root"}]}])
 
         elif method == "list_organizational_units_for_parent":
+
             def _ou_pages(**kwargs: Any) -> Any:
                 parent_id = kwargs.get("ParentId", "")
                 items = (ous_by_parent or {}).get(parent_id, [])
                 return iter([{"OrganizationalUnits": items}])
+
             pag.paginate.side_effect = _ou_pages
 
         elif method == "list_accounts":
             pag.paginate.return_value = iter([{"Accounts": accounts or []}])
 
         elif method == "list_parents":
+
             def _parent_pages(**kwargs: Any) -> Any:
                 child_id = kwargs.get("ChildId", "")
                 items = (parents_by_child or {}).get(child_id, [])
                 return iter([{"Parents": items}])
+
             pag.paginate.side_effect = _parent_pages
 
         return pag
@@ -310,9 +314,7 @@ class TestDiscoverOrganizations:
             parents_by_child={"222222222222": [{"Id": OU_ID_1, "Type": "ORGANIZATIONAL_UNIT"}]},
         )
 
-        with patch(
-            "omniscience_connectors.aws.connector._org_client", return_value=client
-        ):
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=client):
             refs = _discover_organizations(SECRETS, [])
 
         resource_types = {r.metadata["resource_type"] for r in refs}
@@ -482,9 +484,7 @@ class TestAwsConnectorDiscoverOrganizations:
                 "omniscience_connectors.aws.connector._get_account_id",
                 return_value=ACCOUNT_ID,
             ),
-            patch(
-                "omniscience_connectors.aws.connector._discover_organizations"
-            ) as mock_org,
+            patch("omniscience_connectors.aws.connector._discover_organizations") as mock_org,
         ):
             refs = [ref async for ref in connector.discover(config, SECRETS)]
 
@@ -545,16 +545,12 @@ class TestAwsConnectorFetchOrganizations:
             metadata=meta,
         )
 
-    async def test_fetch_organization(
-        self, connector: AwsConnector, config: AwsConfig
-    ) -> None:
+    async def test_fetch_organization(self, connector: AwsConnector, config: AwsConfig) -> None:
         mock_client = MagicMock()
         mock_client.describe_organization.return_value = {"Organization": _make_org()}
         ref = self._make_ref("aws_organization", org_id=ORG_ID)
 
-        with patch(
-            "omniscience_connectors.aws.connector._org_client", return_value=mock_client
-        ):
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=mock_client):
             doc = await connector.fetch(config, SECRETS, ref)
 
         data = json.loads(doc.content_bytes)
@@ -569,9 +565,7 @@ class TestAwsConnectorFetchOrganizations:
         }
         ref = self._make_ref("aws_organizations_ou", ou_id=OU_ID_1)
 
-        with patch(
-            "omniscience_connectors.aws.connector._org_client", return_value=mock_client
-        ):
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=mock_client):
             doc = await connector.fetch(config, SECRETS, ref)
 
         data = json.loads(doc.content_bytes)
@@ -581,14 +575,10 @@ class TestAwsConnectorFetchOrganizations:
     async def test_fetch_account(self, connector: AwsConnector, config: AwsConfig) -> None:
         acct_id = "777777777777"
         mock_client = MagicMock()
-        mock_client.describe_account.return_value = {
-            "Account": _make_account(acct_id, "prod")
-        }
+        mock_client.describe_account.return_value = {"Account": _make_account(acct_id, "prod")}
         ref = self._make_ref("aws_organizations_account", account_id=acct_id)
 
-        with patch(
-            "omniscience_connectors.aws.connector._org_client", return_value=mock_client
-        ):
+        with patch("omniscience_connectors.aws.connector._org_client", return_value=mock_client):
             doc = await connector.fetch(config, SECRETS, ref)
 
         data = json.loads(doc.content_bytes)

--- a/tests/test_cli_mcp_coverage.py
+++ b/tests/test_cli_mcp_coverage.py
@@ -102,9 +102,7 @@ class TestMcpServeStdio:
 class TestMcpServeHttp:
     def test_clean_exit_zero(self) -> None:
         with patch("subprocess.run", return_value=_proc(0)) as mock_run:
-            result = runner.invoke(
-                app, ["mcp", "serve", "--transport", "http"]
-            )
+            result = runner.invoke(app, ["mcp", "serve", "--transport", "http"])
         assert result.exit_code == 0
         cmd = mock_run.call_args[0][0]
         assert "uvicorn" in cmd
@@ -117,31 +115,23 @@ class TestMcpServeHttp:
 
     def test_custom_port(self) -> None:
         with patch("subprocess.run", return_value=_proc(0)) as mock_run:
-            runner.invoke(
-                app, ["mcp", "serve", "--transport", "http", "--port", "9090"]
-            )
+            runner.invoke(app, ["mcp", "serve", "--transport", "http", "--port", "9090"])
         cmd = mock_run.call_args[0][0]
         assert "9090" in cmd
 
     def test_nonzero_exit_aborts(self) -> None:
         with patch("subprocess.run", return_value=_proc(2)):
-            result = runner.invoke(
-                app, ["mcp", "serve", "--transport", "http"]
-            )
+            result = runner.invoke(app, ["mcp", "serve", "--transport", "http"])
         assert result.exit_code != 0
 
     def test_sigint_exit_clean(self) -> None:
         with patch("subprocess.run", return_value=_proc(-2)):
-            result = runner.invoke(
-                app, ["mcp", "serve", "--transport", "http"]
-            )
+            result = runner.invoke(app, ["mcp", "serve", "--transport", "http"])
         assert result.exit_code == 0
 
     def test_file_not_found_aborts(self) -> None:
         with patch("subprocess.run", side_effect=FileNotFoundError):
-            result = runner.invoke(
-                app, ["mcp", "serve", "--transport", "http"]
-            )
+            result = runner.invoke(app, ["mcp", "serve", "--transport", "http"])
         assert result.exit_code != 0
 
     def test_short_flags(self) -> None:

--- a/tests/test_components_endpoint.py
+++ b/tests/test_components_endpoint.py
@@ -397,9 +397,7 @@ async def test_components_graceful_degrade_one_store_error() -> None:
     mock_broken_graph_store._config = MagicMock()
     mock_broken_graph_store._config.database = "neo4j"
     broken_driver = MagicMock()
-    broken_driver.session = MagicMock(
-        side_effect=RuntimeError("neo4j connection refused")
-    )
+    broken_driver.session = MagicMock(side_effect=RuntimeError("neo4j connection refused"))
     mock_broken_graph_store._driver = broken_driver
     app.state.graph_store = mock_broken_graph_store
 

--- a/tests/test_incident_scoring_coverage.py
+++ b/tests/test_incident_scoring_coverage.py
@@ -841,9 +841,7 @@ class TestSaveWorkspaceConfig:
         ws_id = uuid.uuid4()
         cfg = IncidentScoringConfig(confidence_threshold=0.7)
 
-        with patch(
-            "omniscience_retrieval.incidents.scoring.flag_modified"
-        ) as mock_flag:
+        with patch("omniscience_retrieval.incidents.scoring.flag_modified") as mock_flag:
             await save_workspace_config(session, ws_id, cfg)
 
         # settings should now contain the SETTINGS_KEY

--- a/tests/test_k8s_connector_ca.py
+++ b/tests/test_k8s_connector_ca.py
@@ -41,11 +41,9 @@ import ssl
 import subprocess
 import warnings
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
-from pydantic import BaseModel
 
 # Suppress the module-level DeprecationWarning during import in tests.
 with warnings.catch_warnings():
@@ -201,9 +199,7 @@ class TestDeterministicMode:
             use_llm_kind_selection=False,
         )
         # No LLM mock needed — we assert it is NEVER called
-        with patch(
-            "omniscience_connectors.agentic.llm.build_provider"
-        ) as mock_build_provider:
+        with patch("omniscience_connectors.agentic.llm.build_provider") as mock_build_provider:
             refs = await _collect_discover(connector, cfg)
             mock_build_provider.assert_not_called()
 
@@ -333,12 +329,11 @@ class TestBearerTokenHeader:
         connector = K8sAgenticConnector()
         cfg = K8sAgenticConfig(api_server="https://k8s.example.com", verify_ssl=False)
 
-        mock_client_cls, mock_client = _make_httpx_mock()
+        mock_client_cls, _ = _make_httpx_mock()
 
         with patch("httpx.AsyncClient", mock_client_cls):
             await connector.validate(cfg, {"token": "my-sa-token"})
 
-        call_kwargs = mock_client.get.call_args
         # Header must be set at client construction time via AsyncClient(headers=...)
         client_init_kwargs = mock_client_cls.call_args[1]
         assert "Authorization" in client_init_kwargs.get("headers", {})
@@ -353,7 +348,7 @@ class TestBearerTokenHeader:
             metadata={"kind": "Deployment", "cluster": "test", "namespace": ""},
         )
 
-        mock_client_cls, mock_client = _make_httpx_mock(
+        mock_client_cls, _ = _make_httpx_mock(
             response_data={"items": []},
         )
 
@@ -397,7 +392,7 @@ class TestBearerTokenHeader:
         connector = K8sAgenticConnector()
         cfg = K8sAgenticConfig(api_server="https://k8s.example.com", verify_ssl=False)
 
-        mock_client_cls, mock_client = _make_httpx_mock()
+        mock_client_cls, _ = _make_httpx_mock()
 
         with patch("httpx.AsyncClient", mock_client_cls):
             await connector.validate(cfg, {})
@@ -419,7 +414,7 @@ class TestHttpxVerifyWiring:
             ca_cert_pem=_TEST_CA_PEM,
         )
 
-        mock_client_cls, mock_client = _make_httpx_mock()
+        mock_client_cls, _ = _make_httpx_mock()
 
         with patch("httpx.AsyncClient", mock_client_cls):
             await connector.validate(cfg, {})
@@ -435,7 +430,7 @@ class TestHttpxVerifyWiring:
             uri="k8s://test/ConfigMap",
             metadata={"kind": "ConfigMap", "cluster": "test", "namespace": ""},
         )
-        mock_client_cls, mock_client = _make_httpx_mock(response_data={"items": []})
+        mock_client_cls, _ = _make_httpx_mock(response_data={"items": []})
 
         with patch("httpx.AsyncClient", mock_client_cls):
             await connector.fetch(cfg, {"ca_cert_b64": _TEST_CA_B64}, ref)
@@ -450,7 +445,7 @@ class TestHttpxVerifyWiring:
             verify_ssl=False,
         )
 
-        mock_client_cls, mock_client = _make_httpx_mock()
+        mock_client_cls, _ = _make_httpx_mock()
 
         with patch("httpx.AsyncClient", mock_client_cls):
             await connector.validate(cfg, {})

--- a/tests/test_migration_verify_coverage.py
+++ b/tests/test_migration_verify_coverage.py
@@ -792,9 +792,7 @@ class TestVerifyRunnerRun:
     @pytest.mark.asyncio
     async def test_two_workspaces_isolation_check_no_breach(self) -> None:
         src_a = _make_source_mock(source_id=_SRC_1, tenant_id=_WS_A, name="src-a")
-        src_b = _make_source_mock(
-            source_id=uuid.uuid4(), tenant_id=_WS_B, name="src-b"
-        )
+        src_b = _make_source_mock(source_id=uuid.uuid4(), tenant_id=_WS_B, name="src-b")
         gs = _make_graph_store()
         vs = _make_vector_store()
         cfg = _make_config()
@@ -847,9 +845,7 @@ class TestVerifyRunnerRun:
     @pytest.mark.asyncio
     async def test_two_workspaces_isolation_breach_detected(self) -> None:
         src_a = _make_source_mock(source_id=_SRC_1, tenant_id=_WS_A, name="src-a")
-        src_b = _make_source_mock(
-            source_id=uuid.uuid4(), tenant_id=_WS_B, name="src-b"
-        )
+        src_b = _make_source_mock(source_id=uuid.uuid4(), tenant_id=_WS_B, name="src-b")
         gs = _make_graph_store()
         vs = _make_vector_store()
         cfg = _make_config()
@@ -1010,9 +1006,7 @@ class TestQdrantCountChunks:
         vs = _make_vector_store()
         vs._qc.count = AsyncMock(return_value=count_result)
 
-        with patch(
-            "omniscience_index.migration.verify.QdrantFilterBuilder"
-        ) as mock_fb:
+        with patch("omniscience_index.migration.verify.QdrantFilterBuilder") as mock_fb:
             mock_fb.return_value.with_source_ids.return_value = mock_fb.return_value
             mock_fb.return_value.exclude_tombstoned.return_value = mock_fb.return_value
             mock_fb.return_value.build.return_value = MagicMock()

--- a/tests/test_neo4j_store_as_of.py
+++ b/tests/test_neo4j_store_as_of.py
@@ -238,7 +238,6 @@ async def test_find_related_default_uses_latest_template() -> None:
         return_value=[
             {
                 "id": str(uuid.uuid4()),
-
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(uuid.uuid4()),
@@ -267,7 +266,6 @@ async def test_find_related_as_of_routes_to_bitemporal_template() -> None:
         return_value=[
             {
                 "id": str(uuid.uuid4()),
-
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(uuid.uuid4()),
@@ -305,7 +303,6 @@ async def test_traverse_passes_as_of_through_to_find_related() -> None:
         return_value=[
             {
                 "id": str(uuid.uuid4()),
-
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(uuid.uuid4()),
@@ -438,7 +435,6 @@ async def test_find_related_legacy_3_tuple_edges_still_parse() -> None:
         return_value=[
             {
                 "id": str(uuid.uuid4()),
-
                 "seed_name": "svc.auth",
                 "seed_kind": "service",
                 "seed_source_id": str(src),

--- a/tests/test_neo4j_store_bitemporal_schema.py
+++ b/tests/test_neo4j_store_bitemporal_schema.py
@@ -300,8 +300,7 @@ async def test_connect_creates_all_adr_0008_constraints_and_indexes() -> None:
                     async for record in await session.run("SHOW CONSTRAINTS YIELD name")
                 ]
                 idx_rows = [
-                    record.data()
-                    async for record in await session.run("SHOW INDEXES YIELD name")
+                    record.data() async for record in await session.run("SHOW INDEXES YIELD name")
                 ]
         finally:
             await store.close()

--- a/tests/test_otlp_ingester_coverage.py
+++ b/tests/test_otlp_ingester_coverage.py
@@ -215,9 +215,7 @@ async def test_ingest_reuses_existing_source() -> None:
     await ingester.ingest(workspace_id=ws_id, parsed=_single_trace())
 
     # Source.add() must NOT have been called with a Source object
-    source_adds = [
-        c for c in session.add.call_args_list if isinstance(c.args[0], Source)
-    ]
+    source_adds = [c for c in session.add.call_args_list if isinstance(c.args[0], Source)]
     assert source_adds == []
 
 
@@ -428,9 +426,7 @@ async def test_ingest_entity_update_path_on_existing() -> None:
 
     # The existing trace entity was returned, so no new trace entity is added
     new_trace_entities = [
-        o
-        for o in added
-        if isinstance(o, Entity) and o.entity_type == OTEL_TRACE_ENTITY_TYPE
+        o for o in added if isinstance(o, Entity) and o.entity_type == OTEL_TRACE_ENTITY_TYPE
     ]
     assert len(new_trace_entities) == 0
     # metadata on existing entity was updated

--- a/tests/test_rest_postmortem_coverage.py
+++ b/tests/test_rest_postmortem_coverage.py
@@ -446,12 +446,15 @@ async def test_postmortem_400_invalid_format_from_render() -> None:
     app = _make_app(tok)
     report = _make_report()
 
-    with patch(
-        "omniscience_server.rest.postmortem.generate_postmortem",
-        new=AsyncMock(return_value=report),
-    ), patch(
-        "omniscience_server.rest.postmortem.render",
-        side_effect=PostmortemError(INVALID_FORMAT_CODE, "pdf"),
+    with (
+        patch(
+            "omniscience_server.rest.postmortem.generate_postmortem",
+            new=AsyncMock(return_value=report),
+        ),
+        patch(
+            "omniscience_server.rest.postmortem.render",
+            side_effect=PostmortemError(INVALID_FORMAT_CODE, "pdf"),
+        ),
     ):
         async with await _client(app) as c:
             resp = await c.get(

--- a/tests/test_temporal_retention.py
+++ b/tests/test_temporal_retention.py
@@ -1,22 +1,25 @@
 """Integration tests for bitemporality and retention (issue #135, ADR-0009).
 
-Verifies that the orchestrated IndexWriter and RetentionWorker maintain 
+Verifies that the orchestrated IndexWriter and RetentionWorker maintain
 consistent bitemporal history across Postgres, Neo4j, and Qdrant.
 """
 
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from omniscience_core.storage.graph import EntityNodeView, GraphResultView
 from omniscience_index import ChunkData, IndexWriter
 from omniscience_retrieval.models import (
-    SearchHit, SearchResult, QueryStats, Citation, 
-    SourceInfo, ChunkLineage
+    ChunkLineage,
+    Citation,
+    QueryStats,
+    SearchHit,
+    SearchResult,
+    SourceInfo,
 )
 
 # ---------------------------------------------------------------------------
@@ -33,27 +36,28 @@ _T2 = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
 # Test Setup
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_bitemporal_update_and_retention_flow() -> None:
     """End-to-end verification of temporal consistency."""
-    
+
     mock_session = AsyncMock()
     mock_begin = AsyncMock()
     mock_begin.__aenter__ = AsyncMock()
     mock_begin.__aexit__ = AsyncMock()
     mock_session.begin = MagicMock(return_value=mock_begin)
-    
+
     session_factory = MagicMock()
     mock_factory_cm = AsyncMock()
     mock_factory_cm.__aenter__ = AsyncMock(return_value=mock_session)
     mock_factory_cm.__aexit__ = AsyncMock()
     session_factory.return_value = mock_factory_cm
-    
+
     graph_store = MagicMock()
     graph_store.upsert_graph = AsyncMock()
     vector_store = MagicMock()
     vector_store.upsert_chunks = AsyncMock()
-    
+
     writer = IndexWriter(
         session_factory=session_factory,
         graph_store=graph_store,
@@ -64,12 +68,12 @@ async def test_bitemporal_update_and_retention_flow() -> None:
     mock_doc.id = uuid.uuid4()
     mock_doc.content_hash = "old-hash"
     mock_doc.doc_version = 1
-    
+
     # --- STEP 1: CREATE VERSION 1 ---
     with (
         patch.object(writer, "_find_document", AsyncMock(return_value=None)),
         patch.object(writer, "_insert_document", AsyncMock(return_value=mock_doc)),
-        patch.object(writer, "_insert_chunks", AsyncMock())
+        patch.object(writer, "_insert_chunks", AsyncMock()),
     ):
         chunks = [ChunkData(ord=0, text="Version 1 content", embedding=[0.1, 0.1])]
         await writer.upsert_document(
@@ -91,7 +95,7 @@ async def test_bitemporal_update_and_retention_flow() -> None:
         patch.object(writer, "_find_document", AsyncMock(return_value=mock_doc)),
         patch.object(writer, "_update_document", AsyncMock()),
         patch.object(writer, "_delete_chunks", AsyncMock()),
-        patch.object(writer, "_insert_chunks", AsyncMock())
+        patch.object(writer, "_insert_chunks", AsyncMock()),
     ):
         chunks_v2 = [ChunkData(ord=0, text="Version 2 content", embedding=[0.2, 0.2])]
         await writer.upsert_document(
@@ -108,7 +112,7 @@ async def test_bitemporal_update_and_retention_flow() -> None:
 
     # --- STEP 3: TEMPORAL RETRIEVAL SIMULATION ---
     from omniscience_retrieval.graph_rag import GraphRAGComposer
-    
+
     def _make_result(text: str) -> SearchResult:
         hit = SearchHit(
             chunk_id=uuid.uuid4(),
@@ -122,18 +126,15 @@ async def test_bitemporal_update_and_retention_flow() -> None:
                 embedding_provider="test",
                 parser_version="test",
                 chunker_strategy="test",
-                ingestion_run_id=uuid.uuid4()
+                ingestion_run_id=uuid.uuid4(),
             ),
-            metadata={}
+            metadata={},
         )
         return SearchResult(
             hits=[hit],
             query_stats=QueryStats(
-                total_matches_before_filters=1,
-                vector_matches=1,
-                text_matches=0,
-                duration_ms=1.0
-            )
+                total_matches_before_filters=1, vector_matches=1, text_matches=0, duration_ms=1.0
+            ),
         )
 
     async def mock_search_v1(**kwargs: Any) -> Any:
@@ -147,26 +148,22 @@ async def test_bitemporal_update_and_retention_flow() -> None:
         vector_store=vector_store,
         legacy_service=MagicMock(),
     )
-    
+
     with (
         patch("omniscience_retrieval.graph_rag._should_use_graphrag", return_value=True),
-        patch("omniscience_retrieval.graph_rag._stamp_envelope", side_effect=lambda x, **k: x)
+        patch("omniscience_retrieval.graph_rag._stamp_envelope", side_effect=lambda x, **k: x),
     ):
         composer._graphrag_active = True
-        
+
         # Query for Version 1
         res1 = await composer.search(
-            MagicMock(query="content", top_k=1, filters={}),
-            workspace_id=_WS_ID,
-            as_of=_T1
+            MagicMock(query="content", top_k=1, filters={}), workspace_id=_WS_ID, as_of=_T1
         )
         assert "Version 1" in res1.hits[0].text
-        
+
         # Query for Version 2
         res2 = await composer.search(
-            MagicMock(query="content", top_k=1, filters={}),
-            workspace_id=_WS_ID,
-            as_of=_T2
+            MagicMock(query="content", top_k=1, filters={}), workspace_id=_WS_ID, as_of=_T2
         )
         assert "Version 2" in res2.hits[0].text
 
@@ -174,6 +171,7 @@ async def test_bitemporal_update_and_retention_flow() -> None:
     vector_store.mark_retention_warm = AsyncMock()
     await vector_store.mark_retention_warm(workspace_id=_WS_ID, cutoff=_T2)
     vector_store.mark_retention_warm.assert_awaited_once()
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_tokens_workspace_scope.py
+++ b/tests/test_tokens_workspace_scope.py
@@ -108,16 +108,9 @@ async def test_create_token_with_workspace_id_persists_it() -> None:
     read_model = _make_read_model(tok)
     session = _make_session(tok)
 
-    # Capture what ApiToken(...) was constructed with.
+    # Capture what ApiToken(...) was constructed with (via the patched
+    # side_effect below, which records kwargs into constructed_kwargs).
     constructed_kwargs: dict[str, Any] = {}
-
-    original_init = ApiToken.__init__
-
-    def _capture_init(self: ApiToken, **kwargs: Any) -> None:
-        constructed_kwargs.update(kwargs)
-        # Set attributes directly so the object behaves realistically.
-        for k, v in kwargs.items():
-            object.__setattr__(self, k, v)
 
     with (
         patch(
@@ -127,7 +120,7 @@ async def test_create_token_with_workspace_id_persists_it() -> None:
         patch("omniscience_server.routes.tokens.hash_token", return_value="hashed"),
         patch(
             "omniscience_server.routes.tokens.ApiToken",
-            side_effect=lambda **kw: (constructed_kwargs.update(kw) or tok),
+            side_effect=lambda **kw: constructed_kwargs.update(kw) or tok,
         ),
         patch(
             "omniscience_server.routes.tokens.ApiTokenRead.model_validate",
@@ -182,7 +175,7 @@ async def test_create_token_without_workspace_id_stays_null() -> None:
         patch("omniscience_server.routes.tokens.hash_token", return_value="hashed2"),
         patch(
             "omniscience_server.routes.tokens.ApiToken",
-            side_effect=lambda **kw: (constructed_kwargs.update(kw) or tok),
+            side_effect=lambda **kw: constructed_kwargs.update(kw) or tok,
         ),
         patch(
             "omniscience_server.routes.tokens.ApiTokenRead.model_validate",


### PR DESCRIPTION
## Problem

The CI `lint` job (`uv run ruff check .` + `ruff format --check .`) is **red on main** — ~80 check errors and 34 unformatted files accumulated across recent merges (#276/#280/#283/#285/#286 and the v0.4 discovery preview). This makes every PR show UNSTABLE regardless of its own diff.

## Changes (no behavioural change)

- **Auto-fixed**: trailing/blank-line whitespace (W291/W293), import ordering (I001), and `ruff format` across 33 files.
- **`scripts/*` per-file-ignores**: added `S108` (/tmp paths), `S310` (urlopen to the trusted cluster API), `SIM115` (`json.load(open(...))`) — idiomatic for one-shot operational glue scripts, consistent with the existing `tests/*` S108 ignore.
- **`tests/test_k8s_connector_ca.py`**: removed an unused `call_args` capture and switched 6 unused unpacked mock instances to `_` (F841/RUF059).
- **`tests/test_tokens_workspace_scope.py`**: removed dead `original_init`/`_capture_init` (kwargs capture actually happens via the patched `side_effect`).

## Verification

```
uv run ruff check .        → All checks passed!
uv run ruff format --check . → 410 files already formatted
edited test files: 35 passed
```