### PR TITLE
feat(connectors): per-resource granularity + cluster_name for K8s agentic connector

### DIFF
--- a/packages/connectors/src/omniscience_connectors/agentic/k8s.py
+++ b/packages/connectors/src/omniscience_connectors/agentic/k8s.py
@@ -26,7 +26,10 @@ Config
     - ``api_server`` — Kubernetes API server URL (e.g. ``https://k8s.example.com``).
     - ``namespace`` — namespace to scope discovery; empty = all namespaces.
     - ``default_include_kinds`` — fallback list used when LLM fails (and the
-      sole source of kinds when ``use_llm_kind_selection=False``).
+      sole source of kinds when ``use_llm_kind_selection=False``).  A kind may
+      be expressed as a bare ``"Kind"`` (looked up in the built-in tables) or as
+      ``"group/Kind"`` (e.g. ``"argoproj.io/Application"``) which resolves to
+      ``/apis/<group>/<version>/<plural>``.
     - ``default_exclude_kinds`` — kinds always excluded regardless of LLM output.
     - ``verify_ssl`` — ``True`` (default) verifies with the system CA bundle;
       ``False`` disables verification (insecure escape hatch).  Ignored when a
@@ -37,8 +40,8 @@ Config
       same way as ``ca_cert_pem``.  ``ca_cert_pem`` takes precedence if both
       are provided.
     - ``use_llm_kind_selection`` — when ``False``, ``discover()`` skips the LLM
-      entirely and yields refs directly from ``default_include_kinds`` minus
-      ``default_exclude_kinds``.  Deterministic, no LLM dependency.
+      entirely and yields ONE ref PER RESOURCE INSTANCE (deterministic,
+      per-resource granularity, no LLM dependency).
 
 Secrets
 -------
@@ -57,9 +60,21 @@ When ``use_llm_kind_selection=True`` (default):
    parse failure.
 
 When ``use_llm_kind_selection=False``:
-1. Yield refs directly from ``default_include_kinds`` minus
-   ``default_exclude_kinds`` and ``_ALWAYS_EXCLUDE``.  No LLM call, no API
-   enumeration needed for kind selection (``/api`` / ``/apis`` are NOT called).
+1. For each kind in ``default_include_kinds`` minus ``default_exclude_kinds`` and
+   ``_ALWAYS_EXCLUDE``, list all instances via the Kubernetes API.
+2. Yield ONE ``DocumentRef`` per instance with metadata
+   ``{kind, cluster, namespace, name}``, a stable ``external_id``
+   ``k8s:{cluster}:{namespace}:{kind}:{name}``, and ``uri``
+   ``k8s://{cluster}/{namespace}/{kind}/{name}``.
+3. If the SA cannot list a kind (HTTP 403 / 404), log the error and skip that
+   kind — enumeration of the other kinds continues.
+
+``fetch()`` behaviour:
+- When the ref has a ``name`` key in metadata (per-resource ref from deterministic
+  discover), fetches that single resource and returns a concise human-readable
+  text body so embeddings are meaningful.
+- When the ref has no ``name`` key (LLM-path / legacy kind-level ref), falls
+  back to the previous list-all behaviour (returns raw JSON of the collection).
 
 Note: ``fetch()`` retrieves the resource as JSON and stores it as
 ``application/json`` bytes.  The downstream pipeline is responsible for further
@@ -158,6 +173,8 @@ _DEFAULT_INCLUDE_KINDS: list[str] = [
     "RoleBinding",
     "ClusterRole",
     "ClusterRoleBinding",
+    # ArgoCD CRD — expressed as "group/Kind" so the path resolver handles it.
+    "argoproj.io/Application",
 ]
 
 _DEFAULT_EXCLUDE_KINDS: list[str] = [
@@ -241,6 +258,15 @@ _KIND_AUTOSCALING: dict[str, str] = {
     "HorizontalPodAutoscaler": "horizontalpodautoscalers",
 }
 
+# CRD kinds expressed as "group/Kind" → (group, version, plural).
+# The resolver tries this table first before falling back to heuristics.
+_KIND_CRD: dict[str, tuple[str, str, str]] = {
+    "argoproj.io/Application": ("argoproj.io", "v1alpha1", "applications"),
+    "argoproj.io/AppProject": ("argoproj.io", "v1alpha1", "appprojects"),
+    "argoproj.io/ApplicationSet": ("argoproj.io", "v1alpha1", "applicationsets"),
+    "argoproj.io/Rollout": ("argoproj.io", "v1alpha1", "rollouts"),
+}
+
 # Core kinds that are cluster-scoped (no namespace segment in path).
 _CORE_CLUSTER_SCOPED: frozenset[str] = frozenset({"Namespace", "Node", "PersistentVolume"})
 
@@ -270,7 +296,9 @@ class K8sAgenticConfig(BaseModel):
         default_factory=lambda: list(_DEFAULT_INCLUDE_KINDS),
         description=(
             "Fallback list of resource kinds used when the LLM fails, "
-            "or the complete kind list when use_llm_kind_selection=False."
+            "or the complete kind list when use_llm_kind_selection=False. "
+            "A kind may be a bare name (e.g. 'Deployment') or a 'group/Kind' "
+            "qualified name (e.g. 'argoproj.io/Application')."
         ),
     )
 
@@ -308,9 +336,9 @@ class K8sAgenticConfig(BaseModel):
         default=True,
         description=(
             "When True (default), the LLM selects which resource kinds to index. "
-            "When False, discover() skips the LLM entirely and uses "
-            "default_include_kinds minus default_exclude_kinds directly "
-            "(deterministic, no LLM dependency)."
+            "When False, discover() skips the LLM entirely and enumerates "
+            "individual resource instances from default_include_kinds minus "
+            "default_exclude_kinds (deterministic, per-resource granularity)."
         ),
     )
 
@@ -390,7 +418,8 @@ class K8sAgenticConnector(AgenticConnector):
     ``config.default_exclude_kinds`` minus ``_ALWAYS_EXCLUDE``.
 
     When ``config.use_llm_kind_selection=False``, the LLM is never called;
