### PR TITLE
fix(aws): source_type enum migration + describe graceful per-service skip

### DIFF
--- a/packages/connectors/src/omniscience_connectors/aws/connector.py
+++ b/packages/connectors/src/omniscience_connectors/aws/connector.py
@@ -1356,33 +1356,57 @@ class AwsConnector(Connector):
                 yield ref
             return
 
-        # --- describe path (original, byte-for-byte preserved) ---
+        # --- describe path ---
+        # Each service block is isolated: an AccessDenied / SCP deny on one
+        # service (e.g. an org SCP blocking s3:ListAllMyBuckets) logs a warning
+        # and is skipped, so the remaining services still ingest.  Mirrors the
+        # per-kind graceful skip in the config path and the K8s connector.
         account_id = await asyncio.to_thread(_get_account_id, secrets)
         filters = cfg.resource_type_filters
 
         # Global services (no region iteration)
         if "s3" in cfg.services:
-            refs = await asyncio.to_thread(_discover_s3, secrets, account_id, filters)
-            for ref in refs:
+            for ref in await self._safe_discover("s3", _discover_s3, secrets, account_id, filters):
                 yield ref
 
         if "iam" in cfg.services:
-            refs = await asyncio.to_thread(_discover_iam, secrets, account_id, filters)
-            for ref in refs:
+            for ref in await self._safe_discover(
+                "iam", _discover_iam, secrets, account_id, filters
+            ):
                 yield ref
 
         # Regional services
         if "ec2" in cfg.services:
             for region in cfg.regions:
-                refs = await asyncio.to_thread(_discover_ec2, secrets, account_id, region, filters)
-                for ref in refs:
+                for ref in await self._safe_discover(
+                    f"ec2/{region}", _discover_ec2, secrets, account_id, region, filters
+                ):
                     yield ref
 
         # Organizations (opt-in, global)
         if cfg.include_organizations:
-            refs = await asyncio.to_thread(_discover_organizations, secrets, filters)
-            for ref in refs:
+            for ref in await self._safe_discover(
+                "organizations", _discover_organizations, secrets, filters
+            ):
                 yield ref
+
+    @staticmethod
+    async def _safe_discover(
+        label: str,
+        fn: Any,
+        *args: Any,
+    ) -> list[DocumentRef]:
+        """Run a synchronous describe helper, skipping it on access errors.
+
+        Returns the helper's refs, or an empty list (with a warning) when the
+        call is denied — so one inaccessible service never aborts the whole sync.
+        """
+        try:
+            return await asyncio.to_thread(fn, *args)
+        except botocore.exceptions.ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            logger.warning("aws.describe.service_skipped", extra={"service": label, "code": code})
+            return []
 
     async def _discover_config(
         self,

--- a/packages/core/alembic/versions/0009_source_type_aws_s3_alerts.py
+++ b/packages/core/alembic/versions/0009_source_type_aws_s3_alerts.py
@@ -1,0 +1,60 @@
+"""Add ``s3``, ``aws``, ``alerts`` values to the ``source_type`` enum.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-06-07 00:00:00.000000
+
+Context
+-------
+
+``SourceType`` (``packages/core/.../db/models.py``) defines ``s3``, ``aws``, and
+``alerts`` members, but no migration ever added them to the Postgres
+``source_type`` enum.  Creating a Source of those types failed at the DB layer
+with ``InvalidTextRepresentationError: invalid input value for enum
+source_type: "aws"`` (caught while wiring the AWS connector end-to-end, ADR-0014).
+
+Additive-only — same shape as ``0005_source_type_otel`` and
+``0006_source_type_k8s_operator``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision: str = "0009"
+down_revision: str | None = "0008"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NEW_VALUES = ("s3", "aws", "alerts")
+
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # ``ALTER TYPE ... ADD VALUE`` cannot run inside a transaction in
+    # Postgres < 12; pin AUTOCOMMIT for the duration of this DDL so the
+    # migration applies cleanly on every supported server version.
+    op.execute("COMMIT")
+    for value in _NEW_VALUES:
+        op.execute(f"ALTER TYPE source_type ADD VALUE IF NOT EXISTS '{value}'")
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    # Postgres does not support ``ALTER TYPE ... DROP VALUE``; downgrade is
+    # a no-op (consistent with 0005/0006 and the rest of the tree).
+    pass

--- a/tests/test_aws_config_connector.py
+++ b/tests/test_aws_config_connector.py
@@ -508,6 +508,40 @@ class TestAwsConnectorDiscoverDescribeRegression:
         assert len(refs) == 1
         assert refs[0].metadata["kind"] == "aws_live"
 
+    async def test_access_denied_service_skipped_others_continue(self) -> None:
+        """An AccessDenied/SCP-deny on one service is skipped; others still yield.
+
+        Regression for the laptop smoke test: an org SCP denying
+        s3:ListAllMyBuckets aborted the whole sync. Now s3 is skipped and ec2
+        still ingests.
+        """
+        connector = AwsConnector()
+        cfg = AwsConfig(services=["s3", "ec2"], regions=["eu-west-1"])
+
+        ec2_ref = DocumentRef(
+            external_id=f"arn:aws:ec2:eu-west-1:{ACCOUNT}:instance/i-1",
+            uri=f"aws://{ACCOUNT}/eu-west-1/ec2/instance/i-1",
+            metadata={"resource_type": "aws_instance"},
+        )
+        with (
+            patch(
+                "omniscience_connectors.aws.connector._get_account_id",
+                return_value=ACCOUNT,
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_s3",
+                side_effect=_client_error("AccessDenied"),
+            ),
+            patch(
+                "omniscience_connectors.aws.connector._discover_ec2",
+                return_value=[ec2_ref],
+            ),
+        ):
+            refs = [r async for r in connector.discover(cfg, SECRETS)]
+
+        assert len(refs) == 1
+        assert refs[0].metadata["resource_type"] == "aws_instance"
+
 
 # ---------------------------------------------------------------------------
 # AwsConnector.fetch — config mode


### PR DESCRIPTION
Two latent bugs surfaced while wiring the AWS connector end-to-end from a laptop (ADR-0014 dev path):

1. **enum gap** — `SourceType.{s3,aws,alerts}` exist in Python but were never added to the Postgres `source_type` enum, so `POST /sources` with `type:aws` failed **500** (`InvalidTextRepresentationError: invalid input value for enum source_type: "aws"`). Adds **migration 0009** (additive `ALTER TYPE ... ADD VALUE IF NOT EXISTS`, same shape as 0005/0006).
2. **describe abort-on-deny** — one denied service (an org SCP blocking `s3:ListAllMyBuckets`) aborted the entire sync, so `ec2`/`iam` never ran. Each service block now **skips on `ClientError`** (logged `aws.describe.service_skipped`) and the rest still ingest — mirrors the config-path / K8s per-kind graceful skip. Regression test added.

40 AWS tests pass; ruff/format/mypy clean.