### PR TITLE
fix: resolve mypy typecheck errors (10 in 7 files)

### DIFF
--- a/apps/server/src/omniscience_server/discovery_worker.py
+++ b/apps/server/src/omniscience_server/discovery_worker.py
@@ -2,6 +2,12 @@
 
 Periodically runs discovery connectors (GitHub, GitLab) to find new
 repositories and register them as Sources in the database.
+
+Design note: The ``Source`` model is keyed by ``(tenant_id, name)``
+(unique constraint ``uq_sources_tenant_name``).  There is no ``uri``
+column; the clone URL is stored inside the ``config`` JSONB field under
+the ``"uri"`` key so it is preserved without requiring a schema change.
+Deduplication uses ``name`` as the stable identifier.
 """
 
 from __future__ import annotations
@@ -14,7 +20,7 @@ from typing import Any
 import structlog
 from omniscience_connectors.github_discovery import GitHubDiscoveryConnector
 from omniscience_core.config import Settings
-from omniscience_core.db.models import Source, Workspace
+from omniscience_core.db.models import Source, SourceType, Workspace
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -90,8 +96,16 @@ class DiscoveryWorker:
     async def _ensure_source(
         self, session: AsyncSession, workspace_id: uuid.UUID, ds: Any
     ) -> None:
-        """Create source if it doesn't exist (keyed by URI)."""
-        stmt = select(Source).where(Source.uri == ds.uri, Source.tenant_id == workspace_id)
+        """Create source if it doesn't exist (keyed by name within workspace).
+
+        The ``Source`` model is deduplicated by ``(tenant_id, name)`` per the
+        unique constraint ``uq_sources_tenant_name``.  The clone URL is stored
+        in ``config["uri"]`` so it can be recovered by connectors at fetch time.
+        """
+        stmt = select(Source).where(
+            Source.name == ds.name,
+            Source.tenant_id == workspace_id,
+        )
         result = await session.execute(stmt)
         existing = result.scalar_one_or_none()
 
