### PR TITLE
chore: fix ruff format drift (worker.py, stats activity)

### DIFF
--- a/apps/server/src/omniscience_server/ingestion/worker.py
+++ b/apps/server/src/omniscience_server/ingestion/worker.py
@@ -471,9 +471,7 @@ class IngestionWorker:
         """
         async with self._session_factory() as session:
             await session.execute(
-                update(Source)
-                .where(Source.id == source_id)
-                .values(last_sync_at=datetime.now(UTC))
+                update(Source).where(Source.id == source_id).values(last_sync_at=datetime.now(UTC))
             )
             await session.commit()
 

--- a/packages/core/src/omniscience_core/stats/models.py
+++ b/packages/core/src/omniscience_core/stats/models.py
@@ -78,9 +78,7 @@ class ActivityResponse(BaseModel):
     updated: int = Field(
         ..., ge=0, description="Documents re-indexed (content changed) within the window."
     )
-    tombstoned: int = Field(
-        ..., ge=0, description="Documents soft-deleted within the window."
-    )
+    tombstoned: int = Field(..., ge=0, description="Documents soft-deleted within the window.")
     window_hours: int = Field(
         ..., ge=1, description="The time window in hours (echoed from the request)."
     )

--- a/tests/test_stats_activity.py
+++ b/tests/test_stats_activity.py
@@ -148,6 +148,7 @@ async def test_activity_service_issues_three_queries() -> None:
 @pytest.mark.asyncio
 async def test_activity_service_window_hours_echoed() -> None:
     """window_hours must be echoed back in the response."""
+
     async def _execute(stmt: Any) -> Any:
         result = MagicMock()
         result.scalar_one.return_value = 0
@@ -325,9 +326,7 @@ async def test_activity_default_24h() -> None:
     tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
 
     activity_response = ActivityResponse(new=5, updated=2, tombstoned=1, window_hours=24)
-    svc = _stub_stats_service_with_activity(
-        activity_fn=AsyncMock(return_value=activity_response)
-    )
+    svc = _stub_stats_service_with_activity(activity_fn=AsyncMock(return_value=activity_response))
     app = _build_app(token=tok, stats_service=svc)
 
     async with await _client_for(app) as client:
@@ -351,9 +350,7 @@ async def test_activity_7d_window() -> None:
     tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
 
     activity_response = ActivityResponse(new=120, updated=45, tombstoned=8, window_hours=168)
-    svc = _stub_stats_service_with_activity(
-        activity_fn=AsyncMock(return_value=activity_response)
-    )
+    svc = _stub_stats_service_with_activity(activity_fn=AsyncMock(return_value=activity_response))
     app = _build_app(token=tok, stats_service=svc)
 
     async with await _client_for(app) as client:
@@ -375,9 +372,7 @@ async def test_activity_30d_window() -> None:
     tok, pt = _make_token(["stats:read"], workspace_id=workspace_id)
 
     activity_response = ActivityResponse(new=500, updated=200, tombstoned=50, window_hours=720)
-    svc = _stub_stats_service_with_activity(
-        activity_fn=AsyncMock(return_value=activity_response)
-    )
+    svc = _stub_stats_service_with_activity(activity_fn=AsyncMock(return_value=activity_response))
     app = _build_app(token=tok, stats_service=svc)
 
     async with await _client_for(app) as client:


### PR DESCRIPTION
`ruff format --check .` was failing on main (3 files from #294/#296) → every PR shows lint red. Format-only, no logic change.