### PR TITLE
fix(connectors): per-instance CRD fetch path (ArgoCD Applications)

### DIFF
--- a/packages/connectors/src/omniscience_connectors/agentic/k8s.py
+++ b/packages/connectors/src/omniscience_connectors/agentic/k8s.py
@@ -684,11 +684,14 @@ class K8sAgenticConnector(AgenticConnector):
 
         name = ref.metadata.get("name", "")
         namespace = ref.metadata.get("namespace", cfg.namespace)
+        # Path building must use the fully-qualified kind so CRDs resolve to
+        # /apis/<group>/<version>/...; the bare ``kind`` is display-only.
+        api_kind = ref.metadata.get("api_kind", kind)
 
         if name:
-            path = _kind_to_resource_path(kind, namespace, name)
+            path = _kind_to_resource_path(api_kind, namespace, name)
         else:
-            path = _kind_to_api_path(kind, cfg.namespace)
+            path = _kind_to_api_path(api_kind, cfg.namespace)
 
         url = f"{cfg.api_server}{path}"
 
@@ -873,6 +876,11 @@ class K8sAgenticConnector(AgenticConnector):
                 uri=uri,
                 metadata={
                     "kind": bare_kind,
+                    # Preserve the fully-qualified kind ("group/Kind") so fetch()
+                    # can rebuild the correct CRD path (/apis/<group>/<version>/...).
+                    # The bare kind alone loses the group and resolves to a wrong
+                    # core-style path for CRDs (e.g. ArgoCD Applications).
+                    "api_kind": kind,
                     "cluster": cfg.cluster_name,
                     "namespace": namespace,
                     "name": name,

--- a/tests/test_k8s_connector_discovery.py
+++ b/tests/test_k8s_connector_discovery.py
@@ -413,12 +413,14 @@ class TestFetchPerInstanceRef:
         name: str = "api-server",
         namespace: str = "default",
         cluster: str = "prod",
+        api_kind: str | None = None,
     ) -> DocumentRef:
         return DocumentRef(
             external_id=f"k8s:{cluster}:{namespace}:{kind}:{name}",
             uri=f"k8s://{cluster}/{namespace}/{kind}/{name}",
             metadata={
                 "kind": kind,
+                "api_kind": api_kind or kind,
                 "cluster": cluster,
                 "namespace": namespace,
                 "name": name,
@@ -479,6 +481,47 @@ class TestFetchPerInstanceRef:
         text = doc.content_bytes.decode()
         assert "Service" in text
         assert "my-service" in text
+
+    async def test_fetch_crd_instance_uses_qualified_api_path(self) -> None:
+        """Regression: a per-instance CRD ref must fetch via the fully-qualified
+        /apis/<group>/<version>/namespaces/<ns>/<plural>/<name> path.
+
+        The bare ``kind`` ("Application") loses the group and would resolve to a
+        wrong core-style path; fetch must use ``api_kind`` ("argoproj.io/Application").
+        """
+        connector = K8sAgenticConnector()
+        cfg = K8sAgenticConfig(api_server="https://k8s.test", verify_ssl=False)
+        ref = self._make_per_instance_ref(
+            kind="Application",
+            api_kind="argoproj.io/Application",
+            name="argocd-qbiq-shared",
+            namespace="argocd",
+            cluster="qbiq-shared",
+        )
+
+        resource_body = {
+            "metadata": {"name": "argocd-qbiq-shared", "namespace": "argocd"},
+            "spec": {"project": "default"},
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json = MagicMock(return_value=resource_body)
+        mock_resp.content = json.dumps(resource_body).encode()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await connector.fetch(cfg, {}, ref)
+
+        called_url = mock_client.get.call_args.args[0]
+        assert called_url == (
+            "https://k8s.test/apis/argoproj.io/v1alpha1/"
+            "namespaces/argocd/applications/argocd-qbiq-shared"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

After #291, a live K8s sync of `qbiq-shared` enumerated all 15 ArgoCD Applications (the LIST call works) but **every per-instance fetch failed** (`total=88 errors=15`) with the malformed URL `/apis/namespaces/argocd/applications/<name>` — missing `argoproj.io/v1alpha1`.

## Root cause

`discover()` stores the **bare** kind (`Application`) in ref metadata (group stripped). `fetch()` then passed that bare kind to the path builder, which doesn't recognise it as a CRD and falls back to a core-style path. The LIST call worked because it used the qualified kind directly.

## Fix

- Preserve the fully-qualified kind as `metadata['api_kind']` (`argoproj.io/Application`) at discovery; bare `kind` stays display-only.
- `fetch()` builds the resource path from `api_kind`, so CRD instances resolve to `/apis/<group>/<version>/namespaces/<ns>/<plural>/<name>`.
- Regression test asserts an Application instance fetches via `/apis/argoproj.io/v1alpha1/namespaces/argocd/applications/<name>`.

## Verification

```
tests/test_k8s_connector_discovery.py + test_k8s_connector_ca.py: 60 passed
ruff check + format: clean
```
Live re-verification (ArgoCD docs indexed) follows after merge + app rebuild.