@@ -108,13 +122,13 @@ class DiscoveryWorker:
         new_source = Source(
             id=uuid.uuid4(),
             name=ds.name,
-            type=ds.type,
-            uri=ds.uri,
+            type=SourceType(ds.type),
             tenant_id=workspace_id,
             status="active",
             freshness_sla_seconds=86400,  # Default 1 day
             last_sync_at=None,
-            source_metadata={
+            config={
+                "uri": ds.uri,
                 **ds.metadata,
                 "provisioned_by": "discovery_worker",
                 "discovered_at": datetime.now(UTC).isoformat(),

--- a/apps/server/src/omniscience_server/incident_timeline.py
+++ b/apps/server/src/omniscience_server/incident_timeline.py
@@ -72,7 +72,9 @@ from omniscience_server.as_of import (
 )
 from omniscience_server.incidents import (
     ALERT_NOT_FOUND_CODE,
-    _validate_alert_id,  # re-used: same alert_id grammar as resolve_incident
+)
+from omniscience_server.incidents import (
+    validate_alert_id as _validate_alert_id,  # re-used: same alert_id grammar as resolve_incident
 )
 
 # ---------------------------------------------------------------------------

--- a/apps/server/src/omniscience_server/ingestion/pipeline.py
+++ b/apps/server/src/omniscience_server/ingestion/pipeline.py
@@ -181,7 +181,7 @@ class EntityLinkerProtocol(Protocol):
     Tests inject a mock that also satisfies it.
     """
 
-    async def link_entities(self, source_id: UUID) -> int: ...
+    async def link_entities(self, source_id: UUID, workspace_id: UUID) -> int: ...
 
 
 # ---------------------------------------------------------------------------

--- a/apps/server/src/omniscience_server/rest/admin_session.py
+++ b/apps/server/src/omniscience_server/rest/admin_session.py
@@ -34,6 +34,7 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from omniscience_core.auth.middleware import _lookup_token
 from omniscience_core.auth.scopes import Scope, check_scopes
 from pydantic import BaseModel, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 log = structlog.get_logger(__name__)
 
@@ -56,8 +57,10 @@ class _SessionCreateRequest(BaseModel):
         return v
 
 
-def _require_db_factory(request: Request) -> object:
-    factory = getattr(request.app.state, "db_session_factory", None)
+def _require_db_factory(request: Request) -> async_sessionmaker[AsyncSession]:
+    factory: async_sessionmaker[AsyncSession] | None = getattr(
+        request.app.state, "db_session_factory", None
+    )
     if factory is None:
         raise HTTPException(status_code=503, detail="Database not available")
     return factory

--- a/apps/server/src/omniscience_server/rest/workspace.py
+++ b/apps/server/src/omniscience_server/rest/workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import structlog
@@ -27,7 +28,7 @@ class WorkspaceUpdate(BaseModel):
     metadata: dict[str, Any]
 
 
-async def _get_db(request: Request) -> AsyncSession:
+async def _get_db(request: Request) -> AsyncGenerator[AsyncSession, None]:
     """Helper to get DB session from app state."""
     factory = request.app.state.db_session_factory
     async with factory() as session:

--- a/packages/core/src/omniscience_core/storage/graph.py
+++ b/packages/core/src/omniscience_core/storage/graph.py
@@ -47,6 +47,9 @@ class EntityNodeView:
     chunk_text: str | None
     depth: int = 0
     edge_type: str | None = None
+    # Human-readable label for display / matching (e.g. Jira ticket key).
+    # Optional: populated when the backend stores a distinct display label.
+    display_name: str | None = None
     # ADR-0008 §1 — bitemporal triple.
     valid_from: datetime | None = None
     valid_to: datetime | None = None
@@ -123,6 +126,7 @@ class GraphStore(Protocol):
         document_id: uuid.UUID,
         entities: list[Any],
         edges: list[Any],
+        snapshot_at: datetime | None = None,
     ) -> None: ...
 
     async def upsert_entity(
@@ -152,6 +156,25 @@ class GraphStore(Protocol):
         ...
 
     async def delete_tombstoned(self) -> int: ...
+
+    async def resolve_pending_stubs(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> int:
+        """Merge stub nodes with real entities in the same workspace.
+
+        A *stub* is a placeholder entity node created by
+        :meth:`upsert_edge_by_name` when the target entity does not yet
+        exist.  After the target is ingested, this method performs a
+        batch Cypher MATCH+MERGE to replace stub nodes with the real
+        entity (preserving existing edges).
+
+        Returns:
+            Number of stub nodes resolved (merged into real entities) in
+            this call.  Returns ``0`` when there is nothing to resolve.
+        """
+        ...
 
     # ------------------------------------------------------------------
     # Read API — every method REQUIRES workspace_id (keyword-only)

--- a/packages/core/src/omniscience_core/storage/vector.py
+++ b/packages/core/src/omniscience_core/storage/vector.py
@@ -156,11 +156,17 @@ class VectorStore(Protocol):
         *,
         source_id: uuid.UUID,
         external_id: str,
+        workspace_id: uuid.UUID | None = None,
     ) -> bool:
         """Tombstone the document identified by ``(source_id, external_id)``.
 
         Returns ``True`` when the document existed and was tombstoned;
         ``False`` when no matching active document was found.
+
+        ``workspace_id`` is keyword-only and optional at the protocol
+        level for backward-compatibility; the Qdrant adapter requires it
+        (raises ``ValueError`` when ``None``) per the ACL invariant
+        (ADR-0006 §ACL).
 
         Note: "tombstone" means set ``tombstoned_at`` — hard deletion
         is deferred to ``delete_tombstoned``.  This preserves the


### PR DESCRIPTION
## Summary

Resolves all 10 pre-existing mypy errors that keep the CI `typecheck` job red on `main`. No behavioural changes — every fix is a type-annotation alignment between a Protocol/model and the concrete implementation or call site that already existed.

## Error decisions

| # | File:line | Code | Decision | What changed |
|---|-----------|------|----------|--------------|
| 1 | `packages/index/src/omniscience_index/linker.py:90` | `attr-defined` | **Protocol-extended** | Added `resolve_pending_stubs(*, workspace_id) -> int` to `GraphStore` protocol; method already exists in `Neo4jGraphStore` |
| 2 | `packages/index/src/omniscience_index/linker.py:97` | `no-any-return` | Fixed by #1 | Return type is now `int` once the protocol method is declared |
| 3 | `packages/index/src/omniscience_index/linker.py:132` | `attr-defined` | **Protocol-extended** | Added `display_name: str | None = None` to `EntityNodeView`; mirrors the `EntityUpsert` input dataclass that already had it |
| 4 | `packages/index/src/omniscience_index/writer.py:154` | `call-arg` | **Protocol-extended** | Added `workspace_id: uuid.UUID | None = None` to `VectorStore.delete_by_document`; matches `QdrantVectorStore` concrete signature |
| 5 | `packages/index/src/omniscience_index/writer.py:195` | `call-arg` | **Protocol-extended** | Added `snapshot_at: datetime | None = None` to `GraphStore.upsert_graph`; matches `Neo4jGraphStore` concrete signature |
| 6 | `apps/server/src/omniscience_server/rest/workspace.py:30` | `misc` | **Caller-fixed** | Changed `_get_db` return annotation from `AsyncSession` to `AsyncGenerator[AsyncSession, None]` — function uses `yield`, making it an async generator |
| 7 | `apps/server/src/omniscience_server/rest/admin_session.py:131` | `operator` | **Caller-fixed** | Changed `_require_db_factory` return type from `object` to `async_sessionmaker[AsyncSession]` with explicit typed local variable so mypy knows `factory()` is callable |
| 8 | `apps/server/src/omniscience_server/incident_timeline.py:73` | `attr-defined` | **Caller-fixed** | Import the public re-export `validate_alert_id as _validate_alert_id` instead of the private `_validate_alert_id` not in `__all__` |
| 9 | `apps/server/src/omniscience_server/discovery_worker.py:94` | `attr-defined` | **GENUINE BUG FIXED** | `Source` SQLAlchemy model has no `uri` column; filter and constructor both used it. Fixed to deduplicate by `name` (existing `(tenant_id, name)` unique constraint) and store the clone URL in `config["uri"]` (JSONB). Non-existent `source_metadata` kwarg also removed from the `Source()` call. |
| 10 | `apps/server/src/omniscience_server/ingestion/pipeline.py:648` | `call-arg` | **Protocol-extended** | Added `workspace_id: UUID` to `EntityLinkerProtocol.link_entities` to match the concrete `EntityLinker` signature and the pipeline call site |

## Genuine latent runtime bug (error #9)

`discovery_worker.py` was filtering `Source.uri == ds.uri` and constructing `Source(uri=..., source_metadata=...)` — both referencing columns that do not exist on the `Source` SQLAlchemy model. This would have raised `AttributeError` at runtime the first time the discovery worker executed its `_ensure_source` code path.

Fix: use `name` as the dedup key (backed by the existing `uq_sources_tenant_name` unique constraint on `(tenant_id, name)`), and store the clone URL in `config["uri"]` (the JSONB `config` field that all sources already have).

No schema migration required — no new columns added.

## Test results

```
uv run mypy apps/ packages/
Success: no issues found in 250 source files

uv run ruff check .
All checks passed!

uv run ruff format --check .
412 files already formatted

uv run pytest --tb=short -q
2937 passed, 45 skipped, 1 failed
```

The 1 failed test (`test_health_version_from_settings`) is a pre-existing failure on `main` unrelated to this PR — it fails because the repo's `.env` file has `APP_VERSION=0.1.0` which overrides the default `0.2.0` from `Settings`, while the test asserts `0.2.0`.