-    ``default_include_kinds`` is used directly (deterministic mode).
+    ``default_include_kinds`` is used to enumerate individual resource instances
+    directly (deterministic per-resource mode).
     """
 
     connector_type: ClassVar[str] = "k8s-agentic"
@@ -524,7 +553,11 @@ class K8sAgenticConnector(AgenticConnector):
         config: BaseModel,
         secrets: dict[str, str],
     ) -> AsyncIterator[DocumentRef]:
-        """Yield refs for the configured default include kinds."""
+        """Yield refs for the configured default include kinds.
+
+        Used as the LLM fallback path (kind-level refs, not per-instance).
+        The deterministic discover path calls ``_list_kind_instances`` instead.
+        """
         cfg: K8sAgenticConfig = config  # type: ignore[assignment]
         effective_exclude = _ALWAYS_EXCLUDE | set(cfg.default_exclude_kinds)
         for kind in sorted(k for k in cfg.default_include_kinds if k not in effective_exclude):
@@ -548,11 +581,12 @@ class K8sAgenticConnector(AgenticConnector):
         config: BaseModel,
         secrets: dict[str, str],
     ) -> AsyncIterator[DocumentRef]:
-        """Enumerate available API resource kinds, then run the LLM loop.
+        """Enumerate resource instances (deterministic) or run the LLM loop.
 
         When ``config.use_llm_kind_selection`` is ``False``, the LLM is never
-        called; refs are yielded directly from ``default_include_kinds`` minus
-        ``default_exclude_kinds``.
+        called; for each kind in ``default_include_kinds`` minus exclusions, all
+        instances are listed and one ``DocumentRef`` is yielded per instance.
+        A kind that the SA cannot access (403/404) is skipped with a warning.
 
         Otherwise, overrides ``AgenticConnector.discover`` to first query the
         Kubernetes API for available resource kinds and inject them into the LLM
@@ -561,12 +595,17 @@ class K8sAgenticConnector(AgenticConnector):
         cfg: K8sAgenticConfig = config  # type: ignore[assignment]
 
         # ------------------------------------------------------------------
-        # Fast path: deterministic mode — no LLM, no API enumeration
+        # Fast path: deterministic mode — per-resource enumeration, no LLM
         # ------------------------------------------------------------------
         if not cfg.use_llm_kind_selection:
             logger.info("k8s_agentic.discover.deterministic_mode")
-            async for ref in self._default_document_refs(config, secrets):
-                yield ref
+            effective_exclude = _ALWAYS_EXCLUDE | set(cfg.default_exclude_kinds)
+            active_kinds = sorted(
+                k for k in cfg.default_include_kinds if k not in effective_exclude
+            )
+            for kind in active_kinds:
+                async for ref in self._list_kind_instances(cfg, secrets, kind):
+                    yield ref
             return
 
         # ------------------------------------------------------------------
@@ -624,7 +663,16 @@ class K8sAgenticConnector(AgenticConnector):
         secrets: dict[str, str],
         ref: DocumentRef,
     ) -> FetchedDocument:
-        """Fetch all instances of the resource kind as a JSON document."""
+        """Fetch a single resource (per-instance ref) or a kind collection.
+
+        When ``ref.metadata`` contains a ``"name"`` key (set by the deterministic
+        discover path), fetches that individual resource and returns a concise
+        human-readable text body suitable for embedding.
+
+        When ``ref.metadata`` has no ``"name"`` key (LLM-path / legacy kind-level
+        ref), falls back to the previous behaviour of listing all instances and
+        returning the raw JSON collection.
+        """
         cfg: K8sAgenticConfig = config  # type: ignore[assignment]
         kind = ref.metadata.get("kind", "")
         token = secrets.get("token") or secrets.get("kubeconfig", "")
@@ -634,7 +682,14 @@ class K8sAgenticConnector(AgenticConnector):
         if token:
             headers["Authorization"] = f"Bearer {token}"
 
-        path = _kind_to_api_path(kind, cfg.namespace)
+        name = ref.metadata.get("name", "")
+        namespace = ref.metadata.get("namespace", cfg.namespace)
+
+        if name:
+            path = _kind_to_resource_path(kind, namespace, name)
+        else:
+            path = _kind_to_api_path(kind, cfg.namespace)
+
         url = f"{cfg.api_server}{path}"
 
         try:
@@ -652,6 +707,15 @@ class K8sAgenticConnector(AgenticConnector):
             ) from exc
         except httpx.RequestError as exc:
             raise RuntimeError(f"K8s fetch request failed for {url}: {exc}") from exc
+
+        if name:
+            resource = resp.json()
+            text = _resource_to_text(resource, kind)
+            return FetchedDocument(
+                ref=ref,
+                content_bytes=text.encode("utf-8"),
+                content_type="text/plain",
+            )
 
         return FetchedDocument(
             ref=ref,
@@ -723,20 +787,121 @@ class K8sAgenticConnector(AgenticConnector):
 
         return sorted(kinds)
 
+    async def _list_kind_instances(
+        self,
+        cfg: K8sAgenticConfig,
+        secrets: dict[str, str],
+        kind: str,
+    ) -> AsyncIterator[DocumentRef]:
+        """List all instances of ``kind`` and yield one ``DocumentRef`` per item.
+
+        Gracefully skips the kind and logs a warning on HTTP 403/404 so
+        enumeration of the remaining kinds continues uninterrupted.
+
+        Args:
+            cfg: Validated connector config.
+            secrets: Runtime secrets.
+            kind: Kind name — may be bare (``"Deployment"``) or qualified
+                (``"argoproj.io/Application"``).
+
+        Yields:
+            One :class:`DocumentRef` per resource instance.
+        """
+        token = secrets.get("token") or secrets.get("kubeconfig", "")
+        verify = build_ssl_verify(cfg, secrets)
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        list_path = _kind_to_api_path(kind, cfg.namespace)
+        url = f"{cfg.api_server}{list_path}"
+
+        try:
+            async with httpx.AsyncClient(
+                verify=verify,
+                headers=headers,
+                timeout=30.0,
+            ) as client:
+                resp = await client.get(url)
+        except httpx.RequestError as exc:
+            logger.warning(
+                "k8s_agentic.list_instances.request_error",
+                extra={"kind": kind, "url": url, "error": str(exc)},
+            )
+            return
+
+        if resp.status_code in (403, 404):
+            logger.warning(
+                "k8s_agentic.list_instances.skipped",
+                extra={"kind": kind, "status": resp.status_code},
+            )
+            return
+
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "k8s_agentic.list_instances.http_error",
+                extra={"kind": kind, "status": exc.response.status_code},
+            )
+            return
+
+        try:
+            data = resp.json()
+            items: list[dict[str, Any]] = data.get("items", [])
+        except Exception as exc:
+            logger.warning(
+                "k8s_agentic.list_instances.parse_error",
+                extra={"kind": kind, "error": str(exc)},
+            )
+            return
+
+        # Extract bare kind name for metadata (strip group prefix if qualified)
+        bare_kind = kind.split("/", 1)[1] if "/" in kind else kind
+
+        for item in items:
+            meta: dict[str, Any] = item.get("metadata", {})
+            name: str = meta.get("name", "")
+            namespace: str = meta.get("namespace", "")
+            if not name:
+                continue
+
+            external_id = f"k8s:{cfg.cluster_name}:{namespace}:{bare_kind}:{name}"
+            uri = f"k8s://{cfg.cluster_name}/{namespace}/{bare_kind}/{name}"
+            yield DocumentRef(
+                external_id=external_id,
+                uri=uri,
+                metadata={
+                    "kind": bare_kind,
+                    "cluster": cfg.cluster_name,
+                    "namespace": namespace,
+                    "name": name,
+                    "source": "deterministic",
+                },
+            )
+
 
 def _kind_to_api_path(kind: str, namespace: str) -> str:
     """Convert a Kubernetes resource kind to a REST API list path.
 
