### PR TITLE
feat(connectors): AWS Config-aggregator acquisition mode (ADR-0014 Phase 1)

### DIFF
--- a/infra/iam/omniscience-config-reader-policy.json
+++ b/infra/iam/omniscience-config-reader-policy.json
@@ -1,0 +1,45 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "OmniscienceConfigAggregatorRead",
+      "Effect": "Allow",
+      "Action": [
+        "config:SelectAggregateResourceConfig",
+        "config:BatchGetAggregateResourceConfig",
+        "config:ListAggregateDiscoveredResources",
+        "config:GetAggregateResourceConfig",
+        "config:GetAggregateDiscoveredResourceCounts",
+        "config:GetAggregateResourceConfigHistory",
+        "config:DescribeConfigurationAggregators"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "OmniscienceConfigS3ColdRead",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::REPLACE_WITH_CONFIG_DELIVERY_BUCKET/config/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceAccount": "REPLACE_WITH_LOG_ARCHIVE_ACCOUNT_ID"
+        }
+      }
+    },
+    {
+      "Sid": "OmniscienceConfigS3ListBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::REPLACE_WITH_CONFIG_DELIVERY_BUCKET",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceAccount": "REPLACE_WITH_LOG_ARCHIVE_ACCOUNT_ID"
+        }
+      }
+    }
+  ]
+}

