### PR TITLE
fix(ingestion): stamp Source.last_sync_at on successful sync

### DIFF
--- a/apps/server/src/omniscience_server/ingestion/worker.py
+++ b/apps/server/src/omniscience_server/ingestion/worker.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import asyncio
 import os
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -64,7 +65,7 @@ from omniscience_core.secrets import SecretsResolver
 from omniscience_embeddings.base import EmbeddingProvider
 from omniscience_index.workspace import MissingWorkspaceError, resolve_source_workspace
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from omniscience_server.ingestion.dedup import (
@@ -178,6 +179,7 @@ class IngestionWorker:
             if result.action == "error":
                 await msg.nak()
             else:
+                await self._mark_source_synced(result.source_id)
                 await msg.ack()
 
         log.info("ingestion_worker_stopped")
@@ -459,6 +461,21 @@ class IngestionWorker:
         stmt = select(Source).where(Source.id == source_id)
         result = await session.execute(stmt)
         return result.scalar_one_or_none()
+
+    async def _mark_source_synced(self, source_id: uuid.UUID) -> None:
+        """Stamp ``Source.last_sync_at`` after a document is successfully synced.
+
+        Runs in the broker callback's success path so the source's freshness
+        reflects real ingestion progress (the scheduler and admin UI read this).
+        Uses an atomic UPDATE — no read-modify-write — and never blocks the ack.
+        """
+        async with self._session_factory() as session:
+            await session.execute(
+                update(Source)
+                .where(Source.id == source_id)
+                .values(last_sync_at=datetime.now(UTC))
+            )
+            await session.commit()
 
     # ------------------------------------------------------------------
     # Run tracking helpers

--- a/tests/test_discovery_sync.py
+++ b/tests/test_discovery_sync.py
@@ -738,3 +738,30 @@ class TestIsSyncMarker:
             action="updated",
         )
         assert _is_sync_marker(event) is True
+
+
+# ---------------------------------------------------------------------------
+# 9. _mark_source_synced — stamps Source.last_sync_at on successful sync
+# ---------------------------------------------------------------------------
+
+
+class TestMarkSourceSynced:
+    async def test_mark_source_synced_issues_update_and_commits(self) -> None:
+        """_mark_source_synced runs an UPDATE setting last_sync_at and commits."""
+        from sqlalchemy.sql.dml import Update
+
+        worker = _make_worker(connector=MagicMock())
+        session = worker._session_factory.session  # type: ignore[attr-defined]
+        session.commit = AsyncMock()
+        sid = uuid.uuid4()
+
+        await worker._mark_source_synced(sid)
+
+        session.execute.assert_awaited_once()
+        stmt = session.execute.await_args.args[0]
+        assert isinstance(stmt, Update)
+        # The compiled statement targets the sources table's last_sync_at column.
+        compiled = str(stmt)
+        assert "sources" in compiled
+        assert "last_sync_at" in compiled
+        session.commit.assert_awaited_once()


### PR DESCRIPTION
## Problem

The admin UI shows **Last sync: Never** for every source even after clicking Sync. Root cause: the ingestion worker creates/updates `IngestionRun` records but **never writes `Source.last_sync_at`**. The field is read by the scheduler (which therefore treats every source as perpetually stale), `mcp/tools.py` `source_stats`, and the admin UI — but nothing ever set it.

## Fix

Stamp `Source.last_sync_at = now(UTC)` in the worker's broker-callback **success** path (after `process_document` returns a non-error result, before `ack`). Atomic `UPDATE` — no read-modify-write. Errors (`NAK`) do not stamp. Covers both the discovery-sync fan-out (one stamp per sync) and single-document paths.

## Tests

- New `TestMarkSourceSynced` asserts the issued statement is an `Update` targeting `sources.last_sync_at` and that it commits.
- Full ingestion suite green: 132 passed (worker/discovery/dedup/three-stores/unblock).

Companion UI work (editable source config + last-sync rendering) is in a separate admin PR.