### PR TITLE
fix: multi-store integrity, tenant isolation, freshness alerting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,3 +183,7 @@ jobs:
           #   tests/integration/test_incident_demo_historical.py
           #   tests/property/test_bitemporal_contract.py
           OMNISCIENCE_RUN_QDRANT_CONTRACT_TESTS: "1"
+          # Unlocks tests in:
+          #   tests/test_ingestion_e2e.py
+          # Neo4j + Qdrant service containers are already running in this job.
+          OMNISCIENCE_RUN_E2E_INGESTION: "1"

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -319,8 +319,11 @@ async def get_document(
     _require_scope(token, Scope.search)
     _record_tool_invocation(tool_name="get_document", token=token)
 
+    workspace_id = get_workspace_id(token) if token is not None else None
     try:
-        return await mcp_get_document(app=_get_app(), document_id=document_id)
+        return await mcp_get_document(
+            app=_get_app(), document_id=document_id, workspace_id=workspace_id
+        )
     except ValueError as exc:
         msg = str(exc)
         if msg.startswith("document_not_found:"):
@@ -457,7 +460,8 @@ async def list_sources(
     _require_scope(token, Scope.sources_read)
     _record_tool_invocation(tool_name="list_sources", token=token)
 
-    return await mcp_list_sources(app=_get_app())
+    workspace_id = get_workspace_id(token) if token is not None else None
+    return await mcp_list_sources(app=_get_app(), workspace_id=workspace_id)
 
 
 # ---------------------------------------------------------------------------
@@ -478,8 +482,11 @@ async def source_stats(
     _require_scope(token, Scope.sources_read)
     _record_tool_invocation(tool_name="source_stats", token=token)
 
+    workspace_id = get_workspace_id(token) if token is not None else None
     try:
-        return await mcp_source_stats(app=_get_app(), source_id=source_id)
+        return await mcp_source_stats(
+            app=_get_app(), source_id=source_id, workspace_id=workspace_id
+        )
     except ValueError as exc:
         msg = str(exc)
         if msg.startswith("source_not_found:"):

--- a/apps/server/src/omniscience_server/mcp/tools.py
+++ b/apps/server/src/omniscience_server/mcp/tools.py
@@ -4,6 +4,22 @@ Each function is a standalone async callable that accepts the FastAPI
 app (for access to db_session_factory and retrieval_service) and the
 validated tool arguments.  The server.py module wires them to the
 FastMCP instance.
+
+ACL invariant (cross-tenant isolation)
+---------------------------------------
+``mcp_list_sources``, ``mcp_source_stats``, and ``mcp_get_document`` now
+require a ``workspace_id`` argument (extracted from the caller's bearer
+token by the server-layer wrapper in ``mcp/server.py``).  When
+``workspace_id`` is ``None`` (legacy token without workspace scope) the
+function raises ``RuntimeError("forbidden:workspace_required")`` — fail-closed.
+
+For ``mcp_get_document`` and ``mcp_source_stats`` a cross-tenant resource
+access raises ``ValueError("document_not_found:<id>")`` /
+``ValueError("source_not_found:<id>")`` respectively — 404-semantics, no
+existence leak.
+
+``mcp_list_sources`` filters ``Source.tenant_id == workspace_id`` so a
+caller can only enumerate their own workspace's sources.
 """
 
 from __future__ import annotations
@@ -125,8 +141,26 @@ async def mcp_search(
 # ---------------------------------------------------------------------------
 
 
-async def mcp_get_document(app: FastAPI, document_id: str) -> dict[str, Any]:
-    """Fetch a full document and all its chunks by document id."""
+async def mcp_get_document(
+    app: FastAPI,
+    document_id: str,
+    workspace_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """Fetch a full document and all its chunks by document id.
+
+    ACL: ``workspace_id`` is required.  When ``None`` (legacy token) the
+    function raises ``RuntimeError("forbidden:workspace_required")`` —
+    fail-closed.  When the document's parent source belongs to a different
+    workspace the function raises ``ValueError("document_not_found:<id>")``
+    — 404-semantics, avoids existence leak.
+
+    The ``document_not_found:`` error prefix is preserved so the
+    server-layer wrapper in ``mcp/server.py`` can re-wrap it as
+    ``source_not_found:`` for the MCP wire format.
+    """
+    if workspace_id is None:
+        raise RuntimeError("forbidden:workspace_required")
+
     factory = getattr(app.state, "db_session_factory", None)
     if factory is None:
         raise RuntimeError("db_session_factory not available on app.state")
@@ -139,7 +173,11 @@ async def mcp_get_document(app: FastAPI, document_id: str) -> dict[str, Any]:
         if doc_row is None:
             raise ValueError(f"document_not_found:{document_id}")
 
+        # Tenant isolation: verify parent source belongs to caller's workspace.
         source_row = await session.get(Source, doc_row.source_id)
+        if source_row is None or source_row.tenant_id != workspace_id:
+            raise ValueError(f"document_not_found:{document_id}")
+
         chunk_result = await session.execute(
             select(Chunk).where(Chunk.document_id == doc_uuid).order_by(Chunk.ord)
         )
@@ -183,8 +221,20 @@ async def mcp_get_document(app: FastAPI, document_id: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-async def mcp_list_sources(app: FastAPI) -> dict[str, Any]:
-    """List all configured sources with freshness information."""
+async def mcp_list_sources(
+    app: FastAPI,
+    workspace_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """List configured sources with freshness information.
+
+    ACL: ``workspace_id`` is required.  When ``None`` (legacy token) the
+    function raises ``RuntimeError("forbidden:workspace_required")`` —
+    fail-closed.  Results are filtered to
+    ``Source.tenant_id == workspace_id`` — no cross-tenant sources leak.
+    """
+    if workspace_id is None:
+        raise RuntimeError("forbidden:workspace_required")
+
     factory = getattr(app.state, "db_session_factory", None)
     if factory is None:
         raise RuntimeError("db_session_factory not available on app.state")
@@ -193,12 +243,14 @@ async def mcp_list_sources(app: FastAPI) -> dict[str, Any]:
 
     session: AsyncSession
     async with factory() as session:
-        result = await session.execute(select(Source))
+        result = await session.execute(select(Source).where(Source.tenant_id == workspace_id))
         sources = result.scalars().all()
 
-        # Count indexed documents per source
+        # Count indexed documents per source (scoped to same workspace)
         count_result = await session.execute(
             select(Document.source_id, func.count(Document.id).label("cnt"))
+            .join(Source, Document.source_id == Source.id)
+            .where(Source.tenant_id == workspace_id)
             .where(Document.tombstoned_at.is_(None))
             .group_by(Document.source_id)
         )
@@ -251,8 +303,22 @@ async def mcp_list_sources(app: FastAPI) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-async def mcp_source_stats(app: FastAPI, source_id: str) -> dict[str, Any]:
-    """Return detailed statistics for a single source."""
+async def mcp_source_stats(
+    app: FastAPI,
+    source_id: str,
+    workspace_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """Return detailed statistics for a single source.
+
+    ACL: ``workspace_id`` is required.  When ``None`` (legacy token) the
+    function raises ``RuntimeError("forbidden:workspace_required")`` —
+    fail-closed.  When the source belongs to a different workspace the
+    function raises ``ValueError("source_not_found:<id>")`` — 404-semantics,
+    no existence leak.
+    """
+    if workspace_id is None:
+        raise RuntimeError("forbidden:workspace_required")
+
     factory = getattr(app.state, "db_session_factory", None)
     if factory is None:
         raise RuntimeError("db_session_factory not available on app.state")
@@ -262,7 +328,8 @@ async def mcp_source_stats(app: FastAPI, source_id: str) -> dict[str, Any]:
     session: AsyncSession
     async with factory() as session:
         src = await session.get(Source, src_uuid)
-        if src is None:
+        # 404-semantics for absent or cross-tenant source.
+        if src is None or src.tenant_id != workspace_id:
             raise ValueError(f"source_not_found:{source_id}")
 
         doc_count_result = await session.execute(

--- a/apps/server/src/omniscience_server/rest/documents.py
+++ b/apps/server/src/omniscience_server/rest/documents.py
@@ -3,6 +3,14 @@
 GET /api/v1/documents/{id} — retrieve document with all chunks.
 
 Requires ``search`` scope.
+
+ACL invariant (cross-tenant isolation)
+---------------------------------------
+The handler extracts workspace_id from the bearer token and verifies that
+the document's parent Source belongs to the same workspace.  A mismatch
+returns 404 — not 403 — to avoid leaking document/source existence to
+other tenants.  Legacy tokens without workspace_id are rejected fail-closed
+with 403.
 """
 
 from __future__ import annotations
@@ -14,7 +22,8 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from omniscience_core.auth.middleware import require_scope
 from omniscience_core.auth.scopes import Scope
-from omniscience_core.db.models import Chunk, Document
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import ApiToken, Chunk, Document, Source
 from omniscience_core.db.schemas import ChunkRead, DocumentRead
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -44,11 +53,30 @@ class DocumentWithChunks(BaseModel):
 async def get_document(
     document_id: uuid.UUID,
     request: Request,
+    token: ApiToken = _search_scope_dep,
 ) -> DocumentWithChunks:
     """Retrieve a document and all its associated chunks.
 
+    Returns 404 when the document does not exist OR when its parent source
+    belongs to a different workspace than the caller's token.
+    Legacy tokens (no workspace_id) are rejected fail-closed with 403.
+
     Requires scope: ``search``
     """
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "documents_endpoint_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Documents endpoint requires a workspace-scoped token.",
+            },
+        )
+
     factory = getattr(request.app.state, "db_session_factory", None)
     if factory is None:
         raise HTTPException(
@@ -60,6 +88,18 @@ async def get_document(
     async with factory() as db:
         doc = await db.get(Document, document_id)
         if doc is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "code": "document_not_found",
+                    "message": f"Document {document_id} not found",
+                },
+            )
+
+        # Tenant isolation: verify the parent source belongs to our workspace.
+        source = await db.get(Source, doc.source_id)
+        if source is None or source.tenant_id != workspace_id:
+            # 404 — do not reveal that the document exists in another tenant.
             raise HTTPException(
                 status_code=404,
                 detail={

--- a/apps/server/src/omniscience_server/rest/sources.py
+++ b/apps/server/src/omniscience_server/rest/sources.py
@@ -10,6 +10,17 @@ GET    /api/v1/sources/{id}/stats— source statistics
 
 Read operations require ``sources:read`` scope.
 Write operations require ``sources:write`` scope.
+
+ACL invariant (cross-tenant isolation)
+---------------------------------------
+All read and write endpoints extract the caller's workspace_id from the
+bearer token (via ``get_workspace_id``) and enforce ``Source.tenant_id ==
+workspace_id``.  A legacy token with no workspace_id is rejected fail-closed
+with 403 — it is never permitted to see all tenants' data.
+
+For single-resource endpoints (GET/PATCH/DELETE /sources/{id} and
+/sources/{id}/stats) a mismatched tenant returns 404 (not 403) to avoid
+leaking resource existence to other tenants.
 """
 
 from __future__ import annotations
@@ -21,7 +32,14 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from omniscience_core.auth.middleware import require_scope
 from omniscience_core.auth.scopes import Scope
-from omniscience_core.db.models import IngestionRunStatus, Source, SourceStatus, SourceType
+from omniscience_core.auth.workspace import get_workspace_id
+from omniscience_core.db.models import (
+    ApiToken,
+    IngestionRunStatus,
+    Source,
+    SourceStatus,
+    SourceType,
+)
 from omniscience_core.db.schemas import SourceCreate, SourceRead, SourceUpdate
 from omniscience_core.queue.producer import QueueProducer
 from pydantic import BaseModel
@@ -76,9 +94,37 @@ def _get_db_factory(request: Request) -> Any:
     return factory
 
 
-async def _get_source_or_404(db: AsyncSession, source_id: uuid.UUID) -> Source:
+def _require_workspace(token: ApiToken) -> uuid.UUID:
+    """Extract workspace_id from token; raise 403 fail-closed when absent."""
+    workspace_id = get_workspace_id(token)
+    if workspace_id is None:
+        log.warning(
+            "sources_endpoint_rejected_no_workspace",
+            token_prefix=token.token_prefix,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "forbidden",
+                "message": "Sources endpoints require a workspace-scoped token.",
+            },
+        )
+    return workspace_id
+
+
+async def _get_source_or_404(
+    db: AsyncSession,
+    source_id: uuid.UUID,
+    *,
+    workspace_id: uuid.UUID,
+) -> Source:
+    """Fetch source by id; return 404 when absent OR when tenant mismatch.
+
+    Using 404 for tenant mismatch deliberately avoids leaking cross-tenant
+    resource existence (returning 403 would confirm the resource exists).
+    """
     source = await db.get(Source, source_id)
-    if source is None:
+    if source is None or source.tenant_id != workspace_id:
         raise HTTPException(
             status_code=404,
             detail={"code": "source_not_found", "message": f"Source {source_id} not found"},
@@ -147,17 +193,23 @@ async def list_sources(
     request: Request,
     source_type: SourceType | None = None,
     status: SourceStatus | None = None,
+    token: ApiToken = _read_scope_dep,
 ) -> list[SourceRead]:
-    """List all configured sources, optionally filtered by type and/or status.
+    """List sources scoped to the caller's workspace.
 
     Query params: ``source_type``, ``status``
     Requires scope: ``sources:read``
+
+    ACL: token workspace_id must be present; results filtered to
+    ``Source.tenant_id == workspace_id`` only.  Legacy tokens (no
+    workspace_id) are rejected fail-closed with 403.
     """
+    workspace_id = _require_workspace(token)
     factory = _get_db_factory(request)
 
     db: AsyncSession
     async with factory() as db:
-        stmt = select(Source)
+        stmt = select(Source).where(Source.tenant_id == workspace_id)
         if source_type is not None:
             stmt = stmt.where(Source.type == source_type)
         if status is not None:
@@ -214,16 +266,20 @@ async def create_source(
 async def get_source(
     source_id: uuid.UUID,
     request: Request,
+    token: ApiToken = _read_scope_dep,
 ) -> SourceRead:
-    """Retrieve a single source by ID.
+    """Retrieve a single source by ID scoped to the caller's workspace.
 
+    Returns 404 when the source does not exist OR belongs to a different
+    workspace — avoids leaking resource existence.
     Requires scope: ``sources:read``
     """
+    workspace_id = _require_workspace(token)
     factory = _get_db_factory(request)
 
     db: AsyncSession
     async with factory() as db:
-        source = await _get_source_or_404(db, source_id)
+        source = await _get_source_or_404(db, source_id, workspace_id=workspace_id)
         return SourceRead.model_validate(source)
 
 
@@ -237,16 +293,20 @@ async def update_source(
     source_id: uuid.UUID,
     payload: SourceUpdate,
     request: Request,
+    token: ApiToken = _write_scope_dep,
 ) -> SourceRead:
-    """Partially update a source's config, secrets_ref, status, or freshness SLA.
+    """Partially update a source scoped to the caller's workspace.
 
+    Returns 404 when the source does not exist OR belongs to a different
+    workspace.
     Requires scope: ``sources:write``
     """
+    workspace_id = _require_workspace(token)
     factory = _get_db_factory(request)
 
     db: AsyncSession
     async with factory() as db:
-        source = await _get_source_or_404(db, source_id)
+        source = await _get_source_or_404(db, source_id, workspace_id=workspace_id)
 
         update_data = payload.model_dump(exclude_unset=True)
         for field, value in update_data.items():
@@ -269,17 +329,20 @@ async def update_source(
 async def delete_source(
     source_id: uuid.UUID,
     request: Request,
+    token: ApiToken = _write_scope_dep,
 ) -> None:
-    """Remove a source. Associated documents and chunks are tombstoned then
-    purged by the janitor background process.
+    """Remove a source scoped to the caller's workspace.
 
+    Returns 404 when the source does not exist OR belongs to a different
+    workspace.
     Requires scope: ``sources:write``
     """
+    workspace_id = _require_workspace(token)
     factory = _get_db_factory(request)
 
     db: AsyncSession
     async with factory() as db:
-        source = await _get_source_or_404(db, source_id)
+        source = await _get_source_or_404(db, source_id, workspace_id=workspace_id)
         await db.delete(source)
         await db.commit()
 
@@ -296,6 +359,7 @@ async def delete_source(
 async def trigger_sync(
     source_id: uuid.UUID,
     request: Request,
+    token: ApiToken = _write_scope_dep,
 ) -> SyncResponse:
     """Trigger an immediate manual sync for the given source.
 
@@ -305,20 +369,19 @@ async def trigger_sync(
     202 — the caller can monitor run progress via
     ``GET /api/v1/ingestion-runs/{run_id}``.
 
-    The published :class:`~omniscience_server.ingestion.events.DocumentChangeEvent`
-    uses ``external_id="*"`` and ``action="updated"`` as a sentinel that
-    instructs the ingestion worker to perform a full re-sync of the source.
-
+    Returns 404 when the source does not exist OR belongs to a different
+    workspace.
     Requires scope: ``sources:write``
     """
     from omniscience_core.db.models import IngestionRun
 
+    workspace_id = _require_workspace(token)
     factory = _get_db_factory(request)
 
     db: AsyncSession
     async with factory() as db:
-        # Verify source exists and capture its type for the NATS subject.
-        source = await _get_source_or_404(db, source_id)
+        # Verify source exists within the caller's workspace.
+        source = await _get_source_or_404(db, source_id, workspace_id=workspace_id)
         source_type = str(source.type)
 
         # Create an ingestion run record.
@@ -350,19 +413,23 @@ async def trigger_sync(
 async def source_stats(
     source_id: uuid.UUID,
     request: Request,
+    token: ApiToken = _read_scope_dep,
 ) -> SourceStatsResponse:
-    """Return statistics for a source: document counts, chunk count, last sync.
+    """Return statistics for a source scoped to the caller's workspace.
 
+    Returns 404 when the source does not exist OR belongs to a different
+    workspace.
     Requires scope: ``sources:read``
     """
     from omniscience_core.db.models import Chunk, Document, IngestionRun
     from sqlalchemy import func
 
+    workspace_id = _require_workspace(token)
     factory = _get_db_factory(request)
 
     db: AsyncSession
     async with factory() as db:
-        source = await _get_source_or_404(db, source_id)
+        source = await _get_source_or_404(db, source_id, workspace_id=workspace_id)
 
         # Total documents for this source
         total_docs_result = await db.execute(

--- a/apps/server/src/omniscience_server/scheduler.py
+++ b/apps/server/src/omniscience_server/scheduler.py
@@ -95,6 +95,7 @@ class SchedulerWorker:
         "slack": 300,  # 5 min
         "jira": 600,  # 10 min
         "database": 3600,  # 1 hour
+        "k8s": 1800,  # 30 min — agentic connector; launchd/agent outage safety net
     }
 
     def __init__(

--- a/monitoring/prometheus/alerts/freshness.yaml
+++ b/monitoring/prometheus/alerts/freshness.yaml
@@ -1,0 +1,35 @@
+# Prometheus alert rules for source freshness SLO (issue #89 / scheduler blind-spot).
+#
+# Metric: omniscience_source_stale_total (Gauge)
+#   Defined in: packages/core/src/omniscience_core/telemetry/metrics.py
+#   Semantics: number of active sources currently exceeding their
+#              freshness_sla_seconds budget as evaluated by FreshnessChecker.
+#   Set to 0 when all sources are within SLA; increments per stale source.
+#
+# This file mirrors the alert that previously lived only in the inactive
+# Grafana profile (monitoring/grafana/dashboards/freshness.json, panel
+# "omniscience-freshness-stale-alert"). Promoting it to a Prometheus rule
+# ensures the alert fires regardless of Grafana availability and is picked up
+# by Alertmanager.
+#
+# Load this file via the standard `rule_files:` directive in prometheus.yml.
+groups:
+  - name: omniscience-freshness
+    interval: 1m
+    rules:
+      - alert: SourceFreshnessViolation
+        expr: omniscience_source_stale_total > 0
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+          component: freshness-checker
+        annotations:
+          summary: "One or more Omniscience sources have exceeded their freshness SLO"
+          description: |
+            {{ $value }} source(s) have been stale (exceeding freshness_sla_seconds)
+            for at least 5 minutes (omniscience_source_stale_total = {{ $value }}).
+            Common causes: scheduler worker not running, NATS publish failures,
+            or source has no freshness_sla_seconds set (seed_from_docs.py was not
+            updated). Check scheduler logs and verify last_sync_at is advancing.
+          runbook_url: "docs/runbooks/freshness.md#sourcefreshnessviolation"

--- a/packages/index/src/omniscience_index/writer.py
+++ b/packages/index/src/omniscience_index/writer.py
@@ -100,6 +100,9 @@ class IndexWriter:
             await self._insert_chunks(session, doc.id, chunks, ingestion_run_id)
 
             # 2. Qdrant Vector Write (if adapter provided)
+            #    Executed inside session.begin() so that a Qdrant failure
+            #    causes the surrounding context-manager to roll back the PG
+            #    transaction before it is committed.
             if self._vector_store and workspace_id:
                 vector_metadata = dict(metadata)
                 vector_metadata["workspace_id"] = str(workspace_id)
@@ -161,9 +164,25 @@ class IndexWriter:
     async def purge_tombstones(self, older_than: timedelta) -> int:
         """Hard-delete tombstoned documents older than *older_than*.
 
-        Returns the number of documents removed (their chunks cascade-delete
-        automatically via the FK ``ON DELETE CASCADE`` constraint).
+        Deletion order: Qdrant points first, then Postgres rows.
+
+        Rationale: if Qdrant fails, Postgres rows survive and the document
+        remains visible to the next purge run — no data is lost.  The reverse
+        order (PG first) would leave orphan Qdrant vectors with no Postgres
+        anchor, causing ghost points to accumulate silently.  A surviving
+        Qdrant-side orphan (our failure mode) is a temporary space waste;
+        a dangling Postgres reference with no vector is an integrity violation
+        that breaks the hybrid query path.
+
+        When ``_vector_store`` is None the Qdrant step is skipped and only
+        the Postgres DELETE is executed (backward-compatible behaviour).
+
+        Returns the number of Postgres document rows removed (chunks
+        cascade-delete automatically via FK ``ON DELETE CASCADE``).
         """
+        if self._vector_store is not None:
+            await self._vector_store.delete_tombstoned(older_than)
+
         cutoff = datetime.now(UTC) - older_than
         async with self._session_factory() as session, session.begin():
             stmt = (

--- a/scripts/cleanup_orphan_chunks.py
+++ b/scripts/cleanup_orphan_chunks.py
@@ -1,0 +1,102 @@
+"""One-time cleanup of orphaned Qdrant points left by per-run source churn.
+
+Earlier versions of seed_from_docs.py deleted and recreated the Source row
+(with a fresh uuid4) on every run.  Postgres documents were cascade-deleted,
+but the Qdrant points kept the old source_id in their payload and were never
+removed — so search returned N copies of every k8s object, one per run.
+
+This script deletes every point whose payload ``source_id`` is no longer
+present in the Postgres ``sources`` table, across all omniscience-managed
+collections.  Pass --dry-run to only report what would be deleted.
+
+Run inside the app container:
+    /app/.venv/bin/python /tmp/cleanup_orphan_chunks.py [--dry-run]
+"""
+
+import asyncio
+import sys
+
+from omniscience_core.config import Settings
+from omniscience_core.db import create_async_engine, create_session_factory
+from omniscience_core.db.models import Source
+from omniscience_index.stores.qdrant_constants import (
+    COLLECTION_NAME_PREFIX,
+    PAYLOAD_SOURCE_ID,
+)
+from qdrant_client import AsyncQdrantClient
+from qdrant_client import models as qm
+from sqlalchemy import select
+
+DRY_RUN = "--dry-run" in sys.argv
+SCROLL_BATCH = 256
+
+
+async def main() -> None:
+    settings = Settings()
+    engine = create_async_engine(settings)
+    session_factory = create_session_factory(engine)
+
+    async with session_factory() as session:
+        rows = (await session.execute(select(Source.id))).scalars().all()
+    valid_ids = {str(sid) for sid in rows}
+    print(f"Valid sources in Postgres: {len(valid_ids)}")
+
+    client = AsyncQdrantClient(
+        host=settings.qdrant_host,
+        grpc_port=settings.qdrant_grpc_port,
+        port=settings.qdrant_http_port,
+        api_key=settings.qdrant_api_key,
+        https=False,
+        prefer_grpc=True,
+    )
+
+    collections = [
+        c.name
+        for c in (await client.get_collections()).collections
+        if c.name.startswith(COLLECTION_NAME_PREFIX)
+    ]
+    print(f"Collections to scan: {collections}")
+
+    total_deleted = 0
+    for collection in collections:
+        orphan_points: list[str] = []
+        orphan_sources: set[str] = set()
+        offset = None
+        while True:
+            points, offset = await client.scroll(
+                collection_name=collection,
+                limit=SCROLL_BATCH,
+                offset=offset,
+                with_payload=[PAYLOAD_SOURCE_ID],
+                with_vectors=False,
+            )
+            for p in points:
+                sid = (p.payload or {}).get(PAYLOAD_SOURCE_ID)
+                if sid is not None and str(sid) not in valid_ids:
+                    orphan_points.append(str(p.id))
+                    orphan_sources.add(str(sid))
+            if offset is None:
+                break
+
+        print(
+            f"[{collection}] orphan points: {len(orphan_points)} "
+            f"from {len(orphan_sources)} dead sources"
+        )
+        if orphan_points and not DRY_RUN:
+            for i in range(0, len(orphan_points), SCROLL_BATCH):
+                batch = orphan_points[i : i + SCROLL_BATCH]
+                await client.delete(
+                    collection_name=collection,
+                    points_selector=qm.PointIdsList(points=list(batch)),
+                    wait=True,
+                )
+            total_deleted += len(orphan_points)
+
+    verb = "Would delete" if DRY_RUN else "Deleted"
+    print(f"{verb} {total_deleted if not DRY_RUN else 'see per-collection counts'} orphan points")
+    await client.close()
+    await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/seed_from_docs.py
+++ b/scripts/seed_from_docs.py
@@ -1,8 +1,10 @@
 """Seed pre-fetched documents (JSON) into Omniscience with real Ollama embeddings.
 
 Reads /tmp/docs.json (list of {external_id, uri, title, text, metadata}) and a source
-name from argv, then upserts each as a single-chunk document via IndexWriter.
-Run inside the app container:  /app/.venv/bin/python /tmp/seed_from_docs.py <source_name>
+name (+ optional source type, default "k8s") from argv, then upserts each as a
+single-chunk document via IndexWriter.
+Run inside the app container:
+    /app/.venv/bin/python /tmp/seed_from_docs.py <source_name> [<source_type>]
 """
 
 import asyncio
@@ -19,10 +21,11 @@ from omniscience_index.stores.neo4j_store import Neo4jGraphStore, Neo4jStoreConf
 from omniscience_index.stores.qdrant_config import QdrantConfig
 from omniscience_index.stores.qdrant_store import QdrantVectorStore
 from omniscience_index.writer import ChunkData, IndexWriter
-from sqlalchemy import delete
+from sqlalchemy import select
 
 WS_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 SOURCE_NAME = sys.argv[1] if len(sys.argv) > 1 else "external-docs"
+SOURCE_TYPE = SourceType(sys.argv[2]) if len(sys.argv) > 2 else SourceType.k8s
 
 
 async def seed() -> None:
@@ -44,20 +47,29 @@ async def seed() -> None:
     await graph_store.connect()
     await vector_store.connect()
 
-    src_id = uuid.uuid4()
+    # Get-or-create the source: the (source_id, external_id) pair is the
+    # IndexWriter dedup key, so the source id must survive across runs —
+    # a fresh id per run orphans every previous run's Qdrant points.
     async with session_factory() as session:
-        await session.execute(delete(Source).where(Source.name == SOURCE_NAME))
-        session.add(
-            Source(
-                id=src_id,
+        src = (
+            await session.execute(
+                select(Source).where(Source.tenant_id == WS_ID, Source.name == SOURCE_NAME)
+            )
+        ).scalar_one_or_none()
+        if src is None:
+            src = Source(
+                id=uuid.uuid4(),
                 name=SOURCE_NAME,
-                type=SourceType.k8s,
-                config={"cluster": "qbiq-shared"},
+                type=SOURCE_TYPE,
+                config={"seeded_by": "seed_from_docs"},
                 tenant_id=WS_ID,
                 status=SourceStatus.active,
+                # 30 min SLA enables FreshnessChecker staleness alerts.
+                freshness_sla_seconds=1800,
             )
-        )
-        await session.commit()
+            session.add(src)
+            await session.commit()
+        src_id = src.id
 
     writer = IndexWriter(session_factory, graph_store, vector_store)
     model = getattr(settings, "ollama_embedding_model", None) or "nomic-embed-text"
@@ -65,6 +77,7 @@ async def seed() -> None:
     # Batch-embed all texts for speed.
     texts = [d["text"] for d in docs]
     vectors = await provider.embed(texts)
+    actions: dict[str, int] = {}
     for i, d in enumerate(docs):
         chunk = ChunkData(
             ord=0,
@@ -74,7 +87,7 @@ async def seed() -> None:
             embedding_provider="ollama",
             metadata=d.get("metadata", {}),
         )
-        await writer.upsert_document(
+        result = await writer.upsert_document(
             source_id=src_id,
             external_id=d["external_id"],
             uri=d["uri"],
@@ -84,7 +97,10 @@ async def seed() -> None:
             chunks=[chunk],
             workspace_id=WS_ID,
         )
-    print(f"Seeded {len(docs)} documents into source '{SOURCE_NAME}' (workspace {WS_ID})")
+        actions[result.action] = actions.get(result.action, 0) + 1
+    print(
+        f"Seeded {len(docs)} documents into source '{SOURCE_NAME}' (workspace {WS_ID}): {actions}"
+    )
     await vector_store.close()
     await graph_store.close()
     await engine.dispose()

--- a/scripts/wipe_all_index_data.py
+++ b/scripts/wipe_all_index_data.py
@@ -1,0 +1,76 @@
+"""Full wipe of all indexed data — Postgres, Qdrant, Neo4j.
+
+Deletes every source, document, chunk, ingestion run, and (deprecated SQL)
+entity/edge row, drops all omniscience-managed Qdrant collections (they are
+recreated idempotently by the vector store on next connect), and clears the
+Neo4j graph.  Auth and tenancy survive: workspaces, api_tokens, audit_log,
+alembic_version are untouched.
+
+Run inside the app container:
+    /app/.venv/bin/python /tmp/wipe_all_index_data.py --yes
+"""
+
+import asyncio
+import sys
+
+from omniscience_core.config import Settings
+from omniscience_core.db import create_async_engine
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore, Neo4jStoreConfig
+from omniscience_index.stores.qdrant_constants import COLLECTION_NAME_PREFIX
+from qdrant_client import AsyncQdrantClient
+from sqlalchemy import text
+
+WIPE_TABLES = [
+    "chunks",
+    "edges",
+    "entities",
+    "entity_emitter",
+    "documents",
+    "ingestion_runs",
+    "sources",
+]
+
+
+async def main() -> None:
+    if "--yes" not in sys.argv:
+        print("Refusing to wipe without --yes")
+        sys.exit(1)
+
+    settings = Settings()
+
+    engine = create_async_engine(settings)
+    async with engine.begin() as conn:
+        for table in WIPE_TABLES:
+            # Table names come from the hardcoded WIPE_TABLES allow-list,
+            # never from user input.
+            result = await conn.execute(text(f"DELETE FROM {table}"))  # noqa: S608
+            print(f"postgres: {table}: deleted {result.rowcount} rows")
+    await engine.dispose()
+
+    client = AsyncQdrantClient(
+        host=settings.qdrant_host,
+        grpc_port=settings.qdrant_grpc_port,
+        port=settings.qdrant_http_port,
+        api_key=settings.qdrant_api_key,
+        https=False,
+        prefer_grpc=True,
+    )
+    for c in (await client.get_collections()).collections:
+        if c.name.startswith(COLLECTION_NAME_PREFIX):
+            await client.delete_collection(c.name)
+            print(f"qdrant: dropped collection {c.name}")
+    await client.close()
+
+    gs = Neo4jGraphStore(config=Neo4jStoreConfig.from_settings(settings))
+    await gs.connect()
+    async with gs._driver.session(database=gs._config.database) as session:
+        result = await session.run("MATCH (n) DETACH DELETE n")
+        summary = await result.consume()
+        print(f"neo4j: deleted {summary.counters.nodes_deleted} nodes")
+    await gs.close()
+
+    print("Wipe complete.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -444,18 +444,24 @@ async def test_rest_freshness_all_returns_200() -> None:
     app = create_app(settings=settings)
 
     tok, pt = _make_api_token(["sources:read"])
-    ref = datetime.now(tz=UTC)
+    ref = (
+        _NOW  # fixed reference — avoids race between mock-data construction and SUT datetime.now()
+    )
     src = _fresh_source_at(ref, age_seconds=60)
     src.id = uuid.uuid4()
     src.name = "demo"
     factory = _make_rest_session([src])
     app.state.db_session_factory = factory
 
-    with patch(
-        "omniscience_core.auth.middleware._lookup_token",
-        new_callable=AsyncMock,
-        return_value=tok,
+    with (
+        patch(
+            "omniscience_core.auth.middleware._lookup_token",
+            new_callable=AsyncMock,
+            return_value=tok,
+        ),
+        patch("omniscience_core.freshness.datetime") as mock_dt,
     ):
+        mock_dt.now.return_value = ref
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get(
@@ -487,7 +493,9 @@ async def test_rest_freshness_all_stale_count() -> None:
     app = create_app(settings=settings)
 
     tok, pt = _make_api_token(["sources:read"])
-    ref = datetime.now(tz=UTC)
+    ref = (
+        _NOW  # fixed reference — avoids race between mock-data construction and SUT datetime.now()
+    )
     stale = _stale_source_at(ref, age_seconds=9999)
     stale.id = uuid.uuid4()
     stale.name = "stale"
@@ -497,11 +505,15 @@ async def test_rest_freshness_all_stale_count() -> None:
     factory = _make_rest_session([stale, fresh])
     app.state.db_session_factory = factory
 
-    with patch(
-        "omniscience_core.auth.middleware._lookup_token",
-        new_callable=AsyncMock,
-        return_value=tok,
+    with (
+        patch(
+            "omniscience_core.auth.middleware._lookup_token",
+            new_callable=AsyncMock,
+            return_value=tok,
+        ),
+        patch("omniscience_core.freshness.datetime") as mock_dt,
     ):
+        mock_dt.now.return_value = ref
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get(
@@ -532,7 +544,9 @@ async def test_rest_freshness_single_returns_200() -> None:
     app = create_app(settings=settings)
 
     tok, pt = _make_api_token(["sources:read"])
-    ref = datetime.now(tz=UTC)
+    ref = (
+        _NOW  # fixed reference — avoids race between mock-data construction and SUT datetime.now()
+    )
     src_id = uuid.uuid4()
     src = _fresh_source_at(ref, age_seconds=45)
     src.id = src_id
@@ -540,11 +554,15 @@ async def test_rest_freshness_single_returns_200() -> None:
     factory = _make_rest_session([src])
     app.state.db_session_factory = factory
 
-    with patch(
-        "omniscience_core.auth.middleware._lookup_token",
-        new_callable=AsyncMock,
-        return_value=tok,
+    with (
+        patch(
+            "omniscience_core.auth.middleware._lookup_token",
+            new_callable=AsyncMock,
+            return_value=tok,
+        ),
+        patch("omniscience_core.freshness.datetime") as mock_dt,
     ):
+        mock_dt.now.return_value = ref
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.get(
@@ -667,7 +685,10 @@ async def test_mcp_list_sources_includes_is_stale() -> None:
     """mcp_list_sources response includes is_stale per source."""
     from omniscience_server.mcp.tools import mcp_list_sources
 
-    ref = datetime.now(tz=UTC)
+    ref = (
+        _NOW  # fixed reference — avoids race between mock-data construction and SUT datetime.now()
+    )
+    workspace_id = uuid.uuid4()
     stale_src = _stale_source_at(ref, age_seconds=9999)
     stale_src.id = uuid.uuid4()
     stale_src.name = "stale"
@@ -676,7 +697,9 @@ async def test_mcp_list_sources_includes_is_stale() -> None:
     app = MagicMock()
     app.state.db_session_factory = factory
 
-    result = await mcp_list_sources(app=app)
+    with patch("omniscience_server.mcp.tools.datetime") as mock_dt:
+        mock_dt.now.return_value = ref
+        result = await mcp_list_sources(app=app, workspace_id=workspace_id)
 
     assert "sources" in result
     assert len(result["sources"]) == 1
@@ -690,7 +713,10 @@ async def test_mcp_list_sources_includes_age_seconds() -> None:
     """mcp_list_sources response includes age_seconds per source."""
     from omniscience_server.mcp.tools import mcp_list_sources
 
-    ref = datetime.now(tz=UTC)
+    ref = (
+        _NOW  # fixed reference — avoids race between mock-data construction and SUT datetime.now()
+    )
+    workspace_id = uuid.uuid4()
     fresh_src = _fresh_source_at(ref, age_seconds=30)
     fresh_src.id = uuid.uuid4()
     fresh_src.name = "fresh"
@@ -699,11 +725,13 @@ async def test_mcp_list_sources_includes_age_seconds() -> None:
     app = MagicMock()
     app.state.db_session_factory = factory
 
-    result = await mcp_list_sources(app=app)
+    with patch("omniscience_server.mcp.tools.datetime") as mock_dt:
+        mock_dt.now.return_value = ref
+        result = await mcp_list_sources(app=app, workspace_id=workspace_id)
 
     src_dict = result["sources"][0]
     assert "age_seconds" in src_dict
-    assert src_dict["age_seconds"] == pytest.approx(30.0, abs=5.0)
+    assert src_dict["age_seconds"] == pytest.approx(30.0, abs=1.0)
 
 
 @pytest.mark.asyncio
@@ -711,17 +739,35 @@ async def test_mcp_source_stats_includes_is_stale() -> None:
     """mcp_source_stats response includes is_stale."""
     from omniscience_server.mcp.tools import mcp_source_stats
 
-    ref = datetime.now(tz=UTC)
-    stale_src = _stale_source_at(ref, age_seconds=999)
+    ref = (
+        _NOW  # fixed reference — avoids race between mock-data construction and SUT datetime.now()
+    )
+    workspace_id = uuid.uuid4()
     src_id = uuid.uuid4()
+    stale_src = _stale_source_at(ref, age_seconds=999)
     stale_src.id = src_id
     stale_src.name = "stale"
+    stale_src.tenant_id = workspace_id  # ACL check: src.tenant_id must equal workspace_id
 
-    factory = _make_rest_session([stale_src])
+    # mcp_source_stats uses session.get() + multiple scalar_one() execute calls;
+    # build a minimal session mock that satisfies each call in order.
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=stale_src)
+    # scalar_one() for doc_count and chunk_count; scalar_one_or_none() for last_run
+    scalar_result = MagicMock()
+    scalar_result.scalar_one.return_value = 0
+    scalar_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=scalar_result)
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
     app = MagicMock()
     app.state.db_session_factory = factory
 
-    result = await mcp_source_stats(app=app, source_id=str(src_id))
+    with patch("omniscience_server.mcp.tools.datetime") as mock_dt:
+        mock_dt.now.return_value = ref
+        result = await mcp_source_stats(app=app, source_id=str(src_id), workspace_id=workspace_id)
 
     assert "is_stale" in result
     assert result["is_stale"] is True
@@ -732,18 +778,35 @@ async def test_mcp_source_stats_includes_staleness_margin() -> None:
     """mcp_source_stats response includes staleness_margin_seconds."""
     from omniscience_server.mcp.tools import mcp_source_stats
 
-    ref = datetime.now(tz=UTC)
-    stale_src = _stale_source_at(ref, age_seconds=900)
+    ref = (
+        _NOW  # fixed reference — avoids race between mock-data construction and SUT datetime.now()
+    )
+    workspace_id = uuid.uuid4()
     src_id = uuid.uuid4()
+    stale_src = _stale_source_at(ref, age_seconds=900)
     stale_src.id = src_id
     stale_src.name = "overdue"
+    stale_src.tenant_id = workspace_id  # ACL check: src.tenant_id must equal workspace_id
 
-    factory = _make_rest_session([stale_src])
+    # mcp_source_stats uses session.get() + multiple scalar_one() execute calls;
+    # build a minimal session mock that satisfies each call in order.
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=stale_src)
+    scalar_result = MagicMock()
+    scalar_result.scalar_one.return_value = 0
+    scalar_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=scalar_result)
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=session)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
     app = MagicMock()
     app.state.db_session_factory = factory
 
-    result = await mcp_source_stats(app=app, source_id=str(src_id))
+    with patch("omniscience_server.mcp.tools.datetime") as mock_dt:
+        mock_dt.now.return_value = ref
+        result = await mcp_source_stats(app=app, source_id=str(src_id), workspace_id=workspace_id)
 
     assert "staleness_margin_seconds" in result
-    # 900s age - 300s SLA = 600s margin
-    assert result["staleness_margin_seconds"] == pytest.approx(600.0, abs=10.0)
+    # 900s age - 300s SLA = 600s margin (exact, since time is frozen)
+    assert result["staleness_margin_seconds"] == pytest.approx(600.0, abs=1.0)

--- a/tests/test_index_writer.py
+++ b/tests/test_index_writer.py
@@ -389,7 +389,7 @@ class TestAtomicity:
 
 class TestNormalizeContent:
     def test_bom_stripped(self) -> None:
-        with_bom = "\ufeffhello world"
+        with_bom = "﻿hello world"
         assert normalize_content(with_bom) == "hello world"
 
     def test_trailing_whitespace_trimmed(self) -> None:
@@ -414,7 +414,7 @@ class TestNormalizeContent:
         assert normalize_content("") == ""
 
     def test_only_bom(self) -> None:
-        assert normalize_content("\ufeff") == ""
+        assert normalize_content("﻿") == ""
 
 
 class TestComputeContentHash:
@@ -429,7 +429,7 @@ class TestComputeContentHash:
         assert compute_content_hash(a) == compute_content_hash(b)
 
     def test_bom_variant_same_hash(self) -> None:
-        assert compute_content_hash("\ufeffhello") == compute_content_hash("hello")
+        assert compute_content_hash("﻿hello") == compute_content_hash("hello")
 
     def test_extra_blank_lines_same_hash(self) -> None:
         assert compute_content_hash("a\n\n\nb") == compute_content_hash("a\n\nb")
@@ -463,3 +463,295 @@ class TestIdempotency:
 
         assert result.action == "unchanged"
         assert result.chunks_written == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: IndexWriter with vector_store (Qdrant path coverage)
+# ---------------------------------------------------------------------------
+
+
+def _make_session_factory_for_vs(
+    existing_doc: Any = None,
+    rowcount: int = 0,
+) -> MagicMock:
+    """Session factory variant with enough execute slots for VS path.
+
+    upsert_document (new doc): execute[0]=SELECT, execute[1]=chunks DELETE n/a
+    purge_tombstones:          execute[0]=PG DELETE
+    """
+    scalar_result = MagicMock()
+    scalar_result.scalar_one_or_none.return_value = existing_doc
+
+    delete_result = MagicMock()
+    delete_result.rowcount = rowcount
+
+    session = AsyncMock()
+    # Provide a generous side_effect list; unused entries are never consumed.
+    session.execute = AsyncMock(
+        side_effect=[scalar_result, delete_result, delete_result, delete_result]
+    )
+    session.flush = AsyncMock()
+    session.add = MagicMock()
+
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    session.begin = MagicMock(return_value=tx)
+
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    factory = MagicMock()
+    factory.return_value = cm
+    return factory
+
+
+class TestIndexWriterWithVectorStore:
+    """Cover writer.py lines 102-131 (Qdrant path) and the purge fix."""
+
+    # ------------------------------------------------------------------
+    # (a) Happy path: upsert_chunks is awaited with workspace_id in metadata
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_upsert_calls_vector_store_with_workspace_id(self) -> None:
+        """vector_store.upsert_chunks must be awaited; metadata must carry workspace_id."""
+        workspace_id = uuid.uuid4()
+        source_id = uuid.uuid4()
+        vector_store = AsyncMock()
+        factory = _make_session_factory_for_vs(existing_doc=None)
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        result = await writer.upsert_document(
+            source_id=source_id,
+            external_id="doc.py@v1",
+            uri="https://example.com/doc.py",
+            title="Doc",
+            content_hash=_sha256("body"),
+            metadata={"author": "alice"},
+            chunks=[_chunk(0, "chunk zero"), _chunk(1, "chunk one")],
+            workspace_id=workspace_id,
+        )
+
+        assert result.action == "created"
+        assert result.chunks_written == 2
+
+        vector_store.upsert_chunks.assert_awaited_once()
+        _, kwargs = vector_store.upsert_chunks.call_args
+        assert kwargs["source_id"] == source_id
+        assert kwargs["external_id"] == "doc.py@v1"
+        assert kwargs["content_hash"] == _sha256("body")
+        # workspace_id must be injected into metadata for ACL enforcement
+        assert kwargs["metadata"]["workspace_id"] == str(workspace_id)
+        # original metadata keys must be preserved
+        assert kwargs["metadata"]["author"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_upsert_passes_correct_chunk_payloads(self) -> None:
+        """Each ChunkData must be converted to a ChunkPayload dict correctly."""
+        workspace_id = uuid.uuid4()
+        vector_store = AsyncMock()
+        factory = _make_session_factory_for_vs(existing_doc=None)
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        await writer.upsert_document(
+            source_id=uuid.uuid4(),
+            external_id="mod.py@1",
+            uri="https://example.com/mod.py",
+            title=None,
+            content_hash=_sha256("x"),
+            metadata={},
+            chunks=[_chunk(3, "specific text")],
+            workspace_id=workspace_id,
+        )
+
+        _, kwargs = vector_store.upsert_chunks.call_args
+        chunks_sent = kwargs["chunks"]
+        assert len(chunks_sent) == 1
+        c = chunks_sent[0]
+        assert c["ord"] == 3
+        assert c["text"] == "specific text"
+        assert c["embedding_model"] == "bge-large-en-v1.5"
+        assert c["embedding_provider"] == "ollama"
+
+    @pytest.mark.asyncio
+    async def test_upsert_skips_vector_store_when_no_workspace_id(self) -> None:
+        """vector_store must NOT be called when workspace_id is omitted."""
+        vector_store = AsyncMock()
+        factory = _make_session_factory_for_vs(existing_doc=None)
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        result = await writer.upsert_document(
+            source_id=uuid.uuid4(),
+            external_id="no-ws.py",
+            uri="https://example.com/no-ws.py",
+            title=None,
+            content_hash=_sha256("body"),
+            metadata={},
+            chunks=[_chunk()],
+            workspace_id=None,
+        )
+
+        assert result.action == "created"
+        vector_store.upsert_chunks.assert_not_awaited()
+
+    # ------------------------------------------------------------------
+    # (b) Qdrant failure → PG transaction does not commit (rollback path)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_qdrant_failure_propagates_exception(self) -> None:
+        """When upsert_chunks raises, the exception must escape upsert_document."""
+        workspace_id = uuid.uuid4()
+        vector_store = AsyncMock()
+        vector_store.upsert_chunks = AsyncMock(side_effect=RuntimeError("qdrant down"))
+        factory = _make_session_factory_for_vs(existing_doc=None)
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        with pytest.raises(RuntimeError, match="qdrant down"):
+            await writer.upsert_document(
+                source_id=uuid.uuid4(),
+                external_id="broken.py",
+                uri="https://example.com/broken.py",
+                title=None,
+                content_hash=_sha256("data"),
+                metadata={},
+                chunks=[_chunk()],
+                workspace_id=workspace_id,
+            )
+
+    @pytest.mark.asyncio
+    async def test_qdrant_failure_triggers_pg_rollback_path(self) -> None:
+        """When upsert_chunks raises, the begin() context manager receives the
+        exception — in production SQLAlchemy this triggers an automatic rollback.
+        We verify the exception exits through begin().__aexit__ with exc_info.
+        """
+        workspace_id = uuid.uuid4()
+        vector_store = AsyncMock()
+        vector_store.upsert_chunks = AsyncMock(side_effect=RuntimeError("qdrant down"))
+        factory = _make_session_factory_for_vs(existing_doc=None)
+        session_mock = factory.return_value.__aenter__.return_value
+        tx_mock = session_mock.begin.return_value
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        with pytest.raises(RuntimeError, match="qdrant down"):
+            await writer.upsert_document(
+                source_id=uuid.uuid4(),
+                external_id="broken.py",
+                uri="https://example.com/broken.py",
+                title=None,
+                content_hash=_sha256("data"),
+                metadata={},
+                chunks=[_chunk()],
+                workspace_id=workspace_id,
+            )
+
+        # __aexit__ must have been called with the exception type (not None),
+        # which is what SQLAlchemy's real begin() uses to issue ROLLBACK.
+        tx_exit_call = tx_mock.__aexit__.call_args
+        exc_type = tx_exit_call[0][0]  # positional arg 0: exc_type
+        assert exc_type is RuntimeError, (
+            "begin().__aexit__ must receive the exception so SQLAlchemy can rollback"
+        )
+
+    @pytest.mark.asyncio
+    async def test_qdrant_failure_pg_add_was_called_before_raise(self) -> None:
+        """Confirm that session.add() ran (PG write path executed) before the
+        Qdrant exception aborted the transaction — documents are never partially
+        visible because the surrounding begin() rolls the whole unit back.
+        """
+        workspace_id = uuid.uuid4()
+        vector_store = AsyncMock()
+        vector_store.upsert_chunks = AsyncMock(side_effect=RuntimeError("qdrant down"))
+        factory = _make_session_factory_for_vs(existing_doc=None)
+        session_mock = factory.return_value.__aenter__.return_value
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        with pytest.raises(RuntimeError):
+            await writer.upsert_document(
+                source_id=uuid.uuid4(),
+                external_id="broken.py",
+                uri="https://example.com/broken.py",
+                title=None,
+                content_hash=_sha256("data"),
+                metadata={},
+                chunks=[_chunk()],
+                workspace_id=workspace_id,
+            )
+
+        # session.add was called (for the Document), proving PG path ran,
+        # but the transaction was not committed (exception escaped).
+        assert session_mock.add.call_count >= 1
+
+    # ------------------------------------------------------------------
+    # (c) purge_tombstones with vector_store → delete_tombstoned is awaited
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_purge_calls_delete_tombstoned_on_vector_store(self) -> None:
+        """purge_tombstones must delegate to vector_store.delete_tombstoned."""
+        delta = timedelta(days=14)
+        vector_store = AsyncMock()
+        vector_store.delete_tombstoned = AsyncMock(return_value=2)
+
+        delete_result = MagicMock()
+        delete_result.rowcount = 2
+        factory = _make_session_factory_for_vs(rowcount=2)
+        session_mock = factory.return_value.__aenter__.return_value
+        session_mock.execute = AsyncMock(return_value=delete_result)
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        count = await writer.purge_tombstones(delta)
+
+        vector_store.delete_tombstoned.assert_awaited_once_with(delta)
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_purge_qdrant_first_then_pg(self) -> None:
+        """Qdrant deletion must happen before the Postgres DELETE statement.
+
+        We verify ordering by recording the call sequence: delete_tombstoned
+        must precede session.execute (the PG DELETE).
+        """
+        call_order: list[str] = []
+
+        vector_store = AsyncMock()
+
+        async def _vs_delete(older_than: timedelta) -> int:
+            call_order.append("qdrant")
+            return 1
+
+        vector_store.delete_tombstoned = _vs_delete
+
+        delete_result = MagicMock()
+        delete_result.rowcount = 1
+        factory = _make_session_factory_for_vs(rowcount=1)
+        session_mock = factory.return_value.__aenter__.return_value
+
+        async def _pg_execute(stmt: object) -> MagicMock:
+            call_order.append("postgres")
+            return delete_result
+
+        session_mock.execute = AsyncMock(side_effect=_pg_execute)
+
+        writer = IndexWriter(factory, vector_store=vector_store)
+        await writer.purge_tombstones(timedelta(days=7))
+
+        assert call_order == ["qdrant", "postgres"], (
+            f"Expected Qdrant before Postgres; got {call_order}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_purge_skips_qdrant_when_no_vector_store(self) -> None:
+        """Without a vector_store, purge must not raise and must still delete PG rows."""
+        delete_result = MagicMock()
+        delete_result.rowcount = 5
+        factory = _make_session_factory_for_vs(rowcount=5)
+        session_mock = factory.return_value.__aenter__.return_value
+        session_mock.execute = AsyncMock(return_value=delete_result)
+
+        writer = IndexWriter(factory, vector_store=None)
+        count = await writer.purge_tombstones(timedelta(days=1))
+
+        assert count == 5

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -50,6 +50,7 @@ _SRC_ID = uuid.uuid4()
 _DOC_ID = uuid.uuid4()
 _CHUNK_ID = uuid.uuid4()
 _RUN_ID = uuid.uuid4()
+_WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
 
 
 def _make_source(
@@ -61,6 +62,7 @@ def _make_source(
     freshness_sla_seconds: int | None = 300,
     last_error: str | None = None,
     last_error_at: datetime | None = None,
+    tenant_id: uuid.UUID | None = None,
 ) -> MagicMock:
     s = MagicMock(spec=Source)
     s.id = src_id
@@ -71,6 +73,7 @@ def _make_source(
     s.freshness_sla_seconds = freshness_sla_seconds
     s.last_error = last_error
     s.last_error_at = last_error_at
+    s.tenant_id = tenant_id if tenant_id is not None else _WS_A
     return s
 
 
@@ -307,7 +310,7 @@ async def test_mcp_get_document_returns_document_and_chunks() -> None:
     factory.return_value.__aexit__ = AsyncMock(return_value=False)
 
     app = _make_app(factory=factory)
-    result = await mcp_get_document(app=app, document_id=str(_DOC_ID))
+    result = await mcp_get_document(app=app, document_id=str(_DOC_ID), workspace_id=_WS_A)
 
     assert "document" in result
     assert "chunks" in result
@@ -327,7 +330,7 @@ async def test_mcp_get_document_raises_on_missing_doc() -> None:
 
     app = _make_app(factory=factory)
     with pytest.raises(ValueError, match="document_not_found"):
-        await mcp_get_document(app=app, document_id=str(uuid.uuid4()))
+        await mcp_get_document(app=app, document_id=str(uuid.uuid4()), workspace_id=_WS_A)
 
 
 @pytest.mark.asyncio
@@ -335,7 +338,7 @@ async def test_mcp_get_document_invalid_uuid() -> None:
     """mcp_get_document raises ValueError for malformed document_id."""
     app = _make_app(factory=MagicMock())
     with pytest.raises(ValueError):
-        await mcp_get_document(app=app, document_id="not-a-uuid")
+        await mcp_get_document(app=app, document_id="not-a-uuid", workspace_id=_WS_A)
 
 
 # ---------------------------------------------------------------------------
@@ -360,7 +363,7 @@ async def test_mcp_list_sources_returns_sources_key() -> None:
     factory.return_value.__aexit__ = AsyncMock(return_value=False)
 
     app = _make_app(factory=factory)
-    result = await mcp_list_sources(app=app)
+    result = await mcp_list_sources(app=app, workspace_id=_WS_A)
 
     assert "sources" in result
     assert len(result["sources"]) == 1
@@ -389,7 +392,7 @@ async def test_mcp_list_sources_is_stale_when_no_sync() -> None:
     factory.return_value.__aexit__ = AsyncMock(return_value=False)
 
     app = _make_app(factory=factory)
-    result = await mcp_list_sources(app=app)
+    result = await mcp_list_sources(app=app, workspace_id=_WS_A)
 
     assert result["sources"][0]["is_stale"] is True
 
@@ -414,7 +417,7 @@ async def test_mcp_list_sources_not_stale_when_recent() -> None:
     factory.return_value.__aexit__ = AsyncMock(return_value=False)
 
     app = _make_app(factory=factory)
-    result = await mcp_list_sources(app=app)
+    result = await mcp_list_sources(app=app, workspace_id=_WS_A)
 
     assert result["sources"][0]["is_stale"] is False
 
@@ -447,7 +450,7 @@ async def test_mcp_source_stats_returns_full_stats() -> None:
     factory.return_value.__aexit__ = AsyncMock(return_value=False)
 
     app = _make_app(factory=factory)
-    result = await mcp_source_stats(app=app, source_id=str(_SRC_ID))
+    result = await mcp_source_stats(app=app, source_id=str(_SRC_ID), workspace_id=_WS_A)
 
     assert result["indexed_document_count"] == 100
     assert result["indexed_chunk_count"] == 1500
@@ -478,7 +481,7 @@ async def test_mcp_source_stats_no_run() -> None:
     factory.return_value.__aexit__ = AsyncMock(return_value=False)
 
     app = _make_app(factory=factory)
-    result = await mcp_source_stats(app=app, source_id=str(_SRC_ID))
+    result = await mcp_source_stats(app=app, source_id=str(_SRC_ID), workspace_id=_WS_A)
 
     assert result["last_ingestion_run"] is None
 
@@ -495,7 +498,7 @@ async def test_mcp_source_stats_raises_on_missing_source() -> None:
 
     app = _make_app(factory=factory)
     with pytest.raises(ValueError, match="source_not_found"):
-        await mcp_source_stats(app=app, source_id=str(uuid.uuid4()))
+        await mcp_source_stats(app=app, source_id=str(uuid.uuid4()), workspace_id=_WS_A)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -39,6 +39,8 @@ from omniscience_retrieval.models import QueryStats, SearchHit, SearchResult
 from omniscience_server.app import create_app
 from omniscience_server.rest.rate_limit import check_rate_limit, clear_all_buckets
 
+_WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -47,6 +49,7 @@ from omniscience_server.rest.rate_limit import check_rate_limit, clear_all_bucke
 def _make_token(
     scopes: list[str],
     plaintext: str | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> tuple[ApiToken, str]:
     """Build an ApiToken mock and matching plaintext."""
     pt, prefix = generate_token("test")
@@ -59,6 +62,12 @@ def _make_token(
     tok.token_prefix = prefix
     tok.hashed_token = hashed
     tok.scopes = scopes
+    # workspace_id: use the explicitly supplied value when provided;
+    # otherwise leave the MagicMock spec attribute in place so that
+    # existing tests (which never set workspace_id) still route through
+    # _require_workspace without an explicit None.
+    if workspace_id is not None:
+        tok.workspace_id = workspace_id
     tok.expires_at = None
     tok.is_active = True
     tok.last_used_at = None
@@ -707,8 +716,9 @@ async def test_create_source_returns_201() -> None:
 @pytest.mark.asyncio
 async def test_delete_source_204() -> None:
     """DELETE /api/v1/sources/{id} returns 204 when source exists."""
-    tok, pt = _make_token(["sources:write"])
+    tok, pt = _make_token(["sources:write"], workspace_id=_WS_A)
     src = _make_source()
+    src.tenant_id = _WS_A
 
     auth_session = _make_session(scalars=[tok])
     del_session = _make_session(get_result=src)
@@ -794,8 +804,9 @@ async def test_update_source_requires_write_scope() -> None:
 @pytest.mark.asyncio
 async def test_trigger_sync_creates_run() -> None:
     """POST /api/v1/sources/{id}/sync creates a run and returns run_id."""
-    tok, pt = _make_token(["sources:write"])
+    tok, pt = _make_token(["sources:write"], workspace_id=_WS_A)
     src = _make_source()
+    src.tenant_id = _WS_A
     run_id = uuid.uuid4()
 
     auth_session = _make_session(scalars=[tok])
@@ -890,14 +901,25 @@ def _make_chunk(document_id: uuid.UUID) -> Chunk:
 @pytest.mark.asyncio
 async def test_get_document_returns_document_and_chunks() -> None:
     """GET /api/v1/documents/{id} returns document + chunks."""
-    tok, pt = _make_token(["search"])
+    tok, pt = _make_token(["search"], workspace_id=_WS_A)
     doc = _make_document()
     chunk = _make_chunk(doc.id)
+
+    # Source mock whose tenant_id matches the token's workspace.
+    from omniscience_core.db.models import Source as _Source
+
+    src_mock: Any = MagicMock(spec=_Source)
+    src_mock.id = doc.source_id
+    src_mock.tenant_id = _WS_A
+    src_mock.name = "test-source"
+    src_mock.type = SourceType.git
 
     auth_session = _make_session(scalars=[tok])
 
     doc_session = AsyncMock()
-    doc_session.get = AsyncMock(return_value=doc)
+    # First call: db.get(Document, id) → doc
+    # Second call: db.get(Source, doc.source_id) → src_mock
+    doc_session.get = AsyncMock(side_effect=[doc, src_mock])
 
     async def _execute(stmt: Any) -> Any:
         result = MagicMock()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -187,7 +187,18 @@ def test_init_stores_interval() -> None:
 
 def test_default_ttls_contains_expected_types() -> None:
     """DEFAULT_TTLS has entries for all documented source types."""
-    expected = {"git", "fs", "s3", "aws", "confluence", "notion", "slack", "jira", "database"}
+    expected = {
+        "git",
+        "fs",
+        "s3",
+        "aws",
+        "confluence",
+        "notion",
+        "slack",
+        "jira",
+        "database",
+        "k8s",
+    }
     assert expected == set(SchedulerWorker.DEFAULT_TTLS.keys())
 
 
@@ -196,6 +207,21 @@ def test_default_ttls_values_are_positive() -> None:
     for source_type, ttl in SchedulerWorker.DEFAULT_TTLS.items():
         assert isinstance(ttl, int), f"{source_type} TTL is not int"
         assert ttl > 0, f"{source_type} TTL is not positive"
+
+
+def test_default_ttls_k8s_present_and_correct() -> None:
+    """DEFAULT_TTLS must contain 'k8s' with a 30-minute (1800 s) TTL.
+
+    The k8s source type was absent prior to this fix, causing the scheduler
+    to silently skip all k8s sources (logged as 'no TTL applies').  6-day
+    blind spots went undetected when launchd/agent processes were down.
+    """
+    assert "k8s" in SchedulerWorker.DEFAULT_TTLS, (
+        "'k8s' missing from DEFAULT_TTLS — scheduler will never auto-trigger k8s sources"
+    )
+    assert SchedulerWorker.DEFAULT_TTLS["k8s"] == 1800, (
+        f"Expected k8s TTL=1800 (30 min), got {SchedulerWorker.DEFAULT_TTLS['k8s']}"
+    )
 
 
 # ===========================================================================

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -15,12 +15,11 @@ Coverage:
 
 from __future__ import annotations
 
-import asyncio
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -208,6 +207,10 @@ async def test_ttl_cache_hit_does_not_recompute() -> None:
 
 @pytest.mark.asyncio
 async def test_ttl_cache_expires() -> None:
+    # Freeze time instead of sleeping: monotonic returns 0.0 on the first
+    # get_or_compute (entry is stored with expires_at=0.01) and 1.0 on the
+    # second call so the entry is deterministically expired without any real
+    # wall-clock wait.
     cache: TTLCache[int] = TTLCache(ttl_seconds=0.01)
     workspace_id = uuid.uuid4()
     calls = {"n": 0}
@@ -216,9 +219,11 @@ async def test_ttl_cache_expires() -> None:
         calls["n"] += 1
         return calls["n"]
 
-    await cache.get_or_compute(workspace_id=workspace_id, method="m", factory=factory)
-    await asyncio.sleep(0.02)
-    second = await cache.get_or_compute(workspace_id=workspace_id, method="m", factory=factory)
+    with patch("omniscience_core.stats.cache.time") as mock_time:
+        mock_time.monotonic.side_effect = [0.0, 1.0]
+        await cache.get_or_compute(workspace_id=workspace_id, method="m", factory=factory)
+        second = await cache.get_or_compute(workspace_id=workspace_id, method="m", factory=factory)
+
     assert second == 2
 
 

--- a/tests/test_tenant_isolation_mcp.py
+++ b/tests/test_tenant_isolation_mcp.py
@@ -1,0 +1,359 @@
+"""Tenant isolation tests for MCP tool functions.
+
+Tests call the tool implementations in ``omniscience_server.mcp.tools``
+directly (bypassing the FastMCP server layer) to verify that the workspace_id
+parameter is correctly enforced.
+
+Tools under test:
+  mcp_list_sources   — must filter by workspace_id; reject None with RuntimeError
+  mcp_source_stats   — must reject cross-tenant sources and None workspace_id
+  mcp_get_document   — must reject cross-tenant documents and None workspace_id
+
+Security invariants tested:
+  1. mcp_list_sources with workspace_id=None raises RuntimeError (fail-closed).
+  2. mcp_list_sources with workspace_id=A returns only workspace-A sources.
+  3. mcp_list_sources does not leak workspace-B sources to workspace-A token.
+  4. mcp_source_stats with workspace_id=None raises RuntimeError (fail-closed).
+  5. mcp_source_stats with cross-tenant source_id raises ValueError("source_not_found:…").
+  6. mcp_source_stats with own source returns stats normally.
+  7. mcp_get_document with workspace_id=None raises RuntimeError (fail-closed).
+  8. mcp_get_document with cross-tenant document raises ValueError("document_not_found:…").
+  9. mcp_get_document preserves "document_not_found:" prefix (for server.py re-wrap).
+ 10. mcp_get_document with own document returns data normally.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from omniscience_core.db.models import (
+    Document,
+    Source,
+    SourceStatus,
+    SourceType,
+)
+from omniscience_server.mcp.tools import (
+    mcp_get_document,
+    mcp_list_sources,
+    mcp_source_stats,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_WS_B = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_source(
+    *,
+    tenant_id: uuid.UUID | None,
+    name: str = "src",
+    source_id: uuid.UUID | None = None,
+) -> Source:
+    src: Source = MagicMock(spec=Source)
+    src.id = source_id or uuid.uuid4()
+    src.type = SourceType.git
+    src.name = name
+    src.config = {}
+    src.secrets_ref = None
+    src.status = SourceStatus.active
+    src.last_sync_at = None
+    src.last_error = None
+    src.last_error_at = None
+    src.freshness_sla_seconds = None
+    src.tenant_id = tenant_id
+    src.created_at = datetime.now(tz=UTC)
+    src.updated_at = datetime.now(tz=UTC)
+    return src
+
+
+def _make_document(
+    *,
+    source_id: uuid.UUID,
+    doc_id: uuid.UUID | None = None,
+) -> Document:
+    doc: Document = MagicMock(spec=Document)
+    doc.id = doc_id or uuid.uuid4()
+    doc.source_id = source_id
+    doc.external_id = "ext-1"
+    doc.uri = "file:///a.txt"
+    doc.title = "A"
+    doc.doc_version = 1
+    doc.indexed_at = datetime.now(tz=UTC)
+    doc.tombstoned_at = None
+    doc.doc_metadata = {}
+    return doc
+
+
+def _make_session_for_list_sources(sources: list[Source]) -> AsyncMock:
+    """Session that returns ``sources`` from select(Source).where(...)."""
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = sources
+        return res
+
+    session.execute = _execute
+    session.get = AsyncMock(return_value=None)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_session_for_get(get_result: Any) -> AsyncMock:
+    """Session that returns ``get_result`` from session.get(...)."""
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = []
+        res.scalar_one.return_value = 0
+        res.scalar_one_or_none.return_value = None
+        return res
+
+    session.execute = _execute
+    session.get = AsyncMock(return_value=get_result)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_app(session: AsyncMock) -> FastAPI:
+    app = FastAPI()
+    app.state.db_session_factory = MagicMock(return_value=session)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# mcp_list_sources — workspace_id=None is fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_sources_none_workspace_raises() -> None:
+    """mcp_list_sources raises RuntimeError when workspace_id is None (fail-closed)."""
+    session = _make_session_for_list_sources([])
+    app = _make_app(session)
+
+    with pytest.raises(RuntimeError, match="forbidden:workspace_required"):
+        await mcp_list_sources(app=app, workspace_id=None)
+
+
+# ---------------------------------------------------------------------------
+# mcp_list_sources — returns only own-workspace sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_sources_returns_own_workspace_only() -> None:
+    """mcp_list_sources returns sources for workspace A when called with WS_A."""
+    src_a = _make_source(tenant_id=_WS_A, name="ws-a-source")
+    session = _make_session_for_list_sources([src_a])
+    app = _make_app(session)
+
+    result = await mcp_list_sources(app=app, workspace_id=_WS_A)
+
+    assert "sources" in result
+    assert len(result["sources"]) == 1
+    assert result["sources"][0]["name"] == "ws-a-source"
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_sources_excludes_cross_tenant() -> None:
+    """mcp_list_sources returns an empty list when no workspace-A sources exist."""
+    # The SQL filter (Source.tenant_id == workspace_id) is enforced in the tool.
+    # The mock returns an empty list, simulating that WS_B rows were excluded by SQL.
+    session = _make_session_for_list_sources([])
+    app = _make_app(session)
+
+    result = await mcp_list_sources(app=app, workspace_id=_WS_A)
+
+    assert result == {"sources": []}
+
+
+# ---------------------------------------------------------------------------
+# mcp_source_stats — workspace_id=None is fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_stats_none_workspace_raises() -> None:
+    """mcp_source_stats raises RuntimeError when workspace_id is None (fail-closed)."""
+    session = _make_session_for_get(None)
+    app = _make_app(session)
+
+    with pytest.raises(RuntimeError, match="forbidden:workspace_required"):
+        await mcp_source_stats(app=app, source_id=str(uuid.uuid4()), workspace_id=None)
+
+
+# ---------------------------------------------------------------------------
+# mcp_source_stats — cross-tenant source returns source_not_found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_stats_cross_tenant_raises_not_found() -> None:
+    """mcp_source_stats raises ValueError('source_not_found:…') for workspace-B source."""
+    src_b = _make_source(tenant_id=_WS_B)
+    session = _make_session_for_get(src_b)
+    app = _make_app(session)
+
+    with pytest.raises(ValueError, match=f"source_not_found:{src_b.id}"):
+        await mcp_source_stats(app=app, source_id=str(src_b.id), workspace_id=_WS_A)
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_stats_missing_source_raises_not_found() -> None:
+    """mcp_source_stats raises ValueError('source_not_found:…') when source is absent."""
+    session = _make_session_for_get(None)
+    app = _make_app(session)
+    fake_id = str(uuid.uuid4())
+
+    with pytest.raises(ValueError, match=f"source_not_found:{fake_id}"):
+        await mcp_source_stats(app=app, source_id=fake_id, workspace_id=_WS_A)
+
+
+# ---------------------------------------------------------------------------
+# mcp_source_stats — own workspace source returns data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_source_stats_own_workspace_returns_stats() -> None:
+    """mcp_source_stats returns stats when source belongs to the caller's workspace."""
+    src_a = _make_source(tenant_id=_WS_A, name="own-source")
+    session = _make_session_for_get(src_a)
+    app = _make_app(session)
+
+    result = await mcp_source_stats(app=app, source_id=str(src_a.id), workspace_id=_WS_A)
+
+    assert result["id"] == str(src_a.id)
+    assert result["name"] == "own-source"
+    assert "indexed_document_count" in result
+    assert "indexed_chunk_count" in result
+
+
+# ---------------------------------------------------------------------------
+# mcp_get_document — workspace_id=None is fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_none_workspace_raises() -> None:
+    """mcp_get_document raises RuntimeError when workspace_id is None (fail-closed)."""
+    session = _make_session_for_get(None)
+    app = _make_app(session)
+
+    with pytest.raises(RuntimeError, match="forbidden:workspace_required"):
+        await mcp_get_document(app=app, document_id=str(uuid.uuid4()), workspace_id=None)
+
+
+# ---------------------------------------------------------------------------
+# mcp_get_document — cross-tenant document returns document_not_found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_cross_tenant_raises_not_found() -> None:
+    """mcp_get_document raises ValueError('document_not_found:…') for workspace-B document."""
+    src_b = _make_source(tenant_id=_WS_B)
+    doc = _make_document(source_id=src_b.id)
+
+    # Build a session that returns doc then src_b on successive .get() calls.
+    session = AsyncMock()
+    call_count: list[int] = [0]
+
+    async def _get(model: Any, pk: Any) -> Any:
+        call_count[0] += 1
+        return doc if call_count[0] == 1 else src_b
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = []
+        return res
+
+    session.get = _get
+    session.execute = _execute
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(session)
+
+    with pytest.raises(ValueError, match=f"document_not_found:{doc.id}"):
+        await mcp_get_document(app=app, document_id=str(doc.id), workspace_id=_WS_A)
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_not_found_raises_not_found() -> None:
+    """mcp_get_document raises ValueError('document_not_found:…') when doc is absent."""
+    session = _make_session_for_get(None)
+    app = _make_app(session)
+    fake_id = str(uuid.uuid4())
+
+    with pytest.raises(ValueError, match=f"document_not_found:{fake_id}"):
+        await mcp_get_document(app=app, document_id=fake_id, workspace_id=_WS_A)
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_error_prefix_preserved() -> None:
+    """mcp_get_document ValueError starts with 'document_not_found:' for server re-wrap."""
+    # The server-layer wrapper in server.py re-maps this prefix to 'source_not_found:'.
+    # Verify the exact prefix is preserved.
+    session = _make_session_for_get(None)
+    app = _make_app(session)
+    doc_id = str(uuid.uuid4())
+
+    with pytest.raises(ValueError) as exc_info:
+        await mcp_get_document(app=app, document_id=doc_id, workspace_id=_WS_A)
+
+    assert str(exc_info.value).startswith("document_not_found:")
+
+
+# ---------------------------------------------------------------------------
+# mcp_get_document — own workspace document returns data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_document_own_workspace_returns_data() -> None:
+    """mcp_get_document returns document and chunks when source is in caller's workspace."""
+    src_a = _make_source(tenant_id=_WS_A)
+    doc = _make_document(source_id=src_a.id)
+
+    session = AsyncMock()
+    call_count: list[int] = [0]
+
+    async def _get(model: Any, pk: Any) -> Any:
+        call_count[0] += 1
+        return doc if call_count[0] == 1 else src_a
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = []
+        return res
+
+    session.get = _get
+    session.execute = _execute
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    app = _make_app(session)
+
+    result = await mcp_get_document(app=app, document_id=str(doc.id), workspace_id=_WS_A)
+
+    assert "document" in result
+    assert result["document"]["id"] == str(doc.id)
+    assert "chunks" in result

--- a/tests/test_tenant_isolation_rest.py
+++ b/tests/test_tenant_isolation_rest.py
@@ -1,0 +1,582 @@
+"""Tenant isolation tests for REST endpoints.
+
+Verifies that bearer tokens scoped to workspace A cannot read, modify, or
+delete resources that belong to workspace B.
+
+Endpoints under test:
+  GET    /api/v1/sources            — list_sources
+  GET    /api/v1/sources/{id}       — get_source
+  PATCH  /api/v1/sources/{id}       — update_source
+  DELETE /api/v1/sources/{id}       — delete_source
+  GET    /api/v1/sources/{id}/stats — source_stats
+  GET    /api/v1/documents/{id}     — get_document
+
+Security invariants tested:
+  1. Token for workspace A sees only workspace-A sources in list.
+  2. Token for workspace A gets 404 (not 403) for a workspace-B source by id.
+  3. Token for workspace A cannot PATCH a workspace-B source (404).
+  4. Token for workspace A cannot DELETE a workspace-B source (404).
+  5. Token for workspace A gets 404 for stats of a workspace-B source.
+  6. Token for workspace A gets 404 for a document whose parent source is in workspace B.
+  7. Legacy token (workspace_id=None) is rejected fail-closed with 403 on
+     all read and write source endpoints, and on the document endpoint.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from omniscience_core.auth.tokens import generate_token, hash_token
+from omniscience_core.config import Settings
+from omniscience_core.db.models import (
+    ApiToken,
+    Document,
+    Source,
+    SourceStatus,
+    SourceType,
+)
+from omniscience_server.app import create_app
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_WS_B = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_token(
+    *,
+    workspace_id: uuid.UUID | None,
+    scopes: list[str],
+) -> tuple[ApiToken, str]:
+    """Return an (ApiToken mock, plaintext) pair."""
+    plaintext, prefix = generate_token("test")
+    hashed = hash_token(plaintext)
+
+    tok: ApiToken = MagicMock(spec=ApiToken)
+    tok.id = uuid.uuid4()
+    tok.name = f"token-ws-{workspace_id}"
+    tok.token_prefix = prefix
+    tok.hashed_token = hashed
+    tok.scopes = scopes
+    tok.workspace_id = workspace_id
+    tok.expires_at = None
+    tok.is_active = True
+    tok.last_used_at = None
+    return tok, plaintext
+
+
+def _make_source(
+    *,
+    tenant_id: uuid.UUID | None,
+    name: str = "src",
+    source_id: uuid.UUID | None = None,
+) -> Source:
+    """Minimal Source mock."""
+    src: Source = MagicMock(spec=Source)
+    src.id = source_id or uuid.uuid4()
+    src.type = SourceType.git
+    src.name = name
+    src.config = {}
+    src.secrets_ref = None
+    src.status = SourceStatus.active
+    src.last_sync_at = None
+    src.last_error = None
+    src.last_error_at = None
+    src.freshness_sla_seconds = None
+    src.tenant_id = tenant_id
+    src.created_at = datetime.now(tz=UTC)
+    src.updated_at = datetime.now(tz=UTC)
+    return src
+
+
+def _make_document(
+    *,
+    source_id: uuid.UUID,
+    doc_id: uuid.UUID | None = None,
+) -> Document:
+    """Minimal Document mock."""
+    doc: Document = MagicMock(spec=Document)
+    doc.id = doc_id or uuid.uuid4()
+    doc.source_id = source_id
+    doc.external_id = "ext-1"
+    doc.uri = "file:///a.txt"
+    doc.title = "A"
+    doc.content_hash = "abc123"
+    doc.doc_version = 1
+    doc.indexed_at = datetime.now(tz=UTC)
+    doc.tombstoned_at = None
+    doc.doc_metadata = {}
+    return doc
+
+
+def _make_settings() -> Settings:
+    return Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+
+
+def _make_auth_session(token: ApiToken) -> AsyncMock:
+    """Session that returns ``token`` for auth middleware queries."""
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = [token]
+        return res
+
+    session.execute = _execute
+    session.get = AsyncMock(return_value=None)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.delete = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _make_data_session(
+    *,
+    get_result: Any = None,
+    scalars: list[Any] | None = None,
+) -> AsyncMock:
+    """Session used for business-logic queries."""
+    session = AsyncMock()
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        items = scalars or []
+        res.scalars.return_value.all.return_value = items
+        res.scalars.return_value.first.return_value = items[0] if items else None
+        res.scalar_one.return_value = 0
+        res.scalar_one_or_none.return_value = None
+        return res
+
+    session.execute = _execute
+    session.get = AsyncMock(return_value=get_result)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.delete = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+def _build_app(
+    token: ApiToken,
+    data_session: AsyncMock,
+) -> FastAPI:
+    """Create the full app with auth and data sessions."""
+    app = create_app(settings=_make_settings())
+    auth_session = _make_auth_session(token)
+    call_count: list[int] = [0]
+
+    def _factory() -> AsyncMock:
+        call_count[0] += 1
+        return auth_session if call_count[0] == 1 else data_session
+
+    app.state.db_session_factory = _factory
+    return app
+
+
+async def _get_client(app: FastAPI) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+# ---------------------------------------------------------------------------
+# list_sources — workspace isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sources_returns_only_own_workspace_sources() -> None:
+    """GET /sources returns only sources with tenant_id matching the token's workspace."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:read"])
+    # Data session returns a source that belongs to workspace A
+    src_a = _make_source(tenant_id=_WS_A, name="ws-a-source")
+    data_session = _make_data_session(scalars=[src_a])
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            "/api/v1/sources",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) == 1
+    assert body[0]["name"] == "ws-a-source"
+
+
+@pytest.mark.asyncio
+async def test_list_sources_cross_tenant_excluded() -> None:
+    """GET /sources does not return sources from workspace B when token is workspace A."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:read"])
+    # Data session returns no rows (because the SQL filter by tenant_id would exclude WS_B rows)
+    data_session = _make_data_session(scalars=[])
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            "/api/v1/sources",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_sources_legacy_token_rejected_403() -> None:
+    """GET /sources with a legacy token (workspace_id=None) returns 403 fail-closed."""
+    tok, pt = _make_token(workspace_id=None, scopes=["sources:read"])
+    data_session = _make_data_session(scalars=[])
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            "/api/v1/sources",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["error"]["code"] == "forbidden"
+
+
+# ---------------------------------------------------------------------------
+# get_source — cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_source_cross_tenant_returns_404() -> None:
+    """GET /sources/{id} returns 404 when the source belongs to workspace B."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:read"])
+    # The source exists but belongs to WS_B
+    src_b = _make_source(tenant_id=_WS_B, name="ws-b-source")
+    data_session = _make_data_session(get_result=src_b)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/sources/{src_b.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["error"]["code"] == "source_not_found"
+
+
+@pytest.mark.asyncio
+async def test_get_source_legacy_token_rejected_403() -> None:
+    """GET /sources/{id} with legacy token (workspace_id=None) returns 403."""
+    tok, pt = _make_token(workspace_id=None, scopes=["sources:read"])
+    src = _make_source(tenant_id=_WS_A)
+    data_session = _make_data_session(get_result=src)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/sources/{src.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_get_source_own_workspace_succeeds() -> None:
+    """GET /sources/{id} succeeds when source belongs to the token's workspace."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:read"])
+    src = _make_source(tenant_id=_WS_A, name="my-source")
+    data_session = _make_data_session(get_result=src)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/sources/{src.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "my-source"
+
+
+# ---------------------------------------------------------------------------
+# update_source — cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_source_cross_tenant_returns_404() -> None:
+    """PATCH /sources/{id} returns 404 when source belongs to workspace B."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:write"])
+    src_b = _make_source(tenant_id=_WS_B)
+    data_session = _make_data_session(get_result=src_b)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.patch(
+            f"/api/v1/sources/{src_b.id}",
+            json={"name": "hacked"},
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "source_not_found"
+
+
+@pytest.mark.asyncio
+async def test_update_source_legacy_token_rejected_403() -> None:
+    """PATCH /sources/{id} with legacy token returns 403 fail-closed."""
+    tok, pt = _make_token(workspace_id=None, scopes=["sources:write"])
+    src = _make_source(tenant_id=_WS_A)
+    data_session = _make_data_session(get_result=src)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.patch(
+            f"/api/v1/sources/{src.id}",
+            json={"name": "attempt"},
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# delete_source — cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_source_cross_tenant_returns_404() -> None:
+    """DELETE /sources/{id} returns 404 when source belongs to workspace B."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:write"])
+    src_b = _make_source(tenant_id=_WS_B)
+    data_session = _make_data_session(get_result=src_b)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.delete(
+            f"/api/v1/sources/{src_b.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "source_not_found"
+
+
+@pytest.mark.asyncio
+async def test_delete_source_legacy_token_rejected_403() -> None:
+    """DELETE /sources/{id} with legacy token returns 403 fail-closed."""
+    tok, pt = _make_token(workspace_id=None, scopes=["sources:write"])
+    src = _make_source(tenant_id=_WS_A)
+    data_session = _make_data_session(get_result=src)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.delete(
+            f"/api/v1/sources/{src.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# source_stats — cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_source_stats_cross_tenant_returns_404() -> None:
+    """GET /sources/{id}/stats returns 404 when source belongs to workspace B."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:read"])
+    src_b = _make_source(tenant_id=_WS_B)
+    data_session = _make_data_session(get_result=src_b)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/sources/{src_b.id}/stats",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "source_not_found"
+
+
+@pytest.mark.asyncio
+async def test_source_stats_legacy_token_rejected_403() -> None:
+    """GET /sources/{id}/stats with legacy token returns 403 fail-closed."""
+    tok, pt = _make_token(workspace_id=None, scopes=["sources:read"])
+    src = _make_source(tenant_id=_WS_A)
+    data_session = _make_data_session(get_result=src)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/sources/{src.id}/stats",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# get_document — cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_document_cross_tenant_returns_404() -> None:
+    """GET /documents/{id} returns 404 when document's source is in workspace B."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["search"])
+
+    src_b = _make_source(tenant_id=_WS_B)
+    doc = _make_document(source_id=src_b.id)
+
+    # We need a session that returns the doc from .get(Document, ...) on first
+    # call and the source from .get(Source, ...) on the second call.
+    session = AsyncMock()
+    call_count: list[int] = [0]
+
+    async def _get(model: Any, pk: Any) -> Any:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return doc  # Document lookup
+        return src_b  # Source lookup
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = []
+        return res
+
+    session.get = _get
+    session.execute = _execute
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    tok_obj = tok  # ApiToken object
+    auth_session = _make_auth_session(tok_obj)
+
+    app = create_app(settings=_make_settings())
+    req_count: list[int] = [0]
+
+    def _factory() -> Any:
+        req_count[0] += 1
+        return auth_session if req_count[0] == 1 else session
+
+    app.state.db_session_factory = _factory
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/documents/{doc.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "document_not_found"
+
+
+@pytest.mark.asyncio
+async def test_get_document_own_workspace_succeeds() -> None:
+    """GET /documents/{id} succeeds when document's source is in the same workspace."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["search"])
+
+    src_a = _make_source(tenant_id=_WS_A)
+    doc = _make_document(source_id=src_a.id)
+
+    session = AsyncMock()
+    call_count: list[int] = [0]
+
+    async def _get(model: Any, pk: Any) -> Any:
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return doc
+        return src_a
+
+    async def _execute(stmt: Any) -> Any:
+        res = MagicMock()
+        res.scalars.return_value.all.return_value = []
+        return res
+
+    session.get = _get
+    session.execute = _execute
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    auth_session = _make_auth_session(tok)
+    app = create_app(settings=_make_settings())
+    req_count: list[int] = [0]
+
+    def _factory() -> Any:
+        req_count[0] += 1
+        return auth_session if req_count[0] == 1 else session
+
+    app.state.db_session_factory = _factory
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/documents/{doc.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "document" in data
+    assert "chunks" in data
+
+
+@pytest.mark.asyncio
+async def test_get_document_legacy_token_rejected_403() -> None:
+    """GET /documents/{id} with legacy token (workspace_id=None) returns 403."""
+    tok, pt = _make_token(workspace_id=None, scopes=["search"])
+    src = _make_source(tenant_id=_WS_A)
+    doc = _make_document(source_id=src.id)
+
+    data_session = _make_data_session(get_result=doc)
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.get(
+            f"/api/v1/documents/{doc.id}",
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "forbidden"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -168,10 +168,16 @@ async def test_delivery_tracker_different_ids_not_duplicate() -> None:
 @pytest.mark.asyncio
 async def test_delivery_tracker_expired_not_duplicate() -> None:
     """IDs older than the window are purged and no longer count as duplicates."""
-    tracker = DeliveryTracker(window_seconds=0.05)  # 50 ms window
-    await tracker.record("expiring-id")
-    await asyncio.sleep(0.1)
-    assert await tracker.is_duplicate("expiring-id") is False
+    # Freeze time instead of sleeping: the first two monotonic() calls happen
+    # inside record() (_purge_expired + timestamp write) at t=0.0; the third
+    # call happens inside is_duplicate()/_purge_expired at t=100.0, making
+    # cutoff = 100.0 - 0.05 = 99.95 which is greater than the stored 0.0,
+    # so the entry is deterministically purged without any real wall-clock wait.
+    with patch("omniscience_server.rest.delivery_tracker.time") as mock_time:
+        mock_time.monotonic.side_effect = [0.0, 0.0, 100.0]
+        tracker = DeliveryTracker(window_seconds=0.05)
+        await tracker.record("expiring-id")
+        assert await tracker.is_duplicate("expiring-id") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes from a multi-agent review of the retrieval / index / ingestion stack. Four independent issues, each with tests. No conceptual/architectural changes here — those (bitemporal `as_of` gap between graph and vector, multi-store write atomicity / outbox, enumerate-mode retrieval + ADR sync) are deliberately left for separate ADR-amended PRs.

## What's fixed

### 🔴 Cross-tenant isolation (Source / Document layer)
The relational layer was **not** scoped by workspace, unlike the graph (Neo4j) and vector (Qdrant) layers. Any valid token could list sources of all tenants (including `secrets_ref`), read any document by UUID, and update/delete other tenants' sources.

- `rest/sources.py` — list / get / update / delete / trigger_sync / stats now filter by `Source.tenant_id == workspace_id`
- `rest/documents.py` — `get_document` joins Source and verifies tenant
- `mcp/tools.py` — `list_sources` / `source_stats` / `get_document` take `workspace_id`; `mcp/server.py` passes it from the token
- Cross-tenant access → **404** (no existence oracle); legacy token without `workspace_id` → **fail-closed 403 / forbidden**
- Independently re-verified by a security pass (VETO lifted)

### 🔴 Qdrant point leak on tombstone purge
`writer.py:purge_tombstones` deleted documents from Postgres but left the Qdrant points forever. Now orchestrates `delete_tombstoned` on the vector store (Qdrant-first, then Postgres — an orphan vector is tolerable, a dangling Postgres ref is not).

### 🔴 k8s ingest freshness alerting
A 6-day launchd outage went unnoticed because of three blind spots: no `k8s` TTL in the scheduler, no `freshness_sla_seconds` on the seeded source, no Prometheus rule.
- `scheduler.py` — add `"k8s": 1800` TTL (in-stack auto-trigger fallback)
- `seed_from_docs.py` — set `freshness_sla_seconds=1800` on create
- `monitoring/prometheus/alerts/freshness.yaml` — alert on `omniscience_source_stale_total > 0`

### 🟠 CI / test reliability
- `ci.yml` — enable `OMNISCIENCE_RUN_E2E_INGESTION` so the only ingest→index→search E2E test actually runs (Neo4j + Qdrant containers are already up in that job)
- Freeze clocks in freshness / TTL-cache / webhook tests (removed real `asyncio.sleep` / unfrozen `datetime.now`) — no new dependency introduced

## Tests
- New `test_tenant_isolation_rest.py` / `test_tenant_isolation_mcp.py`
- Qdrant path of `IndexWriter` now covered: success, Qdrant-failure → PG rollback, purge orchestration
- Scheduler `k8s` TTL assertion
- All touched suites green; `ruff check .` and `ruff format --check .` clean

## Notes / follow-ups
- `auth/workspace.py` `workspace_filter` still has an `or_(col == workspace_id, col == null())` branch that exposes NULL-tenant rows to every workspace. These handlers bypass it with a strict `== workspace_id`, but it deserves a separate ticket (data backfill + remove the null branch).
- Two operational AWS-scrape scripts from the review session were intentionally left out of this PR (crude one-shot glue, unrelated to these fixes).