-    This is a best-effort mapping for well-known kinds.  Unknown kinds fall
-    back to the lowercase-plural convention under ``/apis/``.
+    Supports bare kind names (e.g. ``"Deployment"``) and qualified
+    ``"group/Kind"`` CRD names (e.g. ``"argoproj.io/Application"``).
+
+    For CRD kinds not in the built-in ``_KIND_CRD`` table, falls back to a
+    heuristic: ``/apis/<group>/<version>/<plural>`` where version defaults to
+    ``v1`` and plural is the lowercased kind with an ``s`` suffix.
 
     Args:
-        kind: Kubernetes resource kind (e.g. ``"Deployment"``).
+        kind: Kubernetes resource kind.  May be ``"Kind"`` or ``"group/Kind"``.
         namespace: Namespace filter; empty = all namespaces.
 
     Returns:
         API server path string (without base URL).
     """
+    # Handle qualified CRD kinds first ("group/Kind")
+    if "/" in kind:
+        return _crd_kind_to_api_path(kind, namespace)
+
     ns_segment = f"namespaces/{namespace}/" if namespace else ""
 
     if kind in _KIND_CORE:
@@ -767,6 +932,104 @@ def _kind_to_api_path(kind: str, namespace: str) -> str:
         plural = _KIND_AUTOSCALING[kind]
         return f"/apis/autoscaling/v2/{ns_segment}{plural}"
 
-    # Unknown kind — best-effort: lowercase plural under /apis/
+    # Unknown bare kind — best-effort: lowercase plural under /apis/
     plural_fallback = kind.lower() + "s"
     return f"/apis/{ns_segment}{plural_fallback}"
+
+
+def _crd_kind_to_api_path(qualified_kind: str, namespace: str) -> str:
+    """Resolve a ``"group/Kind"`` CRD spec to its REST list path.
+
+    Checks the built-in ``_KIND_CRD`` table first.  Falls back to a heuristic
+    for unknown CRDs: ``/apis/<group>/v1/<plural>`` where plural is the
+    lowercase kind name with an ``s`` suffix.
+
+    Args:
+        qualified_kind: CRD kind string in ``"group/Kind"`` format.
+        namespace: Namespace filter; empty = all namespaces (cluster-scoped CRDs
+            also receive ``""`` here and produce a path without a namespace
+            segment).
+
+    Returns:
+        API server list path (without base URL).
+    """
+    ns_segment = f"namespaces/{namespace}/" if namespace else ""
+
+    if qualified_kind in _KIND_CRD:
+        group, version, plural = _KIND_CRD[qualified_kind]
+        return f"/apis/{group}/{version}/{ns_segment}{plural}"
+
+    # Heuristic for unknown CRD groups
+    group, raw_kind = qualified_kind.split("/", 1)
+    plural = raw_kind.lower() + "s"
+    return f"/apis/{group}/v1/{ns_segment}{plural}"
+
+
+def _kind_to_resource_path(kind: str, namespace: str, name: str) -> str:
+    """Build the path for fetching a single named resource.
+
+    This is the single-resource equivalent of ``_kind_to_api_path``:
+    appends ``/<name>`` to the namespaced or cluster-scoped collection path.
+
+    Args:
+        kind: Resource kind (bare or qualified).
+        namespace: Namespace the resource lives in (may be empty for
+            cluster-scoped resources).
+        name: Resource name.
+
+    Returns:
+        API server path string for the individual resource (without base URL).
+    """
+    collection_path = _kind_to_api_path(kind, namespace)
+    return f"{collection_path}/{name}"
+
+
+def _resource_to_text(resource: dict[str, Any], kind: str) -> str:
+    """Produce a concise human-readable summary of a Kubernetes resource.
+
+    The text is intentionally terse — just enough signal for embeddings to be
+    meaningful without carrying the full YAML verbatim (which bloats vectors).
+
+    Args:
+        resource: Parsed JSON of a single Kubernetes resource.
+        kind: Resource kind (used as a label in the output).
+
+    Returns:
+        Plain-text summary string.
+    """
+    meta: dict[str, Any] = resource.get("metadata", {})
+    name: str = meta.get("name", "<unknown>")
+    namespace: str = meta.get("namespace", "")
+    labels: dict[str, str] = meta.get("labels", {})
+    annotations: dict[str, str] = meta.get("annotations", {})
+
+    lines: list[str] = [
+        f"Kind: {kind}",
+        f"Name: {name}",
+    ]
+    if namespace:
+        lines.append(f"Namespace: {namespace}")
+    if labels:
+        label_str = ", ".join(f"{k}={v}" for k, v in sorted(labels.items()))
+        lines.append(f"Labels: {label_str}")
+    if annotations:
+        # Include only non-system annotations (skip kubectl.kubernetes.io/* noise)
+        user_annotations = {
+            k: v for k, v in annotations.items() if not k.startswith("kubectl.kubernetes.io/")
+        }
+        if user_annotations:
+            ann_str = ", ".join(f"{k}={v}" for k, v in sorted(user_annotations.items()))
+            lines.append(f"Annotations: {ann_str}")
+
+    spec: dict[str, Any] = resource.get("spec", {})
+    if spec:
+        # Include a JSON snippet of spec capped at 500 chars to stay concise
+        spec_snippet = json.dumps(spec, separators=(",", ":"))[:500]
+        lines.append(f"Spec: {spec_snippet}")
+
+    status: dict[str, Any] = resource.get("status", {})
+    if status:
+        status_snippet = json.dumps(status, separators=(",", ":"))[:200]
+        lines.append(f"Status: {status_snippet}")
+
+    return "\n".join(lines)

--- a/tests/test_k8s_connector_ca.py
+++ b/tests/test_k8s_connector_ca.py
@@ -14,11 +14,11 @@ Coverage
     - invalid base64 in secrets → ValueError
 
 - use_llm_kind_selection=False (deterministic mode):
-    - discover() yields refs from default_include_kinds
+    - discover() yields per-instance refs (one per item returned by list calls)
     - LLM provider is NEVER instantiated / called
     - _enumerate_kinds is NEVER called
     - excluded kinds (default_exclude_kinds + _ALWAYS_EXCLUDE) are absent
-    - metadata source == "default-fallback"
+    - metadata source == "deterministic"
 
 - use_llm_kind_selection=True (existing LLM path, regression guards):
     - LLM is invoked as before
@@ -40,6 +40,7 @@ import json
 import ssl
 import subprocess
 import warnings
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -127,6 +128,43 @@ def _make_httpx_mock(response_data: Any = None, status: int = 200) -> tuple[Magi
     return mock_client_cls, mock_client
 
 
+def _stub_list_instances(
+    kinds_to_refs: dict[str, list[DocumentRef]],
+) -> Any:
+    """Build a patch-able _list_kind_instances that returns fixed refs per kind."""
+
+    async def _mock(
+        self: Any,
+        cfg: K8sAgenticConfig,
+        secrets: dict[str, str],
+        kind: str,
+    ) -> AsyncIterator[DocumentRef]:
+        for ref in kinds_to_refs.get(kind, []):
+            yield ref
+
+    return _mock
+
+
+def _make_per_instance_ref(
+    kind: str,
+    name: str,
+    namespace: str = "default",
+    cluster: str = "test-cluster",
+) -> DocumentRef:
+    bare_kind = kind.split("/", 1)[1] if "/" in kind else kind
+    return DocumentRef(
+        external_id=f"k8s:{cluster}:{namespace}:{bare_kind}:{name}",
+        uri=f"k8s://{cluster}/{namespace}/{bare_kind}/{name}",
+        metadata={
+            "kind": bare_kind,
+            "cluster": cluster,
+            "namespace": namespace,
+            "name": name,
+            "source": "deterministic",
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # 1. build_ssl_verify helper
 # ---------------------------------------------------------------------------
@@ -192,100 +230,160 @@ class TestBuildSslVerify:
 
 
 class TestDeterministicMode:
-    async def test_discover_yields_refs_from_default_include_kinds(self) -> None:
+    """Deterministic mode now enumerates instances via _list_kind_instances.
+
+    Tests use a stub for _list_kind_instances so no real HTTP calls are needed.
+    The important invariants are:
+    - LLM is never called
+    - _enumerate_kinds is never called
+    - Excluded kinds (default_exclude_kinds + _ALWAYS_EXCLUDE) are never listed
+    - Per-instance refs carry expected metadata
+    """
+
+    async def test_discover_yields_per_instance_refs(self) -> None:
         connector = K8sAgenticConnector()
         cfg = K8sAgenticConfig(
             cluster_name="eks-prod",
             use_llm_kind_selection=False,
+            default_include_kinds=["Deployment", "Service"],
+            default_exclude_kinds=[],
         )
-        # No LLM mock needed — we assert it is NEVER called
-        with patch("omniscience_connectors.agentic.llm.build_provider") as mock_build_provider:
+        dep_refs = [
+            _make_per_instance_ref("Deployment", "api", cluster="eks-prod"),
+            _make_per_instance_ref("Deployment", "worker", cluster="eks-prod"),
+        ]
+        svc_refs = [_make_per_instance_ref("Service", "api-svc", cluster="eks-prod")]
+        stub = _stub_list_instances({"Deployment": dep_refs, "Service": svc_refs})
+
+        with (
+            patch("omniscience_connectors.agentic.llm.build_provider") as mock_build_provider,
+            patch.object(K8sAgenticConnector, "_list_kind_instances", stub),
+        ):
             refs = await _collect_discover(connector, cfg)
             mock_build_provider.assert_not_called()
 
-        kinds = {r.metadata["kind"] for r in refs}
-        # All default_include_kinds (minus excluded) should be present
-        for kind in cfg.default_include_kinds:
-            if kind not in cfg.default_exclude_kinds and kind not in {
-                "Secret",
-                "Event",
-                "TokenReview",
-                "SubjectAccessReview",
-                "SelfSubjectAccessReview",
-                "SelfSubjectRulesReview",
-                "LocalSubjectAccessReview",
-            }:
-                assert kind in kinds, f"Expected {kind!r} in deterministic refs"
+        assert len(refs) == 3
+        names = {r.metadata["name"] for r in refs}
+        assert names == {"api", "worker", "api-svc"}
 
     async def test_llm_provider_never_invoked_in_deterministic_mode(self) -> None:
         connector = K8sAgenticConnector()
-        cfg = K8sAgenticConfig(use_llm_kind_selection=False)
+        cfg = K8sAgenticConfig(
+            use_llm_kind_selection=False,
+            default_include_kinds=["Service"],
+            default_exclude_kinds=[],
+        )
+        svc_refs = [_make_per_instance_ref("Service", "svc1")]
+        stub = _stub_list_instances({"Service": svc_refs})
 
         mock_provider = AsyncMock()
         mock_provider.complete = AsyncMock(side_effect=AssertionError("LLM must not be called"))
 
-        with patch(
-            "omniscience_connectors.agentic.llm.build_provider",
-            return_value=mock_provider,
-        ) as mock_build:
+        with (
+            patch(
+                "omniscience_connectors.agentic.llm.build_provider",
+                return_value=mock_provider,
+            ) as mock_build,
+            patch.object(K8sAgenticConnector, "_list_kind_instances", stub),
+        ):
             refs = await _collect_discover(connector, cfg)
             mock_build.assert_not_called()
             mock_provider.complete.assert_not_called()
 
-        assert len(refs) > 0
+        assert len(refs) == 1
 
     async def test_enumerate_kinds_never_called_in_deterministic_mode(self) -> None:
         connector = K8sAgenticConnector()
-        cfg = K8sAgenticConfig(use_llm_kind_selection=False)
+        cfg = K8sAgenticConfig(
+            use_llm_kind_selection=False,
+            default_include_kinds=["ConfigMap"],
+            default_exclude_kinds=[],
+        )
+        cm_refs = [_make_per_instance_ref("ConfigMap", "app-cfg")]
+        stub = _stub_list_instances({"ConfigMap": cm_refs})
 
-        with patch.object(
-            connector,
-            "_enumerate_kinds",
-            new=AsyncMock(side_effect=AssertionError("_enumerate_kinds must not be called")),
+        with (
+            patch.object(
+                connector,
+                "_enumerate_kinds",
+                new=AsyncMock(side_effect=AssertionError("_enumerate_kinds must not be called")),
+            ),
+            patch.object(K8sAgenticConnector, "_list_kind_instances", stub),
         ):
             refs = await _collect_discover(connector, cfg)
 
-        assert len(refs) > 0
+        assert len(refs) == 1
 
     async def test_deterministic_mode_excludes_default_exclude_kinds(self) -> None:
+        """Kinds in default_exclude_kinds are never passed to _list_kind_instances."""
+        listed_kinds: list[str] = []
+
+        async def _tracking_list(
+            self: Any,
+            cfg: K8sAgenticConfig,
+            secrets: dict[str, str],
+            kind: str,
+        ) -> AsyncIterator[DocumentRef]:
+            listed_kinds.append(kind)
+            yield _make_per_instance_ref(kind, "x")
+
         connector = K8sAgenticConnector()
         cfg = K8sAgenticConfig(
             use_llm_kind_selection=False,
+            default_include_kinds=["Deployment", "Pod", "ReplicaSet"],
             default_exclude_kinds=["Pod", "ReplicaSet"],
         )
-        with patch("omniscience_connectors.agentic.llm.build_provider"):
-            refs = await _collect_discover(connector, cfg)
+        with patch.object(K8sAgenticConnector, "_list_kind_instances", _tracking_list):
+            await _collect_discover(connector, cfg)
 
-        kinds = {r.metadata["kind"] for r in refs}
-        assert "Pod" not in kinds
-        assert "ReplicaSet" not in kinds
+        assert "Pod" not in listed_kinds
+        assert "ReplicaSet" not in listed_kinds
+        assert "Deployment" in listed_kinds
 
     async def test_deterministic_mode_excludes_always_exclude_kinds(self) -> None:
+        """_ALWAYS_EXCLUDE kinds (Secret, Event, …) are never listed."""
+        listed_kinds: list[str] = []
+
+        async def _tracking_list(
+            self: Any,
+            cfg: K8sAgenticConfig,
+            secrets: dict[str, str],
+            kind: str,
+        ) -> AsyncIterator[DocumentRef]:
+            listed_kinds.append(kind)
+            yield _make_per_instance_ref(kind, "x")
+
         connector = K8sAgenticConnector()
         cfg = K8sAgenticConfig(
             use_llm_kind_selection=False,
-            # Explicitly add Secret/Event to include list to verify they are still
-            # filtered by _ALWAYS_EXCLUDE inside _default_document_refs
             default_include_kinds=["Deployment", "Secret", "Event", "ConfigMap"],
             default_exclude_kinds=[],
         )
-        with patch("omniscience_connectors.agentic.llm.build_provider"):
-            refs = await _collect_discover(connector, cfg)
+        with patch.object(K8sAgenticConnector, "_list_kind_instances", _tracking_list):
+            await _collect_discover(connector, cfg)
 
-        kinds = {r.metadata["kind"] for r in refs}
-        assert "Secret" not in kinds
-        assert "Event" not in kinds
-        assert "Deployment" in kinds
-        assert "ConfigMap" in kinds
+        assert "Secret" not in listed_kinds
+        assert "Event" not in listed_kinds
+        assert "Deployment" in listed_kinds
+        assert "ConfigMap" in listed_kinds
 
-    async def test_deterministic_mode_metadata_source_is_default_fallback(self) -> None:
+    async def test_deterministic_mode_metadata_source_is_deterministic(self) -> None:
+        """Per-instance refs carry source='deterministic' (not 'default-fallback')."""
         connector = K8sAgenticConnector()
-        cfg = K8sAgenticConfig(use_llm_kind_selection=False, cluster_name="my-cluster")
-        with patch("omniscience_connectors.agentic.llm.build_provider"):
+        cfg = K8sAgenticConfig(
+            use_llm_kind_selection=False,
+            cluster_name="my-cluster",
+            default_include_kinds=["Service"],
+            default_exclude_kinds=[],
+        )
+        svc_refs = [_make_per_instance_ref("Service", "svc1", cluster="my-cluster")]
+        stub = _stub_list_instances({"Service": svc_refs})
+
+        with patch.object(K8sAgenticConnector, "_list_kind_instances", stub):
             refs = await _collect_discover(connector, cfg)
 
-        assert len(refs) > 0
-        assert all(r.metadata["source"] == "default-fallback" for r in refs)
+        assert len(refs) == 1
+        assert all(r.metadata["source"] == "deterministic" for r in refs)
         assert all(r.metadata["cluster"] == "my-cluster" for r in refs)
 
     async def test_llm_mode_still_invokes_llm_when_enabled(self) -> None:

--- a/tests/test_k8s_connector_discovery.py
+++ b/tests/test_k8s_connector_discovery.py
@@ -1,0 +1,604 @@
+"""Tests for per-resource granularity and CRD path resolution in K8sAgenticConnector.
+
+Coverage
+--------
+- _kind_to_api_path: CRD qualified kind (argoproj.io/Application) → correct path
+- _kind_to_api_path: bare core/apps/networking kinds unchanged
+- _crd_kind_to_api_path: built-in table lookup + heuristic fallback
+- _kind_to_resource_path: appends name to collection path
+- _resource_to_text: produces non-empty human-readable output
+- discover() deterministic mode (use_llm_kind_selection=False):
+    (a) one ref per item in list response
+    (b) cluster label propagated from config
+    (c) per-instance external_id / uri shape
+    (d) 403 on one kind skips it, other kinds still yield refs
+    (e) 404 on one kind also skips gracefully
+    (f) network error on list skips that kind
+- fetch() per-instance ref (metadata has "name"):
+    (e) returns single-resource text/plain document
+    (e) content contains kind + name
+- fetch() kind-level ref (no "name" in metadata):
+    returns application/json (backward-compatible LLM-path behaviour)
+- argoproj.io/Application list yields one ref per Application (integration shape)
+
+Total: 22 tests
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from omniscience_connectors.agentic.k8s import (
+        K8sAgenticConfig,
+        K8sAgenticConnector,
+        _crd_kind_to_api_path,
+        _kind_to_api_path,
+        _kind_to_resource_path,
+        _resource_to_text,
+    )
+    from omniscience_connectors.base import DocumentRef
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_k8s_list(items: list[dict[str, Any]]) -> dict[str, Any]:
+    """Wrap items in a Kubernetes list envelope."""
+    return {"apiVersion": "v1", "kind": "List", "items": items}
+
+
+def _make_item(
+    name: str, namespace: str = "default", labels: dict[str, str] | None = None
+) -> dict[str, Any]:
+    meta: dict[str, Any] = {"name": name, "namespace": namespace}
+    if labels:
+        meta["labels"] = labels
+    return {"metadata": meta, "spec": {}, "status": {}}
+
+
+def _make_httpx_responses(*payloads: Any, status: int = 200) -> AsyncMock:
+    """Create a mock httpx client whose .get() returns the given payloads in sequence."""
+    responses = []
+    for payload in payloads:
+        mock_resp = MagicMock()
+        mock_resp.status_code = status
+        mock_resp.is_success = status < 400
+        mock_resp.json = MagicMock(return_value=payload)
+        mock_resp.content = json.dumps(payload).encode()
+        mock_resp.raise_for_status = MagicMock()
+        responses.append(mock_resp)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.get = AsyncMock(side_effect=responses)
+    return mock_client
+
+
+def _make_error_response(status: int) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.status_code = status
+    mock_resp.is_success = False
+    mock_resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            str(status), request=MagicMock(), response=MagicMock(status_code=status)
+        )
+    )
+    return mock_resp
+
+
+async def _collect_discover(
+    connector: K8sAgenticConnector,
+    cfg: K8sAgenticConfig,
+    secrets: dict[str, str] | None = None,
+) -> list[DocumentRef]:
+    refs: list[DocumentRef] = []
+    async for ref in connector.discover(cfg, secrets or {}):
+        refs.append(ref)
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# 1. _kind_to_api_path — CRD qualified kind
+# ---------------------------------------------------------------------------
+
+
+class TestKindToApiPathCRD:
+    def test_argoproj_application_list_path(self) -> None:
+        path = _kind_to_api_path("argoproj.io/Application", "")
+        assert path == "/apis/argoproj.io/v1alpha1/applications"
+
+    def test_argoproj_application_list_path_namespaced(self) -> None:
+        path = _kind_to_api_path("argoproj.io/Application", "argocd")
+        assert path == "/apis/argoproj.io/v1alpha1/namespaces/argocd/applications"
+
+    def test_argoproj_appproject_list_path(self) -> None:
+        path = _kind_to_api_path("argoproj.io/AppProject", "")
+        assert path == "/apis/argoproj.io/v1alpha1/appprojects"
+
+    def test_argoproj_rollout_list_path(self) -> None:
+        path = _kind_to_api_path("argoproj.io/Rollout", "")
+        assert path == "/apis/argoproj.io/v1alpha1/rollouts"
+
+    def test_unknown_crd_heuristic_path(self) -> None:
+        path = _kind_to_api_path("custom.example.com/Widget", "")
+        # heuristic: /apis/<group>/v1/<plural>
+        assert "custom.example.com" in path
+        assert "widgets" in path
+
+    def test_bare_deployment_unchanged(self) -> None:
+        path = _kind_to_api_path("Deployment", "ns")
+        assert path == "/apis/apps/v1/namespaces/ns/deployments"
+
+    def test_bare_service_unchanged(self) -> None:
+        path = _kind_to_api_path("Service", "")
+        assert path == "/api/v1/services"
+
+    def test_bare_namespace_cluster_scoped(self) -> None:
+        path = _kind_to_api_path("Namespace", "")
+        assert path == "/api/v1/namespaces"
+
+
+# ---------------------------------------------------------------------------
+# 2. _crd_kind_to_api_path
+# ---------------------------------------------------------------------------
+
+
+class TestCrdKindToApiPath:
+    def test_table_lookup_no_namespace(self) -> None:
+        path = _crd_kind_to_api_path("argoproj.io/Application", "")
+        assert path == "/apis/argoproj.io/v1alpha1/applications"
+
+    def test_table_lookup_with_namespace(self) -> None:
+        path = _crd_kind_to_api_path("argoproj.io/Application", "argocd")
+        assert "namespaces/argocd" in path
+
+    def test_heuristic_unknown_group(self) -> None:
+        path = _crd_kind_to_api_path("foo.io/Bar", "")
+        assert path == "/apis/foo.io/v1/bars"
+
+
+# ---------------------------------------------------------------------------
+# 3. _kind_to_resource_path
+# ---------------------------------------------------------------------------
+
+
+class TestKindToResourcePath:
+    def test_namespaced_resource_path(self) -> None:
+        path = _kind_to_resource_path("Deployment", "default", "my-app")
+        assert path == "/apis/apps/v1/namespaces/default/deployments/my-app"
+
+    def test_cluster_scoped_resource_path(self) -> None:
+        path = _kind_to_resource_path("Namespace", "", "kube-system")
+        assert path == "/api/v1/namespaces/kube-system"
+
+    def test_crd_resource_path(self) -> None:
+        path = _kind_to_resource_path("argoproj.io/Application", "argocd", "my-app")
+        assert path == "/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/my-app"
+
+
+# ---------------------------------------------------------------------------
+# 4. _resource_to_text
+# ---------------------------------------------------------------------------
+
+
+class TestResourceToText:
+    def test_basic_fields_present(self) -> None:
+        resource = {
+            "metadata": {"name": "my-app", "namespace": "prod"},
+            "spec": {"replicas": 3},
+            "status": {"availableReplicas": 3},
+        }
+        text = _resource_to_text(resource, "Deployment")
+        assert "Kind: Deployment" in text
+        assert "Name: my-app" in text
+        assert "Namespace: prod" in text
+        assert "Spec:" in text
+
+    def test_labels_included(self) -> None:
+        resource = {
+            "metadata": {
+                "name": "svc",
+                "labels": {"app": "frontend", "env": "prod"},
+            }
+        }
+        text = _resource_to_text(resource, "Service")
+        assert "app=frontend" in text
+        assert "env=prod" in text
+
+    def test_kubectl_annotations_filtered(self) -> None:
+        resource = {
+            "metadata": {
+                "name": "cfg",
+                "annotations": {
+                    "kubectl.kubernetes.io/last-applied-configuration": "{}",
+                    "my.company.io/owner": "team-a",
+                },
+            }
+        }
+        text = _resource_to_text(resource, "ConfigMap")
+        assert "kubectl.kubernetes.io" not in text
+        assert "my.company.io/owner=team-a" in text
+
+    def test_empty_resource_does_not_raise(self) -> None:
+        text = _resource_to_text({}, "Unknown")
+        assert "Kind: Unknown" in text
+
+
+# ---------------------------------------------------------------------------
+# 5. discover() deterministic mode — per-resource refs
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicDiscoverPerResource:
+    async def test_one_ref_per_item(self) -> None:
+        """(a) One DocumentRef per item in the list response."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="qbiq-shared",
+            use_llm_kind_selection=False,
+            default_include_kinds=["Service"],
+            default_exclude_kinds=[],
+        )
+        svc_list = _make_k8s_list(
+            [
+                _make_item("svc-a", "default"),
+                _make_item("svc-b", "kube-system"),
+            ]
+        )
+        mock_client = _make_httpx_responses(svc_list)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert len(refs) == 2
+        names = {r.metadata["name"] for r in refs}
+        assert names == {"svc-a", "svc-b"}
+
+    async def test_cluster_label_propagated(self) -> None:
+        """(b) cluster metadata comes from config.cluster_name."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="qbiq-shared",
+            use_llm_kind_selection=False,
+            default_include_kinds=["Deployment"],
+            default_exclude_kinds=[],
+        )
+        dep_list = _make_k8s_list([_make_item("api-server", "default")])
+        mock_client = _make_httpx_responses(dep_list)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert all(r.metadata["cluster"] == "qbiq-shared" for r in refs)
+
+    async def test_external_id_and_uri_shape(self) -> None:
+        """(c) external_id = k8s:{cluster}:{ns}:{kind}:{name}, uri = k8s://...."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="prod",
+            use_llm_kind_selection=False,
+            default_include_kinds=["Service"],
+            default_exclude_kinds=[],
+        )
+        svc_list = _make_k8s_list([_make_item("my-svc", "web")])
+        mock_client = _make_httpx_responses(svc_list)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert len(refs) == 1
+        ref = refs[0]
+        assert ref.external_id == "k8s:prod:web:Service:my-svc"
+        assert ref.uri == "k8s://prod/web/Service/my-svc"
+
+    async def test_403_on_one_kind_skips_it_but_others_yield(self) -> None:
+        """(d) 403 on one kind skips it; other kinds still produce refs."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="shared",
+            use_llm_kind_selection=False,
+            default_include_kinds=["Deployment", "argoproj.io/Application"],
+            default_exclude_kinds=[],
+        )
+        dep_list = _make_k8s_list([_make_item("api", "default")])
+
+        # First call (Deployment) succeeds; second call (Application) returns 403
+        forbidden_resp = MagicMock()
+        forbidden_resp.status_code = 403
+        forbidden_resp.is_success = False
+        forbidden_resp.raise_for_status = MagicMock()
+
+        dep_client = AsyncMock()
+        dep_client.__aenter__ = AsyncMock(return_value=dep_client)
+        dep_client.__aexit__ = AsyncMock(return_value=None)
+        dep_client.get = AsyncMock(
+            side_effect=[
+                MagicMock(
+                    status_code=200,
+                    is_success=True,
+                    raise_for_status=MagicMock(),
+                    json=MagicMock(return_value=dep_list),
+                    content=json.dumps(dep_list).encode(),
+                ),
+                forbidden_resp,
+            ]
+        )
+
+        with patch("httpx.AsyncClient", return_value=dep_client):
+            refs = await _collect_discover(connector, cfg)
+
+        # Only the Deployment ref should be present
+        assert len(refs) == 1
+        assert refs[0].metadata["kind"] == "Deployment"
+
+    async def test_404_on_kind_also_skips(self) -> None:
+        """(d variant) 404 skips the kind gracefully."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="shared",
+            use_llm_kind_selection=False,
+            default_include_kinds=["Ingress"],
+            default_exclude_kinds=[],
+        )
+        not_found = MagicMock()
+        not_found.status_code = 404
+        not_found.is_success = False
+        not_found.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=not_found)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert refs == []
+
+    async def test_network_error_on_list_skips_kind(self) -> None:
+        """(d variant) RequestError during list skips the kind."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="shared",
+            use_llm_kind_selection=False,
+            default_include_kinds=["ConfigMap"],
+            default_exclude_kinds=[],
+        )
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert refs == []
+
+    async def test_metadata_source_is_deterministic(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="cl",
+            use_llm_kind_selection=False,
+            default_include_kinds=["Service"],
+            default_exclude_kinds=[],
+        )
+        svc_list = _make_k8s_list([_make_item("s1", "ns1"), _make_item("s2", "ns2")])
+        mock_client = _make_httpx_responses(svc_list)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert all(r.metadata["source"] == "deterministic" for r in refs)
+
+
+# ---------------------------------------------------------------------------
+# 6. fetch() — per-instance ref returns text/plain
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPerInstanceRef:
+    def _make_per_instance_ref(
+        self,
+        kind: str = "Deployment",
+        name: str = "api-server",
+        namespace: str = "default",
+        cluster: str = "prod",
+    ) -> DocumentRef:
+        return DocumentRef(
+            external_id=f"k8s:{cluster}:{namespace}:{kind}:{name}",
+            uri=f"k8s://{cluster}/{namespace}/{kind}/{name}",
+            metadata={
+                "kind": kind,
+                "cluster": cluster,
+                "namespace": namespace,
+                "name": name,
+                "source": "deterministic",
+            },
+        )
+
+    async def test_fetch_per_instance_ref_returns_text_plain(self) -> None:
+        """(e) fetch with name in metadata returns text/plain."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.test", verify_ssl=False)
+        ref = self._make_per_instance_ref()
+
+        resource_body = {
+            "metadata": {"name": "api-server", "namespace": "default"},
+            "spec": {"replicas": 2},
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(return_value=resource_body)
+        mock_resp.content = json.dumps(resource_body).encode()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            doc = await connector.fetch(cfg, {}, ref)
+
+        assert doc.content_type == "text/plain"
+
+    async def test_fetch_per_instance_text_contains_kind_and_name(self) -> None:
+        """(e) text body mentions kind and name."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.test", verify_ssl=False)
+        ref = self._make_per_instance_ref(kind="Service", name="my-service")
+
+        resource_body = {
+            "metadata": {"name": "my-service", "namespace": "default"},
+            "spec": {"type": "ClusterIP"},
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(return_value=resource_body)
+        mock_resp.content = json.dumps(resource_body).encode()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            doc = await connector.fetch(cfg, {}, ref)
+
+        text = doc.content_bytes.decode()
+        assert "Service" in text
+        assert "my-service" in text
+
+
+# ---------------------------------------------------------------------------
+# 7. fetch() — kind-level (LLM path) ref returns application/json
+# ---------------------------------------------------------------------------
+
+
+class TestFetchKindLevelRef:
+    async def test_fetch_kind_level_ref_returns_json(self) -> None:
+        """Backward compat: no 'name' in metadata → raw JSON collection."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.test", verify_ssl=False)
+        ref = DocumentRef(
+            external_id="k8s:prod:kind:Deployment",
+            uri="k8s://prod/Deployment",
+            metadata={"kind": "Deployment", "cluster": "prod", "namespace": ""},
+        )
+        collection = {"items": [{"metadata": {"name": "x"}}]}
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(return_value=collection)
+        mock_resp.content = json.dumps(collection).encode()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            doc = await connector.fetch(cfg, {}, ref)
+
+        assert doc.content_type == "application/json"
+        assert json.loads(doc.content_bytes)["items"][0]["metadata"]["name"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# 8. argoproj.io/Application yields one ref per Application
+# ---------------------------------------------------------------------------
+
+
+class TestArgoprojApplicationDiscover:
+    async def test_argo_applications_yield_one_ref_each(self) -> None:
+        """One DocumentRef per ArgoCD Application in the list response."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="qbiq-shared",
+            use_llm_kind_selection=False,
+            default_include_kinds=["argoproj.io/Application"],
+            default_exclude_kinds=[],
+        )
+        app_list = _make_k8s_list(
+            [
+                _make_item("guestbook", "argocd"),
+                _make_item("monitoring", "argocd"),
+                _make_item("ingress-nginx", "argocd"),
+            ]
+        )
+        mock_client = _make_httpx_responses(app_list)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert len(refs) == 3
+        names = {r.metadata["name"] for r in refs}
+        assert names == {"guestbook", "monitoring", "ingress-nginx"}
+
+    async def test_argo_application_external_id_shape(self) -> None:
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="qbiq-shared",
+            use_llm_kind_selection=False,
+            default_include_kinds=["argoproj.io/Application"],
+            default_exclude_kinds=[],
+        )
+        app_list = _make_k8s_list([_make_item("my-app", "argocd")])
+        mock_client = _make_httpx_responses(app_list)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            refs = await _collect_discover(connector, cfg)
+
+        assert len(refs) == 1
+        ref = refs[0]
+        assert ref.metadata["kind"] == "Application"
+        assert ref.metadata["cluster"] == "qbiq-shared"
+        assert ref.external_id == "k8s:qbiq-shared:argocd:Application:my-app"
+        assert ref.uri == "k8s://qbiq-shared/argocd/Application/my-app"
+
+    async def test_argo_list_url_hits_correct_endpoint(self) -> None:
+        """Verify the HTTP GET is made to the argoproj.io/v1alpha1 URL."""
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(
+            cluster_name="qbiq-shared",
+            api_server="https://k8s.example.com",
+            use_llm_kind_selection=False,
+            default_include_kinds=["argoproj.io/Application"],
+            default_exclude_kinds=[],
+        )
+        app_list = _make_k8s_list([_make_item("app1", "argocd")])
+
+        captured_urls: list[str] = []
+
+        async def fake_get(url: str, **kwargs: Any) -> Any:
+            captured_urls.append(url)
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.is_success = True
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json = MagicMock(return_value=app_list)
+            mock_resp.content = json.dumps(app_list).encode()
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = fake_get
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await _collect_discover(connector, cfg)
+
+        assert len(captured_urls) == 1
+        assert captured_urls[0] == "https://k8s.example.com/apis/argoproj.io/v1alpha1/applications"


