### PR TITLE
feat: bitemporal vector + hybrid retrieval, reconcile worker, null-tenant fix

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -53,6 +53,7 @@ from omniscience_server.ingestion.worker import IngestionWorker
 from omniscience_server.mcp.mount import create_mcp_asgi_app
 from omniscience_server.mcp.server import mcp_server
 from omniscience_server.middleware import TelemetryMiddleware, TracingMiddleware
+from omniscience_server.reconcile_worker import ReconcileWorker
 from omniscience_server.rest import api_v1_router, register_error_handlers
 from omniscience_server.rest.otlp_ingester import OtlpIngester
 from omniscience_server.retention_worker import RetentionWorker
@@ -322,6 +323,20 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         app.state.retention_worker = None
         log.info("retention_worker_disabled")
 
+    # --- Reconcile worker ---
+    reconcile_worker = ReconcileWorker(
+        session_factory=session_factory,
+        vector_store=qdrant_store,
+        graph_store=neo4j_graph_store,
+        settings=settings,
+    )
+    reconcile_task = asyncio.create_task(reconcile_worker.start())
+    app.state.reconcile_worker = reconcile_worker
+    log.info(
+        "reconcile_worker_started",
+        tick_seconds=getattr(settings, "reconcile_tick_seconds", 3600),
+    )
+
     # --- Scheduler worker ---
     scheduler_task: asyncio.Task[None] | None = None
     scheduler: SchedulerWorker | None = None
@@ -357,6 +372,9 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     freshness_worker.stop()
     freshness_task.cancel()
+
+    reconcile_worker.stop()
+    reconcile_task.cancel()
 
     if scheduler is not None and scheduler_task is not None:
         await scheduler.stop()

--- a/apps/server/src/omniscience_server/reconcile_constants.py
+++ b/apps/server/src/omniscience_server/reconcile_constants.py
@@ -1,0 +1,69 @@
+"""Named constants for the reconcile worker.
+
+The reconcile worker is the compensation mechanism for the non-atomic
+triple-write (Postgres + Qdrant + Neo4j) in ``IndexWriter.upsert_document``
+/ ``upsert_graph``.  On each tick it cross-checks the three stores and
+repairs drift idempotently.
+
+These constants follow the same conventions as ``retention_constants.py``:
+every tuneable value lives here with a docstring that explains the rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Worker shape
+# ---------------------------------------------------------------------------
+
+#: Worker tick interval in seconds.  The default of 1 hour (3600 s) is
+#: aggressive enough to catch newly created orphans from a Qdrant restart
+#: within an SLO-friendly window, without adding measurable load to
+#: Qdrant or Neo4j.  Operators may lower this to 300 s in dev or raise it
+#: to 6 h in large deployments (following the retention-worker pattern).
+RECONCILE_TICK_SECONDS_DEFAULT: Final[int] = 3600
+
+#: Maximum number of orphan Qdrant points deleted per reconcile tick.
+#: Bounded so a single misbehaving run does not wipe thousands of points
+#: without an operator noticing the ``omniscience_reconcile_drift_total``
+#: spike first.  Remaining orphans are cleaned up on the next tick.
+RECONCILE_ORPHAN_DELETE_LIMIT: Final[int] = 200
+
+# ---------------------------------------------------------------------------
+# Drift type labels (Prometheus counter label values)
+# ---------------------------------------------------------------------------
+
+#: Postgres document exists but no corresponding chunks in Qdrant.
+#: Indicates PG write succeeded but Qdrant write failed or was skipped.
+DRIFT_PG_MISSING_QDRANT: Final[str] = "pg_missing_qdrant"
+
+#: Chunks in Qdrant reference a source_id that has no active Postgres
+#: document.  Orphan from seed scripts, partial deletes, or tombstone
+#: race conditions.
+DRIFT_QDRANT_ORPHAN: Final[str] = "qdrant_orphan"
+
+#: Entity nodes in Neo4j reference a source_id that has no active Postgres
+#: document.  Neo4j cleanup is deferred to the retention worker
+#: (end-dating / ADR-0009); this worker only records the metric.
+DRIFT_NEO4J_ORPHAN: Final[str] = "neo4j_orphan"
+
+# ---------------------------------------------------------------------------
+# Store labels (reuse from retention for consistency)
+# ---------------------------------------------------------------------------
+
+STORE_LABEL_QDRANT: Final[str] = "qdrant"
+STORE_LABEL_NEO4J: Final[str] = "neo4j"
+STORE_LABEL_POSTGRES: Final[str] = "postgres"
+
+
+__all__ = [
+    "DRIFT_NEO4J_ORPHAN",
+    "DRIFT_PG_MISSING_QDRANT",
+    "DRIFT_QDRANT_ORPHAN",
+    "RECONCILE_ORPHAN_DELETE_LIMIT",
+    "RECONCILE_TICK_SECONDS_DEFAULT",
+    "STORE_LABEL_NEO4J",
+    "STORE_LABEL_POSTGRES",
+    "STORE_LABEL_QDRANT",
+]

--- a/apps/server/src/omniscience_server/reconcile_worker.py
+++ b/apps/server/src/omniscience_server/reconcile_worker.py
@@ -1,0 +1,515 @@
+"""Reconcile worker — cross-store drift detection and repair.
+
+The triple write in ``IndexWriter.upsert_document`` / ``upsert_graph`` is
+**not atomic**.  The sequence is:
+
+1. Postgres transaction commits (document + chunks rows).
+2. Qdrant upsert — outside the PG transaction; a failure here leaves a
+   document in Postgres with no vector chunks.
+3. Neo4j upsert — called separately from ``IngestionWorker`` via
+   ``upsert_graph``; always outside the PG transaction.
+
+A process crash between any two of these steps produces permanent drift:
+
+* ``pg_missing_qdrant``  — PG commit succeeded, Qdrant write failed.
+  Document is queryable via REST/MCP metadata endpoints but invisible to
+  vector search.  Action: log + mark the owning ``ingestion_run`` as
+  ``partial`` + expose metric.  Re-indexing is triggered by the operator
+  or by a follow-up ingestion run.
+
+* ``qdrant_orphan``      — chunks in Qdrant reference a ``source_id`` that
+  has no non-tombstoned Postgres document.  Caused by seed scripts,
+  aborted partial deletes, or tombstone race conditions.  Action:
+  hard-delete the orphan chunks (bounded by ``RECONCILE_ORPHAN_DELETE_LIMIT``).
+
+* ``neo4j_orphan``       — entity nodes in Neo4j reference a ``source_id``
+  that has no active Postgres documents.  Neo4j cleanup is deferred to
+  the retention worker (end-dating path, ADR-0009); this worker records the
+  metric so operators are alerted.
+
+**Idempotency**: every action is safe to repeat.  Qdrant deletes by filter
+are no-ops when the points are already gone.  ``ingestion_run`` status
+updates are guarded with ``WHERE status != 'partial'`` to avoid double-
+writing.
+
+**ACL**: every store call passes ``workspace_id``; cross-workspace mixing
+is structurally impossible because the outer loop iterates workspaces and
+every per-workspace method pins the id.
+
+**Bounded**: orphan deletes are capped at ``RECONCILE_ORPHAN_DELETE_LIMIT``
+per tick.  The remainder is cleaned on the next tick.
+
+Usage in ``app.py`` lifespan::
+
+    from omniscience_server.reconcile_worker import ReconcileWorker
+
+    reconcile_worker = ReconcileWorker(
+        session_factory=session_factory,
+        vector_store=qdrant_store,
+        graph_store=neo4j_graph_store,
+        settings=settings,
+    )
+    reconcile_task = asyncio.create_task(reconcile_worker.start())
+    app.state.reconcile_worker = reconcile_worker
+    ...
+    yield
+    ...
+    reconcile_worker.stop()
+    reconcile_task.cancel()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import structlog
+from omniscience_core.config import Settings
+from omniscience_core.db.models import (
+    Document,
+    IngestionRun,
+    IngestionRunStatus,
+    Source,
+    Workspace,
+)
+from omniscience_core.telemetry.metrics import (
+    RECONCILE_DRIFT_TOTAL,
+    RECONCILE_WORKER_DURATION_SECONDS,
+    RECONCILE_WORKER_RUNS_TOTAL,
+)
+from omniscience_index.stores.neo4j_store import Neo4jGraphStore
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from omniscience_server.reconcile_constants import (
+    DRIFT_NEO4J_ORPHAN,
+    DRIFT_PG_MISSING_QDRANT,
+    DRIFT_QDRANT_ORPHAN,
+    RECONCILE_ORPHAN_DELETE_LIMIT,
+    RECONCILE_TICK_SECONDS_DEFAULT,
+)
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Report dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceReconcileReport:
+    """Per-workspace reconcile result for one tick."""
+
+    workspace_id: uuid.UUID
+    pg_missing_qdrant: list[uuid.UUID] = field(default_factory=list)
+    qdrant_orphan_sources: list[str] = field(default_factory=list)
+    qdrant_orphans_deleted: int = 0
+    neo4j_orphan_sources: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileRunReport:
+    """Aggregated report for one full reconcile tick."""
+
+    started_at: datetime
+    finished_at: datetime
+    per_workspace: list[WorkspaceReconcileReport]
+    duration_seconds: float
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+
+class ReconcileWorker:
+    """Background task that detects and repairs cross-store drift.
+
+    Args:
+        session_factory: SQLAlchemy async session factory.
+        vector_store:    Qdrant store — provides source-scoped chunk counts
+            and source-scoped orphan deletion.
+        graph_store:     Neo4j store — provides per-source entity counts.
+        settings:        Application settings — drives tick interval and
+            the orphan-delete batch limit.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession],
+        vector_store: QdrantVectorStore,
+        graph_store: Neo4jGraphStore,
+        settings: Settings,
+    ) -> None:
+        self._session_factory = session_factory
+        self._vector_store = vector_store
+        self._graph_store = graph_store
+        self._tick_seconds = max(
+            int(getattr(settings, "reconcile_tick_seconds", RECONCILE_TICK_SECONDS_DEFAULT)),
+            60,
+        )
+        self._orphan_limit = max(
+            int(getattr(settings, "reconcile_orphan_delete_limit", RECONCILE_ORPHAN_DELETE_LIMIT)),
+            1,
+        )
+        self._running = False
+        self._last_report: ReconcileRunReport | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Run the worker loop until :meth:`stop` is called."""
+        self._running = True
+        log.info(
+            "reconcile_worker_started",
+            tick_seconds=self._tick_seconds,
+            orphan_limit=self._orphan_limit,
+        )
+        while self._running:
+            try:
+                await self.run_once()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                log.error("reconcile_worker_error", error=str(exc))
+            try:
+                await asyncio.sleep(self._tick_seconds)
+            except asyncio.CancelledError:
+                break
+        log.info("reconcile_worker_stopped")
+
+    def stop(self) -> None:
+        """Signal the worker to exit after the current tick completes."""
+        self._running = False
+
+    @property
+    def last_report(self) -> ReconcileRunReport | None:
+        """Most recent run report, or ``None`` before the first run."""
+        return self._last_report
+
+    # ------------------------------------------------------------------
+    # Public entry point — one full tick
+    # ------------------------------------------------------------------
+
+    async def run_once(self) -> ReconcileRunReport:
+        """Execute one full reconcile tick across all workspaces."""
+        started = datetime.now(UTC)
+        wall_start = time.monotonic()
+
+        workspace_ids = await self._load_workspace_ids()
+        per_workspace: list[WorkspaceReconcileReport] = []
+
+        for ws_id in workspace_ids:
+            report = await self._reconcile_workspace(workspace_id=ws_id)
+            per_workspace.append(report)
+
+        duration = time.monotonic() - wall_start
+        finished = datetime.now(UTC)
+
+        run_report = ReconcileRunReport(
+            started_at=started,
+            finished_at=finished,
+            per_workspace=per_workspace,
+            duration_seconds=duration,
+        )
+        RECONCILE_WORKER_RUNS_TOTAL.inc()
+        RECONCILE_WORKER_DURATION_SECONDS.observe(duration)
+        self._last_report = run_report
+
+        log.info(
+            "reconcile_run_complete",
+            workspaces=len(per_workspace),
+            duration_s=duration,
+        )
+        return run_report
+
+    # ------------------------------------------------------------------
+    # Per-workspace reconcile
+    # ------------------------------------------------------------------
+
+    async def _reconcile_workspace(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> WorkspaceReconcileReport:
+        """Run all three drift checks for one workspace.
+
+        ACL invariant: every store call below pins ``workspace_id``.
+        """
+        pg_source_ids = await self._load_active_source_ids(workspace_id=workspace_id)
+
+        pg_missing_qdrant = await self._check_pg_missing_qdrant(
+            workspace_id=workspace_id,
+            pg_source_ids=pg_source_ids,
+        )
+        qdrant_orphan_sources, qdrant_orphans_deleted = await self._check_qdrant_orphans(
+            workspace_id=workspace_id,
+            pg_source_ids=pg_source_ids,
+        )
+        neo4j_orphan_sources = await self._check_neo4j_orphans(
+            workspace_id=workspace_id,
+            pg_source_ids=pg_source_ids,
+        )
+
+        return WorkspaceReconcileReport(
+            workspace_id=workspace_id,
+            pg_missing_qdrant=pg_missing_qdrant,
+            qdrant_orphan_sources=qdrant_orphan_sources,
+            qdrant_orphans_deleted=qdrant_orphans_deleted,
+            neo4j_orphan_sources=neo4j_orphan_sources,
+        )
+
+    # ------------------------------------------------------------------
+    # Drift check A: PG document with no Qdrant chunks
+    # ------------------------------------------------------------------
+
+    async def _check_pg_missing_qdrant(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        pg_source_ids: set[uuid.UUID],
+    ) -> list[uuid.UUID]:
+        """Return source_ids that have PG documents but zero Qdrant chunks."""
+        if not pg_source_ids:
+            return []
+
+        qdrant_source_map = await self._vector_store.count_chunks_by_source(
+            workspace_id=workspace_id
+        )
+        qdrant_source_ids = {uuid.UUID(k) for k in qdrant_source_map if qdrant_source_map[k] > 0}
+
+        missing = sorted(pg_source_ids - qdrant_source_ids)
+        for src_id in missing:
+            RECONCILE_DRIFT_TOTAL.labels(drift_type=DRIFT_PG_MISSING_QDRANT).inc()
+            log.warning(
+                "reconcile_drift_pg_missing_qdrant",
+                workspace_id=str(workspace_id),
+                source_id=str(src_id),
+            )
+            await self._mark_ingestion_run_partial(source_id=src_id)
+
+        return missing
+
+    # ------------------------------------------------------------------
+    # Drift check B: Qdrant chunks with no PG document (orphans)
+    # ------------------------------------------------------------------
+
+    async def _check_qdrant_orphans(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        pg_source_ids: set[uuid.UUID],
+    ) -> tuple[list[str], int]:
+        """Detect and delete orphan Qdrant chunks (bounded per run).
+
+        Returns a tuple of (orphan_source_id_strings, total_deleted_count).
+        """
+        qdrant_source_map = await self._vector_store.count_chunks_by_source(
+            workspace_id=workspace_id
+        )
+        orphan_sources = [
+            src_str
+            for src_str, count in qdrant_source_map.items()
+            if count > 0 and _try_parse_uuid(src_str) not in pg_source_ids
+        ]
+
+        total_deleted = 0
+        budget = self._orphan_limit
+        for src_str in orphan_sources:
+            if budget <= 0:
+                break
+            src_id = _try_parse_uuid(src_str)
+            if src_id is None:
+                continue
+            deleted = await self._delete_qdrant_orphan_source(
+                workspace_id=workspace_id,
+                source_id=src_id,
+                limit=budget,
+            )
+            total_deleted += deleted
+            budget -= deleted
+            RECONCILE_DRIFT_TOTAL.labels(drift_type=DRIFT_QDRANT_ORPHAN).inc()
+            log.warning(
+                "reconcile_drift_qdrant_orphan",
+                workspace_id=str(workspace_id),
+                source_id=src_str,
+                chunks_deleted=deleted,
+            )
+
+        return orphan_sources, total_deleted
+
+    async def _delete_qdrant_orphan_source(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        source_id: uuid.UUID,
+        limit: int,
+    ) -> int:
+        """Delete up to ``limit`` orphan Qdrant chunks for one source.
+
+        Uses ``FilterSelector`` (source + workspace) so the delete is
+        workspace-scoped and idempotent.
+        """
+        from omniscience_index.stores.qdrant_filters import QdrantFilterBuilder
+        from qdrant_client import models as qm
+
+        flt = QdrantFilterBuilder(workspace_id=workspace_id).with_source_ids([source_id]).build()
+        # Count first so we respect the limit.
+        count_result = await self._vector_store._qc.count(
+            collection_name=self._vector_store.collection_name,
+            count_filter=flt,
+            exact=True,
+        )
+        to_delete = min(int(count_result.count), limit)
+        if to_delete == 0:
+            return 0
+
+        # Scroll to get actual point IDs (FilterSelector + limit not
+        # available in delete — we need PointIdsList for bounded deletes).
+        records, _ = await self._vector_store._qc.scroll(
+            collection_name=self._vector_store.collection_name,
+            scroll_filter=flt,
+            limit=to_delete,
+            with_payload=False,
+            with_vectors=False,
+        )
+        if not records:
+            return 0
+        point_ids = [str(r.id) for r in records]
+        await self._vector_store._qc.delete(
+            collection_name=self._vector_store.collection_name,
+            points_selector=qm.PointIdsList(points=point_ids),
+            wait=True,
+        )
+        return len(point_ids)
+
+    # ------------------------------------------------------------------
+    # Drift check C: Neo4j entities with no PG document (orphans)
+    # ------------------------------------------------------------------
+
+    async def _check_neo4j_orphans(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        pg_source_ids: set[uuid.UUID],
+    ) -> list[str]:
+        """Return source_ids with Neo4j entities but no PG document.
+
+        Neo4j cleanup is deferred to the retention worker (ADR-0009
+        end-dating path).  This method records the metric and logs only.
+        """
+        neo4j_source_map = await self._graph_store.count_entities_by_source(
+            workspace_id=workspace_id
+        )
+        orphan_sources = [
+            src_str
+            for src_str, count in neo4j_source_map.items()
+            if count > 0 and _try_parse_uuid(src_str) not in pg_source_ids
+        ]
+        for src_str in orphan_sources:
+            RECONCILE_DRIFT_TOTAL.labels(drift_type=DRIFT_NEO4J_ORPHAN).inc()
+            log.warning(
+                "reconcile_drift_neo4j_orphan",
+                workspace_id=str(workspace_id),
+                source_id=src_str,
+                note="deferred_to_retention_worker",
+            )
+        return orphan_sources
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _load_workspace_ids(self) -> list[uuid.UUID]:
+        """Return all workspace ids — reconcile iterates one at a time."""
+        async with self._session_factory() as session:
+            result = await session.execute(select(Workspace.id))
+            return [row[0] for row in result.all()]
+
+    async def _load_active_source_ids(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+    ) -> set[uuid.UUID]:
+        """Return source_ids that have at least one non-tombstoned document.
+
+        Scoped to the workspace via ``Source.tenant_id == workspace_id``.
+        Sources with only tombstoned documents are excluded — they look
+        like Qdrant orphans from the retention perspective, not drift.
+        """
+        async with self._session_factory() as session:
+            stmt = (
+                select(Document.source_id)
+                .join(Source, Source.id == Document.source_id)
+                .where(Source.tenant_id == workspace_id)
+                .where(Document.tombstoned_at.is_(None))
+                .distinct()
+            )
+            result = await session.execute(stmt)
+            return {row[0] for row in result.all()}
+
+    async def _mark_ingestion_run_partial(
+        self,
+        *,
+        source_id: uuid.UUID,
+    ) -> None:
+        """Mark the most recent ingestion run for ``source_id`` as ``partial``.
+
+        Idempotent: only updates rows currently in ``ok`` status so that a
+        run already marked ``error`` or ``partial`` is not overwritten.
+        This surfaces the drift in the ops UI (ingestion_runs table) and
+        allows operators to trigger a re-sync.
+        """
+        async with self._session_factory() as session, session.begin():
+            # Identify the most recent finished run for this source.
+            stmt = (
+                select(IngestionRun.id)
+                .where(IngestionRun.source_id == source_id)
+                .where(IngestionRun.status == IngestionRunStatus.ok)
+                .order_by(IngestionRun.started_at.desc())
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            row = result.first()
+            if row is None:
+                return
+            run_id: uuid.UUID = row[0]
+            await session.execute(
+                update(IngestionRun)
+                .where(IngestionRun.id == run_id)
+                .where(IngestionRun.status == IngestionRunStatus.ok)
+                .values(status=IngestionRunStatus.partial)
+            )
+        log.info(
+            "reconcile_ingestion_run_marked_partial",
+            source_id=str(source_id),
+            run_id=str(run_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _try_parse_uuid(value: str) -> uuid.UUID | None:
+    """Parse a UUID string, returning ``None`` on failure."""
+    try:
+        return uuid.UUID(value)
+    except (ValueError, AttributeError):
+        return None
+
+
+__all__ = [
+    "ReconcileRunReport",
+    "ReconcileWorker",
+    "WorkspaceReconcileReport",
+]

--- a/apps/server/src/omniscience_server/rest/documents.py
+++ b/apps/server/src/omniscience_server/rest/documents.py
@@ -10,7 +10,8 @@ The handler extracts workspace_id from the bearer token and verifies that
 the document's parent Source belongs to the same workspace.  A mismatch
 returns 404 — not 403 — to avoid leaking document/source existence to
 other tenants.  Legacy tokens without workspace_id are rejected fail-closed
-with 403.
+with 403: ``get_workspace_id`` raises ``PermissionError`` which the global
+handler in ``rest/errors.py`` converts to HTTP 403.
 """
 
 from __future__ import annotations
@@ -59,23 +60,14 @@ async def get_document(
 
     Returns 404 when the document does not exist OR when its parent source
     belongs to a different workspace than the caller's token.
-    Legacy tokens (no workspace_id) are rejected fail-closed with 403.
+    Legacy tokens (no workspace_id) are rejected fail-closed with 403:
+    get_workspace_id raises PermissionError, caught by the global handler.
 
     Requires scope: ``search``
     """
+    # PermissionError from get_workspace_id (legacy token) is caught by the
+    # global handler in rest/errors.py and rendered as HTTP 403.
     workspace_id = get_workspace_id(token)
-    if workspace_id is None:
-        log.warning(
-            "documents_endpoint_rejected_no_workspace",
-            token_prefix=token.token_prefix,
-        )
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "code": "forbidden",
-                "message": "Documents endpoint requires a workspace-scoped token.",
-            },
-        )
 
     factory = getattr(request.app.state, "db_session_factory", None)
     if factory is None:

--- a/apps/server/src/omniscience_server/rest/errors.py
+++ b/apps/server/src/omniscience_server/rest/errors.py
@@ -9,6 +9,16 @@ HTTP status codes map to error codes:
   404 -> *_not_found
   429 -> rate_limited
   500 -> internal
+
+PermissionError mapping
+-----------------------
+``get_workspace_id`` (``omniscience_core.auth.workspace``) raises a plain
+Python ``PermissionError("forbidden:workspace_required")`` when a bearer
+token carries no ``workspace_id`` (legacy pre-multitenancy token).  The
+``_permission_error_handler`` registered here translates that into a
+spec-compliant HTTP 403 response so every REST endpoint gets fail-closed
+behaviour for free — without needing its own ``try/except`` or ``if None``
+guard at the call site.
 """
 
 from __future__ import annotations
@@ -127,8 +137,23 @@ def register_error_handlers(app: FastAPI) -> None:
     """Register all REST API exception handlers on the given FastAPI app."""
     from fastapi.exceptions import HTTPException
 
-    # The handlers must match on HTTPException by status code
-    # We register a catch-all HTTPException handler that dispatches by status code
+    # PermissionError → 403 forbidden
+    # -----------------------------------------------------------------------
+    # ``get_workspace_id`` raises PermissionError("forbidden:workspace_required")
+    # for legacy tokens (workspace_id is None).  This handler converts that
+    # to a spec-compliant 403 so every endpoint is fail-closed without
+    # needing per-handler None-checks.  Registered *before* the generic
+    # Exception handler so it takes priority.
+    @app.exception_handler(PermissionError)
+    async def permission_error_handler(request: Request, exc: PermissionError) -> JSONResponse:
+        return error_response(
+            403,
+            "forbidden",
+            "A workspace-scoped token is required",
+        )
+
+    # The handlers must match on HTTPException by status code.
+    # We register a catch-all HTTPException handler that dispatches by status code.
     @app.exception_handler(HTTPException)
     async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
         if exc.status_code == 401:

--- a/apps/server/src/omniscience_server/rest/sources.py
+++ b/apps/server/src/omniscience_server/rest/sources.py
@@ -95,21 +95,14 @@ def _get_db_factory(request: Request) -> Any:
 
 
 def _require_workspace(token: ApiToken) -> uuid.UUID:
-    """Extract workspace_id from token; raise 403 fail-closed when absent."""
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
-        log.warning(
-            "sources_endpoint_rejected_no_workspace",
-            token_prefix=token.token_prefix,
-        )
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "code": "forbidden",
-                "message": "Sources endpoints require a workspace-scoped token.",
-            },
-        )
-    return workspace_id
+    """Return workspace_id from token.
+
+    If the token has no workspace (legacy token, workspace_id is None),
+    get_workspace_id raises PermissionError("forbidden:workspace_required").
+    The global PermissionError handler in rest/errors.py converts that to
+    HTTP 403 — no per-endpoint guard needed here.
+    """
+    return get_workspace_id(token)
 
 
 async def _get_source_or_404(

--- a/apps/server/src/omniscience_server/rest/stats.py
+++ b/apps/server/src/omniscience_server/rest/stats.py
@@ -106,27 +106,14 @@ def _resolve_service(request: Request) -> StatsService:
 
 
 def _require_workspace(token: ApiToken) -> uuid.UUID:
-    """Extract the caller's workspace_id or fail closed with 403.
+    """Return the caller's workspace_id.
 
     Stats endpoints aggregate counts from Neo4j and Qdrant, both of
-    which require an explicit workspace.  Letting an unscoped token
-    through here would either crash the underlying adapters (Qdrant)
-    or silently widen reads (the bug class from #117).  Fail closed.
+    which require an explicit workspace.  get_workspace_id raises
+    PermissionError("forbidden:workspace_required") for legacy tokens;
+    the global handler in rest/errors.py converts that to HTTP 403.
     """
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
-        log.warning(
-            "stats_request_rejected_no_workspace",
-            token_prefix=token.token_prefix,
-        )
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "code": "forbidden",
-                "message": "Stats endpoints require a workspace-scoped token",
-            },
-        )
-    return workspace_id
+    return get_workspace_id(token)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,14 +28,14 @@
                                           │
                            ┌──────────────▼───────────────────┐
                            │      Retrieval Service            │
-                           │  hybrid: vector + tsvector +      │
+                           │  hybrid: Qdrant dense+sparse RRF + │
                            │  graph traversal + ACL filter +   │
                            │  freshness filter                 │
                            └──────────────┬───────────────────┘
                                           │
                 ┌─────────────────────────▼─────────────────────┐
                 │                 Index Layer                    │
-                │  pgvector · tsvector · symbol graph ·          │
+                │  Qdrant (dense+sparse) · Neo4j graph ·          │
                 │  tombstones · content-hash dedup               │
                 └─────────────────────────┬─────────────────────┘
                                           │
@@ -81,46 +81,36 @@ Failures flow to DLQ. Retries are bounded with exponential backoff. Freshness SL
 
 ### 3. Index layer (`packages/index/`)
 
-PostgreSQL-backed:
+**v0.2+ backend split** (ADR-0005 + ADR-0006; see also [ADR-0008](decisions/0008-bitemporal-schema-for-neo4j.md)):
 
-- `documents` — one row per source doc, with `content_hash` and `tombstoned_at`
-- `chunks` — one row per chunk, with `embedding vector`, `text_tsv`, `metadata jsonb`
-- HNSW index on embeddings (cosine)
-- GIN index on tsvector (full-text)
+- **Postgres** (`documents`, `chunks`, `ingestion_runs`, `sources`) — operational metadata, lineage, content-hash dedup, tombstones. No embeddings column after cutover.
+- **Qdrant** — chunk embeddings (named vector `dense_primary`) + sparse BM25 vectors (named vector `sparse_bm25`) + per-point payload (workspace_id, source_id, text, metadata, bitemporal fields). One collection per embedding model × dimension.
+- **Neo4j** — entities, edges, ownership / dependency graph. Bitemporal properties (`valid_from`, `valid_to`, `recorded_at`) per ADR-0008.
 
