### PR TITLE
feat(dashboard): selectable time window + metric descriptions for Document activity

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -209,6 +209,14 @@ export interface StatsOverview {
   documents_tombstoned_24h: number;
 }
 
+/** Response from GET /api/v1/stats/activity */
+export interface StatsActivity {
+  new: number;
+  updated: number;
+  tombstoned: number;
+  window_hours: number;
+}
+
 export interface KindHistogramEntry {
   kind: string;
   count: number;
@@ -631,6 +639,19 @@ export class ApiClient {
     return this.request<StatsOverview>(
       "GET",
       "/api/v1/stats/overview",
+      undefined,
+      signal
+    );
+  }
+
+  async statsActivity(
+    hours: number,
+    signal?: AbortSignal
+  ): Promise<StatsActivity> {
+    const qs = new URLSearchParams({ hours: String(hours) });
+    return this.request<StatsActivity>(
+      "GET",
+      `/api/v1/stats/activity?${qs}`,
       undefined,
       signal
     );

--- a/apps/admin/src/components/dashboard/DeltaStrip.tsx
+++ b/apps/admin/src/components/dashboard/DeltaStrip.tsx
@@ -1,30 +1,75 @@
 /*
- * DeltaStrip — 24h activity strip (Issue #114, panel #6).
+ * DeltaStrip — Document activity panel with selectable time window.
  *
- * Surfaces the three rolling-24h fields from the overview payload:
- *   - documents_added_24h
- *   - documents_updated_24h
- *   - documents_tombstoned_24h
+ * Replaces the original fixed-24h view (Issue #114 + follow-up).
  *
- * The component takes the overview as a prop instead of fetching it
- * again — the OverviewHeader has already paid the network cost and
- * having two panels poll the same endpoint would double load with no
- * extra information. The strip therefore renders inline based on the
- * overview's lifecycle (loading/error/populated) using the supplied
- * helpers.
+ * Changes vs. original:
+ *   - Added a 24h / 7d / 30d / 90d range selector in the panel header.
+ *   - On window change the panel calls the new `GET /api/v1/stats/activity`
+ *     endpoint via `client.statsActivity(hours, signal)` instead of reusing
+ *     the overview payload.
+ *   - Added inline legend / tooltip descriptions for all three metric names
+ *     (New / Updated / Tombstoned) so operators understand exact semantics.
+ *   - Panel subtitle and loading text adapt to the selected window.
+ *   - Maintains the existing `PanelFrame` + `PanelBody` chrome and color
+ *     coding from Issue #114.
  *
- * Color encoding follows the issue's "color is not the only channel"
- * rule: each delta has both a color and an icon-shaped glyph (▲ ▼ ●).
+ * Accessibility:
+ *   - Selector is a labelled <fieldset>/<legend> containing three
+ *     visually-styled radio buttons so it is keyboard-navigable and
+ *     announced correctly by screen readers.
+ *   - Each metric cell's descriptive tooltip uses the HTML `title`
+ *     attribute for universal screen-reader support while the visible
+ *     label carries an aria-label that includes the description.
  */
 
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { ApiClient, StatsOverview } from "../../api/client";
+import { ApiClient, StatsActivity } from "../../api/client";
 import { useTokenContext } from "../../context/TokenContext";
 import { usePanelFetch } from "../../hooks/usePanelFetch";
 import { PanelBody, PanelFrame } from "./PanelFrame";
 import { PanelErrorBoundary } from "./PanelErrorBoundary";
 
 const REFRESH_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Window options
+// ---------------------------------------------------------------------------
+
+type WindowOption = {
+  /** Hours forwarded to the API. */
+  hours: number;
+  /** Short label shown in the selector button. */
+  label: string;
+  /** Longer subtitle shown in the panel header. */
+  subtitle: string;
+};
+
+const WINDOW_OPTIONS: readonly WindowOption[] = [
+  { hours: 24, label: "24h", subtitle: "Last 24 hours" },
+  { hours: 168, label: "7d", subtitle: "Last 7 days" },
+  { hours: 720, label: "30d", subtitle: "Last 30 days" },
+  { hours: 2160, label: "90d", subtitle: "Last 90 days" },
+] as const;
+
+const DEFAULT_WINDOW = WINDOW_OPTIONS[0];
+
+// ---------------------------------------------------------------------------
+// Metric descriptions (used for tooltip title + aria-label)
+// ---------------------------------------------------------------------------
+
+const METRIC_DESCRIPTIONS = {
+  new: "Documents indexed for the first time in the selected window (first time this external ID was seen).",
+  updated:
+    "Existing documents re-indexed because their content changed (content hash differs) within the window.",
+  tombstoned:
+    "Documents soft-deleted in the window because the source stopped reporting them; they remain recoverable until the retention janitor hard-purges them.",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 interface Props {
   client?: ApiClient;
@@ -38,34 +83,41 @@ export function DeltaStrip({
   const ctx = useTokenContext();
   const client = clientOverride ?? ctx.client;
 
-  /* Independent fetch from OverviewHeader: while there is some data
-   * overlap, decoupling cadence and error state per panel matches the
-   * issue's "ONE panel failing must NOT crash the page" requirement.
-   * Server-side cache (5-10s) deduplicates the load anyway. */
+  const [selectedWindow, setSelectedWindow] =
+    useState<WindowOption>(DEFAULT_WINDOW);
+
+  /* Re-fetch whenever the window changes because usePanelFetch rebuilds its
+   * interval when the fetcher closure identity changes (fetcherRef approach).
+   * The closure captures `selectedWindow.hours`, so a window change produces
+   * a new function reference on the next render, which the effect picks up. */
   const { data, error, refreshing, lastRefreshedAt } =
-    usePanelFetch<StatsOverview>(
-      (signal) => client.statsOverview(signal),
+    usePanelFetch<StatsActivity>(
+      (signal) => client.statsActivity(selectedWindow.hours, signal),
       refreshMs
     );
 
   return (
     <PanelFrame
-      title="Last 24 hours"
+      title={selectedWindow.subtitle}
       subtitle="Document activity"
       refreshing={refreshing}
       lastRefreshedAt={lastRefreshedAt}
       refreshMs={refreshMs}
     >
-      <PanelErrorBoundary panelTitle="Last 24 hours">
+      <PanelErrorBoundary panelTitle="Document activity">
+        {/* Window selector — placed inside the panel body above the metric
+            cells so it sits close to the content it controls. */}
+        <WindowSelector
+          options={WINDOW_OPTIONS}
+          selected={selectedWindow}
+          onChange={setSelectedWindow}
+        />
+
         <PanelBody
           data={data}
           error={error}
-          isEmpty={(d) =>
-            d.documents_added_24h === 0 &&
-            d.documents_updated_24h === 0 &&
-            d.documents_tombstoned_24h === 0
-          }
-          emptyTitle="No document changes in the last 24h"
+          isEmpty={(d) => d.new === 0 && d.updated === 0 && d.tombstoned === 0}
+          emptyTitle={`No document changes in ${selectedWindow.subtitle.toLowerCase()}`}
           emptyHint={
             <>
               Trigger a sync from{" "}
@@ -78,7 +130,7 @@ export function DeltaStrip({
               to populate.
             </>
           }
-          skeleton={<DeltaSkeleton />}
+          skeleton={<DeltaSkeleton window={selectedWindow.subtitle} />}
         >
           {(d) => <DeltaContent data={d} />}
         </PanelBody>
@@ -87,48 +139,130 @@ export function DeltaStrip({
   );
 }
 
-function DeltaContent({ data }: { data: StatsOverview }) {
+// ---------------------------------------------------------------------------
+// WindowSelector
+// ---------------------------------------------------------------------------
+
+interface WindowSelectorProps {
+  options: readonly WindowOption[];
+  selected: WindowOption;
+  onChange: (option: WindowOption) => void;
+}
+
+function WindowSelector({ options, selected, onChange }: WindowSelectorProps) {
+  return (
+    /* fieldset + legend gives the group a proper accessible name.
+     * We visually hide the legend text but keep it in the a11y tree. */
+    <fieldset className="mb-4">
+      <legend className="sr-only">Activity time window</legend>
+      <div
+        className="inline-flex rounded-md border border-border overflow-hidden"
+        role="group"
+      >
+        {options.map((opt) => {
+          const isSelected = opt.hours === selected.hours;
+          return (
+            <label key={opt.hours} className="relative cursor-pointer">
+              <input
+                type="radio"
+                name="activity-window"
+                value={String(opt.hours)}
+                checked={isSelected}
+                onChange={() => onChange(opt)}
+                className="sr-only"
+                aria-label={`Show activity for ${opt.subtitle}`}
+              />
+              <span
+                className={
+                  "block px-3 py-1 text-xs font-medium select-none transition-colors " +
+                  (isSelected
+                    ? "bg-accent text-accent-fg"
+                    : "bg-elevation-1 text-text-muted hover:bg-elevation-2")
+                }
+              >
+                {opt.label}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DeltaContent
+// ---------------------------------------------------------------------------
+
+function DeltaContent({ data }: { data: StatsActivity }) {
   return (
     <div className="grid grid-cols-3 gap-3">
       <Cell
         glyph="▲"
         label="New"
-        value={data.documents_added_24h}
+        value={data.new}
         toneClass="text-success-fg bg-success-bg"
+        description={METRIC_DESCRIPTIONS.new}
       />
       <Cell
         glyph="●"
         label="Updated"
-        value={data.documents_updated_24h}
+        value={data.updated}
         toneClass="text-info-fg bg-info-bg"
+        description={METRIC_DESCRIPTIONS.updated}
       />
       <Cell
         glyph="▼"
         label="Tombstoned"
-        value={data.documents_tombstoned_24h}
+        value={data.tombstoned}
         toneClass="text-danger-fg bg-danger-bg"
+        description={METRIC_DESCRIPTIONS.tombstoned}
       />
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Cell
+// ---------------------------------------------------------------------------
 
 interface CellProps {
   glyph: string;
   label: string;
   value: number;
   toneClass: string;
+  /** Human-readable description shown as tooltip + screen-reader annotation. */
+  description: string;
 }
 
-function Cell({ glyph, label, value, toneClass }: CellProps) {
+function Cell({ glyph, label, value, toneClass, description }: CellProps) {
   return (
+    /* title provides the tooltip on hover and is read by most screen readers
+     * as supplementary information when the element receives focus. */
     <div
       className={`rounded-lg px-4 py-3 flex items-center gap-3 ${toneClass}`}
+      title={description}
     >
       <span aria-hidden="true" className="text-lg leading-none">
         {glyph}
       </span>
       <div className="min-w-0">
-        <p className="text-xs uppercase tracking-wide opacity-80">{label}</p>
+        {/* aria-label combines the metric name and its description so the
+            count reads in full context to assistive technology. */}
+        <p
+          className="text-xs uppercase tracking-wide opacity-80"
+          aria-label={`${label}: ${description}`}
+        >
+          {label}
+          {/* Inline help indicator — visually signals that a tooltip is
+              available; decorative only (aria-hidden). */}
+          <span
+            aria-hidden="true"
+            className="ml-1 opacity-50 text-[10px] font-normal normal-case"
+          >
+            (?)
+          </span>
+        </p>
         <p className="text-xl font-semibold tabular-nums">
           {value.toLocaleString()}
         </p>
@@ -137,7 +271,15 @@ function Cell({ glyph, label, value, toneClass }: CellProps) {
   );
 }
 
-function DeltaSkeleton() {
+// ---------------------------------------------------------------------------
+// DeltaSkeleton
+// ---------------------------------------------------------------------------
+
+interface DeltaSkeletonProps {
+  window: string;
+}
+
+function DeltaSkeleton({ window }: DeltaSkeletonProps) {
   return (
     <div className="grid grid-cols-3 gap-3">
       {Array.from({ length: 3 }).map((_, i) => (
@@ -148,7 +290,7 @@ function DeltaSkeleton() {
         />
       ))}
       <span className="sr-only" role="status">
-        Loading 24h activity…
+        Loading document activity for {window}…
       </span>
     </div>
   );

--- a/apps/server/src/omniscience_server/rest/stats.py
+++ b/apps/server/src/omniscience_server/rest/stats.py
@@ -7,6 +7,7 @@ Endpoints
 * ``GET /api/v1/stats/sources``            — per-source table
 * ``GET /api/v1/stats/entities-by-kind``   — entity-kind histogram
 * ``GET /api/v1/stats/edges-by-type``      — edge-type histogram
+* ``GET /api/v1/stats/activity``           — windowed document-activity counts
 
 All endpoints require the ``stats:read`` scope.  All responses are
 workspace-scoped: counts include only sources, documents, chunks,
@@ -33,15 +34,16 @@ protocol-level ``workspace_id`` invariants on ``GraphStore`` and
 from __future__ import annotations
 
 import uuid
-from typing import Any
+from typing import Annotated, Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from omniscience_core.auth.middleware import get_current_token, require_scope
 from omniscience_core.auth.scopes import Scope
 from omniscience_core.auth.workspace import get_workspace_id
 from omniscience_core.db.models import ApiToken
 from omniscience_core.stats import (
+    ActivityResponse,
     ClientsStatsResponse,
     ClientsStatsService,
     EdgesByTypeResponse,
@@ -50,6 +52,7 @@ from omniscience_core.stats import (
     StatsOverview,
     StatsService,
 )
+from omniscience_core.stats.service import _ACTIVITY_HOURS_MAX, _ACTIVITY_HOURS_MIN
 from omniscience_core.storage.graph import GraphStore
 from omniscience_core.storage.vector import VectorStore
 
@@ -160,6 +163,47 @@ async def stats_overview(
         chunks=overview.chunks,
     )
     return overview
+
+
+@router.get(
+    "/stats/activity",
+    response_model=ActivityResponse,
+    summary="Windowed document-activity counts",
+    dependencies=[_stats_scope_dep],
+)
+async def stats_activity(
+    request: Request,
+    token: ApiToken = _current_token_dep,
+    hours: Annotated[
+        int,
+        Query(
+            ge=_ACTIVITY_HOURS_MIN,
+            le=_ACTIVITY_HOURS_MAX,
+            description=(
+                f"Width of the time window in hours "
+                f"({_ACTIVITY_HOURS_MIN}-{_ACTIVITY_HOURS_MAX}). "
+                "Default: 24."
+            ),
+        ),
+    ] = 24,
+) -> ActivityResponse:
+    """Windowed document-activity counts for the admin dashboard.
+
+    Returns counts of new, updated, and tombstoned documents within the
+    requested time window, all scoped to the caller's workspace.
+
+    Field semantics:
+    - ``new``        — first-time indexings (``doc_version == 1``) in window.
+    - ``updated``    — re-indexed documents (``doc_version > 1``) in window.
+    - ``tombstoned`` — documents soft-deleted in window.
+    - ``window_hours`` — the window echoed back for client-side cross-check.
+
+    Requires scope: ``stats:read``
+    Requires: token scoped to a workspace (fails closed with 403 otherwise).
+    """
+    workspace_id = _require_workspace(token)
+    service = _resolve_service(request)
+    return await service.activity(workspace_id=workspace_id, window_hours=hours)
 
 
 @router.get(

--- a/packages/core/src/omniscience_core/stats/__init__.py
+++ b/packages/core/src/omniscience_core/stats/__init__.py
@@ -5,9 +5,10 @@ Public surface:
 * :class:`StatsService` — single entry point that aggregates rollups across
   Postgres (operational metadata), Neo4j (entities + edges), and Qdrant
   (chunk counts) for the admin UI dashboard.
-* :class:`StatsOverview`, :class:`SourceStatsRow`, :class:`KindHistogramEntry`,
-  :class:`EdgeTypeHistogramEntry` — Pydantic response models shared with the
-  REST layer (``apps/server/src/omniscience_server/rest/stats.py``).
+* :class:`StatsOverview`, :class:`ActivityResponse`, :class:`SourceStatsRow`,
+  :class:`KindHistogramEntry`, :class:`EdgeTypeHistogramEntry` — Pydantic
+  response models shared with the REST layer
+  (``apps/server/src/omniscience_server/rest/stats.py``).
 
 Design rules
 ------------
@@ -37,6 +38,7 @@ from omniscience_core.stats.clients import (
     ClientsStatsService,
 )
 from omniscience_core.stats.models import (
+    ActivityResponse,
     ClientsStatsResponse,
     EdgesByTypeResponse,
     EdgeTypeHistogramEntry,
@@ -53,6 +55,7 @@ from omniscience_core.stats.service import StatsService
 __all__ = [
     "CLIENTS_STATS_CACHE_TTL_SECONDS",
     "STATS_CACHE_TTL_SECONDS",
+    "ActivityResponse",
     "ClientsStatsResponse",
     "ClientsStatsService",
     "EdgeTypeHistogramEntry",

--- a/packages/core/src/omniscience_core/stats/models.py
+++ b/packages/core/src/omniscience_core/stats/models.py
@@ -58,6 +58,34 @@ class StatsOverview(BaseModel):
     )
 
 
+class ActivityResponse(BaseModel):
+    """Windowed document-activity counts for the admin dashboard.
+
+    Used by ``GET /api/v1/stats/activity?hours=<int>``.  All counts are
+    scoped to the caller's workspace.
+
+    Field semantics:
+    - ``new``         — documents indexed for the first time (doc_version == 1)
+                        within the window.
+    - ``updated``     — existing documents re-indexed (doc_version > 1) within
+                        the window.
+    - ``tombstoned``  — documents soft-deleted within the window.
+    - ``window_hours`` — the requested window echoed back so the caller can
+                         cross-check the value actually used.
+    """
+
+    new: int = Field(..., ge=0, description="Documents first indexed within the window.")
+    updated: int = Field(
+        ..., ge=0, description="Documents re-indexed (content changed) within the window."
+    )
+    tombstoned: int = Field(
+        ..., ge=0, description="Documents soft-deleted within the window."
+    )
+    window_hours: int = Field(
+        ..., ge=1, description="The time window in hours (echoed from the request)."
+    )
+
+
 class SourceStatsRow(BaseModel):
     """One row of the per-source stats table.
 
@@ -157,6 +185,7 @@ class ClientsStatsResponse(BaseModel):
 
 
 __all__ = [
+    "ActivityResponse",
     "ClientsStatsResponse",
     "EdgeTypeHistogramEntry",
     "EdgesByTypeResponse",

--- a/packages/core/src/omniscience_core/stats/service.py
+++ b/packages/core/src/omniscience_core/stats/service.py
@@ -37,6 +37,7 @@ from omniscience_core.auth.workspace import workspace_filter
 from omniscience_core.db.models import Chunk, Document, Source, SourceStatus
 from omniscience_core.stats.cache import STATS_CACHE_TTL_SECONDS, TTLCache
 from omniscience_core.stats.models import (
+    ActivityResponse,
     EdgesByTypeResponse,
     EdgeTypeHistogramEntry,
     EntitiesByKindResponse,
@@ -60,6 +61,10 @@ _METHOD_EDGES_BY_TYPE: Final[str] = "edges_by_type"
 # Window for "last 24h" deltas.  A constant keeps the SQL trivially
 # parameterised and the unit tests trivially controllable via fake clocks.
 _DELTA_WINDOW: Final[timedelta] = timedelta(hours=24)
+
+# Bounds for the windowed activity endpoint (hours).
+_ACTIVITY_HOURS_MIN: Final[int] = 1
+_ACTIVITY_HOURS_MAX: Final[int] = 8760  # 1 year
 
 
 class StatsService:
@@ -99,6 +104,74 @@ class StatsService:
             factory=_build,
         )
         return _as_overview(result)
+
+    async def activity(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        window_hours: int,
+    ) -> ActivityResponse:
+        """Return windowed document-activity counts for the given workspace.
+
+        Mirrors the three delta queries from :meth:`_postgres_overview`
+        but with a caller-supplied window instead of the fixed 24h
+        constant.  Not cached — the window parameter makes the cache key
+        unbounded; the Postgres queries are cheap aggregate SELECTs.
+
+        :param workspace_id: The workspace to scope the query to.
+        :param window_hours: Window width in hours (1..8760).  Callers
+            must validate this before calling; the method does not
+            re-validate (validation lives in the REST layer).
+        """
+        cutoff = datetime.now(tz=UTC) - timedelta(hours=window_hours)
+
+        async with self._session_factory() as session:
+            added_stmt = workspace_filter(
+                select(func.count())
+                .select_from(Document)
+                .join(Source)
+                .where(
+                    Document.indexed_at >= cutoff,
+                    Document.doc_version == 1,
+                ),
+                workspace_id,
+            )
+            updated_stmt = workspace_filter(
+                select(func.count())
+                .select_from(Document)
+                .join(Source)
+                .where(
+                    Document.indexed_at >= cutoff,
+                    Document.doc_version > 1,
+                ),
+                workspace_id,
+            )
+            tombstoned_stmt = workspace_filter(
+                select(func.count())
+                .select_from(Document)
+                .join(Source)
+                .where(Document.tombstoned_at >= cutoff),
+                workspace_id,
+            )
+
+            new_count = int((await session.execute(added_stmt)).scalar_one())
+            updated_count = int((await session.execute(updated_stmt)).scalar_one())
+            tombstoned_count = int((await session.execute(tombstoned_stmt)).scalar_one())
+
+        log.info(
+            "stats_activity",
+            workspace_id=str(workspace_id),
+            window_hours=window_hours,
+            new=new_count,
+            updated=updated_count,
+            tombstoned=tombstoned_count,
+        )
+        return ActivityResponse(
+            new=new_count,
+            updated=updated_count,
+            tombstoned=tombstoned_count,
+            window_hours=window_hours,
+        )
 
     async def sources(self, *, workspace_id: uuid.UUID) -> SourcesStatsResponse:
         """Per-source table for the dashboard."""
@@ -490,4 +563,4 @@ def _as_edges_type(value: object) -> EdgesByTypeResponse:
     return value
 
 
-__all__ = ["StatsService"]
+__all__ = ["_ACTIVITY_HOURS_MAX", "_ACTIVITY_HOURS_MIN", "StatsService"]

--- a/tests/test_stats_activity.py
+++ b/tests/test_stats_activity.py
@@ -1,0 +1,501 @@
+"""Tests for the windowed activity endpoint (GET /api/v1/stats/activity).
+
+Coverage:
+- 24h / 168h / 720h windowed counts via StatsService.activity()
+- workspace isolation: workspace A counts do not bleed to workspace B
+- 422 on bad hours values (<=0, >8760, non-integer)
+- 401 without token
+- 403 without stats:read scope
+- 403 with no-workspace token
+- happy path with various window sizes
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.db.models import ApiToken
+from omniscience_core.stats import ActivityResponse, StatsService
+from omniscience_server.app import create_app
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_token(
+    scopes: list[str],
+    *,
+    workspace_id: uuid.UUID | None = None,
+) -> tuple[ApiToken, str]:
+    pt, prefix = generate_token("test")
+    hashed = hash_token(pt)
+
+    tok: ApiToken = MagicMock(spec=ApiToken)
+    tok.id = uuid.uuid4()
+    tok.token_prefix = prefix
+    tok.hashed_token = hashed
+    tok.scopes = scopes
+    tok.workspace_id = workspace_id
+    tok.expires_at = None
+    tok.is_active = True
+    tok.last_used_at = None
+    return tok, pt
+
+
+def _auth_session(token: ApiToken) -> AsyncMock:
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [token]
+        result.scalars.return_value.first.return_value = token
+        result.scalar_one.return_value = 1
+        return result
+
+    session.execute = _execute
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _build_app(
+    *,
+    token: ApiToken,
+    stats_service: StatsService | None = None,
+) -> FastAPI:
+    from omniscience_core.config import Settings
+
+    settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+    app = create_app(settings=settings)
+    app.state.db_session_factory = MagicMock(return_value=_auth_session(token))
+
+    if stats_service is not None:
+        app.state.stats_service = stats_service
+    return app
+
+
+async def _client_for(app: FastAPI) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+def _stub_stats_service_with_activity(
+    *,
+    activity_fn: Any | None = None,
+) -> StatsService:
+    """Return a StatsService stub whose activity() can be customised."""
+    svc = MagicMock(spec=StatsService)
+    if activity_fn is not None:
+        svc.activity = activity_fn
+    else:
+        svc.activity = AsyncMock(
+            return_value=ActivityResponse(new=0, updated=0, tombstoned=0, window_hours=24)
+        )
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# StatsService.activity() unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activity_service_issues_three_queries() -> None:
+    """activity() must execute exactly 3 scalar SELECT statements."""
+    call_log: list[Any] = []
+
+    async def _execute(stmt: Any) -> Any:
+        call_log.append(stmt)
+        result = MagicMock()
+        result.scalar_one.return_value = 5
+        return result
+
+    session = AsyncMock()
+    session.execute = _execute
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=session)
+
+    svc = StatsService(
+        db_session_factory=factory,
+        graph_store=AsyncMock(),
+        vector_store=AsyncMock(),
+    )
+    result = await svc.activity(workspace_id=uuid.uuid4(), window_hours=24)
+
+    assert len(call_log) == 3
+    assert result.new == 5
+    assert result.updated == 5
+    assert result.tombstoned == 5
+    assert result.window_hours == 24
+
+
+@pytest.mark.asyncio
+async def test_activity_service_window_hours_echoed() -> None:
+    """window_hours must be echoed back in the response."""
+    async def _execute(stmt: Any) -> Any:
+        result = MagicMock()
+        result.scalar_one.return_value = 0
+        return result
+
+    session = AsyncMock()
+    session.execute = _execute
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    factory = MagicMock(return_value=session)
+
+    svc = StatsService(
+        db_session_factory=factory,
+        graph_store=AsyncMock(),
+        vector_store=AsyncMock(),
+    )
+
+    for window in (24, 168, 720):
+        result = await svc.activity(workspace_id=uuid.uuid4(), window_hours=window)
+        assert result.window_hours == window
+
+
+@pytest.mark.asyncio
+async def test_activity_service_workspace_isolation() -> None:
+    """Workspace A activity must not bleed into workspace B."""
+    workspace_a = uuid.uuid4()
+    workspace_b = uuid.uuid4()
+
+    # Track which workspace_id was used on each session call.
+    seen_workspace_ids: list[uuid.UUID] = []
+
+    def _make_session(ws_id: uuid.UUID) -> AsyncMock:
+        """Return a session mock that records its workspace_id."""
+        seen_workspace_ids.append(ws_id)
+
+        async def _execute(stmt: Any) -> Any:
+            result = MagicMock()
+            # Workspace A gets count=3, workspace B gets count=99.
+            result.scalar_one.return_value = 3 if ws_id == workspace_a else 99
+            return result
+
+        session = AsyncMock()
+        session.execute = _execute
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        return session
+
+    # The session factory is called once per activity() invocation.
+    factory = MagicMock()
+    factory.side_effect = [
+        _make_session(workspace_a),
+        _make_session(workspace_b),
+    ]
+
+    svc = StatsService(
+        db_session_factory=factory,
+        graph_store=AsyncMock(),
+        vector_store=AsyncMock(),
+    )
+
+    result_a = await svc.activity(workspace_id=workspace_a, window_hours=24)
+    result_b = await svc.activity(workspace_id=workspace_b, window_hours=24)
+
+    assert result_a.new == 3
+    assert result_b.new == 99
+    assert seen_workspace_ids == [workspace_a, workspace_b]
+
+
+# ---------------------------------------------------------------------------
+# REST: auth + scope enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activity_requires_auth() -> None:
+    tok, _ = _make_token(["stats:read"])
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.get("/api/v1/stats/activity")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_activity_requires_stats_scope() -> None:
+    tok, pt = _make_token(["sources:read"], workspace_id=uuid.uuid4())
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_activity_rejects_no_workspace_token() -> None:
+    tok, pt = _make_token(["stats:read"], workspace_id=None)
+    app = _build_app(token=tok)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["error"]["code"] == "forbidden"
+
+
+# ---------------------------------------------------------------------------
+# REST: validation — bad hours values
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activity_rejects_hours_zero() -> None:
+    tok, pt = _make_token(["stats:read"], workspace_id=uuid.uuid4())
+    svc = _stub_stats_service_with_activity()
+    app = _build_app(token=tok, stats_service=svc)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=0",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_activity_rejects_hours_negative() -> None:
+    tok, pt = _make_token(["stats:read"], workspace_id=uuid.uuid4())
+    svc = _stub_stats_service_with_activity()
+    app = _build_app(token=tok, stats_service=svc)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=-1",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_activity_rejects_hours_above_max() -> None:
+    tok, pt = _make_token(["stats:read"], workspace_id=uuid.uuid4())
+    svc = _stub_stats_service_with_activity()
+    app = _build_app(token=tok, stats_service=svc)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=8761",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_activity_rejects_non_integer_hours() -> None:
+    tok, pt = _make_token(["stats:read"], workspace_id=uuid.uuid4())
+    svc = _stub_stats_service_with_activity()
+    app = _build_app(token=tok, stats_service=svc)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=abc",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# REST: happy paths — 24h / 168h / 720h
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activity_default_24h() -> None:
+    """Default (no hours param) is 24h."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+
+    activity_response = ActivityResponse(new=5, updated=2, tombstoned=1, window_hours=24)
+    svc = _stub_stats_service_with_activity(
+        activity_fn=AsyncMock(return_value=activity_response)
+    )
+    app = _build_app(token=tok, stats_service=svc)
+
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["new"] == 5
+    assert body["updated"] == 2
+    assert body["tombstoned"] == 1
+    assert body["window_hours"] == 24
+    svc.activity.assert_awaited_once_with(workspace_id=workspace_id, window_hours=24)
+
+
+@pytest.mark.asyncio
+async def test_activity_7d_window() -> None:
+    """hours=168 maps to 7-day window."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+
+    activity_response = ActivityResponse(new=120, updated=45, tombstoned=8, window_hours=168)
+    svc = _stub_stats_service_with_activity(
+        activity_fn=AsyncMock(return_value=activity_response)
+    )
+    app = _build_app(token=tok, stats_service=svc)
+
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=168",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["window_hours"] == 168
+    assert body["new"] == 120
+    svc.activity.assert_awaited_once_with(workspace_id=workspace_id, window_hours=168)
+
+
+@pytest.mark.asyncio
+async def test_activity_30d_window() -> None:
+    """hours=720 maps to 30-day window."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+
+    activity_response = ActivityResponse(new=500, updated=200, tombstoned=50, window_hours=720)
+    svc = _stub_stats_service_with_activity(
+        activity_fn=AsyncMock(return_value=activity_response)
+    )
+    app = _build_app(token=tok, stats_service=svc)
+
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=720",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["window_hours"] == 720
+    assert body["new"] == 500
+    svc.activity.assert_awaited_once_with(workspace_id=workspace_id, window_hours=720)
+
+
+@pytest.mark.asyncio
+async def test_activity_boundary_hours_1() -> None:
+    """Minimum valid value: hours=1."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+    svc = _stub_stats_service_with_activity(
+        activity_fn=AsyncMock(
+            return_value=ActivityResponse(new=0, updated=0, tombstoned=0, window_hours=1)
+        )
+    )
+    app = _build_app(token=tok, stats_service=svc)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=1",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["window_hours"] == 1
+
+
+@pytest.mark.asyncio
+async def test_activity_boundary_hours_8760() -> None:
+    """Maximum valid value: hours=8760 (1 year)."""
+    workspace_id = uuid.uuid4()
+    tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
+    svc = _stub_stats_service_with_activity(
+        activity_fn=AsyncMock(
+            return_value=ActivityResponse(new=0, updated=0, tombstoned=0, window_hours=8760)
+        )
+    )
+    app = _build_app(token=tok, stats_service=svc)
+    async with await _client_for(app) as client:
+        resp = await client.get(
+            "/api/v1/stats/activity?hours=8760",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["window_hours"] == 8760
+
+
+# ---------------------------------------------------------------------------
+# REST: workspace ACL isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activity_workspace_acl_isolation() -> None:
+    """Two workspaces receive distinct activity counts — no cross-bleed."""
+    workspace_a = uuid.uuid4()
+    workspace_b = uuid.uuid4()
+
+    activity_a = ActivityResponse(new=10, updated=3, tombstoned=1, window_hours=24)
+    activity_b = ActivityResponse(new=99, updated=50, tombstoned=20, window_hours=24)
+
+    svc = MagicMock(spec=StatsService)
+
+    async def _activity(*, workspace_id: uuid.UUID, window_hours: int) -> ActivityResponse:
+        if workspace_id == workspace_a:
+            return activity_a
+        if workspace_id == workspace_b:
+            return activity_b
+        raise AssertionError(f"unexpected workspace_id: {workspace_id}")
+
+    svc.activity = _activity
+
+    tok_a, pt_a = _make_token(["stats:read"], workspace_id=workspace_a)
+    app_a = _build_app(token=tok_a, stats_service=svc)
+    async with await _client_for(app_a) as client:
+        resp_a = await client.get(
+            "/api/v1/stats/activity",
+            headers={"Authorization": f"Bearer {pt_a}"},
+        )
+
+    tok_b, pt_b = _make_token(["stats:read"], workspace_id=workspace_b)
+    app_b = _build_app(token=tok_b, stats_service=svc)
+    async with await _client_for(app_b) as client:
+        resp_b = await client.get(
+            "/api/v1/stats/activity",
+            headers={"Authorization": f"Bearer {pt_b}"},
+        )
+
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+    assert resp_a.json()["new"] == 10
+    assert resp_b.json()["new"] == 99
+    assert resp_a.json()["new"] != resp_b.json()["new"]
+
+
+# ---------------------------------------------------------------------------
+# ActivityResponse model validation
+# ---------------------------------------------------------------------------
+
+
+def test_activity_response_rejects_negative_counts() -> None:
+    """Pydantic model must reject negative counts."""
+    import pytest as pt_module
+
+    with pt_module.raises(Exception):
+        ActivityResponse(new=-1, updated=0, tombstoned=0, window_hours=24)
+
+
+def test_activity_response_rejects_zero_window_hours() -> None:
+    """Pydantic model must reject window_hours < 1."""
+    import pytest as pt_module
+
+    with pt_module.raises(Exception):
+        ActivityResponse(new=0, updated=0, tombstoned=0, window_hours=0)


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/stats/activity?hours=<int>` backend endpoint: windowed document-activity counts (`new`, `updated`, `tombstoned`, `window_hours`). Validates `hours` in range 1–8760 (422 on bad values), workspace-scoped, `stats:read` scope required, fail-closed 403 for no-workspace tokens. Does not touch the existing `/stats/overview` shape.
- Extend `DeltaStrip` panel with a **24h / 7d / 30d / 90d** radio selector. On change, calls `client.statsActivity(hours, signal)` (new typed method, zero `any`). Panel title updates to match the selected window.
- Add **inline descriptions** for all three metrics via `title` tooltip and `aria-label`: New (first-time indexing), Updated (re-indexed on content change), Tombstoned (soft-deleted, recoverable until janitor).

## Files changed

**Backend**
- `packages/core/src/omniscience_core/stats/models.py` — add `ActivityResponse` pydantic model
- `packages/core/src/omniscience_core/stats/service.py` — add `StatsService.activity(workspace_id, window_hours)` method + `_ACTIVITY_HOURS_MIN/MAX` constants
- `packages/core/src/omniscience_core/stats/__init__.py` — re-export `ActivityResponse`
- `apps/server/src/omniscience_server/rest/stats.py` — add `GET /stats/activity` endpoint with FastAPI `Query(ge=1, le=8760)` validation
- `tests/test_stats_activity.py` — 20 new tests (service unit, REST auth/scope/validation/happy-path/isolation)

**Frontend**
- `apps/admin/src/api/client.ts` — add `StatsActivity` interface + `statsActivity(hours, signal)` method
- `apps/admin/src/components/dashboard/DeltaStrip.tsx` — complete rewrite: window selector, per-metric descriptions, adaptive title/skeleton text

## Test plan

- [ ] `uv run pytest tests/test_stats_activity.py tests/test_stats.py` — 41 tests green
- [ ] Full suite: `uv run pytest tests/` — 2958 passed, 45 skipped (baseline unchanged)
- [ ] `uv run ruff check` / `uv run mypy` — no issues on changed files
- [ ] `npx tsc --noEmit` — TS OK
- [ ] `npx vite build` — 288 kB / 80 kB gzip, 69 modules
- [ ] `npm run lint:colors` — no violations in new/modified files (50 pre-existing in GraphPage/ReplayPage untouched)
- [ ] Live verify: `GET /api/v1/stats/activity?hours=168` → `{"new":155,"updated":10,"tombstoned":0,"window_hours":168}` via workspace-scoped `stats:read` token
- [ ] `hours=0` → 422, `hours=-1` → 422, `hours=8761` → 422, no auth → 401
- [ ] Admin bundle served on port 13001: `stats/activity`, `Document activity`, `Activity time window`, `indexed for the first time`, `Show activity for`, `90d` all present in bundle
- [ ] `/api/` proxy from admin nginx → 200

## Endpoint contract

```
GET /api/v1/stats/activity?hours=<int>
Scope: stats:read
Requires: workspace-scoped token (403 otherwise)

Query params:
  hours  int  1..8760  (default 24)

Response 200:
{
  "new": int,          // doc_version == 1, indexed_at >= cutoff
  "updated": int,      // doc_version > 1,  indexed_at >= cutoff
  "tombstoned": int,   // tombstoned_at >= cutoff
  "window_hours": int  // echoed from request
}

Error responses:
  401 — no/invalid token
  403 — missing stats:read scope OR no workspace on token
  422 — hours out of range or non-integer
```