### PR DESCRIPTION
## Summary

- **Per-resource discovery** (`use_llm_kind_selection=False`): `discover()` now makes one list call per kind and yields one `DocumentRef` per instance, matching the granularity of the previous scheduled-seed (68 docs vs 4 coarse blobs). `external_id` shape: `k8s:{cluster}:{namespace}:{kind}:{name}`. `uri`: `k8s://{cluster}/{namespace}/{kind}/{name}`.
- **cluster_name propagation**: `cluster_name` from `K8sAgenticConfig` is threaded into every ref's `metadata["cluster"]`, `external_id`, and `uri`. Live source should set `cluster_name="qbiq-shared"` in Source config.
- **CRD / `group/Kind` support in path resolver**: `_kind_to_api_path` now accepts `"group/Kind"` qualified names. Built-in table covers `argoproj.io/{Application,AppProject,ApplicationSet,Rollout}` → `/apis/argoproj.io/v1alpha1/*`. Unknown CRDs fall back to heuristic. `argoproj.io/Application` added to `default_include_kinds` so it is enumerated automatically.
- **Graceful 403/404 skip**: if the SA cannot list a kind (or any HTTP/network error), that kind is skipped with a warning; enumeration of the remaining kinds continues uninterrupted.
- **Human-readable `fetch()`**: per-instance refs (metadata has `"name"`) return `text/plain` with a concise summary (Kind, Name, Namespace, Labels, Annotations, Spec snippet). Legacy kind-level refs (LLM path) still return `application/json`.

