### PR TITLE
fix(server): restore fail-closed workspace errors and clear mypy regressions

### DIFF
--- a/apps/server/src/omniscience_server/mcp/incident_timeline.py
+++ b/apps/server/src/omniscience_server/mcp/incident_timeline.py
@@ -66,13 +66,14 @@ async def incident_timeline_tool(
     record_invocation(tool_name="incident_timeline", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_incident_timeline_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Incident timeline requires a workspace-scoped token")
+        raise ValueError("forbidden:Incident timeline requires a workspace-scoped token") from exc
 
     parsed_as_of = parse_as_of(as_of)
     parsed_from = parse_as_of(from_ts)

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -370,13 +370,14 @@ async def get_related_entities(
     # _require_scope raised if token is None, so it is non-None here.
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_graph_request_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     try:
@@ -426,13 +427,14 @@ async def get_entity(
     _record_tool_invocation(tool_name="get_entity", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_get_entity_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     return await mcp_get_entity(
@@ -530,13 +532,14 @@ async def resolve_incident(
     _record_tool_invocation(tool_name="resolve_incident", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_resolve_incident_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     clamped_depth = max(MIN_MAX_DEPTH, min(max_depth, MAX_MAX_DEPTH))
@@ -649,13 +652,14 @@ async def blast_radius(
     _record_tool_invocation(tool_name="blast_radius", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_blast_radius_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     if action_type not in ACTION_TYPES:
         raise ValueError(
@@ -716,13 +720,14 @@ async def replay_context_tool(
     _record_tool_invocation(tool_name="replay_context", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_replay_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Replay requires a workspace-scoped token")
+        raise ValueError("forbidden:Replay requires a workspace-scoped token") from exc
 
     has_audit = audit_log_id is not None and audit_log_id != ""
     has_inline = at_time is not None or tool_name is not None
@@ -805,13 +810,14 @@ async def suggest_runbook(
     _record_tool_invocation(tool_name="suggest_runbook", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_suggest_runbook_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Runbook suggestion requires a workspace-scoped token")
+        raise ValueError("forbidden:Runbook suggestion requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     clamped_top_k = max(1, min(top_k, RUNBOOK_MAX_TOP_K))
@@ -862,13 +868,16 @@ async def find_similar_incidents(
     _record_tool_invocation(tool_name="find_similar_incidents", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_find_similar_incidents_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Similar-incident search requires a workspace-scoped token")
+        raise ValueError(
+            "forbidden:Similar-incident search requires a workspace-scoped token"
+        ) from exc
 
     parsed_as_of = _parse_as_of(as_of)
     clamped_limit = max(1, min(limit, SIMILAR_MAX_LIMIT))
@@ -932,13 +941,16 @@ async def generate_postmortem_tool(
     _record_tool_invocation(tool_name="generate_postmortem", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_generate_postmortem_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Post-mortem generation requires a workspace-scoped token")
+        raise ValueError(
+            "forbidden:Post-mortem generation requires a workspace-scoped token"
+        ) from exc
 
     parsed_start = _parse_as_of(incident_start)
     parsed_end = _parse_as_of(incident_end)

--- a/apps/server/src/omniscience_server/reconcile_worker.py
+++ b/apps/server/src/omniscience_server/reconcile_worker.py
@@ -383,7 +383,7 @@ class ReconcileWorker:
         )
         if not records:
             return 0
-        point_ids = [str(r.id) for r in records]
+        point_ids: list[int | str | uuid.UUID] = [str(r.id) for r in records]
         await self._vector_store._qc.delete(
             collection_name=self._vector_store.collection_name,
             points_selector=qm.PointIdsList(points=point_ids),

--- a/apps/server/src/omniscience_server/rest/operator.py
+++ b/apps/server/src/omniscience_server/rest/operator.py
@@ -156,8 +156,9 @@ def _require_matching_workspace(
     body) so operations can correlate audit-log entries with denied
     requests without exposing credentials.
     """
-    token_workspace = get_workspace_id(token)
-    if token_workspace is None:
+    try:
+        token_workspace = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "operator_endpoint_rejected_no_workspace",
             token_prefix=token.token_prefix,
@@ -168,7 +169,7 @@ def _require_matching_workspace(
                 "code": "forbidden",
                 "message": "Operator endpoint requires a workspace-scoped token.",
             },
-        )
+        ) from exc
     if token_workspace != requested_workspace_id:
         log.warning(
             "operator_endpoint_rejected_workspace_mismatch",

--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -580,7 +580,7 @@ class QdrantVectorStore:
             vectors[NAMED_VECTOR_SPARSE_BM25] = sparse
         return qm.PointStruct(
             id=point_id,
-            vector=vectors,  # type: ignore[arg-type]
+            vector=vectors,
             payload=payload,
         )
 

--- a/tests/test_unblock_ingestion.py
+++ b/tests/test_unblock_ingestion.py
@@ -137,6 +137,14 @@ def _make_app_with_source(source: Source | None = None) -> FastAPI:
     token.is_active = True
     token.last_used_at = None
 
+    # Workspace scoping is mandatory: the token must carry a workspace_id and
+    # the source's tenant_id must match it, otherwise get_workspace_id /
+    # _get_source_or_404 fail-close (403/404).  Bind both to one workspace.
+    workspace_id = uuid.uuid4()
+    token.workspace_id = workspace_id
+    if source is not None:
+        source.tenant_id = workspace_id
+
     app = create_app(settings=_make_settings())
 
     token_session = _make_token_session(token)


### PR DESCRIPTION
## Summary

`origin/main` was CI-red independent of feature work: 2 mypy errors and 17 pytest failures, all from an **incomplete migration** of `get_workspace_id` to its new fail-closed contract (it now raises `PermissionError("forbidden:workspace_required")` instead of returning `None`). Several callers still guarded on the now-impossible `workspace_id is None`, so the `PermissionError` leaked past their error-translation layers. This PR completes that migration and clears the two stale type findings.

## Per-case decisions (test vs. implementation)

| Failure cluster | Verdict | Fix |
|---|---|---|
| 8 MCP graph/incident tools (`test_mcp_server_coverage.py`) | **impl** | `mcp/server.py`: catch `PermissionError`, re-raise the existing `ValueError("forbidden:…")` — the MCP wire layer's error convention. Tests already asserted `ValueError(match="forbidden")`. |
| `incident_timeline_tool` (`test_mcp_incident_timeline_coverage.py`) | **impl** | `mcp/incident_timeline.py`: same conversion. |
| Operator no-workspace 403 (`test_operator_endpoint.py`) | **impl** | `rest/operator.py`: catch `PermissionError`, raise the existing `HTTPException(403)` — matches the sibling workspace-mismatch branch and the body shape the test asserts (`body["detail"]["code"] == "forbidden"`). |
| 7 sync-endpoint tests (`test_unblock_ingestion.py`) | **test** | Mocks never set `workspace_id`/`tenant_id` (pre-dated workspace scoping), so the now-mandatory scoped lookup returned 404. Bind token `workspace_id` and source `tenant_id` to one workspace. |

The REST `PermissionError`→403 path stays centralized in `rest/errors.py` for production; `operator.py` keeps its explicit 403 because its test harness (`_build_app`) intentionally omits the global envelope handler that other passing tests depend on for the default body shape.

### mypy
- `qdrant_store.py:583` — removed a now-unused `# type: ignore[arg-type]`.
- `reconcile_worker.py:389` — annotated `point_ids: list[int | str | uuid.UUID]` to satisfy `PointIdsList`'s invariant parameter.

## Verification
- `uv run mypy apps/ packages/` → **clean** (255 files)
- `uv run ruff check .` → **clean**
- `uv run pytest tests/test_mcp_server_coverage.py tests/test_unblock_ingestion.py tests/test_operator_endpoint.py tests/test_mcp_incident_timeline_coverage.py` → **128 passed** (was 17 failed / 111 passed)
- Broader store-free sweep of MCP/REST/graph suites → **243 passed**, no regressions

## Out of scope (pre-existing, flagged separately)
`uv run ruff format --check .` still reports two unrelated files from the PR #311 AWS-docs merge (`scripts/build_aws_docs.py`, `tests/test_build_aws_docs.py`). Not touched here to keep this PR focused on the typecheck/test gates.

## Test plan
- [ ] CI `typecheck`, `lint` (ruff check), and `test` jobs green on this branch
- [ ] Confirm no behavioral change for workspace-scoped tokens (happy paths covered by existing suites)