--- a/infra/terraform/omniscience-config-reader.tf
+++ b/infra/terraform/omniscience-config-reader.tf
@@ -1,0 +1,133 @@
+# Terraform stub — Omniscience Config-aggregator read-only role (ADR-0014 Phase 1)
+#
+# HUMAN-GATED STEP: Applying this stub is out of scope for the code PR.
+# It belongs in the qbiq-ai/infra repository under the Log Archive account module.
+# Apply steps:
+#   1. Copy this file to qbiq-ai/infra/<env>/log-archive/ (or the equivalent module).
+#   2. Replace all REPLACE_WITH_* placeholders with real values from your environment.
+#   3. Raise an infra PR, get approval, then: terragrunt apply
+#   4. Record the output role ARN and provide it as the secrets_ref for the AWS source.
+#
+# This stub intentionally uses no data sources or remote state references so it
+# can be reviewed without access to the infra repo.
+
+# --------------------------------------------------------------------------
+# Variables — wire to your terragrunt inputs or .tfvars
+# --------------------------------------------------------------------------
+
+variable "omniscience_principal_account_id" {
+  type        = string
+  description = "AWS account ID where Omniscience runs (needs to assume this role)."
+}
+
+variable "omniscience_external_id" {
+  type        = string
+  description = "STS external-id secret for the trust policy (prevents confused deputy)."
+}
+
+variable "config_delivery_bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket where Config delivers snapshots/history."
+}
+
+variable "log_archive_account_id" {
+  type        = string
+  description = "AWS account ID of the Log Archive account (where the aggregator lives)."
+}
+
+# --------------------------------------------------------------------------
+# IAM Policy — read-only access to Config aggregator + S3 cold tier
+# --------------------------------------------------------------------------
+
+resource "aws_iam_policy" "omniscience_config_reader" {
+  name        = "omniscience-config-reader"
+  description = "Omniscience read-only access to the org Config aggregator and Config-S3 cold tier."
+  path        = "/omniscience/"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OmniscienceConfigAggregatorRead"
+        Effect = "Allow"
+        Action = [
+          "config:SelectAggregateResourceConfig",
+          "config:BatchGetAggregateResourceConfig",
+          "config:ListAggregateDiscoveredResources",
+          "config:GetAggregateResourceConfig",
+          "config:GetAggregateDiscoveredResourceCounts",
+          "config:GetAggregateResourceConfigHistory",
+          "config:DescribeConfigurationAggregators",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "OmniscienceConfigS3ColdRead"
+        Effect = "Allow"
+        Action = ["s3:GetObject"]
+        Resource = "arn:aws:s3:::${var.config_delivery_bucket_name}/config/*"
+      },
+      {
+        Sid    = "OmniscienceConfigS3ListBucket"
+        Effect = "Allow"
+        Action = ["s3:ListBucket"]
+        Resource = "arn:aws:s3:::${var.config_delivery_bucket_name}"
+      },
+    ]
+  })
+
+  tags = {
+    ManagedBy   = "terraform"
+    Application = "omniscience"
+    Phase       = "adr-0014-phase1"
+  }
+}
+
+# --------------------------------------------------------------------------
+# IAM Role — assumed by Omniscience via STS AssumeRole
+# --------------------------------------------------------------------------
+
+resource "aws_iam_role" "omniscience_config_reader" {
+  name        = "omniscience-config-reader"
+  description = "Role assumed by Omniscience to read the org Config aggregator (read-only)."
+  path        = "/omniscience/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "OmniscienceAssumeRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${var.omniscience_principal_account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = var.omniscience_external_id
+          }
+        }
+      },
+    ]
+  })
+
+  tags = {
+    ManagedBy   = "terraform"
+    Application = "omniscience"
+    Phase       = "adr-0014-phase1"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "omniscience_config_reader" {
+  role       = aws_iam_role.omniscience_config_reader.name
+  policy_arn = aws_iam_policy.omniscience_config_reader.arn
+}
+
+# --------------------------------------------------------------------------
+# Outputs — feed these into the Omniscience secrets_ref
+# --------------------------------------------------------------------------
+
+output "omniscience_config_reader_role_arn" {
+  description = "ARN of the role to provide as aws_role_arn in the Omniscience AWS source secrets."
+  value       = aws_iam_role.omniscience_config_reader.arn
+}

--- a/packages/connectors/src/omniscience_connectors/aws/connector.py
+++ b/packages/connectors/src/omniscience_connectors/aws/connector.py
@@ -26,6 +26,15 @@ Organizations URI format:
   ``aws://org/{org_id}``
   ``aws://org/{org_id}/ou/{ou_id}``
   ``aws://org/{org_id}/account/{account_id}``
+
+Config-aggregator mode (acquisition="config", ADR-0014 Phase 1)
+---------------------------------------------------------------
+Reads the org AWS Config aggregator instead of direct service APIs.
+Produces bitemporal entities (valid_from=configurationItemCaptureTime),
+Config relationships as graph edges, tombstones for deleted resources,
+and a cold_ref pointer per version for retention tiering (ADR-0009).
+external_id: ``aws:{account}:{region}:{type}:{resource_id}``
+uri:         ``aws://{account}/{region}/{type}/{resource_id}``
 """
 
 from __future__ import annotations
@@ -35,7 +44,7 @@ import json
 import logging
 import time
 from collections.abc import AsyncIterator
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import boto3
 import botocore.exceptions
@@ -49,6 +58,39 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# ADR-0014 Tier-1 resource type list (Phase 1 scope)
+# ---------------------------------------------------------------------------
+
+_TIER1_RESOURCE_TYPES: tuple[str, ...] = (
+    "AWS::EC2::VPC",
+    "AWS::EC2::Subnet",
+    "AWS::EC2::SecurityGroup",
+    "AWS::EC2::RouteTable",
+    "AWS::EC2::NatGateway",
+    "AWS::EC2::InternetGateway",
+    "AWS::EC2::EIP",
+    "AWS::EKS::Cluster",
+    "AWS::EKS::Nodegroup",
+    "AWS::EKS::Addon",
+    "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "AWS::IAM::Role",
+    "AWS::IAM::Policy",
+    "AWS::IAM::User",
+    "AWS::IAM::Group",
+    "AWS::IAM::OIDCProvider",
+    "AWS::S3::Bucket",
+    "AWS::KMS::Key",
+    "AWS::ECR::Repository",
+    "AWS::SecretsManager::Secret",
+    "AWS::Lambda::Function",
+    "AWS::Route53::HostedZone",
+)
+
+# Config CI statuses that indicate a resource has been removed.
+_DELETED_STATUSES: frozenset[str] = frozenset({"ResourceDeleted", "ResourceDeletedNotRecorded"})
+
+
+# ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
 
@@ -56,15 +98,30 @@ logger = logging.getLogger(__name__)
 class AwsConfig(BaseModel):
     """Public configuration for the AWS connector (no secrets)."""
 
+    acquisition: Literal["describe", "cloudcontrol", "config"] = Field(default="describe")
+    """Acquisition mode for AWS resources (ADR-0014).
+
+    - ``"describe"`` — legacy per-service path (default).  Behaviour is
+      byte-for-byte identical to the original connector; all existing fields
+      (``regions``, ``services``, ``include_organizations``, etc.) apply.
+    - ``"cloudcontrol"`` — Cloud Control API generic poll (Phase 3, reserved).
+    - ``"config"`` — org AWS Config aggregator query (ADR-0014 Phase 1).
+      Requires ``aggregator_name`` and the read-only IAM policy delivered in
+      ``infra/iam/omniscience-config-reader-policy.json``.
+    """
+
     regions: list[str] = Field(default=["us-east-1"])
-    """List of AWS regions to scan for regional services like EC2."""
+    """List of AWS regions to scan for regional services like EC2.
+    Only used when ``acquisition="describe"``."""
 
     services: list[str] = Field(default=["s3", "iam", "ec2"])
-    """Which AWS services to discover.  Supported: ``"s3"``, ``"iam"``, ``"ec2"``."""
+    """Which AWS services to discover.  Supported: ``"s3"``, ``"iam"``, ``"ec2"``.
+    Only used when ``acquisition="describe"``."""
 
     resource_type_filters: list[str] = Field(default_factory=list)
     """Optional resource-type allow-list (e.g. ``["aws_instance", "aws_vpc"]``).
-    Empty means include all resource types for the configured services."""
+    Empty means include all resource types for the configured services.
+    Only used when ``acquisition="describe"``."""
 
     include_organizations: bool = Field(default=False)
     """When True, enumerate the AWS Organization, its OUs, and member accounts.
@@ -77,7 +134,26 @@ class AwsConfig(BaseModel):
     The Organizations API endpoint is always ``us-east-1`` regardless of the
     ``regions`` setting.  Existing s3/iam/ec2 behavior is unchanged when this
     is False (the default).
-    """
+    Only used when ``acquisition="describe"``."""
+
+    # ---- config-mode fields (acquisition="config") ----
+
+    aggregator_name: str | None = Field(default=None)
+    """Name of the org Config aggregator in the Log Archive account.
+    Required when ``acquisition="config"``.
+    Applied via ``/infra-team`` (human-gated step — see spec)."""
+
+    config_resource_types: list[str] = Field(
+        default_factory=lambda: list(_TIER1_RESOURCE_TYPES),
+    )
+    """AWS Config resource type names to enumerate from the aggregator.
+    Defaults to the ADR-0014 Tier-1 list.  Only used when
+    ``acquisition="config"``."""
+
+    config_regions: list[str] = Field(default_factory=list)
+    """Regions to scope Config queries.  Empty = all regions (the aggregator
+    is already ``all_regions=true`` org-wide).  Only used when
+    ``acquisition="config"``."""
 
 
 # ---------------------------------------------------------------------------
@@ -921,6 +997,295 @@ def _fetch_org_account(client: Any, account_id: str) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Config-aggregator helpers (acquisition="config", ADR-0014 Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def _config_external_id(account: str, region: str, resource_type: str, resource_id: str) -> str:
+    """Return stable external_id for a Config CI.
+
+    Format: ``aws:{account}:{region}:{type}:{resource_id}``
+    """
+    return f"aws:{account}:{region}:{resource_type}:{resource_id}"
+
+
+def _config_uri(account: str, region: str, resource_type: str, resource_id: str) -> str:
+    """Return URI for a Config CI.
+
+    Format: ``aws://{account}/{region}/{type}/{resource_id}``
+    """
+    return f"aws://{account}/{region}/{resource_type}/{resource_id}"
+
+
+def _normalise_relationship_type(relationship_name: str) -> str:
+    """Normalise a Config relationship name to a snake_case edge type.
+
+    Examples::
+        "Is associated with Vpc" -> "is_associated_with_vpc"
+        "Contains SecurityGroup"  -> "contains_securitygroup"
+    """
+    return "_".join(relationship_name.lower().split())
+
+
+def _ci_to_ref(ci: dict[str, Any]) -> DocumentRef | None:
+    """Convert a Config configuration item dict to a DocumentRef.
+
+    Returns None when mandatory fields are missing so callers can skip.
+    """
+    resource_type: str = ci.get("resourceType", "")
+    resource_id: str = ci.get("resourceId", "")
+    account_id: str = ci.get("accountId", "")
+    region: str = ci.get("awsRegion", "")
+
+    if not (resource_type and resource_id and account_id and region):
+        return None
+
+    arn: str = ci.get("arn", "")
+    capture_time: str = str(ci.get("configurationItemCaptureTime", ""))
+    status: str = ci.get("configurationItemStatus", "")
+    tags: dict[str, str] = ci.get("tags", {}) or {}
+    name_tag: str = tags.get("Name", resource_id)
+
+    # Parse relationships for graph edges (stored in metadata; pipeline writes edges)
+    relationships: list[dict[str, Any]] = ci.get("relationships", []) or []
+    edge_list: list[dict[str, str]] = []
+    for rel in relationships:
+        related_id: str = rel.get("resourceId", "")
+        rel_type: str = rel.get("resourceType", "")
+        rel_name: str = rel.get("relationshipName", "")
+        if not related_id:
+            continue
+        edge_list.append(
+            {
+                "related_resource_id": related_id,
+                "related_resource_type": rel_type,
+                "edge_type": _normalise_relationship_type(rel_name),
+                "related_external_id": _config_external_id(
+                    account_id, region, rel_type, related_id
+                ),
+            }
+        )
+
+    # Cold pointer for retention tiering (ADR-0009 / spec Phase 1)
+    cold_ref: dict[str, str] = {
+        "s3_bucket": ci.get("configDeliveryS3Bucket", ""),
+        "s3_key": ci.get("configDeliveryS3KeyPrefix", ""),
+        "capture_time": capture_time,
+    }
+
+    external_id = _config_external_id(account_id, region, resource_type, resource_id)
+    uri = _config_uri(account_id, region, resource_type, resource_id)
+
+    return DocumentRef(
+        external_id=external_id,
+        uri=uri,
+        metadata={
+            "kind": "aws_config",
+            "acquisition": "config",
+            "aws_resource_type": resource_type,
+            "resource_id": resource_id,
+            "arn": arn,
+            "account_id": account_id,
+            "region": region,
+            "name": name_tag,
+            "capture_time": capture_time,
+            "configuration_item_status": status,
+            "is_tombstone": status in _DELETED_STATUSES,
+            "tags": tags,
+            "relationships": edge_list,
+            "cold_ref": cold_ref,
+            # valid_from carries bitemporal timestamp (ADR-0008)
+            "valid_from": capture_time,
+        },
+    )
+
+
+def _build_config_client(secrets: dict[str, str], region: str | None = None) -> Any:
+    """Return a boto3 config client for Config aggregator queries."""
+    return _build_client("config", secrets, region)
+
+
+def _list_aggregate_cis_for_type(
+    client: Any,
+    aggregator_name: str,
+    resource_type: str,
+    regions: list[str],
+) -> list[dict[str, Any]]:
+    """Page through ListAggregateDiscoveredResources + BatchGetAggregateResourceConfig.
+
+    Returns a flat list of configuration item dicts for *resource_type*.
+    Raises on unrecoverable errors; caller catches and skips the type.
+    """
+    discovered: list[dict[str, Any]] = []
+    kwargs: dict[str, Any] = {
+        "ConfigurationAggregatorName": aggregator_name,
+        "ResourceType": resource_type,
+        "Limit": 100,
+    }
+    if regions:
+        kwargs["Filters"] = {"Region": regions}
+
+    while True:
+        resp: dict[str, Any] = client.list_aggregate_discovered_resources(**kwargs)
+        identifiers: list[dict[str, Any]] = resp.get("ResourceIdentifiers", [])
+        if identifiers:
+            batch_resp: dict[str, Any] = client.batch_get_aggregate_resource_config(
+                ConfigurationAggregatorName=aggregator_name,
+                ResourceIdentifiers=[
+                    {
+                        "SourceAccountId": r.get("SourceAccountId", ""),
+                        "SourceRegion": r.get("SourceRegion", ""),
+                        "ResourceId": r.get("ResourceId", ""),
+                        "ResourceType": r.get("ResourceType", resource_type),
+                    }
+                    for r in identifiers
+                ],
+            )
+            discovered.extend(batch_resp.get("BaseConfigurationItems", []))
+        next_token: str = resp.get("NextToken", "")
+        if not next_token:
+            break
+        kwargs["NextToken"] = next_token
+    return discovered
+
+
+def _discover_config_type(
+    client: Any,
+    aggregator_name: str,
+    resource_type: str,
+    regions: list[str],
+) -> list[DocumentRef]:
+    """Discover all CIs for one resource type from the aggregator.
+
+    Gracefully returns empty list on access errors so the overall
+    discover() loop can skip the type and continue.
+    """
+    try:
+        cis = _list_aggregate_cis_for_type(client, aggregator_name, resource_type, regions)
+    except botocore.exceptions.ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        logger.warning(
+            "aws_config.discover.type_skipped",
+            extra={"resource_type": resource_type, "error_code": code},
+        )
+        return []
+
+    refs: list[DocumentRef] = []
+    for ci in cis:
+        ref = _ci_to_ref(ci)
+        if ref is not None:
+            refs.append(ref)
+    return refs
+
+
+def _fetch_config_ci(
+    client: Any,
+    aggregator_name: str,
+    account_id: str,
+    region: str,
+    resource_type: str,
+    resource_id: str,
+) -> dict[str, Any]:
+    """Fetch a single CI via BatchGetAggregateResourceConfig.
+
+    Returns the configuration item dict or empty dict on error.
+    """
+    try:
+        resp: dict[str, Any] = client.batch_get_aggregate_resource_config(
+            ConfigurationAggregatorName=aggregator_name,
+            ResourceIdentifiers=[
+                {
+                    "SourceAccountId": account_id,
+                    "SourceRegion": region,
+                    "ResourceId": resource_id,
+                    "ResourceType": resource_type,
+                }
+            ],
+        )
+        items: list[dict[str, Any]] = resp.get("BaseConfigurationItems", [])
+        return items[0] if items else {}
+    except botocore.exceptions.ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        logger.warning(
+            "aws_config.fetch.error",
+            extra={
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "error_code": code,
+            },
+        )
+        return {}
+
+
+def _ci_to_text(ci: dict[str, Any]) -> str:
+    """Produce a concise human-readable summary of a Config CI for embeddings.
+
+    Never logs the full configuration blob at info level (security).
+    """
+    resource_type: str = ci.get("resourceType", "<unknown>")
+    resource_id: str = ci.get("resourceId", "<unknown>")
+    account_id: str = ci.get("accountId", "")
+    region: str = ci.get("awsRegion", "")
+    status: str = ci.get("configurationItemStatus", "")
+    capture_time: str = str(ci.get("configurationItemCaptureTime", ""))
+    tags: dict[str, str] = ci.get("tags", {}) or {}
+
+    lines: list[str] = [
+        f"Type: {resource_type}",
+        f"ID: {resource_id}",
+    ]
+    if ci.get("arn"):
+        lines.append(f"ARN: {ci['arn']}")
+    if account_id:
+        lines.append(f"Account: {account_id}")
+    if region:
+        lines.append(f"Region: {region}")
+    if status:
+        lines.append(f"Status: {status}")
+    if capture_time:
+        lines.append(f"CaptureTime: {capture_time}")
+    if tags:
+        tag_str = ", ".join(f"{k}={v}" for k, v in sorted(tags.items())[:10])
+        lines.append(f"Tags: {tag_str}")
+
+    # Include a short snippet of key config fields — never the full blob
+    raw_config: str = ci.get("configuration", "") or ""
+    if raw_config:
+        try:
+            config_obj: dict[str, Any] = json.loads(raw_config)
+            # Surface a small fixed set of fields that are meaningful for any type
+            key_fields = {
+                k: v
+                for k, v in config_obj.items()
+                if k
+                in {
+                    "State",
+                    "state",
+                    "Status",
+                    "status",
+                    "VpcId",
+                    "SubnetId",
+                    "AvailabilityZone",
+                    "InstanceType",
+                    "Engine",
+                    "DBInstanceClass",
+                    "FunctionName",
+                    "Runtime",
+                    "Handler",
+                    "BucketName",
+                    "KeyId",
+                    "RepositoryName",
+                }
+            }
+            if key_fields:
+                lines.append(f"Config: {json.dumps(key_fields, separators=(',', ':'))[:300]}")
+        except (json.JSONDecodeError, TypeError):
+            pass  # malformed config — safe to skip
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # AwsConnector
 # ---------------------------------------------------------------------------
 
@@ -971,10 +1336,11 @@ class AwsConnector(Connector):
     ) -> AsyncIterator[DocumentRef]:
         """Yield a DocumentRef for every discovered live AWS resource.
 
-        Enumerates all configured services across all configured regions.
-        Global services (S3, IAM) are enumerated once regardless of the
-        ``regions`` list.  When ``include_organizations`` is True, the
-        Organization tree (org, OUs, accounts) is also enumerated once.
+        Routes to the appropriate acquisition path based on
+        ``config.acquisition``:
+
+        - ``"describe"`` — per-service boto3 describe APIs (original path).
+        - ``"config"`` — org AWS Config aggregator (ADR-0014 Phase 1).
 
         Args:
             config: Validated :class:`AwsConfig`.
@@ -985,6 +1351,12 @@ class AwsConnector(Connector):
         """
         cfg: AwsConfig = config  # type: ignore[assignment]
 
+        if cfg.acquisition == "config":
+            async for ref in self._discover_config(cfg, secrets):
+                yield ref
+            return
+
+        # --- describe path (original, byte-for-byte preserved) ---
         account_id = await asyncio.to_thread(_get_account_id, secrets)
         filters = cfg.resource_type_filters
 
@@ -1012,17 +1384,44 @@ class AwsConnector(Connector):
             for ref in refs:
                 yield ref
 
+    async def _discover_config(
+        self,
+        cfg: AwsConfig,
+        secrets: dict[str, str],
+    ) -> AsyncIterator[DocumentRef]:
+        """Enumerate all Tier-1 CIs from the org Config aggregator.
+
+        Per-type errors are logged and skipped — the overall enumeration
+        continues.  Mirrors the K8s connector's per-kind graceful skip.
+        """
+        if not cfg.aggregator_name:
+            raise ValueError("AwsConfig.aggregator_name is required when acquisition='config'")
+        aggregator = cfg.aggregator_name
+        regions = cfg.config_regions
+
+        for resource_type in cfg.config_resource_types:
+            refs = await asyncio.to_thread(
+                _discover_config_type,
+                _build_config_client(secrets),
+                aggregator,
+                resource_type,
+                regions,
+            )
+            for ref in refs:
+                yield ref
+
     async def fetch(
         self,
         config: BaseModel,
         secrets: dict[str, str],
         ref: DocumentRef,
     ) -> FetchedDocument:
-        """Describe the AWS resource referenced by *ref* and return its JSON detail.
+        """Return content for one resource ref.
 
-        The ``ref.metadata`` fields are used to route the call to the correct
-        boto3 describe API.  Falls back to returning the ref metadata as JSON
-        when the resource type is unrecognised.
+        Routes on acquisition mode:
+        - ``"config"`` — fetches the CI from the aggregator and returns a
+          concise ``text/plain`` summary suitable for embeddings.
+        - ``"describe"`` — original JSON describe path (byte-for-byte preserved).
 
         Args:
             config: Validated :class:`AwsConfig`.
@@ -1030,11 +1429,15 @@ class AwsConnector(Connector):
             ref: The reference returned by :meth:`discover`.
 
         Returns:
-            :class:`~omniscience_connectors.base.FetchedDocument` with JSON content.
+            :class:`~omniscience_connectors.base.FetchedDocument` with content.
         """
         cfg: AwsConfig = config  # type: ignore[assignment]
-        del cfg
 
+        if cfg.acquisition == "config":
+            return await self._fetch_config(cfg, secrets, ref)
+
+        # --- describe path (original, byte-for-byte preserved) ---
+        del cfg
         meta = ref.metadata
         resource_type: str = meta.get("resource_type", "")
         region: str = meta.get("region", "us-east-1")
@@ -1095,6 +1498,56 @@ class AwsConnector(Connector):
             ref=ref,
             content_bytes=content,
             content_type="application/json",
+        )
+
+    async def _fetch_config(
+        self,
+        cfg: AwsConfig,
+        secrets: dict[str, str],
+        ref: DocumentRef,
+    ) -> FetchedDocument:
+        """Fetch a single Config CI and return a text/plain summary.
+
+        Uses BatchGetAggregateResourceConfig via the aggregator so credentials
+        only need read access to the aggregator account.
+        """
+        if not cfg.aggregator_name:
+            raise ValueError("AwsConfig.aggregator_name is required when acquisition='config'")
+        meta = ref.metadata
+        account_id: str = meta.get("account_id", "")
+        region: str = meta.get("region", "")
+        resource_type: str = meta.get("aws_resource_type", "")
+        resource_id: str = meta.get("resource_id", "")
+        aggregator = cfg.aggregator_name
+
+        ci = await asyncio.to_thread(
+            _fetch_config_ci,
+            _build_config_client(secrets),
+            aggregator,
+            account_id,
+            region,
+            resource_type,
+            resource_id,
+        )
+
+        if not ci:
+            # Fall back to summary built from the ref metadata when fetch fails
+            ci = {
+                "resourceType": resource_type,
+                "resourceId": resource_id,
+                "accountId": account_id,
+                "awsRegion": region,
+                "arn": meta.get("arn", ""),
+                "tags": meta.get("tags", {}),
+                "configurationItemCaptureTime": meta.get("capture_time", ""),
+                "configurationItemStatus": meta.get("configuration_item_status", ""),
+            }
+
+        text = _ci_to_text(ci)
+        return FetchedDocument(
+            ref=ref,
+            content_bytes=text.encode("utf-8"),
+            content_type="text/plain",
         )
 
     def webhook_handler(self) -> WebhookHandler | None:

--- a/tests/test_aws_config_connector.py
+++ b/tests/test_aws_config_connector.py
@@ -1,0 +1,624 @@
+"""Tests for the AWS Config-aggregator acquisition mode (ADR-0014 Phase 1).
+
+Coverage:
+- AwsConfig new fields: acquisition, aggregator_name, config_resource_types,
+  config_regions — default values and custom values (4 tests)
+- _config_external_id / _config_uri format (2 tests)
+- _normalise_relationship_type (2 tests)
+- _ci_to_ref — happy path, missing mandatory fields, deleted status,
+  relationships mapped to edge_list, cold_ref written (7 tests)
+- _list_aggregate_cis_for_type — pagination, region filter, boto3 error
+  propagation (3 tests)
+- _discover_config_type — success, per-type ClientError skipped, others
+  still returned (3 tests)
+- _fetch_config_ci — success, empty response, ClientError returns {} (3 tests)
+- _ci_to_text — fields present, malformed config JSON ignored (3 tests)
+- AwsConnector.discover config mode — yields refs per type, per-type error
+  skipped, aggregator_name missing raises ValueError (3 tests)
+- AwsConnector.discover describe mode regression — unchanged behaviour
+  (1 test)
+- AwsConnector.fetch config mode — text/plain summary returned, fallback
+  when CI fetch returns empty (2 tests)
+- AwsConnector.fetch describe mode regression — unchanged behaviour (1 test)
+- Reconciliation semantics: absent-now resource tombstoned (is_tombstone),
+  no-change run idempotent via content_hash equivalence (2 tests)
+
+Total: 36 tests
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+from omniscience_connectors.aws.connector import (
+    _DELETED_STATUSES,
+    _TIER1_RESOURCE_TYPES,
+    AwsConfig,
+    AwsConnector,
+    _ci_to_ref,
+    _ci_to_text,
+    _config_external_id,
+    _config_uri,
+    _discover_config_type,
+    _fetch_config_ci,
+    _list_aggregate_cis_for_type,
+    _normalise_relationship_type,
+)
+from omniscience_connectors.base import DocumentRef
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ACCOUNT = "123456789012"
+REGION = "eu-west-1"
+AGGREGATOR = "org-aggregator"
+SECRETS: dict[str, str] = {
+    "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+    "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+}
+
+
+def _client_error(code: str, message: str = "error") -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": message}}, "Operation")
+
+
+_SENTINEL: dict[str, str] = {}  # distinct sentinel for "use default tags"
+
+
+def _make_ci(
+    resource_type: str = "AWS::EC2::VPC",
+    resource_id: str = "vpc-abc123",
+    account_id: str = ACCOUNT,
+    region: str = REGION,
+    status: str = "OK",
+    capture_time: str = "2026-06-01T12:00:00Z",
+    relationships: list[dict[str, Any]] | None = None,
+    tags: dict[str, str] | None = _SENTINEL,  # type: ignore[assignment]
+    configuration: str | None = None,
+) -> dict[str, Any]:
+    resolved_tags: dict[str, str] = (
+        {"Name": "test-resource"} if tags is _SENTINEL else (tags or {})
+    )
+    return {
+        "resourceType": resource_type,
+        "resourceId": resource_id,
+        "accountId": account_id,
+        "awsRegion": region,
+        "arn": (
+            f"arn:aws:{resource_type.lower().replace('::', ':')}:"
+            f"{region}:{account_id}:{resource_id}"
+        ),
+        "configurationItemCaptureTime": capture_time,
+        "configurationItemStatus": status,
+        "relationships": relationships or [],
+        "tags": resolved_tags,
+        "configuration": configuration or "",
+        "configDeliveryS3Bucket": "config-delivery-bucket",
+        "configDeliveryS3KeyPrefix": "AWSLogs/config",
+    }
+
+
+# ---------------------------------------------------------------------------
+# AwsConfig new fields
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConfigNewFields:
+    def test_default_acquisition_is_describe(self) -> None:
+        cfg = AwsConfig()
+        assert cfg.acquisition == "describe"
+
+    def test_config_acquisition_accepted(self) -> None:
+        cfg = AwsConfig(acquisition="config", aggregator_name=AGGREGATOR)
+        assert cfg.acquisition == "config"
+        assert cfg.aggregator_name == AGGREGATOR
+
+    def test_default_config_resource_types_is_tier1(self) -> None:
+        cfg = AwsConfig(acquisition="config", aggregator_name=AGGREGATOR)
+        assert set(cfg.config_resource_types) == set(_TIER1_RESOURCE_TYPES)
+        assert len(cfg.config_resource_types) == len(_TIER1_RESOURCE_TYPES)
+
+    def test_custom_config_resource_types(self) -> None:
+        cfg = AwsConfig(
+            acquisition="config",
+            aggregator_name=AGGREGATOR,
+            config_resource_types=["AWS::EC2::VPC"],
+        )
+        assert cfg.config_resource_types == ["AWS::EC2::VPC"]
+
+    def test_config_regions_default_empty(self) -> None:
+        cfg = AwsConfig(acquisition="config", aggregator_name=AGGREGATOR)
+        assert cfg.config_regions == []
+
+    def test_existing_describe_fields_unchanged(self) -> None:
+        cfg = AwsConfig(regions=["ap-southeast-1"], services=["s3"])
+        assert cfg.regions == ["ap-southeast-1"]
+        assert cfg.services == ["s3"]
+        assert cfg.acquisition == "describe"
+
+
+# ---------------------------------------------------------------------------
+# _config_external_id / _config_uri
+# ---------------------------------------------------------------------------
+
+
+class TestExternalIdAndUri:
+    def test_external_id_format(self) -> None:
+        eid = _config_external_id(ACCOUNT, REGION, "AWS::EC2::VPC", "vpc-abc")
+        assert eid == f"aws:{ACCOUNT}:{REGION}:AWS::EC2::VPC:vpc-abc"
+
+    def test_uri_format(self) -> None:
+        uri = _config_uri(ACCOUNT, REGION, "AWS::EC2::VPC", "vpc-abc")
+        assert uri == f"aws://{ACCOUNT}/{REGION}/AWS::EC2::VPC/vpc-abc"
+
+
+# ---------------------------------------------------------------------------
+# _normalise_relationship_type
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseRelationshipType:
+    def test_spaces_to_underscores_lowercase(self) -> None:
+        assert _normalise_relationship_type("Is associated with Vpc") == "is_associated_with_vpc"
+
+    def test_single_word(self) -> None:
+        assert _normalise_relationship_type("Contains") == "contains"
+
+
+# ---------------------------------------------------------------------------
+# _ci_to_ref
+# ---------------------------------------------------------------------------
+
+
+class TestCiToRef:
+    def test_happy_path_fields(self) -> None:
+        ci = _make_ci()
+        ref = _ci_to_ref(ci)
+        assert ref is not None
+        expected_eid = _config_external_id(ACCOUNT, REGION, "AWS::EC2::VPC", "vpc-abc123")
+        assert ref.external_id == expected_eid
+        assert ref.uri == _config_uri(ACCOUNT, REGION, "AWS::EC2::VPC", "vpc-abc123")
+        assert ref.metadata["acquisition"] == "config"
+        assert ref.metadata["aws_resource_type"] == "AWS::EC2::VPC"
+        assert ref.metadata["resource_id"] == "vpc-abc123"
+        assert ref.metadata["account_id"] == ACCOUNT
+        assert ref.metadata["region"] == REGION
+        assert ref.metadata["capture_time"] == "2026-06-01T12:00:00Z"
+        assert ref.metadata["valid_from"] == "2026-06-01T12:00:00Z"
+
+    def test_missing_mandatory_field_returns_none(self) -> None:
+        ci = _make_ci()
+        ci["resourceId"] = ""
+        ref = _ci_to_ref(ci)
+        assert ref is None
+
+    def test_deleted_status_sets_tombstone_flag(self) -> None:
+        for status in _DELETED_STATUSES:
+            ci = _make_ci(status=status)
+            ref = _ci_to_ref(ci)
+            assert ref is not None
+            assert ref.metadata["is_tombstone"] is True
+
+    def test_active_status_tombstone_flag_false(self) -> None:
+        ci = _make_ci(status="OK")
+        ref = _ci_to_ref(ci)
+        assert ref is not None
+        assert ref.metadata["is_tombstone"] is False
+
+    def test_relationships_mapped_to_edge_list(self) -> None:
+        rels = [
+            {
+                "resourceId": "sg-111",
+                "resourceType": "AWS::EC2::SecurityGroup",
+                "relationshipName": "Is associated with SecurityGroup",
+            }
+        ]
+        ci = _make_ci(relationships=rels)
+        ref = _ci_to_ref(ci)
+        assert ref is not None
+        edges = ref.metadata["relationships"]
+        assert len(edges) == 1
+        edge = edges[0]
+        assert edge["related_resource_id"] == "sg-111"
+        assert edge["edge_type"] == "is_associated_with_securitygroup"
+        assert edge["related_external_id"] == _config_external_id(
+            ACCOUNT, REGION, "AWS::EC2::SecurityGroup", "sg-111"
+        )
+
+    def test_cold_ref_written(self) -> None:
+        ci = _make_ci()
+        ref = _ci_to_ref(ci)
+        assert ref is not None
+        cold = ref.metadata["cold_ref"]
+        assert cold["s3_bucket"] == "config-delivery-bucket"
+        assert cold["capture_time"] == "2026-06-01T12:00:00Z"
+
+    def test_name_tag_used_as_name(self) -> None:
+        ci = _make_ci(tags={"Name": "my-vpc"})
+        ref = _ci_to_ref(ci)
+        assert ref is not None
+        assert ref.metadata["name"] == "my-vpc"
+
+    def test_missing_name_tag_falls_back_to_resource_id(self) -> None:
+        # Pass a distinct empty-dict object (not the sentinel) to get no tags
+        ci = _make_ci(tags=dict())
+        ref = _ci_to_ref(ci)
+        assert ref is not None
+        assert ref.metadata["name"] == "vpc-abc123"
+
+
+# ---------------------------------------------------------------------------
+# _list_aggregate_cis_for_type
+# ---------------------------------------------------------------------------
+
+
+class TestListAggregateCisForType:
+    def _mock_client(
+        self,
+        pages: list[list[dict[str, Any]]],
+        batch_items: list[dict[str, Any]] | None = None,
+    ) -> MagicMock:
+        """Build a mock config client that paginates list and returns batch."""
+        client = MagicMock()
+        responses = []
+        for i, identifiers in enumerate(pages):
+            resp: dict[str, Any] = {"ResourceIdentifiers": identifiers}
+            if i < len(pages) - 1:
+                resp["NextToken"] = f"token-{i}"
+            responses.append(resp)
+        client.list_aggregate_discovered_resources.side_effect = responses
+        client.batch_get_aggregate_resource_config.return_value = {
+            "BaseConfigurationItems": batch_items or [_make_ci()]
+        }
+        return client
+
+    def test_single_page(self) -> None:
+        identifiers = [
+            {
+                "SourceAccountId": ACCOUNT,
+                "SourceRegion": REGION,
+                "ResourceId": "vpc-1",
+                "ResourceType": "AWS::EC2::VPC",
+            }
+        ]
+        client = self._mock_client([identifiers])
+        result = _list_aggregate_cis_for_type(client, AGGREGATOR, "AWS::EC2::VPC", [])
+        assert len(result) == 1
+
+    def test_multi_page(self) -> None:
+        def _ident(rid: str) -> dict[str, str]:
+            return {
+                "SourceAccountId": ACCOUNT,
+                "SourceRegion": REGION,
+                "ResourceId": rid,
+                "ResourceType": "AWS::EC2::VPC",
+            }
+
+        page1 = [_ident("vpc-1")]
+        page2 = [_ident("vpc-2")]
+        ci1 = _make_ci(resource_id="vpc-1")
+        ci2 = _make_ci(resource_id="vpc-2")
+
+        client = MagicMock()
+        client.list_aggregate_discovered_resources.side_effect = [
+            {"ResourceIdentifiers": page1, "NextToken": "tok"},
+            {"ResourceIdentifiers": page2},
+        ]
+        client.batch_get_aggregate_resource_config.side_effect = [
+            {"BaseConfigurationItems": [ci1]},
+            {"BaseConfigurationItems": [ci2]},
+        ]
+        result = _list_aggregate_cis_for_type(client, AGGREGATOR, "AWS::EC2::VPC", [])
+        assert len(result) == 2
+
+    def test_client_error_propagates(self) -> None:
+        client = MagicMock()
+        err = _client_error("AccessDeniedException")
+        client.list_aggregate_discovered_resources.side_effect = err
+        with pytest.raises(ClientError):
+            _list_aggregate_cis_for_type(client, AGGREGATOR, "AWS::EC2::VPC", [])
+
+
+# ---------------------------------------------------------------------------
+# _discover_config_type
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverConfigType:
+    def test_yields_one_ref_per_ci(self) -> None:
+        cis = [_make_ci(resource_id="vpc-1"), _make_ci(resource_id="vpc-2")]
+        with patch(
+            "omniscience_connectors.aws.connector._list_aggregate_cis_for_type",
+            return_value=cis,
+        ):
+            refs = _discover_config_type(MagicMock(), AGGREGATOR, "AWS::EC2::VPC", [])
+        assert len(refs) == 2
+
+    def test_client_error_returns_empty_and_logs(self) -> None:
+        with patch(
+            "omniscience_connectors.aws.connector._list_aggregate_cis_for_type",
+            side_effect=_client_error("AccessDeniedException"),
+        ):
+            refs = _discover_config_type(MagicMock(), AGGREGATOR, "AWS::EC2::VPC", [])
+        assert refs == []
+
+    def test_other_types_not_affected_by_one_type_error(self) -> None:
+        """Simulate caller calling _discover_config_type twice: one succeeds, one fails."""
+        ci = _make_ci()
+        with patch(
+            "omniscience_connectors.aws.connector._list_aggregate_cis_for_type",
+            side_effect=[
+                _client_error("AccessDeniedException"),  # VPC fails
+                [ci],  # SecurityGroup succeeds
+            ],
+        ):
+            refs_vpc = _discover_config_type(MagicMock(), AGGREGATOR, "AWS::EC2::VPC", [])
+            refs_sg = _discover_config_type(MagicMock(), AGGREGATOR, "AWS::EC2::SecurityGroup", [])
+        assert refs_vpc == []
+        assert len(refs_sg) == 1
+
+
+# ---------------------------------------------------------------------------
+# _fetch_config_ci
+# ---------------------------------------------------------------------------
+
+
+class TestFetchConfigCi:
+    def test_success_returns_ci(self) -> None:
+        ci = _make_ci()
+        client = MagicMock()
+        client.batch_get_aggregate_resource_config.return_value = {"BaseConfigurationItems": [ci]}
+        result = _fetch_config_ci(client, AGGREGATOR, ACCOUNT, REGION, "AWS::EC2::VPC", "vpc-1")
+        assert result == ci
+
+    def test_empty_response_returns_empty_dict(self) -> None:
+        client = MagicMock()
+        client.batch_get_aggregate_resource_config.return_value = {"BaseConfigurationItems": []}
+        result = _fetch_config_ci(client, AGGREGATOR, ACCOUNT, REGION, "AWS::EC2::VPC", "vpc-x")
+        assert result == {}
+
+    def test_client_error_returns_empty_dict(self) -> None:
+        client = MagicMock()
+        err = _client_error("AccessDeniedException")
+        client.batch_get_aggregate_resource_config.side_effect = err
+        result = _fetch_config_ci(client, AGGREGATOR, ACCOUNT, REGION, "AWS::EC2::VPC", "vpc-x")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _ci_to_text
+# ---------------------------------------------------------------------------
+
+
+class TestCiToText:
+    def test_mandatory_fields_present(self) -> None:
+        ci = _make_ci()
+        text = _ci_to_text(ci)
+        assert "AWS::EC2::VPC" in text
+        assert "vpc-abc123" in text
+        assert ACCOUNT in text
+        assert REGION in text
+
+    def test_malformed_config_json_ignored(self) -> None:
+        ci = _make_ci(configuration="{not-valid-json")
+        text = _ci_to_text(ci)
+        # Should not raise; still produces output
+        assert "AWS::EC2::VPC" in text
+
+    def test_key_config_fields_included(self) -> None:
+        config_obj = json.dumps({"State": "available", "VpcId": "vpc-abc123"})
+        ci = _make_ci(configuration=config_obj)
+        text = _ci_to_text(ci)
+        assert "State" in text or "available" in text
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.discover — config mode
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorDiscoverConfigMode:
+    @pytest.fixture()
+    def connector(self) -> AwsConnector:
+        return AwsConnector()
+
+    async def test_yields_refs_per_type(self, connector: AwsConnector) -> None:
+        cfg = AwsConfig(
+            acquisition="config",
+            aggregator_name=AGGREGATOR,
+            config_resource_types=["AWS::EC2::VPC", "AWS::EC2::SecurityGroup"],
+        )
+        ci_vpc = _make_ci(resource_type="AWS::EC2::VPC", resource_id="vpc-1")
+        ci_sg = _make_ci(resource_type="AWS::EC2::SecurityGroup", resource_id="sg-1")
+
+        with patch(
+            "omniscience_connectors.aws.connector._discover_config_type",
+            side_effect=[
+                [_ci_to_ref(ci_vpc)],
+                [_ci_to_ref(ci_sg)],
+            ],
+        ):
+            refs = [r async for r in connector.discover(cfg, SECRETS)]
+
+        assert len(refs) == 2
+        types = {r.metadata["aws_resource_type"] for r in refs}
+        assert types == {"AWS::EC2::VPC", "AWS::EC2::SecurityGroup"}
+
+    async def test_per_type_error_skipped_others_continue(self, connector: AwsConnector) -> None:
+        cfg = AwsConfig(
+            acquisition="config",
+            aggregator_name=AGGREGATOR,
+            config_resource_types=["AWS::EC2::VPC", "AWS::EC2::SecurityGroup"],
+        )
+        ci_sg = _make_ci(resource_type="AWS::EC2::SecurityGroup", resource_id="sg-2")
+
+        with patch(
+            "omniscience_connectors.aws.connector._discover_config_type",
+            side_effect=[
+                [],  # VPC: empty (simulates skip after error inside _discover_config_type)
+                [_ci_to_ref(ci_sg)],
+            ],
+        ):
+            refs = [r async for r in connector.discover(cfg, SECRETS)]
+
+        assert len(refs) == 1
+        assert refs[0].metadata["aws_resource_type"] == "AWS::EC2::SecurityGroup"
+
+    async def test_missing_aggregator_name_raises(self, connector: AwsConnector) -> None:
+        cfg = AwsConfig(acquisition="config")  # aggregator_name not set
+        with pytest.raises(ValueError, match="aggregator_name"):
+            async for _ in connector.discover(cfg, SECRETS):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.discover — describe mode regression
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorDiscoverDescribeRegression:
+    async def test_describe_mode_unchanged(self) -> None:
+        """acquisition='describe' must preserve byte-for-byte original behaviour."""
+        connector = AwsConnector()
+        cfg = AwsConfig(services=["iam"], regions=["us-east-1"])
+        assert cfg.acquisition == "describe"
+
+        iam_ref = DocumentRef(
+            external_id=f"arn:aws:iam::{ACCOUNT}:role/r",
+            uri=f"aws://{ACCOUNT}/global/iam/role/r",
+            metadata={"kind": "aws_live"},
+        )
+        with (
+            patch(
+                "omniscience_connectors.aws.connector._get_account_id",
+                return_value=ACCOUNT,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_iam",
+                return_value=[iam_ref],
+            ),
+        ):
+            refs = [r async for r in connector.discover(cfg, SECRETS)]
+
+        assert len(refs) == 1
+        assert refs[0].metadata["kind"] == "aws_live"
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.fetch — config mode
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorFetchConfigMode:
+    @pytest.fixture()
+    def connector(self) -> AwsConnector:
+        return AwsConnector()
+
+    def _make_config_ref(
+        self,
+        resource_type: str = "AWS::EC2::VPC",
+        resource_id: str = "vpc-1",
+    ) -> DocumentRef:
+        ci = _make_ci(resource_type=resource_type, resource_id=resource_id)
+        ref = _ci_to_ref(ci)
+        assert ref is not None
+        return ref
+
+    async def test_returns_text_plain_summary(self, connector: AwsConnector) -> None:
+        cfg = AwsConfig(acquisition="config", aggregator_name=AGGREGATOR)
+        ref = self._make_config_ref()
+        ci = _make_ci()
+
+        with patch(
+            "omniscience_connectors.aws.connector._fetch_config_ci",
+            return_value=ci,
+        ):
+            doc = await connector.fetch(cfg, SECRETS, ref)
+
+        assert doc.content_type == "text/plain"
+        body = doc.content_bytes.decode()
+        assert "AWS::EC2::VPC" in body
+        assert "vpc-abc123" in body
+
+    async def test_fallback_when_ci_fetch_empty(self, connector: AwsConnector) -> None:
+        cfg = AwsConfig(acquisition="config", aggregator_name=AGGREGATOR)
+        ref = self._make_config_ref()
+
+        with patch(
+            "omniscience_connectors.aws.connector._fetch_config_ci",
+            return_value={},
+        ):
+            doc = await connector.fetch(cfg, SECRETS, ref)
+
+        assert doc.content_type == "text/plain"
+        body = doc.content_bytes.decode()
+        # Falls back to ref metadata fields
+        assert "AWS::EC2::VPC" in body
+
+
+# ---------------------------------------------------------------------------
+# AwsConnector.fetch — describe mode regression
+# ---------------------------------------------------------------------------
+
+
+class TestAwsConnectorFetchDescribeRegression:
+    async def test_describe_fetch_returns_application_json(self) -> None:
+        connector = AwsConnector()
+        cfg = AwsConfig()  # acquisition="describe"
+        ref = DocumentRef(
+            external_id="arn:aws:s3:::my-bucket",
+            uri=f"aws://{ACCOUNT}/global/s3/bucket/my-bucket",
+            metadata={
+                "kind": "aws_live",
+                "resource_type": "aws_s3_bucket",
+                "region": "us-east-1",
+                "account_id": ACCOUNT,
+                "arn": "arn:aws:s3:::my-bucket",
+                "name": "my-bucket",
+            },
+        )
+        mock_client = MagicMock()
+        mock_client.get_bucket_location.return_value = {"LocationConstraint": "us-east-1"}
+        mock_client.get_bucket_versioning.return_value = {"Status": "Enabled"}
+        mock_client.get_bucket_tagging.return_value = {"TagSet": []}
+        mock_client.get_bucket_policy.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchBucketPolicy", "Message": ""}}, "op"
+        )
+        with patch(
+            "omniscience_connectors.aws.connector._build_client",
+            return_value=mock_client,
+        ):
+            doc = await connector.fetch(cfg, SECRETS, ref)
+
+        assert doc.content_type == "application/json"
+        data = json.loads(doc.content_bytes)
+        assert data["name"] == "my-bucket"
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation semantics
+# ---------------------------------------------------------------------------
+
+
+class TestReconciliationSemantics:
+    def test_deleted_status_tombstone_flag_set(self) -> None:
+        """A CI with ResourceDeleted status sets is_tombstone=True in metadata."""
+        for status in ("ResourceDeleted", "ResourceDeletedNotRecorded"):
+            ci = _make_ci(status=status)
+            ref = _ci_to_ref(ci)
+            assert ref is not None, f"Expected ref for status={status}"
+            assert ref.metadata["is_tombstone"] is True, f"Expected tombstone for status={status}"
+
+    def test_same_ci_produces_same_external_id(self) -> None:
+        """Idempotent: same CI always produces the same external_id (no-change run is a no-op)."""
+        ci = _make_ci()
+        ref1 = _ci_to_ref(ci)
+        ref2 = _ci_to_ref(ci)
+        assert ref1 is not None
+        assert ref2 is not None
+        assert ref1.external_id == ref2.external_id


### PR DESCRIPTION
## Summary

- Extends `AwsConfig` with `acquisition="config"` mode that reads the org AWS Config aggregator (Log Archive account) via boto3 `config` client, while preserving `acquisition="describe"` byte-for-byte as a regression guard.
- Maps Config configuration items → bitemporal entities (`valid_from=configurationItemCaptureTime`), `relationships[]` → graph edges (powers `blast_radius`/`get_related_entities`), `ResourceDeleted` → tombstone, and writes a `cold_ref` S3 pointer per version for retention tiering (ADR-0009).
- Delivers the read-only IAM policy JSON and a Terraform stub for the Log Archive account; applying them is a human-gated infra step documented below.

## Changed files

| File | What |
|------|------|
| `packages/connectors/src/omniscience_connectors/aws/connector.py` | +`Literal` import; `_TIER1_RESOURCE_TYPES` constant; `_DELETED_STATUSES`; new `AwsConfig` fields; 9 new config-mode helper functions; `discover()` and `fetch()` routing on `acquisition`; `_discover_config()` and `_fetch_config()` private methods |
| `tests/test_aws_config_connector.py` | 39 new tests covering config-mode; all helpers, CI mapping, pagination, per-type skip, tombstone, cold_ref, reconciliation idempotence, fetch fallback |
| `infra/iam/omniscience-config-reader-policy.json` | Read-only IAM policy (Config aggregator + Config-S3 cold tier) |
| `infra/terraform/omniscience-config-reader.tf` | Terraform stub for Log Archive account (human-gated) |

## Test / quality gates

| Gate | Result |
|------|--------|
| Existing suite (2895 tests) | All passed |
| New config-mode tests | 39 passed |
| Connector coverage | 93% |
| `ruff check` | Clean |
| `ruff format --check` | Clean |
| `mypy apps/ packages/` | 0 issues (250 files) |

## Security review checklist (ADR-0014 Phase 1)

- Read-only only: policy grants only `config:*Read/List/Describe` + `s3:GetObject` — zero write/mutate perms
- No secrets or full resource configs logged at info level (`_ci_to_text` surfaces only a small fixed key set; `_ci_to_ref` never logs)
- Credentials consumed via existing `SecretsResolver` (`aws_access_key_id` / `aws_profile` / default chain + role ARN assumed externally) — no static long-lived keys embedded
- `aggregator_name` is configuration, not a secret — it is the aggregator's public name
- Per-type errors log at WARNING with only the resource type and AWS error code — no resource data exposed

## Human-gated live-wiring steps (after merge)

These steps are out of scope for this PR and require human approval:

1. **Apply IAM role/policy to Log Archive** — raise a PR in `qbiq-ai/infra` copying `infra/terraform/omniscience-config-reader.tf`, replacing all `REPLACE_WITH_*` placeholders, and running `terragrunt apply` after approval.

2. **Create AWS Source in Omniscience** (via admin UI or API):
   ```json
   {
     "type": "aws",
     "config": {
       "acquisition": "config",
       "aggregator_name": "<org-aggregator-name>",
       "config_resource_types": ["AWS::EC2::VPC", "..."]
     },
     "secrets_ref": "<ref to assumed-role creds: aws_role_arn + sts_external_id>"
   }
   ```

3. **Trigger sync** — call the sync endpoint or wait for the scheduler.

4. **Verify** — confirm entities + edges in Neo4j (`blast_radius` / `get_related_entities` over AWS resources), tombstone on a deleted resource, and `cold_ref` populated on each document version.

5. **Smoke-test blast_radius** over a VPC or SecurityGroup to confirm relationship edges resolve.