### PR TITLE
fix(retrieval): deterministic crc32 sparse tokenizer (was process-salted hash)

### DIFF
--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -69,6 +69,7 @@ import logging
 import re
 import time
 import uuid
+import zlib
 from collections import Counter as _Counter
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -1600,9 +1601,13 @@ def _tokenize_to_sparse(text: str) -> qm.SparseVector:
     1. Lowercase + split on non-alphanumeric characters.
     2. Remove stopwords and single-character tokens.
     3. Count term frequencies.
-    4. Map tokens to integer indices via a deterministic hash
-       (hash(token) mod SPARSE_VOCAB_SIZE).  Collisions are rare
+    4. Map tokens to integer indices via a process-stable hash
+       (crc32(token) mod SPARSE_VOCAB_SIZE).  Collisions are rare
        at 2^20 slots and acceptable for retrieval purposes.
+       NOTE: the builtin ``hash()`` MUST NOT be used here — string
+       hashing is salted per-process (PYTHONHASHSEED), so an index-time
+       token and a query-time token would map to different slots in
+       different processes and never match. crc32 is deterministic.
     5. Normalise values to [0, 1] (max-TF normalisation).
 
     This approximates BM25 without a corpus-level IDF pass.  For the
@@ -1618,7 +1623,7 @@ def _tokenize_to_sparse(text: str) -> qm.SparseVector:
     for tok in tokens:
         if len(tok) <= 1 or tok in _STOPWORDS:
             continue
-        idx = hash(tok) % _SPARSE_VOCAB_SIZE
+        idx = zlib.crc32(tok.encode("utf-8")) % _SPARSE_VOCAB_SIZE
         counts[idx] += 1
     if not counts:
         return qm.SparseVector(indices=[], values=[])

--- a/tests/test_qdrant_store_hybrid.py
+++ b/tests/test_qdrant_store_hybrid.py
@@ -140,6 +140,47 @@ def test_tokenize_deterministic() -> None:
     assert a.values == b.values
 
 
+def test_tokenize_indices_are_golden_crc32() -> None:
+    """Index-time and query-time tokens must map to the SAME slots.
+
+    Regression guard for the builtin hash() bug: string hashing is salted
+    per-process (PYTHONHASHSEED), so hash()-based indices differed between
+    the seed process and the search process, breaking sparse search entirely.
+    These golden values come from crc32(token) % 2**20 and are stable across
+    processes — if someone reverts to hash(), this assertion fails.
+    """
+    sv = _tokenize_to_sparse("cilium gateway loadbalancer")
+    # crc32("cilium")=...%2**20=909609, "gateway"=974207, "loadbalancer"=602382
+    assert sorted(sv.indices) == sorted([909609, 974207, 602382])
+
+
+def test_tokenize_stable_across_processes() -> None:
+    """A fresh interpreter (different PYTHONHASHSEED) yields identical indices.
+
+    This is the cross-process check the in-process determinism test cannot
+    make: builtin hash() would pass test_tokenize_deterministic but fail here.
+    """
+    import subprocess
+    import sys
+
+    code = (
+        "from omniscience_index.stores.qdrant_store import _tokenize_to_sparse;"
+        "sv=_tokenize_to_sparse('cilium gateway loadbalancer');"
+        "print(sorted(sv.indices))"
+    )
+    runs = [
+        subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env={"PYTHONHASHSEED": seed, "PATH": __import__("os").environ.get("PATH", "")},
+            check=True,
+        ).stdout.strip()
+        for seed in ("0", "1", "12345")
+    ]
+    assert runs[0] == runs[1] == runs[2], f"indices vary across PYTHONHASHSEED: {runs}"
+
+
 def test_tokenize_empty_string() -> None:
     sv = _tokenize_to_sparse("")
     assert sv.indices == []


### PR DESCRIPTION
## The bug

`_tokenize_to_sparse` used builtin `hash(token)` to map tokens to sparse slots. Python salts string hashing per-process (`PYTHONHASHSEED`), so a token indexed in the **seed process** and the same token hashed in the **server process** landed in different slots — sparse/hybrid search matched nothing in production (`text_matches` always 0), even though points carried valid `sparse_bm25` vectors.

Surfaced on the live stack: a direct sparse query for "cilium gateway loadbalancer" produced query indices `[39227, 132705, 675035]` that did not intersect any document indices → 0 hits. The hybrid GraphRAG contract test passed only because indexing and search ran in **one** interpreter.

## Fix
- `zlib.crc32(token)` — process-stable, deterministic across interpreters
- golden-value test (asserts known crc32 slots) + cross-process test (subprocess under PYTHONHASHSEED 0/1/12345) — both fail on the old `hash()`

## Deploy
Requires a sparse reseed/reindex: existing points hold indices from the old salted hash and must be rewritten under crc32.