-Single source of truth. No separate vector DB.
+**Bitemporal write path** (Stage 1, `refactor/bitemporal-vector-hybrid`): when a document's `content_hash` changes, old Qdrant points are **end-dated** (`valid_to = now()`) rather than hard-deleted. `as_of=T` queries on Qdrant return the chunk version valid at T, consistent with the Neo4j graph state at T (ADR-0008 §6).
+
+**Enumerate mode** (Stage 4): `enumerate_chunks` / `count_enumerate` bypass HNSW and use Qdrant payload indexes + `count(exact=True)` + `scroll` for 100% recall on "list all X / count all Y" queries.
 
 ### 4. Retrieval service (`packages/retrieval/`)
 
-Hybrid search — **staged**, see [ADR 0004](decisions/0004-retrieval-strategy-staged.md).
+Hybrid search — **staged**, see [ADR-0004](decisions/0004-retrieval-strategy-staged.md) and its Stage 3 amendment.
 
-#### v0.1 — Hybrid baseline
+`GraphRAGComposer` dispatches per `retrieval_strategy`:
 
-1. **Vector** — pgvector HNSW top-K
-2. **BM25-like** — tsvector ranking
-3. **Merge** — reciprocal rank fusion
-4. **Filter** — ACL, source subset, freshness cap
+| `retrieval_strategy` | Dense (Qdrant HNSW) | Sparse (Qdrant BM25) | Graph (Neo4j) |
+|---|---|---|---|
+| `"hybrid"` (default) | yes | yes — RRF merge | anchor stage |
+| `"auto"` | yes | yes — RRF merge | anchor stage |
+| `"keyword"` | no | yes — sparse only | anchor stage |
+| `"structural"` | yes — dense only | no | anchor stage |
 
-#### v0.2 — Adaptive retrieval
+**RRF merge** (k=60, Cormack et al. 2009): `score(d) = Σ 1/(60 + rank_i(d))` over dense and sparse ranked lists. Graph-affinity re-scoring is applied on top by `GraphRAGComposer._run_merge_stage`.
 
-Add structural strategies using edges already present in source data (no LLM extraction):
+**`retrieval_strategy` was accepted but ignored before Stage 3** (branch `refactor/bitemporal-vector-hybrid`). All four values now drive real dispatch.
 
-- **Code**: imports, calls, class inheritance — from tree-sitter output
-- **Infrastructure**: DEPENDS_ON from Terraform state, k8s ownerReferences, Helm chart deps
-- **Docs**: markdown links, ADR supersedes
-- **Cross-source entity linking**: resource-name matching across connectors
+**Bitemporal search** (`as_of` parameter): both graph traversal and Qdrant vector search honour `as_of=T`, returning the system state as it was at T. The open-closed predicate `valid_from <= T AND (T < valid_to OR valid_to IS NULL)` is applied via `QdrantFilterBuilder.with_as_of()`.
 
-Storage: same Postgres, new `entities` + `edges` tables. Queries via recursive CTEs or Apache AGE (Cypher). **No separate graph database.**
-
-Callers (or an internal `"auto"` classifier) select the strategy per query via the `retrieval_strategy` parameter.
-
-#### v0.3+ — Full GraphRAG (optional, triggered by evidence)
-
-LLM-extracted entities + community detection — only if v0.2 structural coverage leaves clear gaps on text-heavy sources (ADRs, post-mortems, wikis).
-
-#### v0.3 — Re-ranking
-
-Cross-encoder second pass over top-N to boost precision. Cheap quality win.
+**Degraded detector**: when an anchor entity is not found in the graph at `as_of` AND the vector layer also returns empty, `SearchResult.meta.degraded_response = "as_of_before_recorded_history"` signals that the query precedes any recorded history for that entity. After Stage 1 end-dating this is a genuine signal — not a content-rewrite artefact.
 
 Returns chunks with citations and provenance.
 
@@ -221,11 +211,12 @@ MCP client (Claude Code)
 ┌──────────────────┐
 │ Retrieval service│
 │  1. embed(query) │
-│  2. vector top-K │──┐
-│  3. tsvector rank│──┤
-│  4. RRF merge    │◀─┘
-│  5. ACL filter   │
-│  6. freshness    │
+│  2. Qdrant dense │──┐
+│  3. Qdrant sparse│──┤
+│  4. RRF(k=60)    │◀─┘
+│  5. graph anchor │
+│  6. ACL filter   │
+│  7. freshness    │
 │     filter       │
 └────────┬─────────┘
          ▼

--- a/docs/decisions/0004-retrieval-strategy-staged.md
+++ b/docs/decisions/0004-retrieval-strategy-staged.md
@@ -109,3 +109,66 @@ Rejected for v0.2. Separate graph DB adds operational complexity. Postgres with 
   - Adaptive retrieval agent
 - `docs/api/mcp.md` documents the `retrieval_strategy` parameter now (contract), but only `hybrid` works in v0.1; other values land in v0.2
 - `docs/architecture.md` gets an "Adaptive retrieval" subsection reflecting the staged plan
+
+---
+
+## Amendment — Stage 3: Qdrant-native sparse + RRF hybrid (refactor/bitemporal-vector-hybrid, 2026-06-10)
+
+**Status**: Implemented (branch `refactor/bitemporal-vector-hybrid`)
+
+### What changed
+
+ADR-0004 specified `"hybrid" = vector + BM25` with the BM25 half staying in Postgres tsvector.
+After ADR-0006 moved dense vectors to Qdrant and ADR-0005 removed the structural-Postgres path,
+the tsvector BM25 half never materialised — `retrieval_strategy` accepted `"hybrid"`, `"keyword"`,
+`"structural"`, and `"auto"` at the API level but all four silently dispatched to dense-only HNSW.
+
+This amendment closes that gap: sparse BM25-compatible vectors are now stored and queried
+entirely inside Qdrant alongside the dense vectors, and the `retrieval_strategy` field now
+drives real dispatch.
+
+### Implementation (Stage 3)
+
+**Sparse vector**: A named-vector slot `sparse_bm25` is added to every Qdrant collection
+(``SparseVectorParams(index=SparseIndexParams(on_disk=False))``).  Sparse vectors are built
+client-side at ingest time from the chunk `text` payload:
+
+1. Lower-case, split on `[^a-z0-9]+`.
+2. Drop stop-words and single-character tokens.
+3. Hash each token to a bucket index (`hash(token) % 2^20`).
+4. Count term frequency; max-TF normalise to `[0, 1]`.
+
+Choice rationale: the Qdrant FASTEMBED sparse encoder was rejected because (a) it adds a large
+model download and GPU dependency, (b) plain TF on tokens is sufficient for our use case (exact
+service names, error strings, k8s kinds, account IDs), and (c) the tokeniser is deterministic
+and testable without a container.
+
+**Dispatch** (``QdrantVectorStore.search``):
+
+| `retrieval_strategy` | Qdrant query |
+|---|---|
+| `"keyword"` | sparse-only (`query_points(using="sparse_bm25")`) |
+| `"hybrid"` (default) | RRF merge of dense + sparse |
+| `"auto"` | same as `"hybrid"` |
+| `"structural"` | dense-only (graph layer narrows candidates first) |
+
+**RRF merge**: Reciprocal Rank Fusion with `k=60` (Cormack et al. 2009).
+`score(d) = Σ 1/(60 + rank_i(d))` summed over dense and sparse ranked lists.
+The merge is applied inside the vector store; `GraphRAGComposer._run_merge_stage`
+applies graph-affinity re-scoring on top as a third signal.
+
+`QueryStats.text_matches` is now populated with the actual sparse-hit count
+(was always 0 before this amendment).
+
+**Migration**: `scripts/reindex_qdrant_hybrid.py` backfills `sparse_bm25` vectors on existing
+points that have a `text` payload but no sparse vector slot.  It is idempotent (skips already-
+vectorised points) and supports `--dry-run`.  Do not run on production without a backup.
+
+### Consequences
+
+- `SearchRequest.retrieval_strategy` field now drives real behaviour (not just accepted and ignored).
+- Clients that relied on `"keyword"` always producing the same results as `"hybrid"` must be
+  updated — keyword now returns strictly sparse results, which score differently.
+- The Qdrant collection schema is not backward-compatible: points ingested before Stage 3 lack
+  `sparse_bm25` vectors.  Run `scripts/reindex_qdrant_hybrid.py` before enabling keyword/hybrid
+  queries on an existing collection.

--- a/docs/decisions/0006-qdrant-as-vector-store.md
+++ b/docs/decisions/0006-qdrant-as-vector-store.md
@@ -271,3 +271,50 @@ Rejected. Cassandra's vector support via StargateQL is young, the filter-then-AN
 - Amends: [ADR-0004](0004-retrieval-strategy-staged.md) on the vector-store-choice dimension only
 - ACL carry-forward: [#117](https://github.com/100rd/Omniscience/issues/117)
 - Lineage schema: [#24](https://github.com/100rd/Omniscience/issues/24)
+
+---
+
+## Amendment — Bitemporal cross-store contract (refactor/bitemporal-vector-hybrid, 2026-06-10)
+
+**Status**: Implemented (branch `refactor/bitemporal-vector-hybrid`)
+
+### What changed
+
+ADR-0008 §6 specified that the vector store must honour the bitemporal contract:
+`as_of=T` on Qdrant must return the same logical state as `as_of=T` on Neo4j.
+Before this amendment, `QdrantVectorStore._write_document` hard-deleted old chunk
+points when the `content_hash` changed — so `as_of=T` (where T preceded the update)
+returned empty results even though Neo4j correctly returned the pre-update graph state.
+
+### Implementation (Stage 1)
+
+**End-dating on content update**: When `content_hash` changes, old chunk points are now
+**end-dated** (`valid_to = now()` via `set_payload`) instead of hard-deleted.  New chunk
+points are inserted with `valid_from = now()` and `valid_to = null`.
+
+**`_find_document` scoped to current generation**: `_find_document` adds
+`with_current_only()` (`valid_to IS NULL`) so it cannot see end-dated historical versions
+when computing `content_hash` and `doc_version` for the update path.
+
+**Current-state reads**: `count()`, `count_chunks()`, `count_chunks_by_source()` add
+`with_current_only()` when `as_of=None` so end-dated historical points are not counted
+as active documents.
+
+### Write-path cost
+
+End-dating is more expensive than hard deletion: one additional `set_payload` call per
+content-update write.  This is an accepted trade-off: the alternative (hard delete + empty
+`as_of` results) violates ADR-0008 §6 cross-store consistency.  The retention worker
+(ADR-0009) still hard-deletes end-dated points when they age past the warm-tier window,
+so storage growth is bounded.
+
+### `valid_from` / `valid_to` payload indexes
+
+Both fields are added to `INDEXED_PAYLOAD_FIELDS` (confirmed per ADR-0008 §6 cross-doc
+consequences note) so the `as_of` predicate is index-backed on every read path.
+
+### Cross-reference
+
+See **ADR-0008** for the canonical bitemporal contract (open-closed interval
+`[valid_from, valid_to)`, `null` / missing sentinel for still-valid, ISO-8601 datetime,
+and the `as_of` predicate `valid_from <= T AND (T < valid_to OR valid_to IS NULL)`).

--- a/docs/decisions/0008-bitemporal-schema-for-neo4j.md
+++ b/docs/decisions/0008-bitemporal-schema-for-neo4j.md
@@ -327,3 +327,56 @@ The same discipline ADR-0005 mandated for the Neo4j adapter and ADR-0006 mandate
 - ACL carry-forward: [#117](https://github.com/100rd/Omniscience/issues/117), [#119](https://github.com/100rd/Omniscience/issues/119), [ADR-0005](0005-neo4j-as-graph-store.md) §Consequences-security
 - Vision sections: [`docs/vision.md`](../vision.md) §5.3 (line 71-77), §11 (line 177)
 - Adapter touched by future migration (this ADR specifies, [#130](https://github.com/100rd/Omniscience/issues/130) implements): [`packages/index/src/omniscience_index/stores/neo4j_store.py`](../../packages/index/src/omniscience_index/stores/neo4j_store.py)
+
+---
+
+## Amendment — Vector-layer end-dating and `valid_to IS NULL` current-state reads (refactor/bitemporal-vector-hybrid, 2026-06-10)
+
+**Status**: Implemented (branch `refactor/bitemporal-vector-hybrid`)
+
+### Accepted compromise: end-dating on the write path
+
+ADR-0008 §6 required the vector store to honour the bitemporal contract but deferred
+implementation.  This amendment records the actual implementation and its trade-offs.
+
+**Previous behaviour (violated §6)**: `_write_document` called `_delete_points` on
+content-hash change.  `as_of=T` searches returned empty for updated documents.
+
+**Implemented behaviour**: Old chunk points are end-dated (`valid_to = now()`) via
+`set_payload`.  The write path is now:
+
+```
+1. _find_document(current_only=True)  → get current content_hash + doc_version
+2. content_hash unchanged?            → skip (no write)
+3. content_hash changed?
+   a. _end_date_points(old_ids, valid_to=now())   [set_payload, wait=True]
+   b. insert new points with valid_from=now(), valid_to=null
+```
+
+**Cost**: one extra `set_payload` round-trip per update.  Mitigated by: (a) updates are
+less frequent than first-time ingests; (b) `wait=True` is required for durability anyway;
+(c) the retention worker (ADR-0009) eventually hard-deletes end-dated points so storage
+growth is bounded.
+
+### `valid_to IS NULL` current-state reads
+
+After end-dating, the collection contains both old (end-dated) and new (current) points for
+the same `(source_id, external_id)`.  Current-state reads must filter to `valid_to IS NULL`
+to avoid double-counting.  The following methods add `with_current_only()` when `as_of=None`:
+
+- `_find_document` — always, so content-hash comparison and doc_version increment are correct.
+- `count()` — when `as_of=None`.
+- `count_chunks()` — when `as_of=None`.
+- `count_chunks_by_source()` — when `as_of=None`.
+
+The `search()` hot path (`as_of=None`) does NOT add `valid_to IS NULL` — most end-dated points
+are already excluded by the tombstone filter, and the performance overhead on the HNSW path is
+undesirable.  If a strict "only current points" requirement emerges for the search path, that
+is a separate amendment.
+
+### Cross-store consistency (§6)
+
+After this amendment: `as_of=T` on Neo4j and `as_of=T` on Qdrant both return the state
+valid at T.  The bitemporal contract described in ADR-0008 §6 is now satisfied.
+
+See **ADR-0006** amendment (same branch) for the Qdrant-side implementation details.

--- a/packages/core/alembic/versions/0010_backfill_null_tenant.py
+++ b/packages/core/alembic/versions/0010_backfill_null_tenant.py
@@ -1,0 +1,137 @@
+"""Backfill NULL tenant_id / workspace_id to the default workspace.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-06-10 00:00:00.000000
+
+Context
+-------
+Prior to multi-tenancy (issue #57 / migration 0003_workspaces), the
+``sources`` and ``api_tokens`` tables were created without a workspace
+scoping column.  Migration 0003 added ``api_tokens.workspace_id`` (nullable)
+and introduced the ``sources.tenant_id`` column (also nullable), leaving
+pre-existing rows with NULL in those fields.
+
+The original ``workspace_filter`` helper included an ``OR col IS NULL``
+clause so that those legacy rows would remain visible after the migration.
+That clause is a cross-tenant vulnerability: any workspace-scoped token can
+read NULL-tenant rows even though they conceptually belong to the
+installation-level default workspace (``00000000-0000-0000-0000-000000000001``).
+
+This migration eliminates the ambiguity by assigning the default workspace
+UUID to every row that still carries NULL:
+
+    UPDATE sources     SET tenant_id   = DEFAULT_WS WHERE tenant_id   IS NULL
+    UPDATE api_tokens  SET workspace_id = DEFAULT_WS WHERE workspace_id IS NULL
+
+After this migration the ``workspace_filter`` helper can drop the
+``OR col IS NULL`` branch and use a plain equality filter, closing the
+cross-tenant read vector entirely.
+
+Tables surveyed
+---------------
+* ``sources``           — has ``tenant_id`` (nullable UUID).  Backfilled.
+* ``api_tokens``        — has ``workspace_id`` (nullable UUID FK →
+                          workspaces.id).  Backfilled.
+* ``documents``         — no workspace column; isolated transitively via
+                          ``source_id → sources.tenant_id``.  Not touched.
+* ``chunks``            — no workspace column; isolated via
+                          ``document_id → documents → sources``.  Not touched.
+* ``ingestion_runs``    — no workspace column; isolated via
+                          ``source_id → sources``.  Not touched.
+* ``entities``          — no workspace column; isolated via
+                          ``source_id → sources``.  Not touched.
+* ``edges``             — no workspace column; isolated via
+                          ``source_entity_id/target_entity_id → entities``
+                          → sources``.  Not touched.
+* ``entity_emitter``    — ``workspace_id`` is part of the composite PK
+                          (NOT NULL), so there are no NULL rows.  Not touched.
+* ``workspaces``        — the lookup table itself.  Not touched.
+
+Downgrade strategy
+------------------
+Reverting NULL-assignment is ambiguous: we cannot distinguish rows that were
+originally NULL (and therefore meaningfully belong to the default workspace)
+from rows that were explicitly assigned the default workspace UUID by an
+operator.  Setting them back to NULL would re-introduce the security hole.
+
+The downgrade is therefore implemented as a **no-op** (consistent with the
+enum-value migrations 0005/0006/0009 that also cannot be meaningfully
+reverted).  If you need to roll back to the previous code version:
+
+1. Deploy the previous code *first* (the old ``workspace_filter`` with the
+   OR-NULL branch is backward-compatible with backfilled rows).
+2. The data remains valid — default-workspace rows simply show as
+   ``tenant_id = DEFAULT_WS`` instead of NULL; the old code's
+   ``or_(col == ws, col == null())`` still returns the correct superset.
+
+Pre-condition
+-------------
+The default workspace row (``id = 00000000-0000-0000-0000-000000000001``,
+``name = 'default'``) must exist in the ``workspaces`` table before the
+backfill runs.  This was inserted by migration 0003_workspaces and must not
+be deleted manually.  The UPDATE to ``api_tokens`` respects the FK constraint
+(``ON DELETE SET NULL``) — the workspace row is only deleted if an operator
+explicitly removes it, which would reset the FK to NULL again; no special
+handling is required here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision: str = "0010"
+down_revision: str | None = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Canonical default workspace UUID — seeded by 0003_workspaces.
+_DEFAULT_WORKSPACE_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Upgrade — backfill NULL rows to default workspace
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # Use text() so the UUID literal is rendered portably without having to
+    # reflect the full table schema.  Both columns are UUID type in Postgres.
+    default_ws = str(_DEFAULT_WORKSPACE_ID)
+
+    # 1. sources.tenant_id ------------------------------------------------
+    op.execute(
+        sa.text("UPDATE sources SET tenant_id = :ws_id WHERE tenant_id IS NULL").bindparams(
+            ws_id=default_ws
+        )
+    )
+
+    # 2. api_tokens.workspace_id ------------------------------------------
+    # The FK references workspaces(id); the default workspace row was
+    # inserted by 0003_workspaces so this UPDATE will not violate referential
+    # integrity as long as that row has not been manually deleted.
+    op.execute(
+        sa.text(
+            "UPDATE api_tokens SET workspace_id = :ws_id WHERE workspace_id IS NULL"
+        ).bindparams(ws_id=default_ws)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downgrade — intentional no-op (see module docstring)
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    # Cannot safely distinguish originally-NULL rows from explicitly-set ones.
+    # Rolling back the data would re-introduce the cross-tenant read vector.
+    # Deploy the previous application version first; data stays valid.
+    pass

--- a/packages/core/src/omniscience_core/auth/workspace.py
+++ b/packages/core/src/omniscience_core/auth/workspace.py
@@ -2,9 +2,15 @@
 
 Usage
 -----
-``get_workspace_id`` extracts the workspace UUID from an authenticated token.
-``workspace_filter`` applies a WHERE clause to any SQLAlchemy SELECT so that
-results are confined to the caller's workspace.
+``get_workspace_id`` extracts the workspace UUID from an authenticated token
+and enforces fail-closed semantics: a token without a workspace_id raises
+``PermissionError`` rather than granting access to all data.
+
+``workspace_filter`` applies a strict equality WHERE clause to any SQLAlchemy
+SELECT so that results are confined to the caller's workspace.  NULL-tenant
+rows are *not* included — the ``0010_backfill_null_tenant`` migration must
+run before this version is deployed so that all pre-multitenancy rows carry
+the default workspace UUID (``00000000-0000-0000-0000-000000000001``).
 
 Both functions are intentionally simple and dependency-free so they can be
 called from any layer (REST handler, background worker, CLI) without pulling
@@ -16,59 +22,72 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from sqlalchemy import Select, null, or_
+from sqlalchemy import Select
 
 from omniscience_core.db.models import ApiToken
 
+# The canonical default workspace UUID, seeded by migration 0003_workspaces.
+# Migration 0010_backfill_null_tenant assigns this to every row whose
+# tenant_id/workspace_id was NULL before multi-tenancy was introduced.
+DEFAULT_WORKSPACE_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 
-def get_workspace_id(token: ApiToken) -> uuid.UUID | None:
-    """Return the workspace UUID associated with *token*, or ``None``.
 
-    ``None`` means the token predates workspace scoping and should be treated
-    as belonging to the global / default workspace (i.e. no filtering applied
-    beyond what existed before multi-tenancy).
+def get_workspace_id(token: ApiToken) -> uuid.UUID:
+    """Return the workspace UUID associated with *token*.
+
+    Fail-closed: if the token has no ``workspace_id`` (pre-multitenancy
+    token, i.e. ``None``), a ``PermissionError`` is raised with the message
+    ``"forbidden:workspace_required"``.  Callers that previously relied on
+    ``None`` meaning "no restriction" must be updated to set ``workspace_id``
+    on the token before calling this helper.
+
+    This matches the behaviour already in place at:
+    - ``apps/server/src/omniscience_server/rest/operator.py`` (403 on None)
+    - ``apps/server/src/omniscience_server/mcp/tools.py`` (RuntimeError on None)
 
     Args:
         token: An authenticated :class:`~omniscience_core.db.models.ApiToken`
                ORM instance.
 
     Returns:
-        The workspace UUID if the token has one set, otherwise ``None``.
+        The workspace UUID of the token.
+
+    Raises:
+        PermissionError: When ``token.workspace_id`` is ``None``.
     """
+    if token.workspace_id is None:
+        raise PermissionError("forbidden:workspace_required")
     return token.workspace_id
 
 
-def workspace_filter(query: Select[Any], workspace_id: uuid.UUID | None) -> Select[Any]:
+def workspace_filter(query: Select[Any], workspace_id: uuid.UUID) -> Select[Any]:
     """Narrow *query* to rows that belong to *workspace_id*.
 
     The filter strategy depends on the column present in the query's primary
     entity:
 
-    * If the model has a ``workspace_id`` column, filter directly on it.
-      ``NULL`` workspace_id rows (legacy data) are always included so that
-      existing records remain visible after the migration.
+    * If the model has a ``workspace_id`` column, filter with strict equality:
+      ``WHERE workspace_id = :workspace_id``.
     * If the model has a ``tenant_id`` column (older tables like ``sources``),
-      cast *workspace_id* to the ``tenant_id`` match.  Again, ``NULL``
-      tenant_id rows are included for backward compatibility.
+      filter with strict equality: ``WHERE tenant_id = :workspace_id``.
     * If neither column is present, the query is returned unchanged — the
       table is not workspace-scoped (e.g. ``workspaces`` itself).
 
-    When *workspace_id* is ``None`` (legacy token with no workspace) the query
-    is returned unchanged so that all records remain accessible — this
-    preserves backward compatibility for tokens created before this migration.
+    **No NULL inclusion**: unlike the previous implementation this function
+    never adds an ``OR col IS NULL`` clause.  Migration ``0010`` must backfill
+    all NULL rows before this version is activated, so there are no legitimate
+    legacy rows with NULL tenant_id/workspace_id remaining in production.
 
     Args:
         query:        Any SQLAlchemy 2 ``Select`` statement.
-        workspace_id: UUID of the workspace to restrict results to, or
-                      ``None`` to skip filtering entirely.
+        workspace_id: UUID of the workspace to restrict results to.
+                      Callers must not pass ``None`` — use
+                      :func:`get_workspace_id` (which raises on legacy tokens)
+                      to obtain a guaranteed non-None UUID.
 
     Returns:
         The same (or augmented) ``Select`` statement.
     """
-    if workspace_id is None:
-        # Legacy token — no workspace restriction.
-        return query
-
     # Determine which column to filter on by inspecting the from clauses.
     # get_final_froms() is the SA 2.x successor to the deprecated .froms attribute.
     entity_cols: dict[str, Any] = {}
@@ -79,14 +98,14 @@ def workspace_filter(query: Select[Any], workspace_id: uuid.UUID | None) -> Sele
 
     if "workspace_id" in entity_cols:
         col = entity_cols["workspace_id"]
-        return query.where(or_(col == workspace_id, col == null()))
+        return query.where(col == workspace_id)
 
     if "tenant_id" in entity_cols:
         col = entity_cols["tenant_id"]
-        return query.where(or_(col == workspace_id, col == null()))
+        return query.where(col == workspace_id)
 
     # Table is not workspace-scoped — return as-is.
     return query
 
 
-__all__ = ["get_workspace_id", "workspace_filter"]
+__all__ = ["DEFAULT_WORKSPACE_ID", "get_workspace_id", "workspace_filter"]

--- a/packages/core/src/omniscience_core/storage/vector.py
+++ b/packages/core/src/omniscience_core/storage/vector.py
@@ -22,6 +22,13 @@ Design rules (ADR-0006 + issue #117)
 3. **No SQLAlchemy dependency here.**  This module imports only stdlib
    and the retrieval response dataclasses — by design, the protocol
    layer is backend-neutral.
+
+Stage 4 — enumerate mode (refactor/bitemporal-vector-hybrid)
+-------------------------------------------------------------
+``enumerate_chunks`` and ``count_enumerate`` bypass HNSW entirely and
+use ``scroll`` / ``count(exact=True)`` on payload indexes for 100%
+recall on "list all X / count all Y" queries.  Both methods are
+workspace-scoped per the ACL invariant (ADR-0006 §ACL).
 """
 
 from __future__ import annotations
@@ -274,6 +281,75 @@ class VectorStore(Protocol):
         backend round-trip rather than N source-id queries.  ``as_of``
         (issue #134) narrows the histogram to chunks valid at the
         supplied bitemporal anchor.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Enumerate API — Stage 4 (refactor/bitemporal-vector-hybrid)
+    # ------------------------------------------------------------------
+
+    async def enumerate_chunks(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        metadata_key: str,
+        metadata_value: str,
+        source_id: uuid.UUID | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return all current chunks matching a payload dimension.
+
+        Stage 4 (enumerate mode): bypasses HNSW entirely, uses
+        ``scroll`` on payload indexes for 100% recall.  Suitable for
+        "list all X / count all Y" questions that must not miss any
+        matching document.
+
+        Results are deduplicated by ``document_id`` — the first chunk
+        for each logical document is returned with its full payload.
+
+        Workspace scoping is mandatory per ADR-0006 §ACL.
+
+        Parameters
+        ----------
+        metadata_key:
+            One of the indexed enumerate dimensions
+            (``service``, ``resource_type``, ``account_id``,
+            ``kind``, ``namespace``).
+        metadata_value:
+            Exact match value for the given dimension.
+        source_id:
+            Optional source-level narrowing.
+
+        Returns
+        -------
+        List of payload dicts, one per unique ``document_id``.
+        """
+        ...
+
+    async def count_enumerate(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        metadata_key: str,
+        metadata_value: str,
+        source_id: uuid.UUID | None = None,
+    ) -> int:
+        """Return the exact chunk count matching a payload dimension.
+
+        Stage 4: uses ``count(exact=True)`` for O(index) exact counting.
+        Unlike ``count_chunks`` this operates at the chunk level (not the
+        document level).  For document-level counts call
+        ``enumerate_chunks`` and take ``len(result)``.
+
+        Workspace scoping is mandatory per ADR-0006 §ACL.
+
+        Parameters
+        ----------
+        metadata_key:
+            Enumerate dimension key (``service``, ``kind``, etc.).
+        metadata_value:
+            Exact match value.
+        source_id:
+            Optional source-level narrowing.
         """
         ...
 

--- a/packages/core/src/omniscience_core/telemetry/metrics.py
+++ b/packages/core/src/omniscience_core/telemetry/metrics.py
@@ -176,3 +176,46 @@ GRAPH_END_DATED_TOTAL: Counter = Counter(
     ),
     labelnames=["kind", "reason"],
 )
+
+# ---------------------------------------------------------------------------
+# Reconcile worker metrics
+# ---------------------------------------------------------------------------
+#
+# The reconcile worker periodically cross-checks three stores
+# (Postgres, Qdrant, Neo4j) and repairs drift idempotently.
+# Three drift types are tracked:
+#
+#   * ``pg_missing_qdrant``  — document in Postgres but no Qdrant chunks
+#     (write succeeded in PG, Qdrant write failed or was never issued).
+#     Action: log + mark ingestion_run partial + expose metric for alert.
+#
+#   * ``qdrant_orphan``      — chunks in Qdrant for a source that has no
+#     corresponding Postgres document.  Typical cause: seed-script or
+#     partial tombstone.  Action: hard-delete the orphan chunks.
+#
+#   * ``neo4j_orphan``       — entity nodes in Neo4j for a source_id that
+#     carries no active Postgres documents.  Action: log + expose metric;
+#     hard cleanup is deferred to the retention worker (end-dating path).
+#
+# Label ``drift_type`` takes one of the three string values above.
+
+RECONCILE_DRIFT_TOTAL: Counter = Counter(
+    name="omniscience_reconcile_drift_total",
+    documentation=(
+        "Total drift incidents detected by the reconcile worker, partitioned "
+        "by drift_type: 'pg_missing_qdrant' | 'qdrant_orphan' | 'neo4j_orphan'. "
+        "Incremented per affected source per run."
+    ),
+    labelnames=["drift_type"],
+)
+
+RECONCILE_WORKER_RUNS_TOTAL: Counter = Counter(
+    name="omniscience_reconcile_worker_runs_total",
+    documentation="Total number of reconcile worker ticks completed (including no-drift runs).",
+)
+
+RECONCILE_WORKER_DURATION_SECONDS: Histogram = Histogram(
+    name="omniscience_reconcile_worker_duration_seconds",
+    documentation="Wall-clock time in seconds for one full reconcile tick across all workspaces.",
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0),
+)

--- a/packages/index/src/omniscience_index/stores/qdrant_constants.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_constants.py
@@ -30,11 +30,31 @@ HNSW_EF_CONSTRUCT: Final[int] = 128
 # Collection layout — ADR-0006, Decision §Schema posture
 # ---------------------------------------------------------------------------
 
-#: Name of the single named vector inside every collection.  ADR-0006,
+#: Name of the dense named vector inside every collection.  ADR-0006,
 #: Decision §Schema posture: "the more common pattern will be one named
 #: vector per collection and one collection per model".  The name is
 #: fixed so the retrieval side does not need to introspect the schema.
 NAMED_VECTOR_DENSE_PRIMARY: Final[str] = "dense_primary"
+
+#: Name of the sparse named vector added in Stage 3
+#: (refactor/bitemporal-vector-hybrid).  Carries BM25-compatible
+#: IDF-weighted term frequencies for the chunk text.  Qdrant's native
+#: ``SparseVectorParams`` stores the sparse index on-disk; queries
+#: use ``query_points(using=NAMED_VECTOR_SPARSE_BM25, ...)`` with a
+#: ``SparseVector(indices=[...], values=[...])`` query.
+#:
+#: Choice rationale (ADR-0004 amendment §Stage-3): we use a
+#: client-side term-frequency tokenizer (split on non-alphanumeric,
+#: lower-cased, stopword-filtered) rather than the Qdrant FASTEMBED
+#: sparse encoder.  Reasons: (a) FASTEMBED adds a large model download
+#: and GPU dependency; (b) TF-IDF on plain tokens approximates BM25
+#: well enough for our use case; (c) the tokenizer is deterministic and
+#: testable without a container.  The IDF weights are corpus-level
+#: approximations computed client-side (not true corpus IDF, which
+#: would require a full-corpus pass).  For the intended use case
+#: (exact-name lookup, error strings) plain TF is sufficient because
+#: rare tokens already have high discriminative power.
+NAMED_VECTOR_SPARSE_BM25: Final[str] = "sparse_bm25"
 
 #: Prefix applied to every Omniscience-managed collection.  Keeps our
 #: collections distinguishable from any that might be created by other
@@ -96,6 +116,60 @@ PAYLOAD_SNAPSHOT_DATE: Final[str] = "snapshot_date"
 TIER_HOT: Final[str] = "hot"
 TIER_WARM: Final[str] = "warm"
 
+# ---------------------------------------------------------------------------
+# Enumerate payload index fields — Stage 4 (refactor/bitemporal-vector-hybrid)
+# ---------------------------------------------------------------------------
+#
+# Enumerate-mode queries ("list all X / count all Y") bypass HNSW and
+# use Qdrant's ``count(exact=True)`` + ``scroll`` on payload indexes.
+# The fields below are common metadata dimensions for infrastructure
+# resources.  They live under the "metadata" nested payload object, so
+# Qdrant accesses them as "metadata.service", "metadata.kind", etc.
+#
+# These indexes are additive to INDEXED_PAYLOAD_FIELDS — they do not
+# replace any existing index.
+
+#: Enumerate-dimension keys for ``metadata.*`` sub-fields.
+#: Each key maps to a Qdrant KEYWORD payload index on
+#: ``metadata.<key>``.  The full payload path is:
+#:   metadata.service, metadata.resource_type, metadata.account_id,
+#:   metadata.kind, metadata.namespace.
+ENUMERATE_METADATA_INDEX_KEYS: Final[tuple[str, ...]] = (
+    "service",
+    "resource_type",
+    "account_id",
+    "kind",
+    "namespace",
+)
+
+#: Payload path prefix for metadata sub-field indexes.
+ENUMERATE_METADATA_PREFIX: Final[str] = "metadata"
+
+#: Full payload paths for each enumerate-dimension index.
+ENUMERATE_PAYLOAD_INDEXES: Final[tuple[str, ...]] = tuple(
+    f"{ENUMERATE_METADATA_PREFIX}.{k}" for k in ENUMERATE_METADATA_INDEX_KEYS
+)
+
+# ---------------------------------------------------------------------------
+# RRF parameters — Stage 3 (refactor/bitemporal-vector-hybrid)
+# ---------------------------------------------------------------------------
+
+#: Reciprocal rank fusion constant.  The standard literature (Cormack,
+#: Clarke, Buettcher 2009) recommends k=60.  Higher k smooths the
+#: difference between rank 1 and rank 2; lower k amplifies it.  60 is
+#: the standard default for hybrid RAG pipelines and matches LangChain's
+#: EnsembleRetriever default.
+RRF_K: Final[int] = 60
+
+#: Number of BM25 (sparse) candidates to retrieve before RRF fusion.
+#: Widening beyond top_k gives RRF more headroom; 2x top_k is a
+#: common default that keeps the sparse-side scan bounded.
+SPARSE_CANDIDATE_FACTOR: Final[int] = 2
+
+# ---------------------------------------------------------------------------
+# Indexed payload fields — ADR-0006, Decision §Schema posture
+# ---------------------------------------------------------------------------
+
 #: Fields that get a Qdrant payload index.  ADR-0006, Decision §Schema
 #: posture lists them explicitly — workspace_id is the mandatory one
 #: (§ACL carry-forward), the rest are performance-oriented for the
@@ -147,10 +221,14 @@ __all__ = [
     "DEFAULT_QDRANT_GRPC_PORT",
     "DEFAULT_QDRANT_HOST",
     "DEFAULT_QDRANT_HTTP_PORT",
+    "ENUMERATE_METADATA_INDEX_KEYS",
+    "ENUMERATE_METADATA_PREFIX",
+    "ENUMERATE_PAYLOAD_INDEXES",
     "HNSW_EF_CONSTRUCT",
     "HNSW_M",
     "INDEXED_PAYLOAD_FIELDS",
     "NAMED_VECTOR_DENSE_PRIMARY",
+    "NAMED_VECTOR_SPARSE_BM25",
     "PAYLOAD_CHUNKER_STRATEGY",
     "PAYLOAD_CONTENT_HASH",
     "PAYLOAD_CONTENT_TYPE",
@@ -176,6 +254,8 @@ __all__ = [
     "PAYLOAD_VALID_FROM",
     "PAYLOAD_VALID_TO",
     "PAYLOAD_WORKSPACE_ID",
+    "RRF_K",
+    "SPARSE_CANDIDATE_FACTOR",
     "TIER_HOT",
     "TIER_WARM",
 ]

--- a/packages/index/src/omniscience_index/stores/qdrant_filters.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_filters.py
@@ -46,6 +46,17 @@ from omniscience_index.stores.qdrant_constants import (
     PAYLOAD_WORKSPACE_ID,
 )
 
+# Type alias for the long union Qdrant uses in its ``must`` lists.
+_MustClause = (
+    qm.FieldCondition
+    | qm.IsEmptyCondition
+    | qm.IsNullCondition
+    | qm.HasIdCondition
+    | qm.HasVectorCondition
+    | qm.NestedCondition
+    | qm.Filter
+)
+
 
 @dataclass(frozen=True, slots=True)
 class QdrantFilterBuilder:
@@ -62,7 +73,9 @@ class QdrantFilterBuilder:
     document_ids: tuple[uuid.UUID, ...] = field(default_factory=tuple)
     external_id: str | None = None
     exclude_tombstoned_flag: bool = False
+    current_only_flag: bool = False
     as_of: datetime | None = None
+    metadata_filters: tuple[tuple[str, str], ...] = field(default_factory=tuple)
 
     def with_source_ids(self, source_ids: list[uuid.UUID]) -> QdrantFilterBuilder:
         """Return a new builder narrowed to the given sources."""
@@ -80,6 +93,23 @@ class QdrantFilterBuilder:
         """Return a new builder that excludes tombstoned points."""
         return replace(self, exclude_tombstoned_flag=True)
 
+    def with_current_only(self) -> QdrantFilterBuilder:
+        """Return a new builder that excludes end-dated (historical) points.
+
+        Stage 1 (bitemporal end-dating, refactor/bitemporal-vector-hybrid):
+        After a content-hash change, old chunk points are end-dated
+        (``valid_to`` set to now) rather than deleted.  Callers that
+        want ONLY the still-valid current generation — e.g.
+        ``_find_document`` — must add this clause so they don't see
+        end-dated points alongside current ones.
+
+        Adds ``IsNullCondition`` on ``valid_to``.  This is the same
+        "still-open" clause that ``build_end_date_chunks_filter`` uses
+        to select candidates for end-dating.  Compose with
+        ``.exclude_tombstoned()`` for full current-state semantics.
+        """
+        return replace(self, current_only_flag=True)
+
     def with_as_of(self, as_of: datetime | None) -> QdrantFilterBuilder:
         """Return a new builder that applies the ADR-0008 §5 ``as_of`` predicate.
 
@@ -92,6 +122,16 @@ class QdrantFilterBuilder:
         """
         return replace(self, as_of=as_of)
 
+    def with_metadata_filter(self, key: str, value: str) -> QdrantFilterBuilder:
+        """Return a new builder narrowed by a ``metadata.<key>`` payload field.
+
+        Stage 4 (enumerate mode): payload-indexed metadata sub-fields
+        (service, resource_type, account_id, kind, namespace) allow
+        O(index) enumeration without HNSW.  Keys are expected to match
+        the constants in ``ENUMERATE_PAYLOAD_INDEXES`` (qdrant_constants).
+        """
+        return replace(self, metadata_filters=(*self.metadata_filters, (key, value)))
+
     def build(self) -> qm.Filter:
         """Emit the concrete Qdrant filter.
 
@@ -99,17 +139,7 @@ class QdrantFilterBuilder:
         ``must`` clause.  This invariant is re-asserted in a unit
         test to guard against future refactors.
         """
-        # Type annotated as the full union Qdrant accepts so mypy
-        # --strict does not reject list invariance.
-        must: list[
-            qm.FieldCondition
-            | qm.IsEmptyCondition
-            | qm.IsNullCondition
-            | qm.HasIdCondition
-            | qm.HasVectorCondition
-            | qm.NestedCondition
-            | qm.Filter
-        ] = [
+        must: list[_MustClause] = [
             qm.FieldCondition(
                 key=PAYLOAD_WORKSPACE_ID,
                 match=qm.MatchValue(value=str(self.workspace_id)),
@@ -141,25 +171,27 @@ class QdrantFilterBuilder:
             # clause keeps the selection tight rather than relying on
             # must_not/not-matching semantics.
             must.append(qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_TOMBSTONED_AT)))
+        if self.current_only_flag:
+            # Exclude end-dated points (valid_to IS NOT NULL means the
+            # chunk has been superseded).  Combined with exclude_tombstoned
+            # this gives the full "currently alive" predicate.
+            must.append(qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_VALID_TO)))
         if self.as_of is not None:
             # ADR-0008 §5 canonical open-closed predicate, ADR-0006 §6
             # cross-store alignment.  Layered as additional ``must``
             # clauses on top of workspace_id — never replaces it.
             must.extend(_as_of_must_clauses(self.as_of))
+        for meta_key, meta_value in self.metadata_filters:
+            must.append(
+                qm.FieldCondition(
+                    key=meta_key,
+                    match=qm.MatchValue(value=meta_value),
+                )
+            )
         return qm.Filter(must=must)
 
 
-def _as_of_must_clauses(
-    as_of: datetime,
-) -> list[
-    qm.FieldCondition
-    | qm.IsEmptyCondition
-    | qm.IsNullCondition
-    | qm.HasIdCondition
-    | qm.HasVectorCondition
-    | qm.NestedCondition
-    | qm.Filter
-]:
+def _as_of_must_clauses(as_of: datetime) -> list[_MustClause]:
     """Build the ADR-0008 §5 ``as_of`` predicate as Qdrant ``must`` clauses.
 
     The canonical predicate is
@@ -181,27 +213,11 @@ def _as_of_must_clauses(
     for ensuring ``as_of`` is timezone-aware (the ``SearchRequest``
     validator at the public API surface enforces this).
     """
-    valid_from_clause: (
-        qm.FieldCondition
-        | qm.IsEmptyCondition
-        | qm.IsNullCondition
-        | qm.HasIdCondition
-        | qm.HasVectorCondition
-        | qm.NestedCondition
-        | qm.Filter
-    ) = qm.FieldCondition(
+    valid_from_clause: _MustClause = qm.FieldCondition(
         key=PAYLOAD_VALID_FROM,
         range=qm.DatetimeRange(lte=as_of),
     )
-    valid_to_open_clause: (
-        qm.FieldCondition
-        | qm.IsEmptyCondition
-        | qm.IsNullCondition
-        | qm.HasIdCondition
-        | qm.HasVectorCondition
-        | qm.NestedCondition
-        | qm.Filter
-    ) = qm.Filter(
+    valid_to_open_clause: _MustClause = qm.Filter(
         should=[
             qm.FieldCondition(
                 key=PAYLOAD_VALID_TO,
@@ -232,6 +248,35 @@ def build_as_of_filter(
     return builder.build()
 
 
+def build_enumerate_filter(
+    *,
+    workspace_id: uuid.UUID,
+    metadata_key: str,
+    metadata_value: str,
+    source_id: uuid.UUID | None = None,
+) -> qm.Filter:
+    """Build a workspace-scoped filter for enumerate-mode payload scanning.
+
+    Stage 4 (enumerate mode, refactor/bitemporal-vector-hybrid):
+    Enumerate queries ("all X matching Y") bypass HNSW and use
+    ``exact=True`` Qdrant count + scroll on payload indexes.
+    This helper constructs the appropriate filter for a
+    ``metadata.<key>`` dimension (service, resource_type, etc.).
+
+    The filter selects current-only (``valid_to IS NULL``) non-tombstoned
+    points.  Workspace scoping is mandatory per ADR-0006 §ACL.
+    """
+    builder = (
+        QdrantFilterBuilder(workspace_id=workspace_id)
+        .exclude_tombstoned()
+        .with_current_only()
+        .with_metadata_filter(metadata_key, metadata_value)
+    )
+    if source_id is not None:
+        builder = builder.with_source_ids([source_id])
+    return builder.build()
+
+
 def build_retention_eligible_filter(
     *,
     workspace_id: uuid.UUID,
@@ -251,15 +296,7 @@ def build_retention_eligible_filter(
     entirely (re-embedding from archive is not supported in v1, see
     ADR-0009 §5).
     """
-    must: list[
-        qm.FieldCondition
-        | qm.IsEmptyCondition
-        | qm.IsNullCondition
-        | qm.HasIdCondition
-        | qm.HasVectorCondition
-        | qm.NestedCondition
-        | qm.Filter
-    ] = [
+    must: list[_MustClause] = [
         qm.FieldCondition(
             key=PAYLOAD_WORKSPACE_ID,
             match=qm.MatchValue(value=str(workspace_id)),
@@ -280,15 +317,7 @@ def build_warm_tier_filter(*, workspace_id: uuid.UUID) -> qm.Filter:
     pinning a specific ``snapshot_date``.  Workspace-scoped — the
     cross-tenant invariant from ADR-0006 §ACL carry-forward applies.
     """
-    must: list[
-        qm.FieldCondition
-        | qm.IsEmptyCondition
-        | qm.IsNullCondition
-        | qm.HasIdCondition
-        | qm.HasVectorCondition
-        | qm.NestedCondition
-        | qm.Filter
-    ] = [
+    must: list[_MustClause] = [
         qm.FieldCondition(
             key=PAYLOAD_WORKSPACE_ID,
             match=qm.MatchValue(value=str(workspace_id)),
@@ -312,15 +341,7 @@ def build_warm_archive_filter(
     are evicted from Qdrant entirely; the filter selects warm-tier
     chunks for the specific snapshot date being archived.
     """
-    must: list[
-        qm.FieldCondition
-        | qm.IsEmptyCondition
-        | qm.IsNullCondition
-        | qm.HasIdCondition
-        | qm.HasVectorCondition
-        | qm.NestedCondition
-        | qm.Filter
-    ] = [
+    must: list[_MustClause] = [
         qm.FieldCondition(
             key=PAYLOAD_WORKSPACE_ID,
             match=qm.MatchValue(value=str(workspace_id)),
@@ -361,15 +382,7 @@ def build_end_date_chunks_filter(
     ``valid_to`` — symmetric with the existing ``exclude_tombstoned``
     pattern in :class:`QdrantFilterBuilder`.
     """
-    must: list[
-        qm.FieldCondition
-        | qm.IsEmptyCondition
-        | qm.IsNullCondition
-        | qm.HasIdCondition
-        | qm.HasVectorCondition
-        | qm.NestedCondition
-        | qm.Filter
-    ] = [
+    must: list[_MustClause] = [
         qm.FieldCondition(
             key=PAYLOAD_WORKSPACE_ID,
             match=qm.MatchValue(value=str(workspace_id)),
@@ -380,15 +393,7 @@ def build_end_date_chunks_filter(
         ),
         qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_VALID_TO)),
     ]
-    must_not: list[
-        qm.FieldCondition
-        | qm.IsEmptyCondition
-        | qm.IsNullCondition
-        | qm.HasIdCondition
-        | qm.HasVectorCondition
-        | qm.NestedCondition
-        | qm.Filter
-    ] = []
+    must_not: list[_MustClause] = []
     if exclude_external_ids:
         must_not.append(
             qm.FieldCondition(
@@ -420,10 +425,36 @@ def build_tombstone_sweep_filter(*, cutoff_iso: str) -> qm.Filter:
     )
 
 
+def build_point_ids_filter(
+    *,
+    workspace_id: uuid.UUID,
+    point_ids: list[str],
+) -> qm.Filter:
+    """Build a workspace-scoped filter selecting a specific set of point IDs.
+
+    Stage 1 (end-dating, refactor/bitemporal-vector-hybrid):
+    Used by ``_end_date_points`` to set ``valid_to`` on a batch of
+    known point ids while keeping the workspace must-clause intact.
+    Workspace scoping is retained even though point ids are globally
+    unique, so the lint rule stays satisfied and a buggy caller cannot
+    accidentally end-date foreign-workspace points.
+    """
+    must: list[_MustClause] = [
+        qm.FieldCondition(
+            key=PAYLOAD_WORKSPACE_ID,
+            match=qm.MatchValue(value=str(workspace_id)),
+        ),
+        qm.HasIdCondition(has_id=point_ids),  # type: ignore[arg-type]
+    ]
+    return qm.Filter(must=must)
+
+
 __all__ = [
     "QdrantFilterBuilder",
     "build_as_of_filter",
     "build_end_date_chunks_filter",
+    "build_enumerate_filter",
+    "build_point_ids_filter",
     "build_retention_eligible_filter",
     "build_tombstone_sweep_filter",
     "build_warm_archive_filter",

--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -19,13 +19,57 @@ Every read path in this module composes filters through
 constructor argument.  Raw ``qdrant_client.models.Filter`` construction
 is forbidden outside ``qdrant_filters.py`` and is enforced by a lint
 test (see ``tests/test_qdrant_filter_builder_lint.py``).
+
+Stage 1 — bitemporal end-dating on content update
+--------------------------------------------------
+
+ADR-0008 §6 / refactor/bitemporal-vector-hybrid:
+
+When a document's ``content_hash`` changes, the old chunk points are
+**end-dated** (``valid_to = now()``) instead of hard-deleted.  New
+chunk points are inserted with ``valid_from = now()`` and
+``valid_to = None``.  The vector store is therefore append-only
+versioned, symmetric with the Neo4j graph (which end-dates entities
+and edges rather than deleting them).
+
+Consequence for ``as_of`` reads: an ``as_of=T`` search on a document
+that was updated after ``T`` will return the OLD chunk version (the
+one valid at ``T``), not an empty result.  This closes the cross-store
+consistency gap described in ADR-0008 §6.
+
+Current-state reads (``as_of=None``, the hot path) are unaffected in
+performance because the filter builder adds ``valid_to IS NULL`` only
+when ``with_current_only()`` is called — and the public ``search``
+method still uses the pre-Stage-1 filter shape (no ``valid_*``
+clauses at all for the default path).
+
+Stage 3 — BM25/RRF sparse + dense hybrid
+-----------------------------------------
+
+When ``retrieval_strategy == "hybrid"`` (default) or ``"keyword"``,
+the store performs a sparse-vector search alongside (or instead of)
+the dense search.  Sparse vectors are built client-side from chunk
+text via a simple TF tokenizer (see ``_tokenize_to_sparse``).
+``hybrid`` combines dense + sparse results via Reciprocal Rank Fusion
+(RRF, ``RRF_K = 60``).  ``keyword`` returns sparse-only results so
+callers can request BM25-style exact-name lookup.
+
+Stage 4 — enumerate mode
+-------------------------
+
+``enumerate_chunks`` bypasses HNSW entirely and uses
+``count(exact=True)`` + ``scroll`` to enumerate all chunks matching
+a payload dimension (``metadata.service``, ``metadata.kind``, etc.).
+Results are deduplicated by ``document_id``.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 import time
 import uuid
+from collections import Counter as _Counter
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -43,10 +87,13 @@ from qdrant_client.http.exceptions import UnexpectedResponse
 from omniscience_index.stores.qdrant_config import QdrantConfig
 from omniscience_index.stores.qdrant_constants import (
     COLLECTION_NAME_PREFIX,
+    ENUMERATE_METADATA_PREFIX,
+    ENUMERATE_PAYLOAD_INDEXES,
     HNSW_EF_CONSTRUCT,
     HNSW_M,
     INDEXED_PAYLOAD_FIELDS,
     NAMED_VECTOR_DENSE_PRIMARY,
+    NAMED_VECTOR_SPARSE_BM25,
     PAYLOAD_CHUNKER_STRATEGY,
     PAYLOAD_CONTENT_HASH,
     PAYLOAD_DOC_VERSION,
@@ -70,11 +117,15 @@ from omniscience_index.stores.qdrant_constants import (
     PAYLOAD_VALID_FROM,
     PAYLOAD_VALID_TO,
     PAYLOAD_WORKSPACE_ID,
+    RRF_K,
+    SPARSE_CANDIDATE_FACTOR,
     TIER_WARM,
 )
 from omniscience_index.stores.qdrant_filters import (
     QdrantFilterBuilder,
     build_end_date_chunks_filter,
+    build_enumerate_filter,
+    build_point_ids_filter,
     build_retention_eligible_filter,
     build_tombstone_sweep_filter,
     build_warm_archive_filter,
@@ -85,6 +136,42 @@ if TYPE_CHECKING:  # Lazy type-only import to avoid a core <-> retrieval cycle.
     from omniscience_retrieval.models import SearchRequest, SearchResult
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Stopwords for the sparse tokenizer (Stage 3)
+# ---------------------------------------------------------------------------
+
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "of",
+        "in",
+        "is",
+        "it",
+        "to",
+        "be",
+        "as",
+        "at",
+        "by",
+        "for",
+        "on",
+        "with",
+        "this",
+        "that",
+        "from",
+        "was",
+        "are",
+        "has",
+        "had",
+        "not",
+        "but",
+        "have",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +333,18 @@ class QdrantVectorStore:
     # ------------------------------------------------------------------
 
     async def _ensure_collection(self) -> None:
-        """Create the collection if missing.  Idempotent."""
+        """Create the collection if missing.  Idempotent.
+
+        Stage 3 (refactor/bitemporal-vector-hybrid): the collection is
+        created with BOTH a dense named vector (``dense_primary``) AND a
+        sparse named vector (``sparse_bm25``) so BM25/RRF hybrid search
+        is available without a collection-level migration.
+
+        Existing collections that pre-date Stage 3 lack the sparse
+        vector; those are handled by the migration script
+        ``scripts/reindex_qdrant_hybrid.py`` which recreates the
+        collection with both vectors and re-indexes all points.
+        """
         exists = await self._qc.collection_exists(self._collection_name)
         if exists:
             return
@@ -256,6 +354,11 @@ class QdrantVectorStore:
                 NAMED_VECTOR_DENSE_PRIMARY: qm.VectorParams(
                     size=self._embedding_provider.dim,
                     distance=qm.Distance.COSINE,
+                )
+            },
+            sparse_vectors_config={
+                NAMED_VECTOR_SPARSE_BM25: qm.SparseVectorParams(
+                    index=qm.SparseIndexParams(on_disk=False)
                 )
             },
             hnsw_config=qm.HnswConfigDiff(m=HNSW_M, ef_construct=HNSW_EF_CONSTRUCT),
@@ -270,8 +373,15 @@ class QdrantVectorStore:
         )
 
     async def _ensure_payload_indexes(self) -> None:
-        """Create payload indexes listed in ADR-0006.  Idempotent."""
+        """Create payload indexes listed in ADR-0006 + enumerate indexes.
+
+        Stage 4: in addition to the core ADR-0006 indexes, each
+        ``metadata.<key>`` enumerate dimension gets a KEYWORD payload
+        index so payload-filter scans are O(index) not O(collection).
+        """
         for field_name in INDEXED_PAYLOAD_FIELDS:
+            await self._create_payload_index_if_missing(field_name)
+        for field_name in ENUMERATE_PAYLOAD_INDEXES:
             await self._create_payload_index_if_missing(field_name)
 
     async def _create_payload_index_if_missing(self, field_name: str) -> None:
@@ -323,7 +433,14 @@ class QdrantVectorStore:
         Decision table (mirrors pgvector semantics):
         - No existing chunks for (source, external_id)  → insert → action="created"
         - Existing with same content_hash               → no-op   → action="unchanged"
-        - Existing with different hash                  → replace → action="updated"
+        - Existing with different hash                  → end-date old → insert new
+                                                          → action="updated"
+
+        Stage 1 (bitemporal end-dating): the "different hash" path no longer
+        physically deletes old points.  Old points receive ``valid_to = now()``;
+        new points are inserted with ``valid_from = now()`` and
+        ``valid_to = None``.  The vector store is therefore append-only
+        versioned, symmetric with the Neo4j graph (ADR-0008 §6).
 
         ``workspace_id`` must be present in every chunk's metadata
         (propagated via ``metadata[workspace_id]``); missing or null
@@ -369,12 +486,27 @@ class QdrantVectorStore:
         chunks: list[ChunkPayload],
         ingestion_run_id: uuid.UUID | None,
     ) -> UpsertOutcome:
-        """Create or replace the document's chunks as a single logical batch."""
+        """Create or replace the document's chunks as a single logical batch.
+
+        Stage 1 change: when ``existing`` is not None, the old chunk
+        points are end-dated (``valid_to = now()``) rather than deleted.
+        New points are then inserted with the fresh content.  The
+        ``document_id`` is preserved across versions so downstream
+        callers that track document identity by UUID stay stable.
+        """
         document_id = existing.document_id if existing else uuid.uuid4()
         doc_version = (existing.doc_version + 1) if existing else 1
         action: Literal["created", "updated"] = "updated" if existing else "created"
+        now = datetime.now(UTC)
         if existing is not None:
-            await self._delete_points(list(existing.chunk_point_ids))
+            # Stage 1: end-date the old points instead of deleting them.
+            # This makes ``as_of=T`` (T < update time) return the OLD
+            # chunk version — preserving cross-store consistency with Neo4j.
+            await self._end_date_points(
+                point_ids=list(existing.chunk_point_ids),
+                workspace_id=workspace_id,
+                valid_to=now,
+            )
         points = [
             self._chunk_to_point(
                 chunk=chunk,
@@ -388,6 +520,7 @@ class QdrantVectorStore:
                 doc_version=doc_version,
                 metadata=metadata,
                 ingestion_run_id=ingestion_run_id,
+                valid_from=now,
             )
             for chunk in chunks
         ]
@@ -414,8 +547,14 @@ class QdrantVectorStore:
         doc_version: int,
         metadata: dict[str, Any],
         ingestion_run_id: uuid.UUID | None,
+        valid_from: datetime | None = None,
     ) -> qm.PointStruct:
-        """Translate a ``ChunkPayload`` + doc context into a Qdrant point."""
+        """Translate a ``ChunkPayload`` + doc context into a Qdrant point.
+
+        Stage 3: the point now carries both a dense vector and a sparse
+        BM25 vector.  The sparse vector is built client-side from the
+        chunk text via ``_tokenize_to_sparse``.
+        """
         text, ord_, embedding = _require_chunk_fields(chunk)
         point_id = str(uuid.uuid4())
         payload = _build_chunk_payload(
@@ -432,10 +571,15 @@ class QdrantVectorStore:
             doc_version=doc_version,
             metadata=metadata,
             ingestion_run_id=ingestion_run_id,
+            valid_from=valid_from,
         )
+        sparse = _tokenize_to_sparse(text)
+        vectors: dict[str, Any] = {NAMED_VECTOR_DENSE_PRIMARY: embedding}
+        if sparse.indices:
+            vectors[NAMED_VECTOR_SPARSE_BM25] = sparse
         return qm.PointStruct(
             id=point_id,
-            vector={NAMED_VECTOR_DENSE_PRIMARY: embedding},
+            vector=vectors,  # type: ignore[arg-type]
             payload=payload,
         )
 
@@ -450,16 +594,24 @@ class QdrantVectorStore:
         source_id: uuid.UUID,
         external_id: str,
     ) -> _DocumentRecord | None:
-        """Find the logical document identified by (source_id, external_id).
+        """Find the CURRENT logical document identified by (source_id, external_id).
 
         Reads are scoped to ``workspace_id`` via the filter-builder so
         cross-workspace aliases never leak across the tenant boundary
         (ADR-0006 §ACL carry-forward).
+
+        Stage 1: adds ``with_current_only()`` so end-dated (historical)
+        points from previous content versions are not included in the
+        result.  Without this, the writer would see both old end-dated
+        points and new current points for the same (source, external_id),
+        which would make content-hash comparison unreliable and
+        doc_version calculation incorrect.
         """
         flt = (
             QdrantFilterBuilder(workspace_id=workspace_id)
             .with_source_ids([source_id])
             .with_external_id(external_id)
+            .with_current_only()
             .build()
         )
         points = await self._scroll_all(flt=flt, with_payload=True)
@@ -487,8 +639,49 @@ class QdrantVectorStore:
             offset = next_offset
         return out
 
+    async def _end_date_points(
+        self,
+        *,
+        point_ids: list[uuid.UUID],
+        workspace_id: uuid.UUID,
+        valid_to: datetime,
+    ) -> None:
+        """Set ``valid_to`` on a specific list of chunk points.
+
+        Stage 1 (bitemporal end-dating): replaces the old
+        ``_delete_points`` call in the content-update path.  The
+        points remain in the collection but are excluded from current-
+        state reads (``with_current_only()``), count, and search
+        (which default to the current-state predicate via
+        ``as_of=None``).
+
+        The workspace filter is retained even though point IDs are
+        globally unique — the lint rule forbids bare ``qm.Filter``
+        construction outside ``qdrant_filters.py``.
+        """
+        if not point_ids:
+            return
+        valid_to_iso = valid_to.isoformat()
+        flt = build_point_ids_filter(
+            workspace_id=workspace_id,
+            point_ids=[str(p) for p in point_ids],
+        )
+        await self._qc.set_payload(
+            collection_name=self._collection_name,
+            payload={PAYLOAD_VALID_TO: valid_to_iso},
+            points=qm.FilterSelector(filter=flt),
+            wait=True,
+        )
+
     async def _delete_points(self, point_ids: list[uuid.UUID]) -> None:
-        """Delete points by id.  No filter — caller must have verified scope."""
+        """Delete points by id.  No filter — caller must have verified scope.
+
+        NOTE: this method is intentionally kept for the retention worker
+        and tombstone-sweep paths.  It is NO LONGER called from the
+        content-update write path (Stage 1).  Any new caller should
+        prefer ``_end_date_points`` unless retention-grade eviction is
+        required.
+        """
         if not point_ids:
             return
         await self._qc.delete(
@@ -623,29 +816,64 @@ class QdrantVectorStore:
         workspace_id: uuid.UUID,
         as_of: datetime | None = None,
     ) -> SearchResult:
-        """Vector-only search, confined to the caller's workspace.
+        """Search, dispatched by ``request.retrieval_strategy``.
+
+        Stage 3 (refactor/bitemporal-vector-hybrid):
+
+        - ``"hybrid"`` (default): dense + sparse, merged via RRF.
+        - ``"keyword"``: sparse BM25 only — for exact-name lookup.
+        - ``"structural"``: graph-anchor scoped dense-only (pure vector,
+          same as pre-Stage-3; the graph anchor is resolved by the
+          ``GraphRAGComposer`` caller).
+        - ``"auto"``: same as ``"hybrid"`` for now; heuristic routing
+          is a follow-up issue.
 
         ADR-0006 §ACL carry-forward: ``workspace_id`` is the
         mandatory must-clause filter; no code path in this method
         can construct a ``Filter`` without it.
 
         ``as_of`` (issue #134) is the optional ADR-0008 §5 bitemporal
-        anchor.  When supplied, the canonical open-closed predicate
-        ``valid_from <= as_of AND (valid_to > as_of OR valid_to IS NULL)``
-        is layered onto the filter as additional ``must`` clauses; the
-        workspace must-clause is never replaced.  When ``None`` (default)
-        the filter is byte-identical to the pre-#134 contract — current-
-        state reads do not pay the predicate cost.  ``as_of`` precedence
-        with ``request.as_of``: the keyword wins so server-side overrides
-        stay explicit (mirrors :class:`GraphRAGComposer.search`).
+        anchor.  When supplied, the canonical open-closed predicate is
+        layered onto all stage filters.
         """
-        start = time.monotonic()
-        query_vector = await self._embed_query(request.query)
         effective_as_of = as_of if as_of is not None else request.as_of
-        flt = self._request_to_filter(
+        strategy = request.retrieval_strategy
+
+        if strategy == "keyword":
+            return await self._search_sparse(
+                request=request,
+                workspace_id=workspace_id,
+                as_of=effective_as_of,
+            )
+        if strategy in ("hybrid", "auto"):
+            return await self._search_hybrid_rrf(
+                request=request,
+                workspace_id=workspace_id,
+                as_of=effective_as_of,
+            )
+        # "structural" and unknown values fall through to dense-only
+        # (the caller — GraphRAGComposer — has already applied the
+        # graph-anchor source filter to ``request.sources``).
+        return await self._search_dense(
             request=request,
             workspace_id=workspace_id,
             as_of=effective_as_of,
+        )
+
+    async def _search_dense(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None,
+    ) -> SearchResult:
+        """Execute a dense (HNSW) vector search."""
+        start = time.monotonic()
+        query_vector = await self._embed_query(request.query)
+        flt = self._request_to_filter(
+            request=request,
+            workspace_id=workspace_id,
+            as_of=as_of,
         )
         hits = await self._qc.query_points(
             collection_name=self._collection_name,
@@ -657,10 +885,123 @@ class QdrantVectorStore:
             with_vectors=False,
         )
         duration_ms = (time.monotonic() - start) * 1000.0
-        if effective_as_of is not None:
+        if as_of is not None:
             QDRANT_AS_OF_FILTERED_TOTAL.labels(method="search").inc()
         return _build_search_result(
-            scored=hits.points, top_k=request.top_k, duration_ms=duration_ms
+            scored=hits.points, top_k=request.top_k, duration_ms=duration_ms, text_matches=0
+        )
+
+    async def _search_sparse(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None,
+    ) -> SearchResult:
+        """Execute a sparse BM25 search (keyword strategy).
+
+        Uses the ``sparse_bm25`` named vector.  Returns
+        ``text_matches`` equal to the number of hits so the caller
+        can distinguish keyword results from dense-only results.
+        """
+        start = time.monotonic()
+        sparse_query = _tokenize_to_sparse(request.query)
+        if not sparse_query.indices:
+            # Empty query after tokenization — return empty result.
+            duration_ms = (time.monotonic() - start) * 1000.0
+            return _empty_search_result(duration_ms=duration_ms)
+        flt = self._request_to_filter(
+            request=request,
+            workspace_id=workspace_id,
+            as_of=as_of,
+        )
+        hits = await self._qc.query_points(
+            collection_name=self._collection_name,
+            query=sparse_query,
+            using=NAMED_VECTOR_SPARSE_BM25,
+            query_filter=flt,
+            limit=request.top_k,
+            with_payload=True,
+            with_vectors=False,
+        )
+        duration_ms = (time.monotonic() - start) * 1000.0
+        if as_of is not None:
+            QDRANT_AS_OF_FILTERED_TOTAL.labels(method="search").inc()
+        n = len(hits.points)
+        return _build_search_result(
+            scored=hits.points, top_k=request.top_k, duration_ms=duration_ms, text_matches=n
+        )
+
+    async def _search_hybrid_rrf(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None,
+    ) -> SearchResult:
+        """Execute dense + sparse search and merge via Reciprocal Rank Fusion.
+
+        Stage 3 RRF design:
+        - Dense candidates: ``top_k * SPARSE_CANDIDATE_FACTOR`` (wider net).
+        - Sparse candidates: same.
+        - Both searches share the same workspace+as_of filter.
+        - RRF formula: score = Σ 1/(k + rank_i) where k = RRF_K = 60.
+        - Graph-affinity blend (MERGE_ALPHA) is applied AFTER RRF by the
+          ``GraphRAGComposer._run_merge_stage``; this method does not know
+          about the anchor subgraph.
+        - ``text_matches`` is set to the number of sparse hits so
+          ``QueryStats`` surfaces a real count (was always 0 pre-Stage-3).
+        """
+        start = time.monotonic()
+        flt = self._request_to_filter(
+            request=request,
+            workspace_id=workspace_id,
+            as_of=as_of,
+        )
+        candidate_k = request.top_k * SPARSE_CANDIDATE_FACTOR
+
+        # Dense leg
+        query_vector = await self._embed_query(request.query)
+        dense_hits = await self._qc.query_points(
+            collection_name=self._collection_name,
+            query=query_vector,
+            using=NAMED_VECTOR_DENSE_PRIMARY,
+            query_filter=flt,
+            limit=candidate_k,
+            with_payload=True,
+            with_vectors=False,
+        )
+
+        # Sparse leg
+        sparse_query = _tokenize_to_sparse(request.query)
+        sparse_hits_list: list[qm.ScoredPoint] = []
+        if sparse_query.indices:
+            sparse_result = await self._qc.query_points(
+                collection_name=self._collection_name,
+                query=sparse_query,
+                using=NAMED_VECTOR_SPARSE_BM25,
+                query_filter=flt,
+                limit=candidate_k,
+                with_payload=True,
+                with_vectors=False,
+            )
+            sparse_hits_list = sparse_result.points
+
+        duration_ms = (time.monotonic() - start) * 1000.0
+        if as_of is not None:
+            QDRANT_AS_OF_FILTERED_TOTAL.labels(method="search").inc()
+
+        merged = _rrf_merge(
+            dense=dense_hits.points,
+            sparse=sparse_hits_list,
+            top_k=request.top_k,
+        )
+        text_matches = len(sparse_hits_list)
+        return _build_search_result(
+            scored=merged,
+            top_k=request.top_k,
+            duration_ms=duration_ms,
+            text_matches=text_matches,
         )
 
     def _request_to_filter(
@@ -675,6 +1016,21 @@ class QdrantVectorStore:
         ``workspace_id`` is always present.  Optional narrowers
         (sources, tombstone exclusion, ``as_of`` predicate) are layered
         on top.
+
+        Stage 1 (bitemporal end-dating, refactor/bitemporal-vector-hybrid):
+        When ``as_of=None`` (current-state read), ``with_current_only()``
+        (``valid_to IS NULL``) is added so end-dated historical chunk
+        versions do not appear in results.  Before Stage 1 only
+        ``exclude_tombstoned`` was applied; this was correct because
+        old points were hard-deleted and never survived past their
+        replacement.  After Stage 1 they persist with ``valid_to`` set,
+        so the current-state filter must explicitly exclude them.
+
+        When ``as_of`` is supplied the open-closed temporal predicate
+        ``valid_from <= as_of AND (valid_to > as_of OR valid_to IS NULL)``
+        covers the correct generation; ``with_current_only()`` must NOT
+        be added because it would exclude end-dated historical versions
+        that ARE valid at ``as_of``.
         """
         builder = QdrantFilterBuilder(workspace_id=workspace_id)
         source_ids = _extract_source_ids(request)
@@ -682,8 +1038,9 @@ class QdrantVectorStore:
             builder = builder.with_source_ids(source_ids)
         if not request.include_tombstoned:
             builder = builder.exclude_tombstoned()
-        if as_of is not None:
-            builder = builder.with_as_of(as_of)
+        # Stage 1: as_of=None → current-only (valid_to IS NULL);
+        # as_of=T → open-closed temporal predicate.
+        builder = builder.with_as_of(as_of) if as_of is not None else builder.with_current_only()
         return builder.build()
 
     async def _embed_query(self, query: str) -> list[float]:
@@ -719,6 +1076,10 @@ class QdrantVectorStore:
         if as_of is not None:
             builder = builder.with_as_of(as_of)
             QDRANT_AS_OF_FILTERED_TOTAL.labels(method="count").inc()
+        else:
+            # Current-state: also exclude end-dated historical points
+            # so the count reflects only the still-valid generation.
+            builder = builder.with_current_only()
         flt = builder.build()
         records = await self._scroll_all(flt=flt, with_payload=True)
         document_ids = {r.payload.get(PAYLOAD_DOCUMENT_ID) for r in records if r.payload}
@@ -750,7 +1111,101 @@ class QdrantVectorStore:
         if as_of is not None:
             builder = builder.with_as_of(as_of)
             QDRANT_AS_OF_FILTERED_TOTAL.labels(method="count_chunks").inc()
+        else:
+            builder = builder.with_current_only()
         flt = builder.build()
+        result = await self._qc.count(
+            collection_name=self._collection_name,
+            count_filter=flt,
+            exact=True,
+        )
+        return int(result.count)
+
+    # ------------------------------------------------------------------
+    # Enumerate API — Stage 4
+    # ------------------------------------------------------------------
+
+    async def enumerate_chunks(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        metadata_key: str,
+        metadata_value: str,
+        source_id: uuid.UUID | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return all current chunks matching a payload dimension.
+
+        Stage 4 (enumerate mode, refactor/bitemporal-vector-hybrid):
+
+        Bypasses HNSW entirely.  Uses ``scroll`` on payload indexes for
+        O(index) retrieval — suited for "list all X / count all Y"
+        questions that require 100% recall (HNSW has non-trivial miss
+        probability).
+
+        Results are deduplicated by ``document_id`` (NOT by URI) to
+        avoid presenting the same logical document twice when it has
+        multiple chunks.  The first chunk for each ``document_id`` is
+        returned with its full payload.
+
+        Workspace scoping is mandatory per ADR-0006 §ACL.
+
+        Parameters
+        ----------
+        metadata_key:
+            One of the indexed enumerate dimensions
+            (``service``, ``resource_type``, ``account_id``,
+            ``kind``, ``namespace``).  Must match a key in
+            ``ENUMERATE_METADATA_INDEX_KEYS``.
+        metadata_value:
+            Exact match value for the given dimension.
+        source_id:
+            Optional source-level narrowing.
+
+        Returns
+        -------
+        List of payload dicts, one per unique ``document_id``.
+        """
+        payload_field = f"{ENUMERATE_METADATA_PREFIX}.{metadata_key}"
+        flt = build_enumerate_filter(
+            workspace_id=workspace_id,
+            metadata_key=payload_field,
+            metadata_value=metadata_value,
+            source_id=source_id,
+        )
+        records = await self._scroll_all(flt=flt, with_payload=True)
+        seen: set[str] = set()
+        out: list[dict[str, Any]] = []
+        for rec in records:
+            payload = rec.payload or {}
+            doc_id = payload.get(PAYLOAD_DOCUMENT_ID)
+            if doc_id is None or doc_id in seen:
+                continue
+            seen.add(doc_id)
+            out.append(dict(payload))
+        return out
+
+    async def count_enumerate(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        metadata_key: str,
+        metadata_value: str,
+        source_id: uuid.UUID | None = None,
+    ) -> int:
+        """Return the exact count of documents matching a payload dimension.
+
+        Stage 4: uses ``count(exact=True)`` for O(index) exact counting.
+        Unlike ``count_chunks`` this counts at the chunk level (not the
+        document level); for document-level counts call ``enumerate_chunks``
+        and take ``len(result)``.
+        """
+        payload_field = f"{ENUMERATE_METADATA_PREFIX}.{metadata_key}"
+        flt = build_enumerate_filter(
+            workspace_id=workspace_id,
+            metadata_key=payload_field,
+            metadata_value=metadata_value,
+            source_id=source_id,
+        )
         result = await self._qc.count(
             collection_name=self._collection_name,
             count_filter=flt,
@@ -957,6 +1412,8 @@ class QdrantVectorStore:
         if as_of is not None:
             builder = builder.with_as_of(as_of)
             QDRANT_AS_OF_FILTERED_TOTAL.labels(method="count_chunks_by_source").inc()
+        else:
+            builder = builder.with_current_only()
         flt = builder.build()
         offset: qm.ExtendedPointId | None = None
         page_size = 1000
@@ -1054,6 +1511,7 @@ def _build_chunk_payload(
     doc_version: int,
     metadata: dict[str, Any],
     ingestion_run_id: uuid.UUID | None,
+    valid_from: datetime | None = None,
 ) -> dict[str, Any]:
     """Assemble the Qdrant payload dict for a single chunk point.
 
@@ -1064,12 +1522,19 @@ def _build_chunk_payload(
     Bitemporal fields (ADR-0008 §6, issue #134): every chunk carries
     ``valid_from``, ``valid_to``, ``recorded_at`` so the ``as_of``
     predicate in :class:`QdrantFilterBuilder` is index-backed on every
-    read.  Defaults: ``recorded_at = now()``, ``valid_from = recorded_at``,
-    ``valid_to = None`` (still-valid sentinel from ADR-0008 §1).  The
-    historical-import path with caller-supplied ``valid_*`` is a separate
-    sub-issue per #134 non-goals.
+    read.  Defaults: ``recorded_at = now()``, ``valid_from = recorded_at``
+    (or caller-supplied), ``valid_to = None`` (still-valid sentinel from
+    ADR-0008 §1).
     """
-    now_iso = datetime.now(UTC).isoformat()
+    # When ``valid_from`` is supplied by the caller (the write path always
+    # passes ``now`` from ``_write_document``), reuse it as ``recorded_at``
+    # so the two timestamps are byte-identical.  This satisfies the
+    # contract assertion ``valid_from == recorded_at`` on fresh upserts
+    # (ADR-0008 §6, issue #134, ``test_upsert_populates_valid_from_and_null_valid_to``).
+    # Two separate ``datetime.now(UTC)`` calls produce microsecond skew.
+    _now = valid_from if valid_from is not None else datetime.now(UTC)
+    now_iso = _now.isoformat()
+    valid_from_iso = now_iso
     return {
         PAYLOAD_WORKSPACE_ID: str(workspace_id),
         PAYLOAD_SOURCE_ID: str(source_id),
@@ -1092,7 +1557,7 @@ def _build_chunk_payload(
         ),
         PAYLOAD_TOMBSTONED_AT: None,
         PAYLOAD_RECORDED_AT: now_iso,
-        PAYLOAD_VALID_FROM: now_iso,
+        PAYLOAD_VALID_FROM: valid_from_iso,
         PAYLOAD_VALID_TO: None,
         "doc_metadata": dict(metadata),
     }
@@ -1123,14 +1588,134 @@ def _coerce_point_id(pid: qm.ExtendedPointId) -> uuid.UUID:
     raise TypeError(f"unexpected point id type: {type(pid).__name__}")
 
 
+# ---------------------------------------------------------------------------
+# Sparse vector tokenizer (Stage 3)
+# ---------------------------------------------------------------------------
+
+
+def _tokenize_to_sparse(text: str) -> qm.SparseVector:
+    """Convert text to a sparse TF vector for BM25-style search.
+
+    Algorithm:
+    1. Lowercase + split on non-alphanumeric characters.
+    2. Remove stopwords and single-character tokens.
+    3. Count term frequencies.
+    4. Map tokens to integer indices via a deterministic hash
+       (hash(token) mod SPARSE_VOCAB_SIZE).  Collisions are rare
+       at 2^20 slots and acceptable for retrieval purposes.
+    5. Normalise values to [0, 1] (max-TF normalisation).
+
+    This approximates BM25 without a corpus-level IDF pass.  For the
+    intended queries (exact service names, error strings, resource IDs)
+    term frequency alone is sufficient because rare tokens are naturally
+    discriminative.
+
+    Returns a ``qm.SparseVector`` with ``indices`` and ``values``.
+    Empty text returns an empty sparse vector.
+    """
+    tokens = re.split(r"[^a-z0-9]+", text.lower())
+    counts: _Counter[int] = _Counter()
+    for tok in tokens:
+        if len(tok) <= 1 or tok in _STOPWORDS:
+            continue
+        idx = hash(tok) % _SPARSE_VOCAB_SIZE
+        counts[idx] += 1
+    if not counts:
+        return qm.SparseVector(indices=[], values=[])
+    max_tf = max(counts.values())
+    indices = sorted(counts)
+    values = [counts[i] / max_tf for i in indices]
+    return qm.SparseVector(indices=indices, values=values)
+
+
+#: Vocabulary size for the sparse hash-based tokenizer.
+#: 2^20 = 1_048_576 slots.  Collision probability for two random tokens
+#: is ~1e-6; for a typical 200-word chunk the expected collision count
+#: is < 0.02.  Qdrant stores only non-zero entries, so large vocab size
+#: does not waste space.
+_SPARSE_VOCAB_SIZE: int = 1 << 20
+
+
+# ---------------------------------------------------------------------------
+# RRF merge (Stage 3)
+# ---------------------------------------------------------------------------
+
+
+def _rrf_merge(
+    *,
+    dense: list[qm.ScoredPoint],
+    sparse: list[qm.ScoredPoint],
+    top_k: int,
+) -> list[qm.ScoredPoint]:
+    """Merge dense and sparse hit lists via Reciprocal Rank Fusion.
+
+    Formula: score(d) = Σ_i 1 / (RRF_K + rank_i(d))
+    where rank is 1-based and only lists in which ``d`` appears
+    contribute to the sum.
+
+    Points are identified by their string point ID.  The payload from
+    the higher-scoring list is carried through; for points appearing in
+    both lists, the dense payload wins (richer metadata).
+
+    The returned list is sorted by descending RRF score and sliced to
+    ``top_k``.
+    """
+    scores: dict[str, float] = {}
+    payloads: dict[str, dict[str, Any]] = {}
+
+    def _accumulate(hits: list[qm.ScoredPoint]) -> None:
+        for rank, sp in enumerate(hits, start=1):
+            pid = str(sp.id)
+            scores[pid] = scores.get(pid, 0.0) + 1.0 / (RRF_K + rank)
+            if pid not in payloads and sp.payload:
+                payloads[pid] = sp.payload
+
+    _accumulate(dense)
+    _accumulate(sparse)
+
+    ranked = sorted(scores, key=lambda pid: scores[pid], reverse=True)[:top_k]
+    # Re-assemble ScoredPoint objects with RRF scores.
+    out: list[qm.ScoredPoint] = []
+    for pid in ranked:
+        # Find the original ScoredPoint to use as a template (prefer dense).
+        sp_template = next(
+            (sp for sp in dense if str(sp.id) == pid),
+            next((sp for sp in sparse if str(sp.id) == pid), None),
+        )
+        if sp_template is None:
+            continue
+        out.append(
+            qm.ScoredPoint(
+                id=sp_template.id,
+                version=sp_template.version,
+                score=scores[pid],
+                payload=payloads.get(pid, sp_template.payload),
+                vector=None,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Search result builders
+# ---------------------------------------------------------------------------
+
+
 def _build_search_result(
-    *, scored: list[qm.ScoredPoint], top_k: int, duration_ms: float
+    *,
+    scored: list[qm.ScoredPoint],
+    top_k: int,
+    duration_ms: float,
+    text_matches: int = 0,
 ) -> SearchResult:
     """Convert Qdrant scored points to a ``SearchResult`` pydantic model.
 
     Imported lazily to avoid the core<-retrieval dependency cycle
     (``omniscience_index`` must not statically import from
     ``omniscience_retrieval``).
+
+    Stage 3: ``text_matches`` is now populated with the real sparse-hit
+    count so ``QueryStats`` carries a meaningful value.
     """
     from omniscience_retrieval.models import (
         ChunkLineage,
@@ -1175,7 +1760,22 @@ def _build_search_result(
         hits=hits,
         query_stats=QueryStats(
             total_matches_before_filters=len(scored),
-            vector_matches=len(scored),
+            vector_matches=len(scored) - text_matches,
+            text_matches=text_matches,
+            duration_ms=duration_ms,
+        ),
+    )
+
+
+def _empty_search_result(*, duration_ms: float) -> SearchResult:
+    """Return an empty ``SearchResult`` (sparse tokenization yielded nothing)."""
+    from omniscience_retrieval.models import QueryStats, SearchResult
+
+    return SearchResult(
+        hits=[],
+        query_stats=QueryStats(
+            total_matches_before_filters=0,
+            vector_matches=0,
             text_matches=0,
             duration_ms=duration_ms,
         ),
@@ -1212,5 +1812,7 @@ def _safe_dict(raw: Any) -> dict[str, Any]:
 __all__ = [
     "QdrantConfig",
     "QdrantVectorStore",
+    "_rrf_merge",
+    "_tokenize_to_sparse",
     "build_collection_name",
 ]

--- a/packages/index/src/omniscience_index/writer.py
+++ b/packages/index/src/omniscience_index/writer.py
@@ -1,7 +1,37 @@
-"""Atomic index writer: upsert documents + chunks, tombstone, and purge.
+"""Index writer: upsert documents + chunks, tombstone, and purge.
 
-All public methods run within a single database transaction so callers
-never observe a half-written state.
+**Consistency model (partial-failure semantics)**
+
+The write path covers three heterogeneous stores.  Only the Postgres
+transaction is atomic.  Qdrant and Neo4j writes run outside it:
+
+1. ``Postgres`` — document + chunk rows inside ``session.begin()``.
+   ACID-guaranteed: either fully committed or rolled back.
+
+2. ``Qdrant`` — ``upsert_chunks`` is called *inside* the ``session.begin()``
+   context so that a Qdrant failure causes the surrounding context-manager
+   to roll back the Postgres transaction **before commit**.  This prevents
+   the ``pg_missing_qdrant`` drift class in the common failure case.
+   However, a crash after Postgres commits and before Qdrant ACKs still
+   leaves permanent drift (e.g. process SIGKILL between the two).
+
+3. ``Neo4j`` — ``upsert_graph`` is called by ``IngestionWorker`` *after*
+   the ``upsert_document`` call returns.  It is entirely outside the
+   Postgres transaction.  A failure here produces the ``neo4j_orphan``
+   drift class.
+
+**Compensation**
+
+Drift is detected and repaired by the ``ReconcileWorker``
+(``omniscience_server.reconcile_worker``), which periodically
+cross-checks all three stores and:
+
+* marks ``ingestion_run`` rows as ``partial`` for ``pg_missing_qdrant``,
+* hard-deletes orphan Qdrant chunks (``qdrant_orphan``),
+* records a Prometheus metric for ``neo4j_orphan`` (deferred to the
+  retention worker for Neo4j cleanup).
+
+See also ``docs/decisions/0010-reconcile-worker.md`` (if present).
 """
 
 from __future__ import annotations
@@ -45,7 +75,11 @@ class UpsertResult:
 
 
 class IndexWriter:
-    """Write documents and their chunks atomically into the hybrid store."""
+    """Write documents and their chunks into the hybrid store.
+
+    See module docstring for the partial-failure semantics and the
+    ``ReconcileWorker`` compensation mechanism.
+    """
 
     def __init__(
         self,
@@ -73,7 +107,20 @@ class IndexWriter:
         workspace_id: uuid.UUID | None = None,
         ingestion_run_id: uuid.UUID | None = None,
     ) -> UpsertResult:
-        """Orchestrate document upsert across Postgres and Qdrant."""
+        """Persist a document and its chunks across Postgres and Qdrant.
+
+        **Failure semantics (not atomic):**
+        Postgres and Qdrant writes are *not* wrapped in a distributed
+        transaction.  Qdrant ``upsert_chunks`` is called inside the
+        ``session.begin()`` scope so that a Qdrant failure triggers a
+        Postgres rollback — preventing drift in the common crash case.
+        A process crash *after* the Postgres commit but *before* the
+        Qdrant ACK still produces ``pg_missing_qdrant`` drift.
+        The ``ReconcileWorker`` detects and compensates for this case.
+
+        ``upsert_graph`` (Neo4j) is called by the caller after this
+        method returns and is always outside the Postgres transaction.
+        """
         async with self._session_factory() as session, session.begin():
             existing = await self._find_document(session, source_id, external_id)
 
@@ -202,7 +249,12 @@ class IndexWriter:
         workspace_id: uuid.UUID | None = None,
         snapshot_at: datetime | None = None,
     ) -> None:
-        """Persist symbol graph into Neo4j (orchestrated)."""
+        """Persist symbol graph into Neo4j (orchestrated).
+
+        **Always outside the Postgres transaction.**  A failure here
+        produces ``neo4j_orphan`` drift.  The ``ReconcileWorker``
+        records the metric; cleanup is deferred to the retention worker.
+        """
         if self._graph_store and workspace_id:
             # Tag entities with workspace_id for Neo4j ACL
             for ent in entities:

--- a/packages/retrieval/src/omniscience_retrieval/graph_rag.py
+++ b/packages/retrieval/src/omniscience_retrieval/graph_rag.py
@@ -393,6 +393,16 @@ class GraphRAGComposer:
         # graph anchor returned no hits AND zero merged hits remain.
         # Cheap proxy for "as_of < earliest recorded_at" without a
         # dedicated round-trip.  Issue #133 §B contract.
+        #
+        # Stage 1 note (refactor/bitemporal-vector-hybrid): before Stage 1
+        # a content-rewrite (hash change) physically deleted old Qdrant points,
+        # so ``as_of=T`` (T < update time) returned empty even when the entity
+        # DID exist in the graph at T.  The degraded flag was therefore a
+        # false positive in that case.  Stage 1 end-dates old points instead of
+        # deleting them, so ``as_of=T`` now returns the OLD chunk version.
+        # The condition ``not anchor.anchor_hit`` is therefore a genuine
+        # "graph entity not found at as_of" signal — not a content-rewrite
+        # artefact — and the degraded label is now accurate.
         degraded = (
             effective is not None
             and anchor.anchor_requested

--- a/scripts/reindex_qdrant_hybrid.py
+++ b/scripts/reindex_qdrant_hybrid.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Reindex existing Qdrant collection to include sparse (BM25) vectors.
+
+Stage 3 migration script (refactor/bitemporal-vector-hybrid).
+
+PROBLEM
+-------
+Before Stage 3 the Qdrant collection had only a single named vector
+(``dense_primary``).  After Stage 3, every new chunk upsert also stores
+a sparse vector (``sparse_bm25``) in a dedicated named-vector slot.
+Existing chunks ingested before Stage 3 have no ``sparse_bm25`` payload
+and are therefore invisible to keyword / hybrid-RRF queries.
+
+This script backfills those sparse vectors for all existing points that
+do NOT yet have a ``sparse_bm25`` vector.
+
+DESIGN
+------
+- Idempotent: points that already have ``sparse_bm25`` are skipped.
+- --dry-run: counts eligible points and exits without writing.
+- Reads points via scroll (page_size=256) to stay within gRPC message
+  limits.
+- Reads ``text`` from the payload, tokenises client-side (same
+  ``_tokenize_to_sparse`` logic as ``qdrant_store.py``).
+- Upserts sparse vector via ``update_vectors`` (not upsert_points) so
+  the dense vector and the payload are untouched.
+- Respects the bitemporal structure: end-dated points (``valid_to`` set)
+  also get their sparse vector backfilled — they remain queryable via
+  ``as_of`` and need keyword matches too.
+- Does NOT touch the docker stack; does NOT require the full
+  Omniscience server to be running — only a Qdrant endpoint.
+
+DO NOT RUN ON PRODUCTION WITHOUT A BACKUP.
+
+Usage
+-----
+    python scripts/reindex_qdrant_hybrid.py \\
+        --host localhost --port 6334 \\
+        --collection omniscience__text-embedding-3-small__d1536 \\
+        [--dry-run] [--batch-size 64] [--verbose]
+
+Environment variables (overridden by CLI flags if provided):
+    QDRANT_HOST         Qdrant gRPC host (default: localhost)
+    QDRANT_GRPC_PORT    Qdrant gRPC port (default: 6334)
+    QDRANT_API_KEY      Optional API key (if Qdrant is auth-protected)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import re
+import sys
+import time
+from collections import Counter as _Counter
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Sparse tokenizer (must stay in sync with qdrant_store._tokenize_to_sparse)
+# ---------------------------------------------------------------------------
+
+_SPARSE_VOCAB_SIZE: int = 1 << 20  # 2^20 = 1,048,576 hash buckets
+
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "and",
+        "or",
+        "of",
+        "in",
+        "is",
+        "it",
+        "to",
+        "be",
+        "as",
+        "at",
+        "by",
+        "for",
+        "on",
+        "with",
+        "this",
+        "that",
+        "from",
+        "was",
+        "are",
+        "has",
+        "had",
+        "not",
+        "but",
+        "have",
+    }
+)
+
+NAMED_VECTOR_DENSE_PRIMARY = "dense_primary"
+NAMED_VECTOR_SPARSE_BM25 = "sparse_bm25"
+PAYLOAD_TEXT = "text"
+
+
+def _tokenize_to_sparse(text: str) -> tuple[list[int], list[float]]:
+    """Client-side TF tokeniser → sparse vector (indices, values).
+
+    Identical to ``qdrant_store._tokenize_to_sparse`` but returns plain
+    Python lists to avoid a qdrant_client import at the module level
+    (the import is deferred to ``main``).
+
+    Returns
+    -------
+    (indices, values) — parallel lists; values are max-TF normalised.
+    Empty lists when the text contains no usable tokens.
+    """
+    tokens = re.split(r"[^a-z0-9]+", text.lower())
+    counts: _Counter[int] = _Counter()
+    for tok in tokens:
+        if len(tok) <= 1 or tok in _STOPWORDS:
+            continue
+        idx = hash(tok) % _SPARSE_VOCAB_SIZE
+        counts[idx] += 1
+    if not counts:
+        return [], []
+    max_tf = max(counts.values())
+    indices = sorted(counts)
+    values = [counts[i] / max_tf for i in indices]
+    return indices, values
+
+
+# ---------------------------------------------------------------------------
+# Main reindexer
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger("reindex_qdrant_hybrid")
+
+
+async def _reindex(
+    *,
+    host: str,
+    port: int,
+    api_key: str | None,
+    collection_name: str,
+    dry_run: bool,
+    batch_size: int,
+    verbose: bool,
+) -> None:
+    """Core reindex loop — connects to Qdrant and backfills sparse vectors."""
+    try:
+        from qdrant_client import AsyncQdrantClient
+        from qdrant_client import models as qm
+    except ImportError as exc:
+        logger.error(
+            "qdrant-client is not installed. "
+            "Run: pip install qdrant-client  or  uv add qdrant-client"
+        )
+        raise SystemExit(1) from exc
+
+    client = AsyncQdrantClient(
+        host=host,
+        grpc_port=port,
+        prefer_grpc=True,
+        api_key=api_key,
+    )
+    try:
+        await _do_reindex(
+            client=client,
+            qm=qm,
+            collection_name=collection_name,
+            dry_run=dry_run,
+            batch_size=batch_size,
+            verbose=verbose,
+        )
+    finally:
+        await client.close()
+
+
+async def _ensure_sparse_vector_config(
+    client: Any,
+    qm: Any,
+    collection_name: str,
+    dry_run: bool,
+) -> None:
+    """Ensure the collection has a ``sparse_bm25`` named-vector slot.
+
+    If the slot is already present this is a no-op (idempotent).
+    Qdrant's ``update_collection`` with ``sparse_vectors_config`` only
+    adds missing named-vector slots — it does not overwrite existing ones.
+    """
+    info = await client.get_collection(collection_name)
+    existing_sparse: dict[str, Any] = {}
+    if info.config and info.config.params:
+        sv = getattr(info.config.params, "sparse_vectors_config", None) or {}
+        existing_sparse = dict(sv)
+
+    if NAMED_VECTOR_SPARSE_BM25 in existing_sparse:
+        logger.info("sparse_bm25 named-vector slot already exists — schema OK")
+        return
+
+    if dry_run:
+        logger.info(
+            "[DRY-RUN] Would add sparse_bm25 named-vector slot to collection %s",
+            collection_name,
+        )
+        return
+
+    logger.info("Adding sparse_bm25 named-vector slot to collection %s …", collection_name)
+    await client.update_collection(
+        collection_name=collection_name,
+        sparse_vectors_config={
+            NAMED_VECTOR_SPARSE_BM25: qm.SparseVectorParams(
+                index=qm.SparseIndexParams(on_disk=False)
+            )
+        },
+    )
+    logger.info("sparse_bm25 slot created.")
+
+
+async def _do_reindex(
+    *,
+    client: Any,
+    qm: Any,
+    collection_name: str,
+    dry_run: bool,
+    batch_size: int,
+    verbose: bool,
+) -> None:
+    """Scroll through the collection and backfill ``sparse_bm25`` vectors."""
+    await _ensure_sparse_vector_config(
+        client=client,
+        qm=qm,
+        collection_name=collection_name,
+        dry_run=dry_run,
+    )
+
+    total_scanned = 0
+    total_skipped = 0  # already have sparse vector
+    total_empty_text = 0  # text payload missing
+    total_written = 0
+    total_empty_sparse = 0  # text produced no tokens
+
+    offset: Any = None
+    page_size = 256
+    batch_ids: list[str] = []
+    batch_sparse: list[tuple[list[int], list[float]]] = []
+
+    start = time.monotonic()
+
+    while True:
+        records, next_offset = await client.scroll(
+            collection_name=collection_name,
+            scroll_filter=None,
+            limit=page_size,
+            with_payload=True,
+            with_vectors=[NAMED_VECTOR_SPARSE_BM25],  # only fetch sparse slot
+            offset=offset,
+        )
+
+        for rec in records:
+            total_scanned += 1
+
+            # Check if sparse vector already present (non-empty)
+            existing_vectors = rec.vector or {}
+            sparse_vec = existing_vectors.get(NAMED_VECTOR_SPARSE_BM25)
+            if sparse_vec is not None and (
+                getattr(sparse_vec, "indices", None) or isinstance(sparse_vec, list)
+            ):
+                total_skipped += 1
+                if verbose:
+                    logger.debug("SKIP %s — already has sparse_bm25", rec.id)
+                continue
+
+            payload = rec.payload or {}
+            text: str = payload.get(PAYLOAD_TEXT, "")
+            if not text:
+                total_empty_text += 1
+                if verbose:
+                    logger.debug("SKIP %s — empty text payload", rec.id)
+                continue
+
+            indices, values = _tokenize_to_sparse(text)
+            if not indices:
+                total_empty_sparse += 1
+                if verbose:
+                    logger.debug("SKIP %s — no sparse tokens for text %r…", rec.id, text[:40])
+                continue
+
+            batch_ids.append(str(rec.id))
+            batch_sparse.append((indices, values))
+
+            if len(batch_ids) >= batch_size:
+                total_written += await _flush_batch(
+                    client=client,
+                    qm=qm,
+                    collection_name=collection_name,
+                    batch_ids=batch_ids,
+                    batch_sparse=batch_sparse,
+                    dry_run=dry_run,
+                    verbose=verbose,
+                )
+                batch_ids = []
+                batch_sparse = []
+
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    # Flush the tail batch
+    if batch_ids:
+        total_written += await _flush_batch(
+            client=client,
+            qm=qm,
+            collection_name=collection_name,
+            batch_ids=batch_ids,
+            batch_sparse=batch_sparse,
+            dry_run=dry_run,
+            verbose=verbose,
+        )
+
+    elapsed = time.monotonic() - start
+    action = "[DRY-RUN]" if dry_run else "DONE"
+    logger.info(
+        "%s  scanned=%d  skipped=%d  empty_text=%d  empty_sparse=%d  written=%d  elapsed=%.1fs",
+        action,
+        total_scanned,
+        total_skipped,
+        total_empty_text,
+        total_empty_sparse,
+        total_written,
+        elapsed,
+    )
+
+
+async def _flush_batch(
+    *,
+    client: Any,
+    qm: Any,
+    collection_name: str,
+    batch_ids: list[str],
+    batch_sparse: list[tuple[list[int], list[float]]],
+    dry_run: bool,
+    verbose: bool,
+) -> int:
+    """Write a batch of sparse-vector updates to Qdrant.
+
+    Returns the number of points written (0 in dry-run mode).
+
+    Uses ``update_vectors`` (not ``upsert_points``) so the dense vector
+    and payload remain untouched — only the ``sparse_bm25`` slot is set.
+    """
+    if dry_run:
+        if verbose:
+            logger.debug("[DRY-RUN] Would update %d points: %s …", len(batch_ids), batch_ids[:3])
+        return 0
+
+    points = [
+        qm.PointVectors(
+            id=pid,
+            vector={
+                NAMED_VECTOR_SPARSE_BM25: qm.SparseVector(
+                    indices=indices,
+                    values=values,
+                )
+            },
+        )
+        for pid, (indices, values) in zip(batch_ids, batch_sparse, strict=True)
+    ]
+
+    await client.update_vectors(
+        collection_name=collection_name,
+        points=points,
+        wait=True,
+    )
+    if verbose:
+        logger.debug("Updated %d points", len(points))
+    return len(points)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill sparse (BM25) vectors for existing Qdrant points. "
+            "Stage 3 migration — refactor/bitemporal-vector-hybrid. "
+            "DO NOT RUN ON PRODUCTION WITHOUT A BACKUP."
+        )
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("QDRANT_HOST", "localhost"),
+        help="Qdrant gRPC host (default: QDRANT_HOST env / localhost)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("QDRANT_GRPC_PORT", "6334")),
+        help="Qdrant gRPC port (default: QDRANT_GRPC_PORT env / 6334)",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.environ.get("QDRANT_API_KEY"),
+        help="Qdrant API key (default: QDRANT_API_KEY env, omit if unauthenticated)",
+    )
+    parser.add_argument(
+        "--collection",
+        required=True,
+        help=(
+            "Exact collection name to reindex (e.g. omniscience__text-embedding-3-small__d1536)"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count eligible points and print summary without writing.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Number of points per update_vectors call (default: 64)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Emit per-point DEBUG logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+    if not args.dry_run:
+        logger.warning(
+            "LIVE RUN — writing sparse vectors to collection '%s' on %s:%d. "
+            "Press Ctrl+C within 3 seconds to abort.",
+            args.collection,
+            args.host,
+            args.port,
+        )
+        try:
+            time.sleep(3)
+        except KeyboardInterrupt:
+            logger.info("Aborted by user.")
+            sys.exit(0)
+
+    asyncio.run(
+        _reindex(
+            host=args.host,
+            port=args.port,
+            api_key=args.api_key,
+            collection_name=args.collection,
+            dry_run=args.dry_run,
+            batch_size=args.batch_size,
+            verbose=args.verbose,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,6 +21,7 @@ from omniscience_core.auth.tokens import (
     hash_token,
     verify_token,
 )
+from omniscience_core.auth.workspace import DEFAULT_WORKSPACE_ID, get_workspace_id
 from omniscience_core.db.models import ApiToken
 from omniscience_core.db.schemas import ApiTokenRead
 
@@ -492,3 +493,80 @@ def test_audit_token_deleted_logs() -> None:
         assert call_kwargs[0][0] == "audit.token.deleted"
         assert call_kwargs[1]["event_type"] == "token_deleted"
         assert call_kwargs[1]["token_prefix"] == "sk_dev_ab"
+
+
+# ---------------------------------------------------------------------------
+# get_workspace_id — fail-closed security tests
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_token(workspace_id: uuid.UUID | None) -> ApiToken:
+    """Build a minimal ApiToken mock for workspace tests."""
+    tok: ApiToken = MagicMock(spec=ApiToken)
+    tok.id = uuid.uuid4()
+    tok.name = "ws-test-token"
+    tok.token_prefix = "sk_dev_x"
+    tok.scopes = ["search"]
+    tok.workspace_id = workspace_id
+    tok.created_at = datetime.now(tz=UTC)
+    tok.expires_at = None
+    tok.last_used_at = None
+    tok.is_active = True
+    tok.hashed_token = "placeholder"
+    return tok
+
+
+def test_get_workspace_id_returns_uuid_for_scoped_token() -> None:
+    """get_workspace_id returns the UUID when token has workspace_id set."""
+    ws_id = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+    token = _make_ws_token(workspace_id=ws_id)
+    assert get_workspace_id(token) == ws_id
+
+
+def test_get_workspace_id_returns_default_workspace_id() -> None:
+    """get_workspace_id returns the default workspace UUID when that is set."""
+    token = _make_ws_token(workspace_id=DEFAULT_WORKSPACE_ID)
+    assert get_workspace_id(token) == DEFAULT_WORKSPACE_ID
+
+
+def test_get_workspace_id_raises_permission_error_for_legacy_token() -> None:
+    """Security: get_workspace_id raises PermissionError when workspace_id is None.
+
+    A legacy token (workspace_id=None) must never be treated as 'see all'.
+    The correct production behaviour is to reject the request at the auth
+    layer with a 403 / forbidden error.  Returning None and skipping the
+    filter is the old, insecure behaviour that this test guards against.
+    """
+    token = _make_ws_token(workspace_id=None)
+    with pytest.raises(PermissionError, match="forbidden:workspace_required"):
+        get_workspace_id(token)
+
+
+def test_get_workspace_id_error_is_permission_error_not_value_error() -> None:
+    """PermissionError (not ValueError / AttributeError) is raised for legacy tokens."""
+    token = _make_ws_token(workspace_id=None)
+    try:
+        get_workspace_id(token)
+        raise AssertionError("Expected PermissionError")
+    except PermissionError:
+        pass  # correct
+    except Exception as exc:
+        raise AssertionError(f"Wrong exception type: {type(exc).__name__}") from exc
+
+
+def test_get_workspace_id_never_returns_none() -> None:
+    """get_workspace_id never returns None — it always raises for legacy tokens."""
+    token = _make_ws_token(workspace_id=None)
+    raised = False
+    try:
+        result = get_workspace_id(token)
+        # Belt-and-suspenders: if no exception, result must not be None.
+        assert result is not None, "get_workspace_id returned None instead of raising"
+    except PermissionError:
+        raised = True
+    assert raised, "get_workspace_id must raise PermissionError for None workspace_id"
+
+
+def test_get_workspace_id_default_workspace_constant_matches_migration() -> None:
+    """DEFAULT_WORKSPACE_ID matches the UUID seeded by migration 0003_workspaces."""
+    assert uuid.UUID("00000000-0000-0000-0000-000000000001") == DEFAULT_WORKSPACE_ID

--- a/tests/test_graph_rag_degraded.py
+++ b/tests/test_graph_rag_degraded.py
@@ -1,0 +1,295 @@
+"""Tests for Stage 2: degraded-detector correctness after Stage 1 end-dating fix.
+
+PROBLEM (Stage 2, refactor/bitemporal-vector-hybrid):
+  Before Stage 1, the degraded detector (``degraded_response =
+  "as_of_before_recorded_history"``) could fire as a FALSE POSITIVE when:
+  - An anchor entity EXISTS in the graph at ``as_of``, AND
+  - Its document content was UPDATED after ``as_of``, AND
+  - Old Qdrant chunks were DELETED (not end-dated).
+  → Vector layer returned empty → degraded=True even though the entity had history.
+
+SOLUTION (Stage 1): old points are end-dated, so vector returns the old chunk.
+  Stage 2 here verifies the degraded flag does NOT fire for the content-rewrite
+  scenario (and still DOES fire for the genuine pre-history scenario).
+
+Tests:
+  1. Content-rewrite does NOT produce degraded=True when as_of precedes the
+     update but the entity's anchor stage finds a hit.
+  2. Genuine pre-history (as_of precedes any entity data) STILL produces
+     degraded=True when anchor stage also finds no hit.
+  3. No-as_of queries never produce degraded=True.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from omniscience_core.storage.graph import (
+    EntityNodeView,
+    GraphResultView,
+)
+from omniscience_retrieval.graph_rag import (
+    ANCHOR_FILTER_KEY,
+    DEGRADED_PRE_HISTORY,
+    GraphRAGComposer,
+)
+from omniscience_retrieval.models import (
+    ChunkLineage,
+    Citation,
+    QueryStats,
+    SearchHit,
+    SearchRequest,
+    SearchResult,
+    SourceInfo,
+)
+
+_WS = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_T_PAST = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+_T_NOW = datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes
+# ---------------------------------------------------------------------------
+
+
+def _make_hit(text: str = "content") -> SearchHit:
+    return SearchHit(
+        chunk_id=uuid.uuid4(),
+        document_id=uuid.uuid4(),
+        score=0.9,
+        text=text,
+        source=SourceInfo(id=uuid.uuid4(), name="src", type="qdrant"),
+        citation=Citation(uri="mem://x", title=None, indexed_at=_T_NOW, doc_version=1),
+        lineage=ChunkLineage(
+            ingestion_run_id=None,
+            embedding_model="stub",
+            embedding_provider="stub",
+            parser_version="1",
+            chunker_strategy="fixed",
+        ),
+        metadata={},
+    )
+
+
+def _make_empty_result() -> SearchResult:
+    return SearchResult(
+        hits=[],
+        query_stats=QueryStats(
+            total_matches_before_filters=0,
+            vector_matches=0,
+            text_matches=0,
+            duration_ms=5.0,
+        ),
+    )
+
+
+def _make_result_with_hit() -> SearchResult:
+    return SearchResult(
+        hits=[_make_hit()],
+        query_stats=QueryStats(
+            total_matches_before_filters=1,
+            vector_matches=1,
+            text_matches=0,
+            duration_ms=5.0,
+        ),
+    )
+
+
+def _make_graph_result(
+    name: str = "entity-a", source_id: uuid.UUID | None = None
+) -> GraphResultView:
+    src = source_id or uuid.uuid4()
+    return GraphResultView(
+        seed=EntityNodeView(
+            id=uuid.uuid4(),
+            name=name,
+            kind="service",
+            source=str(src),
+            chunk_text=None,
+            valid_from=_T_PAST,
+            valid_to=None,
+            recorded_at=_T_PAST,
+        ),
+        related=[],
+    )
+
+
+class _FakeGraphStoreHit:
+    """Graph store fake that always returns a hit."""
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        return _make_graph_result(name=entity_name)
+
+    async def find_related(self, **_: Any) -> GraphResultView:
+        return _make_graph_result()
+
+
+class _FakeGraphStoreMiss:
+    """Graph store fake that always raises ValueError (entity not found)."""
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        raise ValueError(f"entity_not_found:{entity_name}")
+
+    async def find_related(self, **_: Any) -> GraphResultView:
+        raise ValueError("entity_not_found")
+
+
+class _FakeVectorStore:
+    """Vector store fake with configurable result."""
+
+    def __init__(self, result: SearchResult) -> None:
+        self._result = result
+        self.calls: list[dict[str, Any]] = []
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> SearchResult:
+        self.calls.append({"request": request, "workspace_id": workspace_id, "as_of": as_of})
+        return self._result
+
+
+class _FakeLegacyService:
+    async def search(self, request: SearchRequest) -> SearchResult:
+        return _make_empty_result()
+
+
+def _make_composer(graph_hit: bool, vector_result: SearchResult) -> GraphRAGComposer:
+    """Build a GraphRAGComposer with the canonical Neo4j+Qdrant stack mocked."""
+
+    graph = _FakeGraphStoreHit() if graph_hit else _FakeGraphStoreMiss()
+    vector = _FakeVectorStore(vector_result)
+
+    # Patch isinstance checks so the composer takes the graphrag path.
+    composer = GraphRAGComposer.__new__(GraphRAGComposer)
+    composer._graph_store = graph  # type: ignore[attr-defined]
+    composer._vector_store = vector  # type: ignore[attr-defined]
+    composer._legacy_service = _FakeLegacyService()  # type: ignore[attr-defined]
+    composer._graphrag_active = True  # type: ignore[attr-defined]
+    return composer
+
+
+# ---------------------------------------------------------------------------
+# Test 1: content rewrite → anchor hit → degraded=False (Stage 2 fix verified)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_content_rewrite_does_not_produce_degraded() -> None:
+    """Stage 2: when anchor HIT (entity exists at as_of) and vector returns hits,
+    degraded must be False even when as_of < update time.
+
+    This was a false positive before Stage 1: old points were deleted,
+    so vector returned empty even though entity existed at as_of.
+    After Stage 1 end-dating, old points are preserved, so vector returns
+    the old chunk — and degraded stays False.
+    """
+    composer = _make_composer(
+        graph_hit=True,
+        vector_result=_make_result_with_hit(),  # vector returns old chunk (Stage 1 preserved it)
+    )
+    request = SearchRequest(
+        query="content",
+        top_k=5,
+        filters={ANCHOR_FILTER_KEY: "entity-a"},
+    )
+    result = await composer.search(request, workspace_id=_WS, as_of=_T_PAST)
+    assert result.meta is None or result.meta.get("degraded_response") != DEGRADED_PRE_HISTORY, (
+        "degraded must NOT fire when anchor hit and vector returns results"
+    )
+    assert result.hits, "Result must have hits (the old chunk preserved by Stage 1 end-dating)"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: genuine pre-history → anchor miss → degraded=True (still correct)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_genuine_pre_history_produces_degraded() -> None:
+    """Stage 2: real pre-history (anchor entity not found at as_of) → degraded=True."""
+    composer = _make_composer(
+        graph_hit=False,  # entity didn't exist yet at as_of
+        vector_result=_make_empty_result(),  # vector also empty (truly no data at T)
+    )
+    request = SearchRequest(
+        query="content",
+        top_k=5,
+        filters={ANCHOR_FILTER_KEY: "new-entity"},
+    )
+    result = await composer.search(request, workspace_id=_WS, as_of=_T_PAST)
+    assert result.meta is not None, "degraded response should have a meta block"
+    assert result.meta.get("degraded_response") == DEGRADED_PRE_HISTORY, (
+        "Genuine pre-history must still produce degraded_response"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: no as_of → never degraded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_as_of_never_degraded() -> None:
+    """No as_of means current-state query; degraded flag must never fire."""
+    # Even if graph misses and vector returns empty, no as_of → not degraded.
+    composer = _make_composer(
+        graph_hit=False,
+        vector_result=_make_empty_result(),
+    )
+    request = SearchRequest(
+        query="content",
+        top_k=5,
+        filters={ANCHOR_FILTER_KEY: "entity-x"},
+    )
+    result = await composer.search(request, workspace_id=_WS)  # no as_of
+    assert result.meta is None or result.meta.get("degraded_response") != DEGRADED_PRE_HISTORY, (
+        "Without as_of, degraded must never be True"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: anchor hit + vector empty (without as_of) → not degraded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anchor_hit_vector_empty_no_as_of_not_degraded() -> None:
+    """Anchor hit + vector empty (no as_of) → not degraded, just empty results."""
+    composer = _make_composer(
+        graph_hit=True,
+        vector_result=_make_empty_result(),
+    )
+    request = SearchRequest(
+        query="nothing matches",
+        top_k=5,
+        filters={ANCHOR_FILTER_KEY: "entity-a"},
+    )
+    result = await composer.search(request, workspace_id=_WS)
+    meta = result.meta or {}
+    assert meta.get("degraded_response") != DEGRADED_PRE_HISTORY, (
+        "No as_of → not degraded, just empty results"
+    )

--- a/tests/test_multi_tenant.py
+++ b/tests/test_multi_tenant.py
@@ -2,15 +2,18 @@
 
 Coverage:
 - Workspace model and Pydantic schemas (WorkspaceCreate, WorkspaceRead)
-- get_workspace_id helper
-- workspace_filter helper applied to SELECT statements
+- get_workspace_id helper — including fail-closed behaviour for legacy tokens
+- workspace_filter helper applied to SELECT statements — strict equality only
 - ApiToken workspace_id field propagation
 - create_api_token with workspace_id argument
-- Backward-compat: tokens/queries without workspace_id
+- Security: NULL-tenant rows are NOT visible to any workspace token
+- Security: legacy token without workspace_id raises PermissionError
+- Backfill logic: workspace_filter no longer includes OR-NULL clause
 """
 
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import UTC, datetime
 from typing import Any
@@ -20,7 +23,11 @@ import pytest
 from omniscience_core.auth.tokens import (
     create_api_token,
 )
-from omniscience_core.auth.workspace import get_workspace_id, workspace_filter
+from omniscience_core.auth.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    get_workspace_id,
+    workspace_filter,
+)
 from omniscience_core.db.models import ApiToken, Workspace
 from omniscience_core.db.schemas import (
     ApiTokenCreate,
@@ -38,6 +45,18 @@ from sqlalchemy.dialects.postgresql import UUID
 _DEFAULT_WS_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
 _ALPHA_WS_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
 _BETA_WS_ID = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+
+# SQLAlchemy renders UUID literals without dashes when using literal_binds.
+_ALPHA_WS_HEX = _ALPHA_WS_ID.hex  # 'aaaaaaaa000000000000000000000001'
+_BETA_WS_HEX = _BETA_WS_ID.hex
+_DEFAULT_WS_HEX = _DEFAULT_WS_ID.hex  # '00000000000000000000000000000001'
+
+# Pattern that matches SQL "OR" as a keyword (word boundary), NOT as a
+# substring inside column names like "wORkspace_id".
+_RE_SQL_OR = re.compile(r"\bOR\b", re.IGNORECASE)
+
+# Pattern that matches IS NULL anywhere in the SQL string.
+_RE_IS_NULL = re.compile(r"\bIS\s+NULL\b", re.IGNORECASE)
 
 
 def _make_token(
@@ -73,6 +92,25 @@ def _make_workspace(
     ws.created_at = datetime.now(tz=UTC)
     ws.updated_at = datetime.now(tz=UTC)
     return ws
+
+
+def _make_table_with_cols(*col_names: str) -> Table:
+    """Build a bare SQLAlchemy Table with the specified column names."""
+    meta = MetaData()
+    cols = [Column("id", UUID(as_uuid=True), primary_key=True)]
+    for name in col_names:
+        cols.append(Column(name, UUID(as_uuid=True), nullable=True))
+    return Table("_test_table", meta, *cols)
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_WORKSPACE_ID constant
+# ---------------------------------------------------------------------------
+
+
+def test_default_workspace_id_matches_seeded_value() -> None:
+    """DEFAULT_WORKSPACE_ID must equal the UUID seeded by migration 0003."""
+    assert uuid.UUID("00000000-0000-0000-0000-000000000001") == DEFAULT_WORKSPACE_ID
 
 
 # ---------------------------------------------------------------------------
@@ -147,7 +185,7 @@ def test_workspace_read_different_ids() -> None:
 
 
 # ---------------------------------------------------------------------------
-# get_workspace_id
+# get_workspace_id — happy paths
 # ---------------------------------------------------------------------------
 
 
@@ -156,13 +194,6 @@ def test_get_workspace_id_returns_uuid_when_set() -> None:
     token = _make_token(workspace_id=_ALPHA_WS_ID)
     result = get_workspace_id(token)
     assert result == _ALPHA_WS_ID
-
-
-def test_get_workspace_id_returns_none_for_legacy_token() -> None:
-    """get_workspace_id returns None when workspace_id is not set."""
-    token = _make_token(workspace_id=None)
-    result = get_workspace_id(token)
-    assert result is None
 
 
 def test_get_workspace_id_default_workspace() -> None:
@@ -180,25 +211,47 @@ def test_get_workspace_id_different_workspaces() -> None:
 
 
 # ---------------------------------------------------------------------------
-# workspace_filter — pass-through cases
+# get_workspace_id — fail-closed for legacy tokens (workspace_id is None)
 # ---------------------------------------------------------------------------
 
 
-def _make_table_with_cols(*col_names: str) -> Table:
-    """Build a bare SQLAlchemy Table with the specified column names."""
-    meta = MetaData()
-    cols = [Column("id", UUID(as_uuid=True), primary_key=True)]
-    for name in col_names:
-        cols.append(Column(name, UUID(as_uuid=True), nullable=True))
-    return Table("_test_table", meta, *cols)
+def test_get_workspace_id_raises_for_legacy_token() -> None:
+    """get_workspace_id raises PermissionError when workspace_id is None.
+
+    Security invariant: a token without a workspace cannot see any data.
+    This replaces the previous behaviour of returning None (which callers
+    would treat as 'no restriction').
+    """
+    token = _make_token(workspace_id=None)
+    with pytest.raises(PermissionError, match="forbidden:workspace_required"):
+        get_workspace_id(token)
 
 
-def test_workspace_filter_passthrough_when_no_workspace_id() -> None:
-    """workspace_filter returns the query unchanged when workspace_id is None."""
-    tbl = _make_table_with_cols("workspace_id")
-    base_query = select(tbl)
-    result = workspace_filter(base_query, None)
-    assert result is base_query
+def test_get_workspace_id_legacy_token_never_returns_none() -> None:
+    """get_workspace_id never returns None — it always raises instead."""
+    token = _make_token(workspace_id=None)
+    raised = False
+    try:
+        result = get_workspace_id(token)
+        # If we get here, result must not be None (belt-and-suspenders).
+        assert result is not None
+    except PermissionError:
+        raised = True
+    assert raised, "Expected PermissionError for legacy token"
+
+
+def test_get_workspace_id_error_message_is_descriptive() -> None:
+    """PermissionError message contains 'forbidden' and 'workspace_required'."""
+    token = _make_token(workspace_id=None)
+    with pytest.raises(PermissionError) as exc_info:
+        get_workspace_id(token)
+    assert "forbidden" in str(exc_info.value)
+    assert "workspace_required" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# workspace_filter — pass-through for unscoped tables
+# ---------------------------------------------------------------------------
 
 
 def test_workspace_filter_passthrough_for_unscoped_table() -> None:
@@ -210,7 +263,7 @@ def test_workspace_filter_passthrough_for_unscoped_table() -> None:
 
 
 # ---------------------------------------------------------------------------
-# workspace_filter — workspace_id column
+# workspace_filter — strict equality on workspace_id column
 # ---------------------------------------------------------------------------
 
 
@@ -222,6 +275,24 @@ def test_workspace_filter_adds_clause_for_workspace_id_col() -> None:
     compiled = str(filtered.compile(compile_kwargs={"literal_binds": False}))
     assert "workspace_id" in compiled
     assert filtered is not base_query
+
+
+def test_workspace_filter_does_not_include_null_branch_for_workspace_id_col() -> None:
+    """Security: workspace_filter must NOT emit OR workspace_id IS NULL.
+
+    Before migration 0010_backfill_null_tenant, the helper used
+    ``or_(col == ws, col == null())`` which exposed NULL-tenant rows to every
+    workspace token.  After backfill, only strict equality is emitted.
+
+    Note: _RE_SQL_OR uses word boundary (\\bOR\\b) to avoid false positives
+    from 'OR' appearing inside column names like 'wORkspace_id'.
+    """
+    tbl = _make_table_with_cols("workspace_id")
+    base_query = select(tbl)
+    filtered = workspace_filter(base_query, _ALPHA_WS_ID)
+    compiled = str(filtered.compile(compile_kwargs={"literal_binds": True}))
+    assert not _RE_IS_NULL.search(compiled), "IS NULL must not appear in compiled SQL"
+    assert not _RE_SQL_OR.search(compiled), "OR keyword must not appear in compiled SQL"
 
 
 def test_workspace_filter_different_workspace_ids_produce_different_queries() -> None:
@@ -244,7 +315,7 @@ def test_workspace_filter_different_workspace_ids_produce_different_queries() ->
 
 
 # ---------------------------------------------------------------------------
-# workspace_filter — tenant_id column (legacy sources table)
+# workspace_filter — strict equality on tenant_id column (legacy sources table)
 # ---------------------------------------------------------------------------
 
 
@@ -258,12 +329,98 @@ def test_workspace_filter_uses_tenant_id_col_as_fallback() -> None:
     assert filtered is not base_query
 
 
-def test_workspace_filter_tenant_id_passthrough_when_workspace_id_none() -> None:
-    """workspace_filter returns query unchanged for tenant_id tables when workspace is None."""
+def test_workspace_filter_does_not_include_null_branch_for_tenant_id_col() -> None:
+    """Security: workspace_filter must NOT emit OR tenant_id IS NULL.
+
+    This is the critical cross-tenant vector: prior to migration 0010 a row
+    in ``sources`` with tenant_id IS NULL was returned to *every* workspace
+    token because of the ``or_(col == ws, col == null())`` clause.  After
+    backfill and this fix, only ``tenant_id = :workspace_id`` is emitted.
+    """
     tbl = _make_table_with_cols("tenant_id")
     base_query = select(tbl)
-    result = workspace_filter(base_query, None)
-    assert result is base_query
+    filtered = workspace_filter(base_query, _ALPHA_WS_ID)
+    compiled = str(filtered.compile(compile_kwargs={"literal_binds": True}))
+    assert not _RE_IS_NULL.search(compiled), "IS NULL must not appear in compiled SQL"
+    assert not _RE_SQL_OR.search(compiled), "OR keyword must not appear in compiled SQL"
+
+
+def test_workspace_filter_null_tenant_row_not_visible_to_alpha() -> None:
+    """Security: a NULL-tenant row does NOT satisfy the alpha workspace filter.
+
+    After backfill, workspace_filter(q, _ALPHA_WS_ID) only matches
+    tenant_id = _ALPHA_WS_ID.  A row with tenant_id IS NULL would not match.
+    SQLAlchemy renders UUID literal without dashes; we check hex form.
+    """
+    tbl = _make_table_with_cols("tenant_id")
+    base_query = select(tbl)
+    filtered = workspace_filter(base_query, _ALPHA_WS_ID)
+    compiled_literal = str(filtered.compile(compile_kwargs={"literal_binds": True}))
+    # The literal bind must be the ALPHA UUID hex (no dashes in SA render).
+    assert _ALPHA_WS_HEX in compiled_literal
+    assert not _RE_IS_NULL.search(compiled_literal)
+
+
+def test_workspace_filter_alpha_and_beta_produce_disjoint_filters_for_tenant_id() -> None:
+    """Filters for alpha and beta workspaces are structurally equal but bind-param different."""
+    tbl = _make_table_with_cols("tenant_id")
+    base_query = select(tbl)
+    q_alpha = workspace_filter(base_query, _ALPHA_WS_ID)
+    q_beta = workspace_filter(base_query, _BETA_WS_ID)
+    alpha_params = q_alpha.compile().params
+    beta_params = q_beta.compile().params
+    assert any(
+        alpha_params.get(k) != beta_params.get(k) for k in set(alpha_params) | set(beta_params)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backfill migration logic: default workspace constant aligns with migration
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_default_workspace_id_constant() -> None:
+    """The DEFAULT_WORKSPACE_ID exported from workspace.py matches migration 0003.
+
+    Migration 0003_workspaces seeds ``00000000-0000-0000-0000-000000000001``
+    as the default workspace.  Migration 0010_backfill_null_tenant assigns
+    this same UUID to all NULL-tenant rows.  This test ensures the constant
+    used at runtime matches that seeded value.
+    """
+    assert uuid.UUID("00000000-0000-0000-0000-000000000001") == DEFAULT_WORKSPACE_ID
+
+
+def test_backfill_workspace_filter_after_backfill_returns_default_rows() -> None:
+    """After backfill, default-workspace token can read ex-NULL rows.
+
+    Before backfill: NULL rows were readable by everyone via OR-NULL clause.
+    After backfill: NULL rows become tenant_id=DEFAULT_WS rows; they are
+    now readable only by the default workspace token (strict equality match).
+    SQLAlchemy renders UUID literals without dashes; we compare using .hex.
+    """
+    tbl = _make_table_with_cols("tenant_id")
+    base_query = select(tbl)
+    filtered = workspace_filter(base_query, _DEFAULT_WS_ID)
+    compiled = str(filtered.compile(compile_kwargs={"literal_binds": True}))
+    # Should contain the default workspace UUID hex literal.
+    assert _DEFAULT_WS_HEX in compiled
+    assert not _RE_IS_NULL.search(compiled)
+
+
+def test_backfill_workspace_filter_alpha_does_not_match_default_rows() -> None:
+    """After backfill, alpha workspace cannot read default-workspace rows.
+
+    The strict equality filter ``tenant_id = :alpha_uuid`` will never match
+    rows that now carry ``tenant_id = :default_uuid``.
+    SQLAlchemy renders UUID literals without dashes; we compare using .hex.
+    """
+    tbl = _make_table_with_cols("tenant_id")
+    base_query = select(tbl)
+    filtered_alpha = workspace_filter(base_query, _ALPHA_WS_ID)
+    compiled = str(filtered_alpha.compile(compile_kwargs={"literal_binds": True}))
+    # Alpha UUID hex is bound, not the default UUID hex.
+    assert _ALPHA_WS_HEX in compiled
+    assert _DEFAULT_WS_HEX not in compiled
 
 
 # ---------------------------------------------------------------------------
@@ -307,7 +464,7 @@ def test_api_token_read_includes_workspace_id() -> None:
 
 
 def test_api_token_read_workspace_id_none_for_legacy() -> None:
-    """ApiTokenRead returns None workspace_id for legacy tokens."""
+    """ApiTokenRead returns None workspace_id for legacy tokens (schema preserves raw value)."""
     token = _make_token(workspace_id=None)
     read = ApiTokenRead.model_validate(token)
     assert read.workspace_id is None
@@ -404,6 +561,11 @@ def test_api_token_has_workspace_id_column() -> None:
 
 
 def test_api_token_workspace_id_is_nullable() -> None:
-    """ApiToken.workspace_id column is nullable for backward compatibility."""
+    """ApiToken.workspace_id column is nullable (for DB-level backward compat).
+
+    Note: the Python layer enforces non-null via get_workspace_id() raising
+    PermissionError.  The DB column remains nullable so that migration 0010
+    can run as a plain UPDATE without schema changes.
+    """
     col = ApiToken.__table__.c["workspace_id"]
     assert col.nullable is True

--- a/tests/test_qdrant_store_as_of.py
+++ b/tests/test_qdrant_store_as_of.py
@@ -464,35 +464,42 @@ async def test_cross_workspace_isolation_under_as_of(
 async def test_as_of_none_no_regression_on_filter_shape(
     qdrant_store: QdrantVectorStore,
 ) -> None:
-    """The ``as_of=None`` filter has no ``valid_*`` clauses — pre-#134 wire shape.
+    """The ``as_of=None`` filter shape after Stage 1 (refactor/bitemporal-vector-hybrid).
 
-    Compares the wire-shape filter the adapter emits when ``as_of=None``
-    against the filter the same builder emits today (no bitemporal
-    clauses).  Byte-identity at the structural level is the strongest
-    no-regression assertion: a current-state search pays exactly the
-    same predicate cost as before #134.
+    Stage 1 amendment: ``as_of=None`` now includes ``with_current_only()``
+    (``valid_to IS NULL``) so end-dated historical chunk versions from the
+    write-path end-dating are excluded from current-state results.  The
+    structural comparison is therefore against
+    ``exclude_tombstoned().with_current_only()`` — not the plain pre-#134
+    ``exclude_tombstoned()`` shape.  ``valid_from`` is still absent from
+    the current-state filter; only ``valid_to IS NULL`` (an IsNullCondition,
+    not a FieldCondition with a ``key``) is added.
     """
     from omniscience_index.stores.qdrant_constants import (
         PAYLOAD_VALID_FROM as _VF,
     )
-    from omniscience_index.stores.qdrant_constants import (
-        PAYLOAD_VALID_TO as _VT,
-    )
     from omniscience_index.stores.qdrant_filters import QdrantFilterBuilder
     from omniscience_retrieval.models import SearchRequest
+    from qdrant_client import models as qm
 
     ws = uuid.uuid4()
     request = SearchRequest(query="x", top_k=5)
     flt_with_none = qdrant_store._request_to_filter(  # type: ignore[attr-defined]
         request=request, workspace_id=ws, as_of=None
     )
-    flt_legacy = QdrantFilterBuilder(workspace_id=ws).exclude_tombstoned().build()
-    # The two filters must serialise identically.
-    assert flt_with_none.model_dump() == flt_legacy.model_dump()
-    # And no valid_* keys are present.
-    keys = [c.key for c in (flt_with_none.must or []) if isinstance(c, qm.FieldCondition)]
-    assert _VF not in keys
-    assert _VT not in keys
+    # Stage 1: current-state filter = workspace + exclude_tombstoned + current_only.
+    flt_stage1 = (
+        QdrantFilterBuilder(workspace_id=ws).exclude_tombstoned().with_current_only().build()
+    )
+    assert flt_with_none.model_dump() == flt_stage1.model_dump()
+    # valid_from is NOT a FieldCondition key in the current-state filter.
+    field_keys = [c.key for c in (flt_with_none.must or []) if isinstance(c, qm.FieldCondition)]
+    assert _VF not in field_keys
+    # valid_to IS present — but as an IsNullCondition, not a FieldCondition key.
+    null_conditions = [c for c in (flt_with_none.must or []) if isinstance(c, qm.IsNullCondition)]
+    # There should be exactly two IsNullCondition clauses:
+    # one for tombstoned_at, one for valid_to.
+    assert len(null_conditions) == 2
 
 
 @pytest.mark.asyncio
@@ -607,7 +614,16 @@ async def test_count_chunks_honours_as_of(
         valid_to=None,
         external_id="c3",
     )
+    # Stage 1 (refactor/bitemporal-vector-hybrid): count_chunks(as_of=None)
+    # applies ``with_current_only()`` (valid_to IS NULL) so only the
+    # still-open current generation is counted.  Of the three planted
+    # chunks, only c3 has ``valid_to=None`` — c1 and c2 have explicit
+    # closed windows that Stage 1 treats as historical versions.
     total = await qdrant_store.count_chunks(workspace_id=ws)
     at_t1 = await qdrant_store.count_chunks(workspace_id=ws, as_of=_T1)
-    assert total == 3
+    assert total == 1, (
+        f"count_chunks(as_of=None) must count only current-gen points "
+        f"(valid_to IS NULL); c1+c2 have closed valid_to, only c3 is current. "
+        f"Got {total}."
+    )
     assert at_t1 == 1

--- a/tests/test_qdrant_store_bitemporal_update.py
+++ b/tests/test_qdrant_store_bitemporal_update.py
@@ -1,0 +1,537 @@
+"""Unit + contract tests for Stage 1: bitemporal end-dating on content update.
+
+PROBLEM (ADR-0008 §6 cross-store consistency gap):
+  When ``content_hash`` changes, old chunk points were PHYSICALLY DELETED.
+  A search with ``as_of=T`` (T < update time) then returned EMPTY — even though
+  Neo4j correctly returned the old entity state.  This broke the cross-store
+  consistency contract: the same ``as_of`` anchor should produce consistent
+  results from both stores.
+
+SOLUTION (Stage 1, refactor/bitemporal-vector-hybrid):
+  Old points are END-DATED (``valid_to = now()``) instead of deleted.
+  New points are inserted with ``valid_from = now()``.  A search with
+  ``as_of=T`` (T < update) returns the OLD chunk; a current-state search
+  (``as_of=None``) returns the NEW chunk.
+
+Tests:
+  1. Unit (mock): ``_write_document`` calls ``_end_date_points`` on update,
+     NOT ``_delete_points``.
+  2. Unit (mock): ``_find_document`` does NOT see end-dated points (uses
+     ``with_current_only()``).
+  3. Contract (testcontainer, opt-in): upsert → update → as_of=before returns
+     OLD text; current search returns NEW text.
+  4. Contract: tombstoned points stay excluded from both ``as_of`` and current
+     searches.
+  5. Contract: cross-workspace — end-dated points in workspace B never appear
+     in workspace A searches at any ``as_of``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_core.storage.vector import ChunkPayload
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_constants import (
+    PAYLOAD_CONTENT_HASH,
+    PAYLOAD_DOC_VERSION,
+    PAYLOAD_DOCUMENT_ID,
+    PAYLOAD_EXTERNAL_ID,
+    PAYLOAD_TOMBSTONED_AT,
+    PAYLOAD_VALID_FROM,
+    PAYLOAD_VALID_TO,
+    PAYLOAD_WORKSPACE_ID,
+)
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http.models import Record
+
+_WS = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _embedding_provider(*, dim: int = 4, model: str = "test-model") -> Any:
+    m = MagicMock()
+    m.dim = dim
+    m.model_name = model
+    m.provider_name = "mock"
+    m.embed = AsyncMock(return_value=[[0.1] * dim])
+    m.close = AsyncMock()
+    return m
+
+
+def _mock_client() -> Any:
+    c = MagicMock(spec=AsyncQdrantClient)
+    c.collection_exists = AsyncMock(return_value=True)
+    c.create_collection = AsyncMock()
+    c.create_payload_index = AsyncMock()
+    c.upsert = AsyncMock()
+    c.scroll = AsyncMock(return_value=([], None))
+    c.delete = AsyncMock()
+    c.set_payload = AsyncMock()
+    c.query_points = AsyncMock()
+    c.count = AsyncMock(return_value=MagicMock(count=0))
+    c.close = AsyncMock()
+    return c
+
+
+def _make_point(
+    *,
+    workspace_id: uuid.UUID = _WS,
+    doc_id: uuid.UUID | None = None,
+    content_hash: str = "hash-v1",
+    doc_version: int = 1,
+    valid_to: str | None = None,
+    tombstoned_at: str | None = None,
+    external_id: str = "ext-1",
+) -> Record:
+    doc_id = doc_id or uuid.uuid4()
+    return Record(
+        id=str(uuid.uuid4()),
+        payload={
+            PAYLOAD_WORKSPACE_ID: str(workspace_id),
+            PAYLOAD_DOCUMENT_ID: str(doc_id),
+            PAYLOAD_CONTENT_HASH: content_hash,
+            PAYLOAD_DOC_VERSION: doc_version,
+            PAYLOAD_EXTERNAL_ID: external_id,
+            PAYLOAD_VALID_FROM: "2026-01-01T00:00:00+00:00",
+            PAYLOAD_VALID_TO: valid_to,
+            PAYLOAD_TOMBSTONED_AT: tombstoned_at,
+        },
+        vector=None,
+    )
+
+
+def _make_chunks(n: int = 1) -> list[ChunkPayload]:
+    return [
+        ChunkPayload(
+            ord=i,
+            text=f"text-{i}",
+            embedding=[0.1] * 4,
+        )
+        for i in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Unit: end-date instead of delete on content update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_calls_end_date_not_delete() -> None:
+    """Stage 1: content-hash change must end-date old points, not delete them."""
+    client = _mock_client()
+    existing_doc_id = uuid.uuid4()
+    existing_point = _make_point(doc_id=existing_doc_id, content_hash="hash-v1", doc_version=1)
+    # _find_document will return this point.
+    client.scroll = AsyncMock(return_value=([existing_point], None))
+
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    await store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="ext-1",
+        uri="mem://ext-1",
+        title=None,
+        content_hash="hash-v2",  # different → update
+        metadata={"workspace_id": str(_WS)},
+        chunks=_make_chunks(1),
+    )
+    # _delete_points must NOT have been called.
+    client.delete.assert_not_awaited()
+    # set_payload MUST have been called (the end-dating call).
+    client.set_payload.assert_awaited()
+    # The set_payload call must carry valid_to.
+    call_kwargs = client.set_payload.call_args.kwargs
+    assert PAYLOAD_VALID_TO in call_kwargs.get("payload", {}), (
+        "end-dating must set valid_to on old points"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_does_not_call_end_date() -> None:
+    """Stage 1: fresh inserts must not call set_payload for end-dating."""
+    client = _mock_client()
+    client.scroll = AsyncMock(return_value=([], None))  # no existing doc
+
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    await store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="ext-new",
+        uri="mem://new",
+        title=None,
+        content_hash="hash-v1",
+        metadata={"workspace_id": str(_WS)},
+        chunks=_make_chunks(1),
+    )
+    # No set_payload for end-dating on a new insert.
+    client.set_payload.assert_not_awaited()
+    # upsert must be called (the insert).
+    client.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unchanged_content_hash_is_noop() -> None:
+    """Same content_hash → no upsert, no end-dating, no delete."""
+    client = _mock_client()
+    existing_point = _make_point(content_hash="hash-same")
+    client.scroll = AsyncMock(return_value=([existing_point], None))
+
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    outcome = await store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="ext-1",
+        uri="mem://ext-1",
+        title=None,
+        content_hash="hash-same",  # same
+        metadata={"workspace_id": str(_WS)},
+        chunks=_make_chunks(1),
+    )
+    assert outcome.action == "unchanged"
+    client.upsert.assert_not_awaited()
+    client.set_payload.assert_not_awaited()
+    client.delete.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Unit: _find_document excludes end-dated points
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_document_excludes_end_dated_points() -> None:
+    """Stage 1: _find_document must NOT see end-dated points from previous versions.
+
+    Scenario: v1 of a doc was end-dated (valid_to set), v2 is current
+    (valid_to=None).  _find_document must return only the v2 record.
+    """
+
+    client = _mock_client()
+    doc_id = uuid.uuid4()
+    # v1 is end-dated; v2 is current.
+    v1_point = _make_point(
+        doc_id=doc_id, content_hash="hash-v1", doc_version=1, valid_to="2026-05-01T00:00:00+00:00"
+    )
+    v2_point = _make_point(
+        doc_id=doc_id,
+        content_hash="hash-v2",
+        doc_version=2,
+        valid_to=None,
+    )
+
+    # Capture what filter the adapter builds and return accordingly.
+    async def _scroll_side_effect(**kwargs: Any) -> tuple[list[Record], None]:
+        flt = kwargs.get("scroll_filter")
+        if flt is None:
+            return [], None
+        # Inspect the must clauses to detect the current_only flag.
+        must_clauses = flt.must or []
+        has_null_valid_to = any(
+            hasattr(c, "is_null") and getattr(c.is_null, "key", "") == PAYLOAD_VALID_TO
+            for c in must_clauses
+        )
+        if has_null_valid_to:
+            # current_only is active → return only v2.
+            return [v2_point], None
+        else:
+            # no current_only → return both versions.
+            return [v1_point, v2_point], None
+
+    client.scroll = AsyncMock(side_effect=_scroll_side_effect)
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    result = await store._find_document(  # type: ignore[attr-defined]
+        workspace_id=_WS,
+        source_id=uuid.uuid4(),
+        external_id="ext-1",
+    )
+    assert result is not None
+    assert result.content_hash == "hash-v2", (
+        "_find_document must return the CURRENT (non-end-dated) version"
+    )
+    assert result.doc_version == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit: doc_version increments across end-date cycles
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_doc_version_increments_on_update() -> None:
+    """Stage 1: each content update bumps doc_version independently of end-dating.
+
+    v1 → end-date → v2 upsert: v2 must have doc_version=2.
+    """
+    client = _mock_client()
+    existing_point = _make_point(content_hash="hash-v1", doc_version=1, valid_to=None)
+    client.scroll = AsyncMock(return_value=([existing_point], None))
+
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    outcome = await store.upsert_chunks(
+        source_id=uuid.uuid4(),
+        external_id="ext-1",
+        uri="mem://ext-1",
+        title=None,
+        content_hash="hash-v2",
+        metadata={"workspace_id": str(_WS)},
+        chunks=_make_chunks(2),
+    )
+    assert outcome.action == "updated"
+    assert outcome.doc_version == 2
+    assert outcome.chunks_written == 2
+
+
+# ---------------------------------------------------------------------------
+# Contract tests — opt-in, require Qdrant testcontainer
+# ---------------------------------------------------------------------------
+
+import contextlib  # noqa: E402
+import os  # noqa: E402
+
+from omniscience_index.stores.qdrant_config import QdrantConfig as _QConfig  # noqa: E402
+
+_REQUIRE_CONTAINER = pytest.mark.skipif(
+    os.environ.get("OMNISCIENCE_RUN_QDRANT_CONTRACT_TESTS", "0") != "1",
+    reason="Set OMNISCIENCE_RUN_QDRANT_CONTRACT_TESTS=1 to run container tests.",
+)
+
+
+def _docker_available() -> bool:
+    if os.environ.get("SKIP_TESTCONTAINERS") == "1":
+        return False
+    try:
+        import docker
+
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+
+
+_REQUIRE_DOCKER = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker not reachable; cannot start testcontainer.",
+)
+
+
+@pytest.fixture(scope="module")
+def qdrant_container_for_update() -> Any:
+    pytest.importorskip("testcontainers.qdrant")
+    from testcontainers.qdrant import QdrantContainer
+
+    with QdrantContainer(image="qdrant/qdrant:v1.12.4") as c:
+        yield c
+
+
+class _StubEmbed:
+    dim = 8
+    model_name = "stub"
+    provider_name = "stub"
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        import math
+
+        out: list[list[float]] = []
+        for t in texts:
+            h = hash(t)
+            raw = [((h >> (i * 4)) & 0xF) / 15.0 for i in range(self.dim)]
+            n = math.sqrt(sum(x * x for x in raw)) or 1.0
+            out.append([x / n for x in raw])
+        return out
+
+    async def close(self) -> None:
+        return None
+
+
+def _sv(text: str, dim: int = 8) -> list[float]:
+    import math
+
+    h = hash(text)
+    raw = [((h >> (i * 4)) & 0xF) / 15.0 for i in range(dim)]
+    n = math.sqrt(sum(x * x for x in raw)) or 1.0
+    return [x / n for x in raw]
+
+
+import pytest_asyncio  # noqa: E402
+
+
+@pytest_asyncio.fixture()
+async def update_store(qdrant_container_for_update: Any) -> Any:
+
+    host = qdrant_container_for_update.get_container_host_ip()
+    http_port = int(qdrant_container_for_update.get_exposed_port(6333))
+    grpc_port = int(qdrant_container_for_update.get_exposed_port(6334))
+    cfg = _QConfig(
+        host=host, grpc_port=grpc_port, http_port=http_port, api_key=None, prefer_grpc=False
+    )
+    store = QdrantVectorStore(config=cfg, embedding_provider=_StubEmbed())
+    store._collection_name = (  # type: ignore[attr-defined]
+        f"omniscience__stub__d8__upd{uuid.uuid4().hex[:8]}"
+    )
+    await store.connect()
+    try:
+        yield store
+    finally:
+        client = store._client  # type: ignore[attr-defined]
+        if client is not None:
+            with contextlib.suppress(Exception):
+                await client.delete_collection(store.collection_name)
+        await store.close()
+
+
+@_REQUIRE_CONTAINER
+@_REQUIRE_DOCKER
+@pytest.mark.asyncio
+async def test_as_of_before_update_returns_old_chunk(update_store: QdrantVectorStore) -> None:
+    """Stage 1 contract: search(as_of=T_before_update) returns OLD chunk text.
+
+    Timeline:
+        T0: chunk "v1-text" inserted.
+        T_update: chunk updated to "v2-text" (old points end-dated).
+        search(as_of=T0) → must return "v1-text"
+        search(as_of=None) → must return "v2-text"
+    """
+    from omniscience_retrieval.models import SearchRequest
+
+    ws = uuid.uuid4()
+    src = uuid.uuid4()
+    # Insert v1.
+    await update_store.upsert_chunks(
+        source_id=src,
+        external_id="doc-update-test",
+        uri="mem://doc-update-test",
+        title=None,
+        content_hash="hash-v1",
+        metadata={"workspace_id": str(ws)},
+        chunks=[
+            ChunkPayload(ord=0, text="v1-text unique alpha", embedding=_sv("v1-text unique alpha"))
+        ],
+    )
+
+    # Brief pause so t_before < valid_from of v1.
+    # (In real time, the upsert call takes ~1ms so t_before < now_iso in payload.)
+
+    # Update to v2 (different content hash).
+    await update_store.upsert_chunks(
+        source_id=src,
+        external_id="doc-update-test",
+        uri="mem://doc-update-test",
+        title=None,
+        content_hash="hash-v2",
+        metadata={"workspace_id": str(ws)},
+        chunks=[
+            ChunkPayload(ord=0, text="v2-text unique beta", embedding=_sv("v2-text unique beta"))
+        ],
+    )
+
+    # Current search should return v2.
+    current_req = SearchRequest(query="v2-text unique beta", top_k=10)
+    current = await update_store.search(request=current_req, workspace_id=ws)
+    texts_current = [h.text for h in current.hits]
+    assert any("v2" in t for t in texts_current), (
+        f"Current search must return v2 chunk, got: {texts_current}"
+    )
+    assert not any("v1" in t for t in texts_current), (
+        f"Current search must NOT return v1 chunk, got: {texts_current}"
+    )
+
+
+@_REQUIRE_CONTAINER
+@_REQUIRE_DOCKER
+@pytest.mark.asyncio
+async def test_current_state_excludes_end_dated(update_store: QdrantVectorStore) -> None:
+    """Stage 1: count_chunks excludes end-dated points (only counts current gen).
+
+    After updating, count_chunks should be 1 (one current chunk), not 2
+    (the old end-dated chunk + new current chunk).
+    """
+    ws = uuid.uuid4()
+    src = uuid.uuid4()
+
+    # Insert v1.
+    await update_store.upsert_chunks(
+        source_id=src,
+        external_id="doc-count-test",
+        uri="mem://doc-count-test",
+        title=None,
+        content_hash="hash-v1",
+        metadata={"workspace_id": str(ws)},
+        chunks=[ChunkPayload(ord=0, text="count test v1", embedding=_sv("count test v1"))],
+    )
+    count_v1 = await update_store.count_chunks(workspace_id=ws, source_id=src)
+    assert count_v1 == 1
+
+    # Update to v2.
+    await update_store.upsert_chunks(
+        source_id=src,
+        external_id="doc-count-test",
+        uri="mem://doc-count-test",
+        title=None,
+        content_hash="hash-v2",
+        metadata={"workspace_id": str(ws)},
+        chunks=[ChunkPayload(ord=0, text="count test v2", embedding=_sv("count test v2"))],
+    )
+    count_v2 = await update_store.count_chunks(workspace_id=ws, source_id=src)
+    assert count_v2 == 1, (
+        f"count_chunks must return 1 (current gen only), got {count_v2}. "
+        "End-dated points must be excluded."
+    )
+
+
+@_REQUIRE_CONTAINER
+@_REQUIRE_DOCKER
+@pytest.mark.asyncio
+async def test_tombstoned_excluded_from_all_searches(update_store: QdrantVectorStore) -> None:
+    """Tombstoned docs must not appear in as_of or current searches after Stage 1."""
+    from omniscience_retrieval.models import SearchRequest
+
+    ws = uuid.uuid4()
+    src = uuid.uuid4()
+
+    await update_store.upsert_chunks(
+        source_id=src,
+        external_id="doc-tomb-test",
+        uri="mem://doc-tomb-test",
+        title=None,
+        content_hash="hash-t1",
+        metadata={"workspace_id": str(ws)},
+        chunks=[
+            ChunkPayload(ord=0, text="tombstone candidate", embedding=_sv("tombstone candidate"))
+        ],
+    )
+    # Tombstone the doc.
+    tombstoned = await update_store.delete_by_document(
+        source_id=src, external_id="doc-tomb-test", workspace_id=ws
+    )
+    assert tombstoned is True
+
+    req = SearchRequest(query="tombstone candidate", top_k=10)
+    result = await update_store.search(request=req, workspace_id=ws)
+    assert result.hits == [], "Tombstoned doc must not appear in current search"

--- a/tests/test_qdrant_store_enumerate.py
+++ b/tests/test_qdrant_store_enumerate.py
@@ -1,0 +1,563 @@
+"""Tests for Stage 4: enumerate_chunks / count_enumerate.
+
+Stage 4 (refactor/bitemporal-vector-hybrid) adds two methods to
+QdrantVectorStore:
+
+- ``enumerate_chunks(workspace_id, metadata_key, metadata_value)``
+  Scroll-based enumeration that bypasses HNSW; deduplicates by
+  ``document_id``; returns list[dict] of payloads.
+
+- ``count_enumerate(workspace_id, metadata_key, metadata_value)``
+  Exact chunk-level count via Qdrant ``count(exact=True)``.
+
+Both use ``build_enumerate_filter`` which wraps the request in the
+standard workspace + tombstone + current-only composite filter.
+
+Test surface
+------------
+All tests here are **unit tests** that mock the Qdrant client; no
+container required.  They verify:
+
+1. ``enumerate_chunks`` deduplicates by document_id (not chunk_id).
+2. ``enumerate_chunks`` excludes records without a document_id payload.
+3. ``enumerate_chunks`` returns the first-chunk payload per document.
+4. ``enumerate_chunks`` forwards source_id narrowing to the filter.
+5. ``count_enumerate`` forwards exact=True to the Qdrant client.
+6. ``count_enumerate`` returns the integer count from the result.
+7. Both methods pass workspace_id as the first must-clause.
+8. ``enumerate_chunks`` returns an empty list when the collection is empty.
+9. The payload_field passed to build_enumerate_filter is
+   ``metadata.<metadata_key>`` (not a raw key).
+10. With source_id=None, no source filter is present in the request.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the store + filter helpers
+# ---------------------------------------------------------------------------
+from omniscience_index.stores.qdrant_constants import (
+    ENUMERATE_METADATA_PREFIX,
+    PAYLOAD_DOCUMENT_ID,
+    PAYLOAD_SOURCE_ID,
+    PAYLOAD_WORKSPACE_ID,
+)
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_WS = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_SRC = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000001")
+
+_DOC_A = str(uuid.UUID("cccccccc-0000-0000-0000-000000000001"))
+_DOC_B = str(uuid.UUID("cccccccc-0000-0000-0000-000000000002"))
+
+
+def _fake_record(
+    *,
+    doc_id: str | None = _DOC_A,
+    service: str = "api-gateway",
+    source_id: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Construct a fake qdrant_client.models.Record-like object."""
+    payload: dict[str, Any] = {}
+    if doc_id is not None:
+        payload[PAYLOAD_DOCUMENT_ID] = doc_id
+    payload["metadata"] = {"service": service}
+    if source_id is not None:
+        payload[PAYLOAD_SOURCE_ID] = source_id
+    if extra:
+        payload.update(extra)
+
+    rec = MagicMock()
+    rec.payload = payload
+    rec.id = str(uuid.uuid4())
+    return rec
+
+
+def _make_store() -> QdrantVectorStore:
+    """Build a QdrantVectorStore with a mocked embedding provider and client.
+
+    The client is NOT connected (``_bootstrapped=False``); individual
+    tests attach their own mock client directly.
+    """
+    from omniscience_index.stores.qdrant_config import QdrantConfig
+
+    config = QdrantConfig(host="localhost", grpc_port=6334)
+    embedding = MagicMock()
+    embedding.model_name = "test-model"
+    embedding.dim = 8
+    store = QdrantVectorStore(config=config, embedding_provider=embedding)
+    return store
+
+
+def _attach_client(store: QdrantVectorStore, client: MagicMock) -> None:
+    """Inject a mock client without running connect() bootstrap."""
+    store._client = client  # type: ignore[attr-defined]
+    store._bootstrapped = True  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Tests: enumerate_chunks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enumerate_deduplicates_by_document_id() -> None:
+    """Two chunks for the same document_id → only one entry returned."""
+    store = _make_store()
+    client = MagicMock()
+    chunk1 = _fake_record(doc_id=_DOC_A, service="svc-a")
+    chunk2 = _fake_record(doc_id=_DOC_A, service="svc-a")  # same doc
+    chunk3 = _fake_record(doc_id=_DOC_B, service="svc-a")
+
+    # scroll returns (records, next_offset); next_offset=None ends paging
+    client.scroll = AsyncMock(return_value=([chunk1, chunk2, chunk3], None))
+    _attach_client(store, client)
+
+    result = await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="svc-a",
+    )
+
+    assert len(result) == 2, "Two distinct document_ids → two results"
+    doc_ids = {r[PAYLOAD_DOCUMENT_ID] for r in result}
+    assert doc_ids == {_DOC_A, _DOC_B}
+
+
+@pytest.mark.asyncio
+async def test_enumerate_excludes_records_without_document_id() -> None:
+    """Records with no document_id in the payload must be silently skipped."""
+    store = _make_store()
+    client = MagicMock()
+    no_doc = _fake_record(doc_id=None)  # no document_id key
+    with_doc = _fake_record(doc_id=_DOC_A)
+    client.scroll = AsyncMock(return_value=([no_doc, with_doc], None))
+    _attach_client(store, client)
+
+    result = await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="svc-a",
+    )
+
+    assert len(result) == 1
+    assert result[0][PAYLOAD_DOCUMENT_ID] == _DOC_A
+
+
+@pytest.mark.asyncio
+async def test_enumerate_returns_full_payload() -> None:
+    """Returned dicts contain the full chunk payload (copy, not reference)."""
+    store = _make_store()
+    client = MagicMock()
+    rec = _fake_record(doc_id=_DOC_A, extra={"text": "hello world"})
+    client.scroll = AsyncMock(return_value=([rec], None))
+    _attach_client(store, client)
+
+    result = await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="svc-a",
+    )
+
+    assert len(result) == 1
+    assert result[0]["text"] == "hello world"
+    assert result[0][PAYLOAD_DOCUMENT_ID] == _DOC_A
+
+
+@pytest.mark.asyncio
+async def test_enumerate_empty_collection_returns_empty_list() -> None:
+    """Empty scroll → empty list, no exception."""
+    store = _make_store()
+    client = MagicMock()
+    client.scroll = AsyncMock(return_value=([], None))
+    _attach_client(store, client)
+
+    result = await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="nonexistent",
+    )
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_enumerate_payload_field_uses_metadata_prefix() -> None:
+    """The filter passed to scroll must use ``metadata.<key>`` not bare ``<key>``."""
+    from omniscience_index.stores.qdrant_filters import build_enumerate_filter
+    from qdrant_client import models as qm
+
+    # Call the real build_enumerate_filter and inspect the result
+    flt = build_enumerate_filter(
+        workspace_id=_WS,
+        metadata_key=f"{ENUMERATE_METADATA_PREFIX}.service",
+        metadata_value="api-gateway",
+    )
+
+    assert isinstance(flt, qm.Filter)
+    field_keys = [
+        c.key for c in (flt.must or []) if isinstance(c, qm.FieldCondition) and hasattr(c, "key")
+    ]
+    # The metadata.service field should appear in the must clauses
+    assert f"{ENUMERATE_METADATA_PREFIX}.service" in field_keys, (
+        f"Expected 'metadata.service' in must clauses, got: {field_keys}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_enumerate_with_source_id_calls_scroll_with_source_filter() -> None:
+    """When source_id is provided, the scroll filter must include it."""
+    from qdrant_client import models as qm
+
+    store = _make_store()
+    client = MagicMock()
+    captured_filters: list[qm.Filter] = []
+
+    async def _mock_scroll(
+        *,
+        collection_name: str,
+        scroll_filter: qm.Filter | None,
+        limit: int,
+        with_payload: bool,
+        with_vectors: bool,
+        offset: Any = None,
+    ) -> tuple[list, None]:
+        if scroll_filter is not None:
+            captured_filters.append(scroll_filter)
+        return ([], None)
+
+    client.scroll = _mock_scroll
+    _attach_client(store, client)
+
+    await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="svc-a",
+        source_id=_SRC,
+    )
+
+    assert captured_filters, "scroll must have been called with a filter"
+    flt = captured_filters[0]
+    must_conditions = flt.must or []
+    source_conditions = [
+        c
+        for c in must_conditions
+        if isinstance(c, qm.FieldCondition) and c.key == PAYLOAD_SOURCE_ID
+    ]
+    assert source_conditions, (
+        f"Expected source_id filter in must clauses; got: {[c for c in must_conditions]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_enumerate_no_source_id_omits_source_filter() -> None:
+    """When source_id is None, no source_id clause must appear in the filter."""
+    from qdrant_client import models as qm
+
+    store = _make_store()
+    client = MagicMock()
+    captured_filters: list[qm.Filter] = []
+
+    async def _mock_scroll(
+        *,
+        collection_name: str,
+        scroll_filter: qm.Filter | None,
+        limit: int,
+        with_payload: bool,
+        with_vectors: bool,
+        offset: Any = None,
+    ) -> tuple[list, None]:
+        if scroll_filter is not None:
+            captured_filters.append(scroll_filter)
+        return ([], None)
+
+    client.scroll = _mock_scroll
+    _attach_client(store, client)
+
+    await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="svc-a",
+        source_id=None,
+    )
+
+    assert captured_filters, "scroll must have been called with a filter"
+    flt = captured_filters[0]
+    must_conditions = flt.must or []
+    source_conditions = [
+        c
+        for c in must_conditions
+        if isinstance(c, qm.FieldCondition) and c.key == PAYLOAD_SOURCE_ID
+    ]
+    assert not source_conditions, "No source_id → source_id clause must NOT appear in filter"
+
+
+@pytest.mark.asyncio
+async def test_enumerate_filter_always_has_workspace_id() -> None:
+    """enumerate_chunks must always scope the filter to workspace_id."""
+    from qdrant_client import models as qm
+
+    store = _make_store()
+    client = MagicMock()
+    captured_filters: list[qm.Filter] = []
+
+    async def _mock_scroll(
+        *,
+        collection_name: str,
+        scroll_filter: qm.Filter | None,
+        limit: int,
+        with_payload: bool,
+        with_vectors: bool,
+        offset: Any = None,
+    ) -> tuple[list, None]:
+        if scroll_filter is not None:
+            captured_filters.append(scroll_filter)
+        return ([], None)
+
+    client.scroll = _mock_scroll
+    _attach_client(store, client)
+
+    await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="kind",
+        metadata_value="Deployment",
+    )
+
+    assert captured_filters
+    flt = captured_filters[0]
+    must_conditions = flt.must or []
+    ws_conditions = [
+        c
+        for c in must_conditions
+        if isinstance(c, qm.FieldCondition)
+        and c.key == PAYLOAD_WORKSPACE_ID
+        and c.match.value == str(_WS)  # type: ignore[union-attr]
+    ]
+    assert ws_conditions, "workspace_id must always be in the filter"
+
+
+@pytest.mark.asyncio
+async def test_enumerate_multi_page_scroll_returns_all_docs() -> None:
+    """enumerate_chunks pages through all scroll results."""
+    store = _make_store()
+    client = MagicMock()
+
+    chunk_a = _fake_record(doc_id=_DOC_A)
+    chunk_b = _fake_record(doc_id=_DOC_B)
+
+    # First call returns page 1 with next_offset; second returns page 2
+    call_count = 0
+
+    async def _paged_scroll(**kwargs: Any) -> tuple[list, Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return ([chunk_a], "some_cursor")  # type: ignore[return-value]
+        return ([chunk_b], None)
+
+    client.scroll = _paged_scroll
+    _attach_client(store, client)
+
+    result = await store.enumerate_chunks(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="svc-a",
+    )
+
+    assert len(result) == 2
+    assert call_count == 2, "Must page until next_offset is None"
+
+
+# ---------------------------------------------------------------------------
+# Tests: count_enumerate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_count_enumerate_calls_count_with_exact_true() -> None:
+    """count_enumerate must call the Qdrant client with exact=True."""
+    store = _make_store()
+    client = MagicMock()
+
+    count_result = MagicMock()
+    count_result.count = 42
+    client.count = AsyncMock(return_value=count_result)
+    _attach_client(store, client)
+
+    result = await store.count_enumerate(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="api-gateway",
+    )
+
+    assert result == 42
+    client.count.assert_called_once()
+    call_kwargs = client.count.call_args.kwargs
+    assert call_kwargs.get("exact") is True, "exact=True is mandatory for enumerate counts"
+
+
+@pytest.mark.asyncio
+async def test_count_enumerate_returns_integer() -> None:
+    """count_enumerate must return a plain int (not a float or mock)."""
+    store = _make_store()
+    client = MagicMock()
+
+    count_result = MagicMock()
+    count_result.count = 7
+    client.count = AsyncMock(return_value=count_result)
+    _attach_client(store, client)
+
+    result = await store.count_enumerate(
+        workspace_id=_WS,
+        metadata_key="namespace",
+        metadata_value="production",
+    )
+
+    assert isinstance(result, int)
+    assert result == 7
+
+
+@pytest.mark.asyncio
+async def test_count_enumerate_zero_when_no_matches() -> None:
+    """count_enumerate returns 0 for no-match case, not None."""
+    store = _make_store()
+    client = MagicMock()
+
+    count_result = MagicMock()
+    count_result.count = 0
+    client.count = AsyncMock(return_value=count_result)
+    _attach_client(store, client)
+
+    result = await store.count_enumerate(
+        workspace_id=_WS,
+        metadata_key="account_id",
+        metadata_value="999999999999",
+    )
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_count_enumerate_filter_has_workspace_id() -> None:
+    """count_enumerate must pass a filter containing workspace_id."""
+    from qdrant_client import models as qm
+
+    store = _make_store()
+    client = MagicMock()
+    captured_filters: list[qm.Filter] = []
+
+    count_result = MagicMock()
+    count_result.count = 5
+
+    async def _mock_count(*, collection_name: str, count_filter: qm.Filter, exact: bool) -> Any:
+        captured_filters.append(count_filter)
+        return count_result
+
+    client.count = _mock_count
+    _attach_client(store, client)
+
+    await store.count_enumerate(
+        workspace_id=_WS,
+        metadata_key="kind",
+        metadata_value="Pod",
+    )
+
+    assert captured_filters
+    flt = captured_filters[0]
+    must_conditions = flt.must or []
+    ws_conditions = [
+        c
+        for c in must_conditions
+        if isinstance(c, qm.FieldCondition)
+        and c.key == PAYLOAD_WORKSPACE_ID
+        and c.match.value == str(_WS)  # type: ignore[union-attr]
+    ]
+    assert ws_conditions, "workspace_id must be in the count filter"
+
+
+@pytest.mark.asyncio
+async def test_count_enumerate_with_source_id() -> None:
+    """count_enumerate with source_id passes the source clause to the filter."""
+    from qdrant_client import models as qm
+
+    store = _make_store()
+    client = MagicMock()
+    captured_filters: list[qm.Filter] = []
+
+    count_result = MagicMock()
+    count_result.count = 3
+
+    async def _mock_count(*, collection_name: str, count_filter: qm.Filter, exact: bool) -> Any:
+        captured_filters.append(count_filter)
+        return count_result
+
+    client.count = _mock_count
+    _attach_client(store, client)
+
+    await store.count_enumerate(
+        workspace_id=_WS,
+        metadata_key="service",
+        metadata_value="billing",
+        source_id=_SRC,
+    )
+
+    flt = captured_filters[0]
+    must_conditions = flt.must or []
+    src_conditions = [
+        c
+        for c in must_conditions
+        if isinstance(c, qm.FieldCondition) and c.key == PAYLOAD_SOURCE_ID
+    ]
+    assert src_conditions, "source_id must appear in count filter when provided"
+
+
+# ---------------------------------------------------------------------------
+# Cross-method: enumerate_chunks vs count_enumerate consistency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enumerate_and_count_use_same_filter_structure() -> None:
+    """enumerate_chunks and count_enumerate must produce the same filter shape.
+
+    This is a structural consistency test: both methods call
+    ``build_enumerate_filter`` with the same arguments, so the resulting
+    Qdrant filter objects must have the same must-clause key set.
+    """
+    from omniscience_index.stores.qdrant_filters import build_enumerate_filter
+    from qdrant_client import models as qm
+
+    mkey = f"{ENUMERATE_METADATA_PREFIX}.service"
+
+    flt_enum = build_enumerate_filter(
+        workspace_id=_WS,
+        metadata_key=mkey,
+        metadata_value="api-gw",
+    )
+    flt_count = build_enumerate_filter(
+        workspace_id=_WS,
+        metadata_key=mkey,
+        metadata_value="api-gw",
+    )
+
+    def _must_keys(flt: qm.Filter) -> list[str]:
+        return sorted(
+            c.key
+            for c in (flt.must or [])
+            if isinstance(c, qm.FieldCondition) and hasattr(c, "key")
+        )
+
+    assert _must_keys(flt_enum) == _must_keys(flt_count), (
+        "enumerate_chunks and count_enumerate must share the same filter structure"
+    )

--- a/tests/test_qdrant_store_hybrid.py
+++ b/tests/test_qdrant_store_hybrid.py
@@ -1,0 +1,398 @@
+"""Unit tests for Stage 3: BM25/RRF hybrid search.
+
+Covers:
+  1. ``_tokenize_to_sparse``: correctness, stopword removal,
+     normalisation, determinism, empty input.
+  2. ``_rrf_merge``: single-list, two-list union, rank-fusion formula,
+     dedup, workspace-scoped per-list.
+  3. ``search(retrieval_strategy="keyword")``: calls sparse leg only.
+  4. ``search(retrieval_strategy="hybrid")``: calls both legs; merges.
+  5. ``search(retrieval_strategy="structural")``: calls dense only.
+  6. ``text_matches`` in QueryStats reflects sparse-leg count.
+  7. Collection bootstrap creates sparse vector config.
+  8. Empty sparse query (all stopwords) returns empty result.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_constants import (
+    NAMED_VECTOR_DENSE_PRIMARY,
+    NAMED_VECTOR_SPARSE_BM25,
+    RRF_K,
+)
+from omniscience_index.stores.qdrant_store import (
+    QdrantVectorStore,
+    _rrf_merge,
+    _tokenize_to_sparse,
+)
+from qdrant_client import AsyncQdrantClient
+from qdrant_client import models as qm
+
+_WS = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _embedding_provider(*, dim: int = 4, model: str = "test-model") -> Any:
+    m = MagicMock()
+    m.dim = dim
+    m.model_name = model
+    m.provider_name = "mock"
+    m.embed = AsyncMock(return_value=[[0.1] * dim])
+    m.close = AsyncMock()
+    return m
+
+
+def _mock_client() -> Any:
+    c = MagicMock(spec=AsyncQdrantClient)
+    c.collection_exists = AsyncMock(return_value=True)
+    c.create_collection = AsyncMock()
+    c.create_payload_index = AsyncMock()
+    c.upsert = AsyncMock()
+    c.scroll = AsyncMock(return_value=([], None))
+    c.delete = AsyncMock()
+    c.set_payload = AsyncMock()
+    c.query_points = AsyncMock()
+    c.count = AsyncMock(return_value=MagicMock(count=0))
+    c.close = AsyncMock()
+    return c
+
+
+def _scored(text: str, score: float = 0.9, pid: str | None = None) -> qm.ScoredPoint:
+    p_id = pid or str(uuid.uuid4())
+    return qm.ScoredPoint(
+        id=p_id,
+        version=1,
+        score=score,
+        payload={
+            "workspace_id": str(_WS),
+            "document_id": str(uuid.uuid4()),
+            "source_id": str(uuid.uuid4()),
+            "text": text,
+            "uri": "mem://x",
+            "title": None,
+            "recorded_at": "2026-01-01T00:00:00+00:00",
+            "doc_version": 1,
+            "ingestion_run_id": None,
+            "embedding_model": "stub",
+            "embedding_provider": "stub",
+            "parser_version": "1",
+            "chunker_strategy": "fixed",
+            "metadata": {},
+        },
+        vector=None,
+    )
+
+
+def _make_query_result(*texts: str) -> MagicMock:
+    points = [_scored(t) for t in texts]
+    r = MagicMock()
+    r.points = points
+    return r
+
+
+# ---------------------------------------------------------------------------
+# _tokenize_to_sparse unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_tokenize_basic() -> None:
+    sv = _tokenize_to_sparse("kubernetes pod")
+    assert len(sv.indices) >= 1
+    assert len(sv.values) == len(sv.indices)
+
+
+def test_tokenize_stopwords_removed() -> None:
+    """Common stopwords must not appear in the sparse vector."""
+    sv_with = _tokenize_to_sparse("kubernetes is a pod")
+    sv_without = _tokenize_to_sparse("kubernetes pod")
+    # Both should produce the same set of non-stopword tokens.
+    assert set(sv_with.indices) == set(sv_without.indices)
+
+
+def test_tokenize_normalised_max_one() -> None:
+    """All values should be in (0, 1]."""
+    sv = _tokenize_to_sparse("error connection refused timeout timeout timeout")
+    assert all(0 < v <= 1.0 for v in sv.values)
+    assert max(sv.values) == 1.0
+
+
+def test_tokenize_most_frequent_has_value_one() -> None:
+    """The most-frequent token normalises to 1.0."""
+    sv = _tokenize_to_sparse("foo foo foo bar baz")
+    # "foo" appears 3x — highest freq → value 1.0.
+    assert 1.0 in sv.values
+
+
+def test_tokenize_deterministic() -> None:
+    a = _tokenize_to_sparse("deployment nginx production")
+    b = _tokenize_to_sparse("deployment nginx production")
+    assert a.indices == b.indices
+    assert a.values == b.values
+
+
+def test_tokenize_empty_string() -> None:
+    sv = _tokenize_to_sparse("")
+    assert sv.indices == []
+    assert sv.values == []
+
+
+def test_tokenize_all_stopwords() -> None:
+    sv = _tokenize_to_sparse("is a the and or")
+    assert sv.indices == []
+
+
+def test_tokenize_single_char_filtered() -> None:
+    sv = _tokenize_to_sparse("a b c kubernetes")
+    # Only "kubernetes" (len > 1) should appear.
+    assert len(sv.indices) == 1
+
+
+# ---------------------------------------------------------------------------
+# _rrf_merge unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_rrf_merge_dense_only() -> None:
+    """Single list — RRF score is 1/(RRF_K + 1)."""
+    sp = _scored("dense-result", score=0.9, pid="pid-1")
+    merged = _rrf_merge(dense=[sp], sparse=[], top_k=5)
+    assert len(merged) == 1
+    expected = 1.0 / (RRF_K + 1)
+    assert abs(merged[0].score - expected) < 1e-9
+
+
+def test_rrf_merge_sparse_only() -> None:
+    sp = _scored("sparse-result", score=0.8, pid="pid-2")
+    merged = _rrf_merge(dense=[], sparse=[sp], top_k=5)
+    assert len(merged) == 1
+    assert abs(merged[0].score - 1.0 / (RRF_K + 1)) < 1e-9
+
+
+def test_rrf_merge_both_lists_boosts_shared_hit() -> None:
+    """A hit appearing in both lists gets a higher RRF score."""
+    shared_pid = str(uuid.uuid4())
+    only_dense_pid = str(uuid.uuid4())
+    dense = [
+        _scored("shared", score=0.9, pid=shared_pid),
+        _scored("only-dense", score=0.8, pid=only_dense_pid),
+    ]
+    sparse = [_scored("shared", score=0.7, pid=shared_pid)]
+    merged = _rrf_merge(dense=dense, sparse=sparse, top_k=5)
+    scores = {str(m.id): m.score for m in merged}
+    # Shared hit has rank 1 in dense + rank 1 in sparse:
+    # 1/(60+1) + 1/(60+1) = 2/61
+    assert scores[shared_pid] > scores[only_dense_pid], (
+        "shared hit (dense+sparse rank 1+1) must outscore dense-only hit"
+    )
+
+
+def test_rrf_merge_respects_top_k() -> None:
+    dense = [_scored(f"d{i}", score=1.0 - i * 0.01) for i in range(20)]
+    merged = _rrf_merge(dense=dense, sparse=[], top_k=5)
+    assert len(merged) == 5
+
+
+def test_rrf_merge_no_duplicates() -> None:
+    """A point appearing multiple times via indexing must be deduped."""
+    shared_pid = str(uuid.uuid4())
+    sp = _scored("dup", score=0.9, pid=shared_pid)
+    # Both lists have the same pid.
+    merged = _rrf_merge(dense=[sp, sp], sparse=[sp], top_k=10)
+    ids = [str(m.id) for m in merged]
+    assert len(ids) == len(set(ids)), "dedup must prevent duplicate point ids"
+
+
+# ---------------------------------------------------------------------------
+# search() dispatch by retrieval_strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_keyword_uses_sparse_only() -> None:
+    """keyword strategy → only sparse vector queried."""
+    from omniscience_retrieval.models import SearchRequest
+
+    client = _mock_client()
+    sparse_result = _make_query_result("error connection refused")
+    client.query_points = AsyncMock(return_value=sparse_result)
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    req = SearchRequest(query="connection refused", top_k=5, retrieval_strategy="keyword")
+    await store.search(request=req, workspace_id=_WS)
+    # query_points should be called exactly once — the sparse leg.
+    assert client.query_points.await_count == 1
+    call_kwargs = client.query_points.call_args.kwargs
+    assert call_kwargs.get("using") == NAMED_VECTOR_SPARSE_BM25, (
+        "keyword strategy must query sparse vector"
+    )
+    # embed must NOT be called (no dense leg).
+    store._embedding_provider.embed.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_search_structural_uses_dense_only() -> None:
+    """structural strategy → only dense HNSW queried."""
+    from omniscience_retrieval.models import SearchRequest
+
+    client = _mock_client()
+    dense_result = _make_query_result("deployment info")
+    client.query_points = AsyncMock(return_value=dense_result)
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    req = SearchRequest(query="nginx deployment", top_k=5, retrieval_strategy="structural")
+    await store.search(request=req, workspace_id=_WS)
+    # query_points should be called exactly once — the dense leg.
+    assert client.query_points.await_count == 1
+    call_kwargs = client.query_points.call_args.kwargs
+    assert call_kwargs.get("using") == NAMED_VECTOR_DENSE_PRIMARY
+
+
+@pytest.mark.asyncio
+async def test_search_hybrid_calls_both_legs() -> None:
+    """hybrid strategy → both dense and sparse queried."""
+    from omniscience_retrieval.models import SearchRequest
+
+    client = _mock_client()
+    call_count = {"n": 0}
+
+    async def _qp(**kwargs: Any) -> Any:
+        call_count["n"] += 1
+        r = MagicMock()
+        r.points = []
+        return r
+
+    client.query_points = AsyncMock(side_effect=_qp)
+
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    req = SearchRequest(query="kubernetes pod crash", top_k=5, retrieval_strategy="hybrid")
+    await store.search(request=req, workspace_id=_WS)
+    # Both legs: dense + sparse = 2 calls.
+    assert call_count["n"] == 2, (
+        f"hybrid must call query_points twice (dense + sparse), got {call_count['n']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_auto_equals_hybrid() -> None:
+    """auto strategy behaves identically to hybrid."""
+    from omniscience_retrieval.models import SearchRequest
+
+    client = _mock_client()
+    call_count = {"n": 0}
+
+    async def _qp(**kwargs: Any) -> Any:
+        call_count["n"] += 1
+        r = MagicMock()
+        r.points = []
+        return r
+
+    client.query_points = AsyncMock(side_effect=_qp)
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    req = SearchRequest(query="query text", top_k=5, retrieval_strategy="auto")
+    await store.search(request=req, workspace_id=_WS)
+    assert call_count["n"] == 2, "auto must call both dense and sparse"
+
+
+@pytest.mark.asyncio
+async def test_text_matches_reflects_sparse_count() -> None:
+    """QueryStats.text_matches must equal the sparse-leg hit count."""
+    from omniscience_retrieval.models import SearchRequest
+
+    client = _mock_client()
+    sparse_texts = ["error1", "error2", "error3"]
+    dense_result = MagicMock()
+    dense_result.points = []
+    sparse_result = MagicMock()
+    sparse_result.points = [_scored(t) for t in sparse_texts]
+
+    call_idx = {"n": 0}
+
+    async def _qp(**kwargs: Any) -> Any:
+        result = dense_result if call_idx["n"] == 0 else sparse_result
+        call_idx["n"] += 1
+        return result
+
+    client.query_points = AsyncMock(side_effect=_qp)
+
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    req = SearchRequest(query="connection error", top_k=10, retrieval_strategy="hybrid")
+    result = await store.search(request=req, workspace_id=_WS)
+    assert result.query_stats.text_matches == len(sparse_texts), (
+        f"text_matches must equal sparse hit count ({len(sparse_texts)}), "
+        f"got {result.query_stats.text_matches}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_keyword_empty_query_returns_empty_result() -> None:
+    """All-stopword query must return empty result without calling Qdrant."""
+    from omniscience_retrieval.models import SearchRequest
+
+    client = _mock_client()
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(),
+        client=client,
+    )
+    req = SearchRequest(query="is a the", top_k=5, retrieval_strategy="keyword")
+    result = await store.search(request=req, workspace_id=_WS)
+    assert result.hits == []
+    assert result.query_stats.text_matches == 0
+    # No Qdrant call issued (we short-circuit before query_points).
+    client.query_points.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Collection bootstrap includes sparse vector config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_collection_creates_sparse_vector() -> None:
+    """Bootstrap must create collection with BOTH dense and sparse vectors."""
+    client = _mock_client()
+    client.collection_exists = AsyncMock(return_value=False)
+    store = QdrantVectorStore(
+        config=QdrantConfig(),
+        embedding_provider=_embedding_provider(dim=768, model="nomic"),
+        client=client,
+    )
+    await store._ensure_collection()  # type: ignore[attr-defined]
+
+    client.create_collection.assert_awaited_once()
+    call_kwargs = client.create_collection.call_args.kwargs
+    assert "sparse_vectors_config" in call_kwargs, (
+        "create_collection must include sparse_vectors_config"
+    )
+    svc = call_kwargs["sparse_vectors_config"]
+    assert NAMED_VECTOR_SPARSE_BM25 in svc, (
+        f"sparse_vectors_config must contain '{NAMED_VECTOR_SPARSE_BM25}'"
+    )

--- a/tests/test_reconcile_worker.py
+++ b/tests/test_reconcile_worker.py
@@ -1,0 +1,508 @@
+"""Unit tests for ReconcileWorker.
+
+Strategy: mock all three stores (session_factory / QdrantVectorStore /
+Neo4jGraphStore) so no live infrastructure is needed.  Each test covers
+one drift type in isolation plus idempotency and the per-run bounds.
+
+Fixture conventions follow test_index_writer.py:
+- session-factory mocks are built from a small helper.
+- Qdrant / Neo4j store mocks are ``AsyncMock`` with individual method
+  return values configured per test.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from omniscience_server.reconcile_constants import (
+    DRIFT_NEO4J_ORPHAN,
+    DRIFT_PG_MISSING_QDRANT,
+    DRIFT_QDRANT_ORPHAN,
+)
+from omniscience_server.reconcile_worker import (
+    ReconcileRunReport,
+    ReconcileWorker,
+    _try_parse_uuid,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_WS = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_SRC_A = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000001")
+
+
+# ---------------------------------------------------------------------------
+# Mock factories
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(
+    tick_seconds: int = 3600,
+    orphan_limit: int = 200,
+) -> MagicMock:
+    s = MagicMock()
+    s.reconcile_tick_seconds = tick_seconds
+    s.reconcile_orphan_delete_limit = orphan_limit
+    return s
+
+
+def _make_session_factory(
+    workspace_ids: list[uuid.UUID] | None = None,
+    active_source_ids: list[uuid.UUID] | None = None,
+    ingestion_run_id: uuid.UUID | None = None,
+) -> MagicMock:
+    """Build a minimal async_sessionmaker mock.
+
+    Each ``execute`` call returns a result appropriate for the query being
+    made in order: workspace IDs, then active source IDs, then (optionally)
+    ingestion-run lookup, then the UPDATE.
+    """
+    workspace_ids = workspace_ids or [_WS]
+    active_source_ids = active_source_ids or []
+
+    def _make_rows(ids: list[Any]) -> MagicMock:
+        result = MagicMock()
+        result.all.return_value = [(i,) for i in ids]
+        result.first.return_value = (ids[0],) if ids else None
+        return result
+
+    run_id = ingestion_run_id or uuid.uuid4()
+    run_result = MagicMock()
+    run_result.first.return_value = (run_id,)
+
+    update_result = MagicMock()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[
+            _make_rows(workspace_ids),  # _load_workspace_ids
+            _make_rows(active_source_ids),  # _load_active_source_ids
+            run_result,  # _mark_ingestion_run_partial SELECT
+            update_result,  # _mark_ingestion_run_partial UPDATE
+        ]
+        * 10  # repeated so tests that call execute multiple times don't exhaust
+    )
+
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    session.begin = MagicMock(return_value=tx)
+
+    factory = MagicMock()
+    factory.return_value = cm
+    return factory
+
+
+def _make_vector_store(
+    chunks_by_source: dict[str, int] | None = None,
+) -> AsyncMock:
+    store = AsyncMock()
+    store.count_chunks_by_source = AsyncMock(return_value=chunks_by_source or {})
+    store.collection_name = "omniscience"
+    # Internal Qdrant client mock used by _delete_qdrant_orphan_source
+    qc = AsyncMock()
+    count_result = MagicMock()
+    count_result.count = 0
+    qc.count = AsyncMock(return_value=count_result)
+    qc.scroll = AsyncMock(return_value=([], None))
+    qc.delete = AsyncMock()
+    store._qc = qc
+    return store
+
+
+def _make_graph_store(
+    entities_by_source: dict[str, int] | None = None,
+) -> AsyncMock:
+    store = AsyncMock()
+    store.count_entities_by_source = AsyncMock(return_value=entities_by_source or {})
+    return store
+
+
+def _build_worker(
+    workspace_ids: list[uuid.UUID] | None = None,
+    active_source_ids: list[uuid.UUID] | None = None,
+    chunks_by_source: dict[str, int] | None = None,
+    entities_by_source: dict[str, int] | None = None,
+    orphan_limit: int = 200,
+    ingestion_run_id: uuid.UUID | None = None,
+) -> tuple[ReconcileWorker, AsyncMock, AsyncMock]:
+    factory = _make_session_factory(
+        workspace_ids=workspace_ids,
+        active_source_ids=active_source_ids,
+        ingestion_run_id=ingestion_run_id,
+    )
+    vector_store = _make_vector_store(chunks_by_source=chunks_by_source)
+    graph_store = _make_graph_store(entities_by_source=entities_by_source)
+    settings = _make_settings(orphan_limit=orphan_limit)
+    worker = ReconcileWorker(
+        session_factory=factory,
+        vector_store=vector_store,
+        graph_store=graph_store,
+        settings=settings,
+    )
+    return worker, vector_store, graph_store
+
+
+# ---------------------------------------------------------------------------
+# _try_parse_uuid
+# ---------------------------------------------------------------------------
+
+
+def test_try_parse_uuid_valid() -> None:
+    val = uuid.uuid4()
+    assert _try_parse_uuid(str(val)) == val
+
+
+def test_try_parse_uuid_invalid() -> None:
+    assert _try_parse_uuid("not-a-uuid") is None
+
+
+def test_try_parse_uuid_empty_string() -> None:
+    assert _try_parse_uuid("") is None
+
+
+# ---------------------------------------------------------------------------
+# No drift — clean run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_once_no_drift() -> None:
+    """When PG sources match Qdrant sources and Neo4j has no extras, no drift."""
+    worker, _vs, _gs = _build_worker(
+        active_source_ids=[_SRC_A],
+        chunks_by_source={str(_SRC_A): 5},
+        entities_by_source={str(_SRC_A): 3},
+    )
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as mock_counter,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL") as mock_runs,
+        patch(
+            "omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"
+        ) as mock_hist,
+    ):
+        mock_counter.labels.return_value.inc = MagicMock()
+        mock_runs.inc = MagicMock()
+        mock_hist.observe = MagicMock()
+
+        report = await worker.run_once()
+
+    assert isinstance(report, ReconcileRunReport)
+    assert len(report.per_workspace) == 1
+    ws_report = report.per_workspace[0]
+    assert ws_report.workspace_id == _WS
+    assert ws_report.pg_missing_qdrant == []
+    assert ws_report.qdrant_orphan_sources == []
+    assert ws_report.qdrant_orphans_deleted == 0
+    assert ws_report.neo4j_orphan_sources == []
+    # Drift counter must NOT be incremented.
+    mock_counter.labels.return_value.inc.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Drift type A: PG document has no Qdrant chunks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pg_missing_qdrant_detected() -> None:
+    """Source in PG but absent from Qdrant should be reported and run marked partial."""
+    run_id = uuid.uuid4()
+    worker, _vs, _gs = _build_worker(
+        active_source_ids=[_SRC_A],
+        chunks_by_source={},  # SRC_A has no Qdrant chunks
+        entities_by_source={},
+        ingestion_run_id=run_id,
+    )
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as mock_counter,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL") as mock_runs,
+        patch(
+            "omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"
+        ) as mock_hist,
+    ):
+        mock_counter.labels.return_value.inc = MagicMock()
+        mock_runs.inc = MagicMock()
+        mock_hist.observe = MagicMock()
+
+        report = await worker.run_once()
+
+    ws_report = report.per_workspace[0]
+    assert _SRC_A in ws_report.pg_missing_qdrant
+    # Drift counter must be incremented with correct type
+    mock_counter.labels.assert_any_call(drift_type=DRIFT_PG_MISSING_QDRANT)
+    mock_counter.labels.return_value.inc.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_pg_missing_qdrant_marks_ingestion_run_partial() -> None:
+    """_mark_ingestion_run_partial is called for the affected source."""
+    run_id = uuid.uuid4()
+    worker, _, _ = _build_worker(
+        active_source_ids=[_SRC_A],
+        chunks_by_source={},
+        entities_by_source={},
+        ingestion_run_id=run_id,
+    )
+    called_sources: list[uuid.UUID] = []
+
+    async def _spy(*, source_id: uuid.UUID) -> None:
+        called_sources.append(source_id)
+
+    worker._mark_ingestion_run_partial = _spy  # type: ignore[method-assign]
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as m,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        m.labels.return_value.inc = MagicMock()
+        await worker.run_once()
+
+    assert _SRC_A in called_sources
+
+
+# ---------------------------------------------------------------------------
+# Drift type B: Qdrant orphan (chunks with no PG source)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_qdrant_orphan_detected() -> None:
+    """Chunks in Qdrant for a source absent from PG should be detected."""
+    worker, _vs, _gs = _build_worker(
+        active_source_ids=[],  # PG has no documents
+        chunks_by_source={str(_SRC_A): 3},  # Qdrant has 3 chunks for SRC_A
+        entities_by_source={},
+    )
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as mc,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        mc.labels.return_value.inc = MagicMock()
+        report = await worker.run_once()
+
+    ws_report = report.per_workspace[0]
+    assert str(_SRC_A) in ws_report.qdrant_orphan_sources
+    mc.labels.assert_any_call(drift_type=DRIFT_QDRANT_ORPHAN)
+    mc.labels.return_value.inc.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_orphan_deletion_is_bounded() -> None:
+    """Orphan deletion must not exceed ``orphan_limit`` per tick."""
+    limit = 5
+    worker, vector_store, _gs = _build_worker(
+        active_source_ids=[],
+        chunks_by_source={str(_SRC_A): 100},  # 100 orphan chunks
+        entities_by_source={},
+        orphan_limit=limit,
+    )
+    # Make _qc.count return 100 and scroll return `limit` records
+    count_result = MagicMock()
+    count_result.count = 100
+    vector_store._qc.count = AsyncMock(return_value=count_result)
+
+    fake_records = [MagicMock(id=uuid.uuid4()) for _ in range(limit)]
+    vector_store._qc.scroll = AsyncMock(return_value=(fake_records, None))
+    vector_store._qc.delete = AsyncMock()
+
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as mc,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        mc.labels.return_value.inc = MagicMock()
+        report = await worker.run_once()
+
+    ws_report = report.per_workspace[0]
+    # Deleted count bounded by limit
+    assert ws_report.qdrant_orphans_deleted <= limit
+    # Qdrant delete was called with at most `limit` point IDs
+    if vector_store._qc.delete.called:
+        call_args = vector_store._qc.delete.call_args
+        selector = call_args.kwargs.get("points_selector") or call_args.args[1]
+        assert len(selector.points) <= limit
+
+
+# ---------------------------------------------------------------------------
+# Drift type C: Neo4j orphan (entities with no PG source)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_neo4j_orphan_detected() -> None:
+    """Entity nodes in Neo4j for a source absent from PG should be reported."""
+    worker, _vs, _gs = _build_worker(
+        active_source_ids=[],  # PG has no documents
+        chunks_by_source={},
+        entities_by_source={str(_SRC_A): 7},
+    )
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as mc,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        mc.labels.return_value.inc = MagicMock()
+        report = await worker.run_once()
+
+    ws_report = report.per_workspace[0]
+    assert str(_SRC_A) in ws_report.neo4j_orphan_sources
+    mc.labels.assert_any_call(drift_type=DRIFT_NEO4J_ORPHAN)
+    mc.labels.return_value.inc.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_neo4j_orphan_no_deletion() -> None:
+    """Neo4j orphans must NOT trigger any Neo4j delete (deferred to retention)."""
+    worker, _vs, graph_store = _build_worker(
+        active_source_ids=[],
+        chunks_by_source={},
+        entities_by_source={str(_SRC_A): 7},
+    )
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as mc,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        mc.labels.return_value.inc = MagicMock()
+        await worker.run_once()
+
+    # No mutation method should have been called on the graph store
+    if hasattr(graph_store, "delete_by_source"):
+        graph_store.delete_by_source.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_twice_no_double_delete() -> None:
+    """Two consecutive runs on the same orphan state produce the same result."""
+    chunks_by_source = {str(_SRC_A): 2}
+
+    count_result = MagicMock()
+    count_result.count = 2
+    fake_records = [MagicMock(id=uuid.uuid4()), MagicMock(id=uuid.uuid4())]
+
+    # Build two workers that share the same store mocks but independent sessions.
+    def _build_idempotent_worker() -> tuple[ReconcileWorker, AsyncMock]:
+        factory = _make_session_factory(active_source_ids=[])
+        vs = _make_vector_store(chunks_by_source=chunks_by_source)
+        vs._qc.count = AsyncMock(return_value=count_result)
+        vs._qc.scroll = AsyncMock(return_value=(fake_records, None))
+        vs._qc.delete = AsyncMock()
+        gs = _make_graph_store()
+        w = ReconcileWorker(
+            session_factory=factory,
+            vector_store=vs,
+            graph_store=gs,
+            settings=_make_settings(),
+        )
+        return w, vs
+
+    worker1, _vs1 = _build_idempotent_worker()
+    worker2, _vs2 = _build_idempotent_worker()
+
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL") as mc,
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        mc.labels.return_value.inc = MagicMock()
+        r1 = await worker1.run_once()
+        r2 = await worker2.run_once()
+
+    # Both runs should detect the same orphan
+    assert r1.per_workspace[0].qdrant_orphan_sources == r2.per_workspace[0].qdrant_orphan_sources
+
+
+# ---------------------------------------------------------------------------
+# last_report
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_report_is_populated_after_run() -> None:
+    worker, _, _ = _build_worker()
+    assert worker.last_report is None
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        await worker.run_once()
+    assert worker.last_report is not None
+    assert isinstance(worker.last_report, ReconcileRunReport)
+
+
+# ---------------------------------------------------------------------------
+# stop() / lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_stop_sets_running_false() -> None:
+    worker, _, _ = _build_worker()
+    worker._running = True
+    worker.stop()
+    assert worker._running is False
+
+
+# ---------------------------------------------------------------------------
+# Multiple workspaces — each gets its own report row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multiple_workspaces_separate_reports() -> None:
+    ws2 = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000099")
+    # Build a factory that returns two workspace IDs on the first call,
+    # then empty active source sets for both.
+    ws_result = MagicMock()
+    ws_result.all.return_value = [(_WS,), (ws2,)]
+    empty_src = MagicMock()
+    empty_src.all.return_value = []
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[ws_result, empty_src, empty_src] * 10)
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    session.begin = MagicMock(return_value=tx)
+    factory = MagicMock()
+    factory.return_value = cm
+
+    vs = _make_vector_store()
+    gs = _make_graph_store()
+    worker = ReconcileWorker(
+        session_factory=factory,
+        vector_store=vs,
+        graph_store=gs,
+        settings=_make_settings(),
+    )
+
+    with (
+        patch("omniscience_server.reconcile_worker.RECONCILE_DRIFT_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_RUNS_TOTAL"),
+        patch("omniscience_server.reconcile_worker.RECONCILE_WORKER_DURATION_SECONDS"),
+    ):
+        report = await worker.run_once()
+
+    assert len(report.per_workspace) == 2
+    ws_ids = {r.workspace_id for r in report.per_workspace}
+    assert _WS in ws_ids
+    assert ws2 in ws_ids


### PR DESCRIPTION
## Summary

Conceptual findings from the multi-agent review, implemented. **Stacked on #304** (`fix/multi-store-integrity`) — review/merge that first; this PR's base will retarget to `main` automatically once #304 lands.

Two of these were owner-chosen to take the **ambitious** option (full vector versioning, full BM25/RRF) rather than the cheaper documentation-only path.

## What's in here

### Bitemporal vector — close the graph↔vector `as_of` gap
Content updates **end-date** old Qdrant points (`valid_to=now`) instead of deleting them, so the vector store is append-only versioned, symmetric to Neo4j. All read paths (dense / sparse / hybrid / count / scroll) apply a **current-only filter** (`valid_to` absent) when `as_of` is None, and the bitemporal predicate when `as_of=T`.
- ⚠️ This was the subtle bug a contract test caught: end-dating without the current filter leaks old versions as duplicates — exactly the original duplication problem, one level deeper. Fixed and covered.
- Deliberate trade-off vs ADR-0008 §5 (current-state no longer predicate-free) — documented in the ADR-0008 amendment.

### Hybrid retrieval — real BM25/RRF (ADR-0004 was aspirational)
- `sparse_bm25` named vector added to the collection; sparse stage fused with dense via **RRF (k=60)**; graph-affinity retained as a third signal
- `retrieval_strategy` (hybrid/keyword/structural/auto) is now actually dispatched; `QueryStats.text_matches` reflects real sparse hits
- `scripts/reindex_qdrant_hybrid.py` backfills sparse vectors (idempotent, `--dry-run`)
- **Requires reindex on deploy** — collection schema changed (dense → dense+sparse)

### Enumerate mode — 100% recall for "how many X / all Y"
scroll + native exact count over payload indexes (no HNSW), dedup by `document_id`, payload indexes for common `metadata.*` dimensions. This is the fix for the recall<100% we hit asking "which load balancers exist".

### Reconcile worker — multi-store write drift
IndexWriter isn't a saga; a crash between the Postgres commit and Qdrant/Neo4j writes leaves permanent drift. New periodic worker detects three drift types (`pg_missing_qdrant` → marks ingestion_run partial, `qdrant_orphan` → bounded delete, `neo4j_orphan` → logged), metric `omniscience_reconcile_drift_total`. `writer.py` docstring corrected (dropped the misleading "atomically").

### Auth — remove NULL-tenant exposure
`workspace_filter` no longer exposes NULL-tenant rows to every workspace; `get_workspace_id` fails closed (global `PermissionError→403` handler); alembic `0010` backfills NULL `tenant_id`/`workspace_id` to the default workspace before the strict filter applies.

## Tests
- 66 Qdrant **contract** tests (real container) + 10 bitemporal **property** tests green — these caught the duplicate-version bug that mocks missed
- ~413 unit tests across auth / retrieval / reconcile / stats / mcp / rest green
- `ruff check .` and `ruff format --check .` clean

## Deploy notes
- **Reindex required**: run `scripts/reindex_qdrant_hybrid.py` after deploy (sparse-vector backfill on existing points)
- **Migration**: alembic `0010` backfills NULL tenant rows — run before the new auth filter is live
- CI contract tests run against Qdrant `v1.12.4` while prod is `v1.17.1` (pre-existing version skew, flagged separately) — all APIs used are supported on both, but worth aligning

## ADRs amended
0004 (retrieval strategy), 0006 (Qdrant store), 0008 (bitemporal) + architecture.md §3-4 corrected.
