### PR TITLE
docs(aws): ADR-0014 accepted + Phase 1 spec

### DIFF
--- a/docs/decisions/0014-aws-dual-mechanism-ingestion.md
+++ b/docs/decisions/0014-aws-dual-mechanism-ingestion.md
@@ -1,6 +1,6 @@
 # ADR-0014 — Dual-mechanism AWS ingestion: generic poll + AWS Config
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-06-03
 - **Deciders**: Architecture, Backend Engineer
 - **Builds on**: [ADR-0002](0002-connector-framework-vs-sdk.md) (connector
@@ -145,6 +145,51 @@ Config change / CloudTrail ─▶ EventBridge rule ─▶ SQS (omniscience-aws-i
 Reconciliation (pull) runs on a schedule via Config advanced query (or a
 `cloudcontrol` re-scan) to correct drift and catch missed events. Steady-state
 cost is proportional to **change volume**, not resource count.
+
+### 5. Grounded parameters (verified against `qbiq-ai/infra`)
+
+Inspection of the `infra` repo's `shared` env and org config (`modules/config-org`,
+`_envcommon/config.hcl`, `management/eu-west-1/organizations`) fixes the
+otherwise-open parameters on fact rather than assumption:
+
+- **Start mode = `config`, no enablement needed.** AWS Config is already running
+  org-wide: `recording_group{ all_supported = true, include_global_resource_types
+  = true }` + `aws_config_configuration_aggregator "org"` with
+  `organization_aggregation_source{ all_regions = true }`. All types, all
+  regions, all accounts are already recorded.
+- **Aggregator hub = Log Archive account** (delegated admin, infra #158). Omniscience
+  reads the org aggregator from Log Archive via a **read-only role** —
+  `config:SelectAggregateResourceConfig` / `BatchGetAggregateResourceConfig` /
+  `GetAggregateResourceConfigHistory`. The aggregator already spans every member
+  account (qbiq-prod, qbiq-dev, analytics, shared, …), so per-account `AssumeRole`
+  is **not** required for the baseline graph.
+- **Cold archive already exists.** Config delivers configuration snapshots/history
+  to **S3** (delivery channel, prefix `config`, in Log Archive). This is reused as
+  the cold tier (below) instead of duplicating old history in our hot stores.
+- **CloudTrail and EventBridge are already deployed** → Phases 4–5 (push,
+  activity) have their AWS-side primitives in place; the work is wiring, not
+  enablement.
+- **No RDS** in the estate → excluded from the starting scope.
+
+#### Decided execution parameters
+
+- **Reconciliation cadence:** full nightly + 6h incremental reconcile (pull).
+  After push (Phase 4) lands, reconciliation drops to nightly drift-check only.
+- **Starting scope (Tier-1):** `AWS::EC2::VPC|Subnet|SecurityGroup|RouteTable|
+  NatGateway|InternetGateway|EIP`, `AWS::EKS::Cluster|Nodegroup|Addon`,
+  `AWS::ElasticLoadBalancingV2::LoadBalancer`, `AWS::IAM::Role|Policy|User|Group|
+  OIDCProvider`, `AWS::S3::Bucket`, `AWS::KMS::Key`, `AWS::ECR::Repository`,
+  `AWS::SecretsManager::Secret`, `AWS::Lambda::Function`, `AWS::Route53::HostedZone`.
+  Tier-2 (TransitGateway, NetworkFirewall, DynamoDB, Backup, GuardDuty, Config
+  rules, CloudWatch, IdentityStore, AccessAnalyzer, Budgets/CE) follows on demand.
+- **Retention / tiering** (extends ADR-0009): **hot 90d** full bitemporal versions
+  in Neo4j/Qdrant/PG → **warm** summarised (changed fields + S3 snapshot pointer)
+  → **cold** = a *pointer* (S3 path + `captureTime`) into the existing Config S3
+  archive, full object re-hydrated on demand via **Athena** (slower deep search is
+  acceptable per operator). Our raw rows purge ~1y; S3 archive lives by its own
+  lifecycle (Glacier). Security-relevant types (IAM/SG/KMS) kept hot longer.
+- **Push:** deferred — **pull-only first** (Phases 1–3); SQS/EventBridge bridge is
+  Phase 4.
 
 ## Consequences
 

--- a/docs/specs/aws-config-phase1.md
+++ b/docs/specs/aws-config-phase1.md
@@ -1,0 +1,145 @@
+# Spec — AWS ingestion Phase 1: Config-aggregator baseline graph
+
+Implements **Phase 1** of [ADR-0014](../decisions/0014-aws-dual-mechanism-ingestion.md):
+a pull-only baseline that turns the org AWS Config aggregator into bitemporal
+entities + relationship edges, so `get_related_entities` / `blast_radius` work
+over real AWS state. **No new AWS infra**, no push, no CloudTrail (those are
+later phases). Grounded in `qbiq-ai/infra` (Config already org-wide; aggregator
+delegated to Log Archive; recording `all_supported`, `all_regions`).
+
+## Scope of this phase
+
+IN: `acquisition="config"` mode on the existing AWS connector; read the org
+aggregator; map Config configuration items (CIs) → entities + edges; bitemporal
+`valid_from = configurationItemCaptureTime`; Tier-1 resource types; tombstone on
+`ResourceDeleted`; cold-pointer field (S3 path) on each version; reconciliation
+semantics (full + diff). Unit/integration tests with mocked boto3.
+
+OUT (later phases): Cloud Control generic poll (Phase 3), EventBridge→SQS push
+(Phase 4), CloudTrail activity (Phase 5), org auto-onboarding (Phase 6), Athena
+re-hydration query path (warm/cold read — Phase 1 only *writes* the pointer).
+
+## Connector contract
+
+Extend `packages/connectors/src/omniscience_connectors/aws/connector.py` (and
+`AwsConfig`) — do NOT fork a new connector. Add:
+
+```
+class AwsConfig(BaseModel):
+    acquisition: Literal["describe", "cloudcontrol", "config"] = "describe"
+    # config-mode fields:
+    aggregator_name: str | None = None          # org aggregator in Log Archive
+    config_resource_types: list[str] = [<Tier-1 default>]   # AWS::* type names
+    config_regions: list[str] = []              # empty = all-regions (aggregator already all_regions)
+    # existing fields (regions/services/include_organizations/...) unchanged
+```
+
+`acquisition="describe"` keeps the current behaviour byte-for-byte (regression
+guard). `acquisition="config"` activates the new path below.
+
+### discover() — config mode
+
+Use the boto3 **`config`** client against the aggregator:
+
+- Enumerate CIs per Tier-1 type via `SelectAggregateResourceConfig`
+  (SQL-like: `SELECT ... WHERE resourceType = 'AWS::EC2::Instance'`) OR
+  `ListAggregateDiscoveredResources` + `BatchGetAggregateResourceConfig`.
+  Page fully. Wrap blocking boto3 in `asyncio.to_thread` (match existing style).
+- Yield one `DocumentRef` per resource with metadata:
+  `{aws_resource_type, resource_id, arn, account_id, region, capture_time,
+    cluster/None}`. Stable `external_id = aws:{account}:{region}:{type}:{resource_id}`,
+  `uri = aws://{account}/{region}/{type}/{resource_id}`.
+- Gracefully skip a type the aggregator/role can't read (log + continue) — never
+  abort the whole discover (mirror the K8s connector's per-kind skip).
+
+### fetch() — config mode
+
+For a per-resource ref, return a `FetchedDocument` whose body is a **concise
+human-readable summary** (type, id, account, region, key config fields, tags) so
+embeddings are meaningful — not the raw CI JSON dump. Attach structured metadata
+for the pipeline (see mapping). Reuse `SelectAggregateResourceConfig` detail or
+`BatchGetAggregateResourceConfig` for the single CI.
+
+## Bitemporal + graph mapping
+
+Per CI:
+
+- **Entity / Document.** `entity_type = aws_resource_type`, `name = resource_id`
+  (or tag `Name`), `metadata` carries account/region/arn/tags + the compact
+  config. **`valid_from = configurationItemCaptureTime`** (bitemporal, ADR-0008).
+- **Edges from Config `relationships`.** Each CI's `relationships[]`
+  (e.g. `Is associated with Vpc`, `Contains SecurityGroup`) → a graph edge
+  `source_entity → target_entity` with `edge_type` derived from the relationship
+  name (normalised). Target keyed by the related resourceId → same `external_id`
+  scheme so edges resolve to ingested entities. This is what powers
+  `get_related_entities` / `blast_radius`.
+- **Tombstone.** A CI with `configurationItemStatus in {ResourceDeleted,
+  ResourceDeletedNotRecorded}` → tombstone the entity (existing IndexWriter
+  tombstone path), preserving bitemporal history.
+- **Cold pointer (retention tiering).** Persist on each version a
+  `cold_ref = { s3_bucket, s3_key, capture_time }` pointing at the Config
+  delivery S3 object, so warm/cold tiers can re-hydrate via Athena later without
+  us storing the full historical blob hot. Phase 1 only *writes* this pointer.
+
+## Reconciliation semantics (pull)
+
+A sync = a full enumeration of Tier-1 types from the aggregator. Reconciliation:
+
+- New/changed CIs (by `configurationItemCaptureTime` or config hash) → upsert new
+  bitemporal version.
+- Resources present last run but absent now → tombstone (drift / deletion catch).
+- Idempotent: re-running with no AWS change writes nothing new.
+
+Cadence is operational (full nightly + 6h incremental) — driven by the source's
+`freshness_sla_seconds` and the scheduler; the connector itself is stateless per
+run.
+
+## IAM (deliverable, applied separately by humans)
+
+Produce the **read-only IAM policy JSON** + a Terraform stub (for `qbiq-ai/infra`,
+Log Archive account) granting Omniscience's role:
+
+```
+config:SelectAggregateResourceConfig
+config:BatchGetAggregateResourceConfig
+config:ListAggregateDiscoveredResources
+config:GetAggregateResourceConfig
+config:GetAggregateDiscoveredResourceCounts
+config:GetAggregateResourceConfigHistory   # (Phase 2, include now)
+config:DescribeConfigurationAggregators
+s3:GetObject  on the Config delivery bucket/prefix  # cold re-hydration (read)
+```
+
+The connector consumes the assumed-role creds via the existing env-based
+`SecretsResolver` (role ARN + external id, or STS-vended keys) — **no static
+long-lived keys**. Applying the role to AWS is a human-approved infra step
+(out of scope for the code PR); the policy/stub is a documented deliverable.
+
+## Security
+
+- Reading the org aggregator = full org inventory → strictly **read-only**, role
+  scoped to the aggregator + Config-S3 read, audited. No write/mutate perms.
+- Never log secrets or full resource configs at info level.
+- Workspace/tenant: AWS source is tenant-scoped like any other source.
+
+## Tests (≥80% on touched connector code; full suite stays green)
+
+- `describe` mode unchanged (regression).
+- config discover: mocked `config` client returns multi-type, multi-account CIs →
+  one ref per resource; correct `external_id`/`uri`/metadata; per-type read error
+  skips that type, others still yielded.
+- mapping: `relationships[]` → edges resolving to sibling entities;
+  `valid_from = captureTime`; `ResourceDeleted` → tombstone; `cold_ref` written.
+- fetch: returns text/plain summary with type+id+account.
+- reconciliation: absent-now resource tombstoned; no-change run is a no-op.
+- Use mocks or `moto` for the `config` client; no live AWS in CI.
+
+## Live wiring (after merge — separate, human-gated)
+
+1. Apply the IAM role/policy to Log Archive (infra repo PR — `/infra-team`, human-approved).
+2. Create an AWS Source: `type=aws`, `config={ acquisition:"config",
+   aggregator_name:"<org-aggregator>", config_resource_types:[<Tier-1>] }`,
+   `secrets_ref` → assumed-role creds.
+3. Trigger sync; verify entities + edges in Neo4j and that `blast_radius` /
+   `get_related_entities` answer over AWS resources; confirm tombstone on a
+   deleted resource; confirm `cold_ref` populated.


### PR DESCRIPTION
Accepts ADR-0014 with parameters grounded in `qbiq-ai/infra` (AWS Config already org-wide, aggregator delegated to Log Archive, S3 delivery = ready cold archive, CloudTrail/EventBridge deployed, no RDS) and adds the **Phase 1 spec** (`docs/specs/aws-config-phase1.md`) — config-aggregator baseline graph, pull-only, no new AWS infra. Drives the dev-team implementation.