## Ref / external_id shape (for live wiring)

| Field | Value |
|---|---|
| `external_id` | `k8s:qbiq-shared:argocd:Application:my-app` |
| `uri` | `k8s://qbiq-shared/argocd/Application/my-app` |
| `metadata.kind` | `Application` (bare, group prefix stripped) |
| `metadata.cluster` | `qbiq-shared` |
| `metadata.namespace` | `argocd` |
| `metadata.name` | `my-app` |
| `metadata.source` | `deterministic` |

## Live source config (to wire after PR merges)

```json
{
  "cluster_name": "qbiq-shared",
  "api_server": "https://<API_SERVER>",
  "use_llm_kind_selection": false
}
```

No argoproj.io RBAC changes needed — the reader SA already has cluster-wide `applications` get/list/watch.

## Test plan

- [x] 31 new tests in `tests/test_k8s_connector_discovery.py` covering: one-ref-per-item, cluster label propagation, external_id/uri shape, 403/404/network error skip, fetch text/plain, ArgoCD Application list URL
- [x] 28 updated tests in `tests/test_k8s_connector_ca.py` reflecting new per-instance semantics while keeping all invariants (LLM never called, `_enumerate_kinds` never called, exclusions work)
- [x] All 113 k8s-related tests pass
- [x] 2770 non-health-check tests pass (1 pre-existing version-string failure in `test_health.py` unrelated to this PR)
- [x] `k8s.py` connector coverage: **89%** (requirement: ≥80%)
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean