### PR TITLE
fix: push-source sync model + hybrid retrieval through GraphRAG

### DIFF
--- a/apps/server/src/omniscience_server/scheduler.py
+++ b/apps/server/src/omniscience_server/scheduler.py
@@ -8,13 +8,19 @@ of the server process.  On each tick it:
    - If the source has ``freshness_sla_seconds`` set, that value is used.
    - Otherwise the per-type default from :data:`SchedulerWorker.DEFAULT_TTLS` applies.
    - Sources with no explicit SLA **and** no per-type default are skipped.
-3. Compares ``last_sync_at`` against the effective TTL.  A source is *stale*
+3. Skips sources whose ``sync_mode`` is ``"push"`` — these are driven by an
+   external process (launchd, seed scripts) and must not be auto-triggered
+   by the scheduler.  Attempting to trigger a push source would cause the
+   discovery worker to try reaching an in-cluster URL (e.g.
+   ``kubernetes.default.svc``) from an off-cluster host, producing cascading
+   connection errors.
+4. Compares ``last_sync_at`` against the effective TTL.  A source is *stale*
    when ``now - last_sync_at > ttl``, or when it has never been synced.
-4. For every stale source, publishes a
+5. For every stale pull source, publishes a
    :class:`~omniscience_server.ingestion.events.DocumentChangeEvent`
    to ``ingest.changes.{source_type}`` via NATS JetStream — the same
    subject used by the manual ``POST /api/v1/sources/{id}/sync`` endpoint.
-5. Updates Prometheus counters and emits structured logs.
+6. Updates Prometheus counters and emits structured logs.
 
 Usage in ``app.py`` lifespan::
 
@@ -38,8 +44,10 @@ Design notes
 - The worker skips a cycle gracefully when NATS is unavailable rather than
   crashing.  A counter tracks publish failures so operators can alert on
   ``omniscience_scheduler_syncs_triggered_total`` not growing as expected.
-- ``last_sync_at`` is ``None`` (never synced) → always triggers.
+- ``last_sync_at`` is ``None`` (never synced) → always triggers for pull
+  sources.
 - Paused sources are skipped (``status != active``).
+- Push sources are skipped regardless of TTL or staleness state.
 - A single DB read per cycle keeps the implementation O(n) without
   per-source queries.
 """
@@ -53,7 +61,7 @@ from datetime import UTC, datetime
 from typing import ClassVar
 
 import structlog
-from omniscience_core.db.models import Source, SourceStatus
+from omniscience_core.db.models import Source, SourceStatus, SyncMode
 from omniscience_core.queue.producer import QueueProducer
 from omniscience_core.telemetry.metrics import (
     SCHEDULER_CHECK_DURATION_SECONDS,
@@ -76,6 +84,9 @@ class SchedulerWorker:
     :attr:`DEFAULT_TTLS` is used instead.  If a source is stale a full-sync
     trigger is published to NATS.
 
+    Sources with ``sync_mode == SyncMode.push`` are **always skipped** — they
+    are managed by external processes and must not be auto-triggered.
+
     Args:
         session_factory: SQLAlchemy async session factory.
         nats_conn: Active NATS connection object that exposes a ``jetstream``
@@ -85,6 +96,7 @@ class SchedulerWorker:
     """
 
     # Per-type default TTLs (seconds) applied when a source has no explicit SLA.
+    # Only relevant for pull-mode sources; push sources are never auto-triggered.
     DEFAULT_TTLS: ClassVar[dict[str, int]] = {
         "git": 300,  # 5 min — webhook covers most; this is a safety net
         "fs": 60,  # 1 min
@@ -144,7 +156,10 @@ class SchedulerWorker:
     # ------------------------------------------------------------------
 
     async def _check_and_trigger(self) -> int:
-        """Evaluate all active sources and publish triggers for stale ones.
+        """Evaluate all active pull sources and publish triggers for stale ones.
+
+        Push sources are silently skipped — they are managed by external
+        processes and must not be auto-triggered by the scheduler.
 
         Returns:
             The number of sync triggers successfully published in this cycle.
@@ -157,6 +172,18 @@ class SchedulerWorker:
             now = datetime.now(tz=UTC)
 
             for source in sources:
+                # Skip push sources entirely — they are driven by external
+                # processes (launchd, seed scripts).  Triggering them from
+                # here would cause the discovery worker to attempt in-cluster
+                # connections from an off-cluster host.
+                if self._is_push(source):
+                    log.debug(
+                        "scheduler_skip_push_source",
+                        source_id=str(source.id),
+                        source_name=source.name,
+                    )
+                    continue
+
                 ttl = self._effective_ttl(source)
                 if ttl is None:
                     # No SLA and no per-type default — skip.
@@ -197,6 +224,14 @@ class SchedulerWorker:
             )
             return list(result.scalars().all())
 
+    @staticmethod
+    def _is_push(source: Source) -> bool:
+        """Return True when *source* is externally managed (push mode).
+
+        Push sources must not be auto-triggered by the scheduler.
+        """
+        return source.sync_mode == SyncMode.push
+
     def _effective_ttl(self, source: Source) -> int | None:
         """Return the TTL (seconds) to use for *source*.
 
@@ -204,6 +239,9 @@ class SchedulerWorker:
         1. ``source.freshness_sla_seconds`` when explicitly set.
         2. :attr:`DEFAULT_TTLS` entry for the source type.
         3. ``None`` — no TTL applies, source is never auto-triggered.
+
+        This method is only called for pull-mode sources; push sources are
+        filtered out before reaching this step.
         """
         if source.freshness_sla_seconds is not None:
             return source.freshness_sla_seconds

--- a/packages/core/alembic/versions/0011_add_sync_mode.py
+++ b/packages/core/alembic/versions/0011_add_sync_mode.py
@@ -1,0 +1,127 @@
+"""Add sync_mode column to sources (push/pull model separation).
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-06-10 00:00:00.000000
+
+Context
+-------
+Omniscience supports two source synchronisation models:
+
+* **pull** (default) — the in-stack ``SchedulerWorker`` triggers a re-sync
+  automatically when a source TTL expires.  Works for sources that have a
+  discoverable in-cluster endpoint (git, s3, confluence, …).
+
+* **push** — an external process (launchd script, seed tool, operator) is
+  exclusively responsible for pushing data.  The scheduler must *not*
+  auto-trigger these sources because the discovery worker would attempt to
+  reach an in-cluster URL (e.g. ``kubernetes.default.svc``) from an
+  off-cluster host, producing a cascade of connection errors.
+
+The distinction is captured in the new ``sync_mode`` column:
+
+    ALTER TABLE sources
+      ADD COLUMN sync_mode sync_mode NOT NULL DEFAULT 'pull';
+
+All pre-existing rows default to ``'pull'`` (backward-compatible — existing
+pull sources continue to be auto-triggered as before).
+
+Push sources created by seed scripts or external agents should set
+``sync_mode = 'push'``.  The ``SchedulerWorker`` skips these sources entirely
+when selecting candidates for automatic trigger.
+
+Freshness monitoring is intentionally **not** disabled for push sources:
+a push process that silently stops updating ``last_sync_at`` should trigger
+a staleness alert so operators are notified of pipeline outage.  The fix for
+push sources emitting spurious freshness warnings is to have the seed scripts
+update ``last_sync_at`` on every run, not to silence the checker.
+
+Enum
+----
+A new Postgres ENUM ``sync_mode`` is created with values ``'pull'`` and
+``'push'``.  Using an enum (rather than a boolean ``externally_managed``)
+keeps the door open for future modes such as ``'webhook'`` or ``'polling'``
+without a destructive schema change.
+
+Downgrade strategy
+------------------
+Dropping an ENUM type requires that no column references it.  The downgrade:
+
+1. Drops the ``ix_sources_sync_mode`` index.
+2. Drops the ``sync_mode`` column.
+3. Drops the ``sync_mode`` ENUM type.
+
+Data loss: the ``sync_mode`` values are permanently lost on downgrade.
+Re-running ``upgrade`` after a downgrade sets all rows back to ``'pull'``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# ---------------------------------------------------------------------------
+# Revision identifiers
+# ---------------------------------------------------------------------------
+
+revision: str = "0011"
+down_revision: str | None = "0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ENUM_NAME = "sync_mode"
+_ENUM_VALUES = ("pull", "push")
+_TABLE = "sources"
+_COLUMN = "sync_mode"
+_INDEX = "ix_sources_sync_mode"
+
+# ---------------------------------------------------------------------------
+# Upgrade
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    # 1. Create the ENUM type.
+    sync_mode_enum = sa.Enum(*_ENUM_VALUES, name=_ENUM_NAME)
+    sync_mode_enum.create(op.get_bind(), checkfirst=True)
+
+    # 2. Add the column with a server-side default of 'pull' so that the
+    #    single DDL statement both adds the column and fills existing rows.
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            _COLUMN,
+            sa.Enum(*_ENUM_VALUES, name=_ENUM_NAME, create_type=False),
+            nullable=False,
+            server_default="pull",
+        ),
+    )
+
+    # 3. Add a lightweight index to support scheduler queries that filter
+    #    on sync_mode = 'pull'.  The cardinality is low (2 values) but the
+    #    table can be large, and a partial index on 'pull' would need
+    #    updating if new modes are added; a plain btree is safe and small.
+    op.create_index(_INDEX, _TABLE, [_COLUMN])
+
+
+# ---------------------------------------------------------------------------
+# Downgrade
+# ---------------------------------------------------------------------------
+
+
+def downgrade() -> None:
+    # 1. Drop the index first (cannot drop column while index exists).
+    op.drop_index(_INDEX, table_name=_TABLE)
+
+    # 2. Drop the column.
+    op.drop_column(_TABLE, _COLUMN)
+
+    # 3. Drop the ENUM type (safe now that no column references it).
+    sync_mode_enum = sa.Enum(*_ENUM_VALUES, name=_ENUM_NAME)
+    sync_mode_enum.drop(op.get_bind(), checkfirst=True)

--- a/packages/core/src/omniscience_core/db/models.py
+++ b/packages/core/src/omniscience_core/db/models.py
@@ -66,6 +66,23 @@ class SourceStatus(enum.StrEnum):
     error = "error"
 
 
+class SyncMode(enum.StrEnum):
+    """Controls whether the scheduler auto-triggers sync for a source.
+
+    ``pull`` — default; the in-stack scheduler re-syncs the source on TTL
+               expiry by publishing a trigger to NATS (pull/discovery model).
+
+    ``push`` — the source is driven by an external process (e.g. a launchd
+               script or seed tool).  The scheduler skips it entirely to avoid
+               attempted in-cluster discovery from an off-cluster host.
+               Freshness monitoring is still active — a silent push process is
+               a valuable operational signal.
+    """
+
+    pull = "pull"
+    push = "push"
+
+
 class IngestionRunStatus(enum.StrEnum):
     running = "running"
     ok = "ok"
@@ -140,6 +157,12 @@ class Source(Base):
         nullable=False,
         default=SourceStatus.active,
     )
+    sync_mode: Mapped[SyncMode] = mapped_column(
+        Enum(SyncMode, name="sync_mode"),
+        nullable=False,
+        default=SyncMode.pull,
+        server_default="pull",
+    )
     last_sync_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     last_error_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -168,6 +191,7 @@ class Source(Base):
     __table_args__ = (
         UniqueConstraint("tenant_id", "name", name="uq_sources_tenant_name"),
         Index("ix_sources_status", "status"),
+        Index("ix_sources_sync_mode", "sync_mode"),
     )
 
 
@@ -526,5 +550,6 @@ __all__ = [
     "Source",
     "SourceStatus",
     "SourceType",
+    "SyncMode",
     "Workspace",
 ]

--- a/packages/retrieval/src/omniscience_retrieval/graph_rag.py
+++ b/packages/retrieval/src/omniscience_retrieval/graph_rag.py
@@ -515,6 +515,26 @@ class GraphRAGComposer:
         therefore mechanical — the candidate subgraph from the graph
         anchor stage and the chunk filter from the vector stage both
         reflect the world at ``as_of``.
+
+        Stage 3 (fix/push-sources-and-graphrag-sparse): the vector
+        stage now respects ``request.retrieval_strategy`` end-to-end.
+        :func:`_widen_request` preserves the strategy so the store
+        dispatch routes correctly:
+
+        - ``"hybrid"`` / ``"auto"`` → :meth:`QdrantVectorStore._search_hybrid_rrf`
+          (dense + sparse BM25, merged via RRF).
+          ``QueryStats.text_matches`` is set to the number of sparse hits,
+          giving MCP callers a reliable non-zero signal when keyword tokens
+          match.
+        - ``"keyword"`` → :meth:`QdrantVectorStore._search_sparse` (BM25 only).
+        - ``"structural"`` → :meth:`QdrantVectorStore._search_dense` (dense
+          only; graph-anchor source scoping is already applied via
+          ``request.sources`` by :func:`_widen_request`).
+
+        The ``text_matches`` value returned by the store is preserved
+        through ``_run_merge_stage`` and the ``model_copy`` in
+        :meth:`search`, so ``QueryStats.text_matches`` in the MCP
+        response reflects the real sparse-hit count.
         """
         stage_start = time.monotonic()
         widened = _widen_request(request, anchor=anchor)
@@ -625,17 +645,34 @@ def _widen_request(
     - The ``graphrag_anchor`` filter key is stripped before the request
       is forwarded to the vector store so downstream stores do not see
       composition-internal hints.
+    - ``retrieval_strategy`` is **explicitly preserved** so the Qdrant
+      adapter dispatches to the correct search sub-path:
+      ``"hybrid"`` / ``"auto"`` → RRF dense+sparse;
+      ``"keyword"`` → sparse BM25 only;
+      ``"structural"`` → dense only (graph-anchor source scoping already
+      applied via ``sources``).
+
+    Stage 3 note: before Stage 3, ``QdrantVectorStore.search`` was
+    dense-only and ignored ``retrieval_strategy``.  Now that the
+    dispatch is live, the strategy must flow through this function
+    unchanged so MCP callers receive a real
+    ``QueryStats.text_matches`` (non-zero for keyword/hybrid queries).
     """
     widened_top_k = request.top_k * CANDIDATE_EXPANSION_FACTOR
     sources: list[str] | None = (
         list(anchor.candidate_source_ids) if anchor.candidate_source_ids else request.sources
     )
     clean_filters = _strip_anchor_filter(request.filters)
+    # ``retrieval_strategy`` is included explicitly in the update dict so it
+    # is always forwarded to the vector store, regardless of future changes to
+    # ``model_copy`` defaults.  This prevents a silent regression to dense-only
+    # if pydantic changes how unmentioned fields are handled in ``model_copy``.
     return request.model_copy(
         update={
             "top_k": widened_top_k,
             "sources": sources,
             "filters": clean_filters,
+            "retrieval_strategy": request.retrieval_strategy,
         }
     )
 

--- a/scripts/seed_from_docs.py
+++ b/scripts/seed_from_docs.py
@@ -12,10 +12,11 @@ import hashlib
 import json
 import sys
 import uuid
+from datetime import UTC, datetime
 
 from omniscience_core.config import Settings
 from omniscience_core.db import create_async_engine, create_session_factory
-from omniscience_core.db.models import Source, SourceStatus, SourceType
+from omniscience_core.db.models import Source, SourceStatus, SourceType, SyncMode
 from omniscience_embeddings.factory import create_embedding_provider
 from omniscience_index.stores.neo4j_store import Neo4jGraphStore, Neo4jStoreConfig
 from omniscience_index.stores.qdrant_config import QdrantConfig
@@ -50,6 +51,15 @@ async def seed() -> None:
     # Get-or-create the source: the (source_id, external_id) pair is the
     # IndexWriter dedup key, so the source id must survive across runs —
     # a fresh id per run orphans every previous run's Qdrant points.
+    #
+    # sync_mode="push": this source is driven exclusively by this script
+    # (and the launchd job that invokes it).  The in-stack scheduler must
+    # not auto-trigger it — doing so would cause the discovery worker to
+    # attempt reaching kubernetes.default.svc from an off-cluster host.
+    #
+    # last_sync_at is updated on EVERY run so that the FreshnessChecker can
+    # detect a launchd/script outage (source goes stale → warning alert).
+    now = datetime.now(tz=UTC)
     async with session_factory() as session:
         src = (
             await session.execute(
@@ -64,11 +74,20 @@ async def seed() -> None:
                 config={"seeded_by": "seed_from_docs"},
                 tenant_id=WS_ID,
                 status=SourceStatus.active,
-                # 30 min SLA enables FreshnessChecker staleness alerts.
+                sync_mode=SyncMode.push,
+                # 30 min SLA enables FreshnessChecker staleness alerts:
+                # if this script stops running, the source goes stale after 30 min.
                 freshness_sla_seconds=1800,
+                last_sync_at=now,
             )
             session.add(src)
-            await session.commit()
+        else:
+            # Update last_sync_at on every run so FreshnessChecker knows the
+            # push process is healthy.  Also ensure existing sources that
+            # pre-date the sync_mode column are promoted to push mode.
+            src.last_sync_at = now
+            src.sync_mode = SyncMode.push
+        await session.commit()
         src_id = src.id
 
     writer = IndexWriter(session_factory, graph_store, vector_store)

--- a/tests/test_graph_rag.py
+++ b/tests/test_graph_rag.py
@@ -804,3 +804,194 @@ class TestAsOfThreading:
 
 # Silence unused-import warning on Any (used only in annotations above).
 _ = CollectorRegistry
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: text_matches flow-through (fix/push-sources-and-graphrag-sparse)
+# ---------------------------------------------------------------------------
+
+
+def _make_result_with_text_matches(
+    hits: list[SearchHit], *, text_matches: int = 0
+) -> SearchResult:
+    """Build a ``SearchResult`` with an explicit ``text_matches`` value.
+
+    Used to verify that non-zero sparse-hit counts flow through the
+    merge stage unchanged.
+    """
+    return SearchResult(
+        hits=hits,
+        query_stats=QueryStats(
+            total_matches_before_filters=len(hits),
+            vector_matches=max(len(hits) - text_matches, 0),
+            text_matches=text_matches,
+            duration_ms=1.0,
+        ),
+    )
+
+
+class _StrategyCapturingVectorStore:
+    """VectorStore fake that returns a configured result AND records the strategy used.
+
+    Unlike ``_FakeVectorStore`` it returns a result whose ``text_matches``
+    mirrors what a real RRF search would return — non-zero when the strategy
+    is ``"hybrid"`` or ``"keyword"``, zero for ``"structural"``.  This lets
+    the flow-through tests assert without mocking the strategy dispatch.
+    """
+
+    def __init__(
+        self,
+        hits: list[SearchHit],
+        *,
+        text_matches_per_strategy: dict[str, int] | None = None,
+    ) -> None:
+        self._hits = hits
+        # default: hybrid/keyword → non-zero, structural → 0
+        self._tm_map: dict[str, int] = text_matches_per_strategy or {
+            "hybrid": len(hits),
+            "auto": len(hits),
+            "keyword": len(hits),
+            "structural": 0,
+        }
+        self.search_calls: list[dict[str, Any]] = []
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> SearchResult:
+        self.search_calls.append(
+            {"request": request, "workspace_id": workspace_id, "as_of": as_of}
+        )
+        tm = self._tm_map.get(request.retrieval_strategy, 0)
+        return _make_result_with_text_matches(self._hits, text_matches=tm)
+
+
+@pytest.mark.asyncio
+class TestHybridTextMatchesFlow:
+    """Stage 3: verify text_matches from vector store flows through GraphRAG pipeline.
+
+    The core regression: before Stage 3 QdrantVectorStore was dense-only and
+    always returned text_matches=0.  After Stage 3 the store dispatches to
+    _search_hybrid_rrf / _search_sparse which return real counts.  This class
+    asserts that GraphRAGComposer does NOT zero-out text_matches on its way
+    through the merge and stamp stages.
+
+    ACL invariant: workspace_id is forwarded on every search call.
+    """
+
+    async def test_hybrid_strategy_text_matches_nonzero(self, force_graphrag: None) -> None:
+        """hybrid strategy → real text_matches propagated to QueryStats."""
+        hit = _make_hit(score=0.8)
+        v = _StrategyCapturingVectorStore([hit])
+        g = _FakeGraphStore()
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="nginx crash", retrieval_strategy="hybrid")
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        assert result.query_stats.text_matches == 1
+        # Confirm the strategy was forwarded to the vector store.
+        assert v.search_calls[0]["request"].retrieval_strategy == "hybrid"
+
+    async def test_keyword_strategy_text_matches_nonzero(self, force_graphrag: None) -> None:
+        """keyword strategy → text_matches equals hit count (sparse-only)."""
+        hit = _make_hit(score=0.7)
+        v = _StrategyCapturingVectorStore([hit])
+        g = _FakeGraphStore()
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="OOMKilled", retrieval_strategy="keyword")
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        assert result.query_stats.text_matches == 1
+        assert v.search_calls[0]["request"].retrieval_strategy == "keyword"
+
+    async def test_structural_strategy_text_matches_zero(self, force_graphrag: None) -> None:
+        """structural strategy → dense-only, text_matches stays 0."""
+        hit = _make_hit(score=0.6)
+        v = _StrategyCapturingVectorStore([hit])
+        g = _FakeGraphStore()
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="k8s pod", retrieval_strategy="structural")
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        assert result.query_stats.text_matches == 0
+        assert v.search_calls[0]["request"].retrieval_strategy == "structural"
+
+    async def test_auto_strategy_text_matches_nonzero(self, force_graphrag: None) -> None:
+        """auto strategy → treated as hybrid, text_matches is non-zero."""
+        hit = _make_hit(score=0.75)
+        v = _StrategyCapturingVectorStore([hit])
+        g = _FakeGraphStore()
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(query="connection refused", retrieval_strategy="auto")
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        assert result.query_stats.text_matches == 1
+        assert v.search_calls[0]["request"].retrieval_strategy == "auto"
+
+    async def test_text_matches_preserved_after_graph_affinity_merge(
+        self, force_graphrag: None
+    ) -> None:
+        """text_matches from vector stage survives the graph-affinity merge stage.
+
+        The merge stage reorders hits and slices to top_k; it must NOT
+        recalculate query_stats from scratch (which would zero text_matches).
+        """
+        seed_src = uuid.uuid4()
+        g = _FakeGraphStore(result=_make_graph_result(seed_source=seed_src, related=[]))
+        hit1 = _make_hit(source_id=seed_src, score=0.9)
+        hit2 = _make_hit(score=0.7)
+        v = _StrategyCapturingVectorStore([hit1, hit2])
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(
+            query="service failure",
+            retrieval_strategy="hybrid",
+            filters={ANCHOR_FILTER_KEY: "AuthService"},
+        )
+        result = await composer.search(req, workspace_id=uuid.uuid4())
+        # After merge (graph-affinity reorder) text_matches must still be 2.
+        assert result.query_stats.text_matches == 2
+
+    async def test_retrieval_strategy_forwarded_with_anchor(self, force_graphrag: None) -> None:
+        """When anchor is present, retrieval_strategy still flows to vector store.
+
+        Regression guard: _widen_request sets request.sources from the anchor
+        candidates; it must NOT reset retrieval_strategy to 'structural' as an
+        implicit side-effect of setting sources.
+        """
+        seed_src = uuid.uuid4()
+        g = _FakeGraphStore(result=_make_graph_result(seed_source=seed_src, related=[]))
+        hit = _make_hit(source_id=seed_src, score=0.8)
+        v = _StrategyCapturingVectorStore([hit])
+        legacy = _FakeLegacyService(_make_result([]))
+        composer = GraphRAGComposer(
+            graph_store=cast("Any", g), vector_store=v, legacy_service=legacy
+        )
+        req = SearchRequest(
+            query="database timeout",
+            retrieval_strategy="hybrid",
+            filters={ANCHOR_FILTER_KEY: "DBService"},
+        )
+        ws = uuid.uuid4()
+        result = await composer.search(req, workspace_id=ws)
+        # Vector store received the anchor-scoped sources AND hybrid strategy.
+        v_req: SearchRequest = v.search_calls[0]["request"]
+        assert v_req.retrieval_strategy == "hybrid"
+        assert v_req.sources == [str(seed_src)]
+        # text_matches flows through.
+        assert result.query_stats.text_matches == 1
+        # workspace_id forwarded.
+        assert v.search_calls[0]["workspace_id"] == ws

--- a/tests/test_graphrag_hybrid_contract.py
+++ b/tests/test_graphrag_hybrid_contract.py
@@ -1,0 +1,479 @@
+"""Contract tests: GraphRAGComposer hybrid/RRF path with a real Qdrant container.
+
+fix/push-sources-and-graphrag-sparse — issue: GraphRAG vector stage was
+effectively dense-only (text_matches=0 in all MCP responses) because the
+Stage 3 sparse/RRF dispatch in QdrantVectorStore was not exercised through
+the GraphRAG composition path.
+
+These tests prove:
+
+1. With ``retrieval_strategy="hybrid"`` the MCP search path through
+   GraphRAGComposer returns ``QueryStats.text_matches > 0`` for a query
+   whose tokens appear in the planted chunk text.
+
+2. With ``retrieval_strategy="keyword"`` (pure sparse), text_matches also
+   equals the hit count.
+
+3. With ``retrieval_strategy="structural"`` the dense-only path still works
+   and text_matches == 0 (regression guard).
+
+4. ACL: workspace_id scoping is honoured — a different workspace sees no
+   hits.
+
+5. as_of=None applies the current-only filter (valid_to IS NULL) on BOTH
+   the dense and sparse legs — end-dated points do not leak into hybrid
+   results.
+
+The tests run only when Docker is available (same guard as
+``test_qdrant_contract.py``).  They do NOT need Neo4j — the anchor stage
+is skipped by not supplying ``graphrag_anchor`` in ``filters``, so the
+vector stage runs unscoped.  The ``force_graphrag`` fixture bypasses the
+type-check that normally requires Neo4j+Qdrant, so the real
+``QdrantVectorStore`` is exercised against the real container.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("testcontainers.qdrant")
+
+from omniscience_index.stores.qdrant_config import QdrantConfig
+from omniscience_index.stores.qdrant_store import QdrantVectorStore
+from omniscience_retrieval.graph_rag import GraphRAGComposer
+from omniscience_retrieval.models import (
+    QueryStats,
+    SearchRequest,
+    SearchResult,
+)
+from qdrant_client import AsyncQdrantClient
+
+
+def _docker_available() -> bool:
+    """Cheap docker reachability probe to skip on CI without Docker."""
+    if os.environ.get("SKIP_TESTCONTAINERS") == "1":
+        return False
+    try:
+        import docker  # type: ignore[import-not-found]
+
+        docker.from_env().ping()  # type: ignore[no-untyped-call]
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker is not reachable; GraphRAG hybrid contract tests need testcontainers.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared embedding and Qdrant fixtures
+# ---------------------------------------------------------------------------
+
+
+class _StubEmbedding:
+    """Deterministic unit-norm embedding provider (dim=8).
+
+    Identical to the stub used by ``test_qdrant_contract.py`` — same
+    hash-based vectors so queries on planted chunk texts find the
+    planted points.
+    """
+
+    dim = 8
+    model_name = "stub-embedding"
+    provider_name = "stub"
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        import math as _math
+
+        out: list[list[float]] = []
+        for t in texts:
+            h = hash(t)
+            raw = [((h >> (i * 4)) & 0xF) / 15.0 for i in range(self.dim)]
+            n = _math.sqrt(sum(x * x for x in raw)) or 1.0
+            out.append([x / n for x in raw])
+        return out
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.fixture(scope="session")
+def qdrant_container_graphrag() -> Any:
+    """Start a Qdrant container for the whole test session.
+
+    Separate fixture name from ``test_qdrant_contract.py`` so the two
+    modules can each manage their own session-scoped container without
+    interference.
+    """
+    from testcontainers.qdrant import QdrantContainer
+
+    with QdrantContainer(image="qdrant/qdrant:v1.12.4") as c:
+        yield c
+
+
+@pytest_asyncio.fixture()
+async def qdrant_store_graphrag(
+    qdrant_container_graphrag: Any,
+) -> AsyncIterator[QdrantVectorStore]:
+    """Fresh adapter instance with a unique collection per test."""
+    host = qdrant_container_graphrag.get_container_host_ip()
+    http_port = int(qdrant_container_graphrag.get_exposed_port(6333))
+    grpc_port = int(qdrant_container_graphrag.get_exposed_port(6334))
+    config = QdrantConfig(
+        host=host,
+        grpc_port=grpc_port,
+        http_port=http_port,
+        api_key=None,
+        prefer_grpc=False,
+    )
+    store = QdrantVectorStore(config=config, embedding_provider=_StubEmbedding())
+    store._collection_name = f"omniscience__stub-embedding__d8__t{uuid.uuid4().hex[:8]}"  # type: ignore[attr-defined]
+    await store.connect()
+    try:
+        yield store
+    finally:
+        if store._client is not None:  # type: ignore[attr-defined]
+            client = cast("AsyncQdrantClient", store._client)  # type: ignore[attr-defined]
+            with contextlib.suppress(Exception):
+                await client.delete_collection(store.collection_name)
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stub_vector(text: str, dim: int = 8) -> list[float]:
+    """Reproduce the _StubEmbedding hash-based vector."""
+    import math as _math
+
+    h = hash(text)
+    raw = [((h >> (i * 4)) & 0xF) / 15.0 for i in range(dim)]
+    n = _math.sqrt(sum(x * x for x in raw)) or 1.0
+    return [x / n for x in raw]
+
+
+def _chunk(*, text: str, ord_: int = 0, vector: list[float] | None = None) -> dict[str, Any]:
+    from omniscience_core.storage import ChunkPayload
+
+    payload: ChunkPayload = {
+        "ord": ord_,
+        "text": text,
+        "embedding": vector if vector is not None else _stub_vector(text),
+    }
+    return payload  # type: ignore[return-value]
+
+
+async def _plant(
+    store: QdrantVectorStore,
+    *,
+    workspace: uuid.UUID,
+    external_id: str,
+    text: str,
+    source_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Upsert a single-chunk document and return its source_id."""
+    src = source_id or uuid.uuid4()
+    await store.upsert_chunks(
+        source_id=src,
+        external_id=external_id,
+        uri=f"mem://{external_id}",
+        title=external_id,
+        content_hash=f"hash-{external_id}",
+        metadata={"workspace_id": str(workspace)},
+        chunks=[_chunk(text=text)],
+    )
+    return src
+
+
+class _NoopGraphStore:
+    """Graph store stub that always raises entity_not_found.
+
+    No anchor resolution; the vector stage runs unscoped.  Satisfies the
+    ``GraphStore`` protocol for ``GraphRAGComposer.__init__``.
+    """
+
+    async def traverse(self, *, entity_name: str, workspace_id: uuid.UUID, **_: Any) -> None:  # type: ignore[override]
+        raise ValueError(f"entity_not_found:{entity_name}")
+
+    async def find_related(self, *, entity_name: str, workspace_id: uuid.UUID, **_: Any) -> None:  # type: ignore[override]
+        raise ValueError(f"entity_not_found:{entity_name}")
+
+
+class _NullLegacyService:
+    """Legacy fallback that always returns an empty result."""
+
+    async def search(self, request: SearchRequest) -> SearchResult:
+        return SearchResult(
+            hits=[],
+            query_stats=QueryStats(
+                total_matches_before_filters=0,
+                vector_matches=0,
+                text_matches=0,
+                duration_ms=0.0,
+            ),
+        )
+
+
+def _build_composer(store: QdrantVectorStore, monkeypatch: pytest.MonkeyPatch) -> GraphRAGComposer:
+    """Build a GraphRAGComposer wired to the real Qdrant store.
+
+    The type-check that normally requires Neo4j+Qdrant is bypassed so we
+    can test the composed pipeline against the real vector store without
+    spinning up a Neo4j container.
+    """
+    import omniscience_retrieval.graph_rag as gr_module
+
+    monkeypatch.setattr(gr_module, "_should_use_graphrag", lambda _g, _v: True)
+    graph_store = cast("Any", _NoopGraphStore())
+    return GraphRAGComposer(
+        graph_store=graph_store,
+        vector_store=store,
+        legacy_service=_NullLegacyService(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hybrid_graphrag_text_matches_nonzero(
+    qdrant_store_graphrag: QdrantVectorStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """hybrid strategy through GraphRAGComposer returns text_matches > 0.
+
+    This is the primary regression test: before fix/push-sources-and-graphrag-sparse,
+    text_matches was always 0 because the GraphRAG vector stage was not
+    dispatching to the RRF path.
+
+    Scenario:
+    - Plant a chunk containing the distinctive keyword "crashloopbackoff".
+    - Search with query="crashloopbackoff" and retrieval_strategy="hybrid".
+    - Assert text_matches > 0 (the sparse leg found the keyword).
+    """
+    ws = uuid.uuid4()
+    await _plant(
+        qdrant_store_graphrag,
+        workspace=ws,
+        external_id="pod-crash-doc",
+        text="pod crashloopbackoff kubernetes restart error",
+    )
+
+    composer = _build_composer(qdrant_store_graphrag, monkeypatch)
+    result = await composer.search(
+        SearchRequest(
+            query="crashloopbackoff",
+            retrieval_strategy="hybrid",
+            top_k=5,
+        ),
+        workspace_id=ws,
+    )
+
+    assert len(result.hits) >= 1, "Expected at least one hit for exact keyword query"
+    assert result.query_stats.text_matches > 0, (
+        f"Expected text_matches > 0 for hybrid query through GraphRAGComposer; "
+        f"got text_matches={result.query_stats.text_matches}. "
+        "This indicates the sparse leg was not exercised — "
+        "retrieval_strategy was not forwarded correctly to QdrantVectorStore."
+    )
+
+
+@pytest.mark.asyncio
+async def test_keyword_graphrag_text_matches_equals_hits(
+    qdrant_store_graphrag: QdrantVectorStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """keyword strategy through GraphRAGComposer: text_matches == len(hits).
+
+    With pure sparse search every returned point is a text match.
+    """
+    ws = uuid.uuid4()
+    await _plant(
+        qdrant_store_graphrag,
+        workspace=ws,
+        external_id="oom-doc",
+        text="pod oomkilled memory limit exceeded kubernetes",
+    )
+
+    composer = _build_composer(qdrant_store_graphrag, monkeypatch)
+    result = await composer.search(
+        SearchRequest(
+            query="oomkilled memory",
+            retrieval_strategy="keyword",
+            top_k=5,
+        ),
+        workspace_id=ws,
+    )
+
+    assert len(result.hits) >= 1
+    assert result.query_stats.text_matches == len(result.hits), (
+        "For keyword strategy, every hit is a sparse match; "
+        f"text_matches={result.query_stats.text_matches} != hits={len(result.hits)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_structural_graphrag_text_matches_zero(
+    qdrant_store_graphrag: QdrantVectorStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """structural strategy through GraphRAGComposer: text_matches == 0.
+
+    structural → dense-only → _search_dense which always returns text_matches=0.
+    This is the expected behaviour for the graph-anchor-scoped dense path.
+    """
+    ws = uuid.uuid4()
+    await _plant(
+        qdrant_store_graphrag,
+        workspace=ws,
+        external_id="evicted-doc",
+        text="pod evicted node pressure disk pressure memory",
+    )
+
+    composer = _build_composer(qdrant_store_graphrag, monkeypatch)
+    result = await composer.search(
+        SearchRequest(
+            query="evicted node pressure",
+            retrieval_strategy="structural",
+            top_k=5,
+        ),
+        workspace_id=ws,
+    )
+
+    assert len(result.hits) >= 1
+    assert result.query_stats.text_matches == 0, (
+        "structural strategy must use dense-only path; "
+        f"unexpected text_matches={result.query_stats.text_matches}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hybrid_graphrag_workspace_isolation(
+    qdrant_store_graphrag: QdrantVectorStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cross-workspace isolation holds on the hybrid GraphRAG path.
+
+    Workspace A's chunk must not appear in workspace B's search results.
+    """
+    ws_a = uuid.uuid4()
+    ws_b = uuid.uuid4()
+
+    # Plant the same keyword text in both workspaces.
+    await _plant(
+        qdrant_store_graphrag,
+        workspace=ws_a,
+        external_id="pvc-doc-a",
+        text="persistentvolumeclaim storage pvc kubernetes bound",
+    )
+    await _plant(
+        qdrant_store_graphrag,
+        workspace=ws_b,
+        external_id="pvc-doc-b",
+        text="persistentvolumeclaim storage pvc kubernetes bound",
+    )
+
+    composer = _build_composer(qdrant_store_graphrag, monkeypatch)
+
+    a_result = await composer.search(
+        SearchRequest(query="persistentvolumeclaim", retrieval_strategy="hybrid", top_k=20),
+        workspace_id=ws_a,
+    )
+    b_result = await composer.search(
+        SearchRequest(query="persistentvolumeclaim", retrieval_strategy="hybrid", top_k=20),
+        workspace_id=ws_b,
+    )
+
+    a_chunk_ids = {h.chunk_id for h in a_result.hits}
+    b_chunk_ids = {h.chunk_id for h in b_result.hits}
+
+    assert a_chunk_ids.isdisjoint(b_chunk_ids), (
+        "Cross-workspace contamination: chunks from workspace A appeared in workspace B's "
+        "hybrid GraphRAG results (or vice versa)."
+    )
+    assert len(a_result.hits) >= 1
+    assert len(b_result.hits) >= 1
+
+
+@pytest.mark.asyncio
+async def test_as_of_none_current_only_hybrid(
+    qdrant_store_graphrag: QdrantVectorStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """as_of=None applies current-only filter (valid_to IS NULL) on both legs.
+
+    Regression guard for fix/push-sources-and-graphrag-sparse Stage 1:
+    end-dated (historical) points must NOT appear in hybrid results when
+    as_of=None.
+
+    Scenario:
+    - Plant chunk v1 (current: valid_to=None).
+    - Update with different content → end-dates v1 (valid_to=now) and
+      creates v2 (valid_to=None).
+    - hybrid search must return only v2, not v1.
+    """
+
+    ws = uuid.uuid4()
+    source_id = uuid.uuid4()
+    external_id = "timeout-doc"
+
+    # v1 — planted first.
+    v1_text = "database connection timeout milliseconds latency"
+    v1_embedding = _stub_vector(v1_text)
+
+    await qdrant_store_graphrag.upsert_chunks(
+        source_id=source_id,
+        external_id=external_id,
+        uri=f"mem://{external_id}",
+        title=external_id,
+        content_hash="hash-v1",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text=v1_text, vector=v1_embedding)],
+    )
+
+    # v2 — update with different content → v1 is end-dated.
+    v2_text = "database connection timeout milliseconds latency updated pooling"
+    v2_embedding = _stub_vector(v2_text)
+
+    await qdrant_store_graphrag.upsert_chunks(
+        source_id=source_id,
+        external_id=external_id,
+        uri=f"mem://{external_id}",
+        title=external_id,
+        content_hash="hash-v2",
+        metadata={"workspace_id": str(ws)},
+        chunks=[_chunk(text=v2_text, vector=v2_embedding)],
+    )
+
+    composer = _build_composer(qdrant_store_graphrag, monkeypatch)
+    result = await composer.search(
+        SearchRequest(
+            query="database connection timeout",
+            retrieval_strategy="hybrid",
+            top_k=10,
+        ),
+        workspace_id=ws,
+        as_of=None,
+    )
+
+    # Only v2 should appear (v1 has valid_to set).
+    hit_texts = [h.text for h in result.hits]
+    assert v2_text in hit_texts, f"Expected v2 text in results but got: {hit_texts}"
+    assert v1_text not in hit_texts, (
+        f"v1 (end-dated) text leaked into hybrid results: {hit_texts}. "
+        "as_of=None current-only filter was NOT applied on the sparse/hybrid leg."
+    )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -31,6 +31,11 @@ Covers:
 28. app.py: scheduler starts when scheduler_enabled=True (state set)
 29. app.py: scheduler not started when scheduler_enabled=False
 30. Multiple stale sources: all triggered, count matches
+31. _is_push returns True for push source, False for pull source
+32. _check_and_trigger skips push source even when stale
+33. _check_and_trigger triggers pull source but not push source in same batch
+34. _check_and_trigger push source with no TTL is still skipped (push takes precedence)
+35. _check_and_trigger push source with explicit SLA is still skipped (push takes precedence)
 """
 
 from __future__ import annotations
@@ -43,7 +48,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from omniscience_core.config import Settings
-from omniscience_core.db.models import Source, SourceStatus, SourceType
+from omniscience_core.db.models import Source, SourceStatus, SourceType, SyncMode
 from omniscience_server.scheduler import SchedulerWorker
 
 # ---------------------------------------------------------------------------
@@ -71,6 +76,7 @@ def _make_source(
     status: SourceStatus = SourceStatus.active,
     freshness_sla_seconds: int | None = None,
     last_sync_at: datetime | None = None,
+    sync_mode: SyncMode = SyncMode.pull,
 ) -> MagicMock:
     s = MagicMock(spec=Source)
     s.id = src_id
@@ -79,6 +85,7 @@ def _make_source(
     s.status = status
     s.freshness_sla_seconds = freshness_sla_seconds
     s.last_sync_at = last_sync_at
+    s.sync_mode = sync_mode
     return s
 
 
@@ -87,6 +94,7 @@ def _fresh_source(
     age_seconds: float = 60.0,
     src_id: uuid.UUID = _SRC_ID,
     source_type: SourceType = SourceType.git,
+    sync_mode: SyncMode = SyncMode.pull,
 ) -> MagicMock:
     """A source synced ``age_seconds`` ago with an explicit SLA of ``ttl``."""
     last_sync = _NOW - timedelta(seconds=age_seconds)
@@ -95,6 +103,7 @@ def _fresh_source(
         source_type=source_type,
         freshness_sla_seconds=ttl,
         last_sync_at=last_sync,
+        sync_mode=sync_mode,
     )
 
 
@@ -103,6 +112,7 @@ def _stale_source(
     age_seconds: float = 600.0,
     src_id: uuid.UUID = _SRC_ID,
     source_type: SourceType = SourceType.git,
+    sync_mode: SyncMode = SyncMode.pull,
 ) -> MagicMock:
     """A source synced ``age_seconds`` ago, past its SLA of ``ttl``."""
     last_sync = _NOW - timedelta(seconds=age_seconds)
@@ -111,6 +121,7 @@ def _stale_source(
         source_type=source_type,
         freshness_sla_seconds=ttl,
         last_sync_at=last_sync,
+        sync_mode=sync_mode,
     )
 
 
@@ -384,6 +395,7 @@ async def test_check_and_trigger_triggers_never_synced_source() -> None:
         source_type=SourceType.fs,
         freshness_sla_seconds=None,  # use DEFAULT_TTLS["fs"]
         last_sync_at=None,
+        sync_mode=SyncMode.pull,
     )
     nats = _make_nats_conn()
     sw = _make_scheduler(sources=[src], nats_conn=nats)
@@ -622,3 +634,141 @@ async def test_multiple_stale_sources_all_triggered() -> None:
 
     assert count == 2
     assert nats.jetstream.publish.call_count == 2
+
+
+# ===========================================================================
+# 31. _is_push
+# ===========================================================================
+
+
+def test_is_push_returns_true_for_push_source() -> None:
+    """_is_push returns True when sync_mode is SyncMode.push."""
+    src = _make_source(sync_mode=SyncMode.push)
+    assert SchedulerWorker._is_push(src) is True
+
+
+def test_is_push_returns_false_for_pull_source() -> None:
+    """_is_push returns False when sync_mode is SyncMode.pull."""
+    src = _make_source(sync_mode=SyncMode.pull)
+    assert SchedulerWorker._is_push(src) is False
+
+
+# ===========================================================================
+# 32. push source is skipped even when stale
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_check_and_trigger_skips_push_source_when_stale() -> None:
+    """A push source that is stale is NOT triggered — external process owns it.
+
+    Without this behaviour the scheduler would attempt to trigger an in-cluster
+    discovery worker from an off-cluster host, producing cascading connection
+    errors (the original k8s bug).
+    """
+    src = _stale_source(
+        src_id=_SRC_ID,
+        source_type=SourceType.k8s,
+        ttl=1800,
+        age_seconds=3600,
+        sync_mode=SyncMode.push,
+    )
+    nats = _make_nats_conn()
+    sw = _make_scheduler(sources=[src], nats_conn=nats)
+
+    with patch("omniscience_server.scheduler.datetime") as mock_dt:
+        mock_dt.now.return_value = _NOW
+        count = await sw._check_and_trigger()
+
+    assert count == 0
+    nats.jetstream.publish.assert_not_called()
+
+
+# ===========================================================================
+# 33. push + pull in same batch: only pull is triggered
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_check_and_trigger_triggers_pull_skips_push_in_same_batch() -> None:
+    """In a mixed batch only pull sources are triggered; push sources are skipped."""
+    pull_src = _stale_source(
+        src_id=_SRC_ID,
+        source_type=SourceType.git,
+        ttl=300,
+        age_seconds=600,
+        sync_mode=SyncMode.pull,
+    )
+    push_src = _stale_source(
+        src_id=_SRC_ID_2,
+        source_type=SourceType.k8s,
+        ttl=1800,
+        age_seconds=3600,
+        sync_mode=SyncMode.push,
+    )
+    nats = _make_nats_conn()
+    factory = _session_factory_for(pull_src, push_src)
+    sw = SchedulerWorker(session_factory=factory, nats_conn=nats)
+
+    with patch("omniscience_server.scheduler.datetime") as mock_dt:
+        mock_dt.now.return_value = _NOW
+        count = await sw._check_and_trigger()
+
+    # Only the pull source is triggered.
+    assert count == 1
+    assert nats.jetstream.publish.call_count == 1
+
+
+# ===========================================================================
+# 34. push source with no TTL is still skipped (push takes precedence)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_check_and_trigger_push_source_no_ttl_still_skipped() -> None:
+    """Push source without a TTL/SLA is skipped before even reaching TTL logic."""
+    src = _make_source(
+        source_type=SourceType.grafana,
+        freshness_sla_seconds=None,
+        last_sync_at=None,
+        sync_mode=SyncMode.push,
+    )
+    nats = _make_nats_conn()
+    sw = _make_scheduler(sources=[src], nats_conn=nats)
+
+    with patch("omniscience_server.scheduler.datetime") as mock_dt:
+        mock_dt.now.return_value = _NOW
+        count = await sw._check_and_trigger()
+
+    assert count == 0
+    nats.jetstream.publish.assert_not_called()
+
+
+# ===========================================================================
+# 35. push source with explicit SLA is still skipped
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_check_and_trigger_push_source_with_sla_still_skipped() -> None:
+    """A push source with an explicit freshness SLA is skipped by the scheduler.
+
+    The SLA is still evaluated by the FreshnessChecker (external process
+    monitoring), but the scheduler must not trigger a discovery run.
+    """
+    src = _stale_source(
+        src_id=_SRC_ID,
+        source_type=SourceType.fs,
+        ttl=60,
+        age_seconds=9999,
+        sync_mode=SyncMode.push,
+    )
+    nats = _make_nats_conn()
+    sw = _make_scheduler(sources=[src], nats_conn=nats)
+
+    with patch("omniscience_server.scheduler.datetime") as mock_dt:
+        mock_dt.now.return_value = _NOW
+        count = await sw._check_and_trigger()
+
+    assert count == 0
+    nats.jetstream.publish.assert_not_called()


### PR DESCRIPTION
## Summary

Three deploy-surfaced issues from the live local run, where features designed for a **pull/operator** model collided with this install's **push/seed** model. All three fixed.

## What's fixed

### Push sources skip the scheduler (no more k8s discovery errors)
The scheduler auto-triggered discovery for the k8s source (via the `k8s` TTL), which then hit the in-cluster `kubernetes.default.svc` URL from the host and errored 19×/cycle. Data is actually fed by external launchd + seed scripts.
- new `Source.sync_mode` enum (`pull`|`push`, default `pull`); alembic `0011` adds the column additively (verified upgrade→downgrade→upgrade on real Postgres)
- scheduler skips `push` sources before the TTL check; `k8s` TTL kept for a future in-cluster operator in pull mode

### Freshness measures real push staleness (no more constant noise)
The freshness worker flagged seeded sources as permanently stale (`age=Infinity`) because the seed scripts never set `last_sync_at`. The worker was right to alert — the data was missing a sync timestamp.
- `seed_from_docs` now stamps `last_sync_at` on every run and marks the source `push`
- the worker is unchanged: it still correctly alerts on a *real* push outage (the original launchd-down detection from #304 stays intact)

### Hybrid retrieval actually runs through MCP (`text_matches` > 0)
`mcp_search` goes through `GraphRAGComposer`, whose `_widen_request` rebuilt the `SearchRequest` **without** `retrieval_strategy` — so the vector stage silently ran dense-only and `text_matches` was always 0, despite the collection carrying `sparse_bm25` vectors.
- `_widen_request` forwards `retrieval_strategy`; hybrid/auto → RRF dense+sparse, keyword → sparse, structural → dense (graph-anchored)
- `text_matches` propagates to the MCP response; `as_of`/current-only filter applies to both legs
- **contract test on real Qdrant asserts `text_matches > 0` via GraphRAG** — the exact gap mocks had hidden

## Tests
- 157 unit (scheduler/freshness/graph_rag/hybrid/isolation/multi-tenant) green
- GraphRAG hybrid **contract** suite (5) green on a real Qdrant container
- alembic `0011` verified on real Postgres; `ruff check .` + `format --check .` clean

## Deploy notes
- alembic `0011` is additive (ADD COLUMN default `pull`) — safe, zero-downtime
- after deploy, existing push sources get `sync_mode=push` + `last_sync_at` on their next seed run
