### PR TITLE
fix: green main CI (workspace boundary errors + AWS region + e2e worker-write + types)

### DIFF
--- a/apps/server/src/omniscience_server/mcp/incident_timeline.py
+++ b/apps/server/src/omniscience_server/mcp/incident_timeline.py
@@ -66,13 +66,16 @@ async def incident_timeline_tool(
     record_invocation(tool_name="incident_timeline", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_incident_timeline_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Incident timeline requires a workspace-scoped token")
+        raise ValueError(
+            "forbidden:Incident timeline requires a workspace-scoped token"
+        ) from exc
 
     parsed_as_of = parse_as_of(as_of)
     parsed_from = parse_as_of(from_ts)

--- a/apps/server/src/omniscience_server/mcp/incident_timeline.py
+++ b/apps/server/src/omniscience_server/mcp/incident_timeline.py
@@ -73,9 +73,7 @@ async def incident_timeline_tool(
             "mcp_incident_timeline_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError(
-            "forbidden:Incident timeline requires a workspace-scoped token"
-        ) from exc
+        raise ValueError("forbidden:Incident timeline requires a workspace-scoped token") from exc
 
     parsed_as_of = parse_as_of(as_of)
     parsed_from = parse_as_of(from_ts)

--- a/apps/server/src/omniscience_server/mcp/server.py
+++ b/apps/server/src/omniscience_server/mcp/server.py
@@ -370,13 +370,14 @@ async def get_related_entities(
     # _require_scope raised if token is None, so it is non-None here.
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_graph_request_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     try:
@@ -426,13 +427,14 @@ async def get_entity(
     _record_tool_invocation(tool_name="get_entity", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_get_entity_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     return await mcp_get_entity(
@@ -530,13 +532,14 @@ async def resolve_incident(
     _record_tool_invocation(tool_name="resolve_incident", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_resolve_incident_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     clamped_depth = max(MIN_MAX_DEPTH, min(max_depth, MAX_MAX_DEPTH))
@@ -649,13 +652,14 @@ async def blast_radius(
     _record_tool_invocation(tool_name="blast_radius", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_blast_radius_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token")
+        raise ValueError("forbidden:Graph retrieval requires a workspace-scoped token") from exc
 
     if action_type not in ACTION_TYPES:
         raise ValueError(
@@ -716,13 +720,14 @@ async def replay_context_tool(
     _record_tool_invocation(tool_name="replay_context", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_replay_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Replay requires a workspace-scoped token")
+        raise ValueError("forbidden:Replay requires a workspace-scoped token") from exc
 
     has_audit = audit_log_id is not None and audit_log_id != ""
     has_inline = at_time is not None or tool_name is not None
@@ -805,13 +810,14 @@ async def suggest_runbook(
     _record_tool_invocation(tool_name="suggest_runbook", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_suggest_runbook_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Runbook suggestion requires a workspace-scoped token")
+        raise ValueError("forbidden:Runbook suggestion requires a workspace-scoped token") from exc
 
     parsed_as_of = _parse_as_of(as_of)
     clamped_top_k = max(1, min(top_k, RUNBOOK_MAX_TOP_K))
@@ -862,13 +868,16 @@ async def find_similar_incidents(
     _record_tool_invocation(tool_name="find_similar_incidents", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_find_similar_incidents_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Similar-incident search requires a workspace-scoped token")
+        raise ValueError(
+            "forbidden:Similar-incident search requires a workspace-scoped token"
+        ) from exc
 
     parsed_as_of = _parse_as_of(as_of)
     clamped_limit = max(1, min(limit, SIMILAR_MAX_LIMIT))
@@ -932,13 +941,16 @@ async def generate_postmortem_tool(
     _record_tool_invocation(tool_name="generate_postmortem", token=token)
     assert token is not None  # noqa: S101 — narrows type for mypy
 
-    workspace_id = get_workspace_id(token)
-    if workspace_id is None:
+    try:
+        workspace_id = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "mcp_generate_postmortem_rejected_no_workspace",
             token_prefix=token.token_prefix,
         )
-        raise ValueError("forbidden:Post-mortem generation requires a workspace-scoped token")
+        raise ValueError(
+            "forbidden:Post-mortem generation requires a workspace-scoped token"
+        ) from exc
 
     parsed_start = _parse_as_of(incident_start)
     parsed_end = _parse_as_of(incident_end)

--- a/apps/server/src/omniscience_server/reconcile_worker.py
+++ b/apps/server/src/omniscience_server/reconcile_worker.py
@@ -383,7 +383,7 @@ class ReconcileWorker:
         )
         if not records:
             return 0
-        point_ids = [str(r.id) for r in records]
+        point_ids: list[int | str | uuid.UUID] = [str(r.id) for r in records]
         await self._vector_store._qc.delete(
             collection_name=self._vector_store.collection_name,
             points_selector=qm.PointIdsList(points=point_ids),

--- a/apps/server/src/omniscience_server/rest/operator.py
+++ b/apps/server/src/omniscience_server/rest/operator.py
@@ -156,8 +156,9 @@ def _require_matching_workspace(
     body) so operations can correlate audit-log entries with denied
     requests without exposing credentials.
     """
-    token_workspace = get_workspace_id(token)
-    if token_workspace is None:
+    try:
+        token_workspace = get_workspace_id(token)
+    except PermissionError as exc:
         log.warning(
             "operator_endpoint_rejected_no_workspace",
             token_prefix=token.token_prefix,
@@ -168,7 +169,7 @@ def _require_matching_workspace(
                 "code": "forbidden",
                 "message": "Operator endpoint requires a workspace-scoped token.",
             },
-        )
+        ) from exc
     if token_workspace != requested_workspace_id:
         log.warning(
             "operator_endpoint_rejected_workspace_mismatch",

--- a/packages/connectors/src/omniscience_connectors/aws/connector.py
+++ b/packages/connectors/src/omniscience_connectors/aws/connector.py
@@ -1100,9 +1100,16 @@ def _ci_to_ref(ci: dict[str, Any]) -> DocumentRef | None:
     )
 
 
+# The Config aggregator API is region-agnostic for org-wide queries, but the
+# boto3 client still needs a home region for its endpoint. Default to us-east-1
+# (mirrors ``_ORG_REGION``) so client construction never raises NoRegionError
+# when no ambient region (env/profile) is configured.
+_CONFIG_CLIENT_REGION = "us-east-1"
+
+
 def _build_config_client(secrets: dict[str, str], region: str | None = None) -> Any:
     """Return a boto3 config client for Config aggregator queries."""
-    return _build_client("config", secrets, region)
+    return _build_client("config", secrets, region or _CONFIG_CLIENT_REGION)
 
 
 def _list_aggregate_cis_for_type(

--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -580,7 +580,7 @@ class QdrantVectorStore:
             vectors[NAMED_VECTOR_SPARSE_BM25] = sparse
         return qm.PointStruct(
             id=point_id,
-            vector=vectors,  # type: ignore[arg-type]
+            vector=vectors,
             payload=payload,
         )
 

--- a/scripts/build_aws_docs.py
+++ b/scripts/build_aws_docs.py
@@ -246,9 +246,7 @@ def enrich_elb(
         _enrich_elb_load_balancers(docs, cli, account_id, account_name, region)
         _enrich_elb_target_groups(docs, cli, account_id, account_name, region)
     except Exception as exc:
-        log.warning(
-            "account %s: elbv2 enrichment error — %s", account_name, exc
-        )
+        log.warning("account %s: elbv2 enrichment error — %s", account_name, exc)
 
 
 def _enrich_elb_load_balancers(
@@ -296,9 +294,7 @@ def _enrich_elb_load_balancers(
                 extra_text=extra_text,
                 extra_meta=extra_meta,
             )
-            _enrich_elb_listeners(
-                docs, cli, lb_arn, account_id, account_name, region
-            )
+            _enrich_elb_listeners(docs, cli, lb_arn, account_id, account_name, region)
 
 
 def _enrich_elb_listeners(
@@ -353,9 +349,7 @@ def _enrich_elb_listeners(
         # Attach listener list to the parent LB document.
         if lb_arn in docs and listeners:
             docs[lb_arn]["metadata"]["lb_listeners"] = listeners
-            ports_str = ", ".join(
-                str(lst["port"]) for lst in listeners if lst.get("port")
-            )
+            ports_str = ", ".join(str(lst["port"]) for lst in listeners if lst.get("port"))
             if ports_str:
                 docs[lb_arn]["text"] += f" Listeners on ports: {ports_str}."
     except Exception as exc:
@@ -452,18 +446,12 @@ def enrich_sg(
                         "sg_name": name,
                         "sg_description": sg.get("Description"),
                         "sg_vpc_id": sg.get("VpcId"),
-                        "sg_inbound_rules": _parse_sg_rules(
-                            sg.get("IpPermissions", [])
-                        ),
-                        "sg_outbound_rules": _parse_sg_rules(
-                            sg.get("IpPermissionsEgress", [])
-                        ),
+                        "sg_inbound_rules": _parse_sg_rules(sg.get("IpPermissions", [])),
+                        "sg_outbound_rules": _parse_sg_rules(sg.get("IpPermissionsEgress", [])),
                     },
                 )
     except Exception as exc:
-        log.warning(
-            "account %s: security-group enrichment error — %s", account_name, exc
-        )
+        log.warning("account %s: security-group enrichment error — %s", account_name, exc)
 
 
 def _parse_sg_rules(
@@ -557,9 +545,7 @@ def enrich_rds(
                     },
                 )
     except Exception as exc:
-        log.warning(
-            "account %s: rds enrichment error — %s", account_name, exc
-        )
+        log.warning("account %s: rds enrichment error — %s", account_name, exc)
 
 
 def enrich_ec2(
@@ -577,13 +563,9 @@ def enrich_ec2(
             for reservation in page["Reservations"]:
                 for inst in reservation["Instances"]:
                     inst_id = inst["InstanceId"]
-                    arn = (
-                        f"arn:aws:ec2:{region}:{account_id}:instance/{inst_id}"
-                    )
+                    arn = f"arn:aws:ec2:{region}:{account_id}:instance/{inst_id}"
                     state = inst.get("State", {}).get("Name", "unknown")
-                    tags = {
-                        t["Key"]: t["Value"] for t in inst.get("Tags", [])
-                    }
+                    tags = {t["Key"]: t["Value"] for t in inst.get("Tags", [])}
                     display_name = tags.get("Name") or inst_id
                     extra_text = (
                         f"Instance type: {inst.get('InstanceType', '?')}. "
@@ -613,16 +595,12 @@ def enrich_ec2(
                             "ec2_subnet_id": inst.get("SubnetId"),
                             "ec2_image_id": inst.get("ImageId"),
                             "ec2_launch_time": (
-                                inst["LaunchTime"].isoformat()
-                                if inst.get("LaunchTime")
-                                else None
+                                inst["LaunchTime"].isoformat() if inst.get("LaunchTime") else None
                             ),
                         },
                     )
     except Exception as exc:
-        log.warning(
-            "account %s: ec2-instances enrichment error — %s", account_name, exc
-        )
+        log.warning("account %s: ec2-instances enrichment error — %s", account_name, exc)
 
 
 def enrich_ecs(
@@ -637,13 +615,9 @@ def enrich_ecs(
     try:
         cluster_arns = _list_ecs_clusters(cli)
         for cluster_arn in cluster_arns:
-            _enrich_ecs_services(
-                docs, cli, cluster_arn, account_id, account_name, region
-            )
+            _enrich_ecs_services(docs, cli, cluster_arn, account_id, account_name, region)
     except Exception as exc:
-        log.warning(
-            "account %s: ecs enrichment error — %s", account_name, exc
-        )
+        log.warning("account %s: ecs enrichment error — %s", account_name, exc)
 
 
 def _list_ecs_clusters(cli: Any) -> list[str]:
@@ -745,9 +719,7 @@ def _scrape_account(
         try:
             fn(docs, session, account_id, account_name, region)
         except Exception as exc:
-            log.warning(
-                "%s (%s): %s enrichment failed — %s", account_name, account_id, label, exc
-            )
+            log.warning("%s (%s): %s enrichment failed — %s", account_name, account_id, label, exc)
 
     log.info(
         "%s (%s): %d docs after enrichment (+%d new)",
@@ -804,9 +776,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_OUTPUT,
         help=f"Output JSON path (default: {DEFAULT_OUTPUT})",
     )
-    parser.add_argument(
-        "--verbose", "-v", action="store_true", help="Enable debug logging."
-    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable debug logging.")
     return parser.parse_args(argv)
 
 
@@ -839,9 +809,9 @@ def main(argv: list[str] | None = None) -> None:
     lb_with_ports = 0
     for doc in docs:
         counter[doc["metadata"].get("resource_type", "unknown")] += 1
-        if "loadbalancer" in doc["metadata"].get("resource_type", "") and doc[
-            "metadata"
-        ].get("lb_listeners"):
+        if "loadbalancer" in doc["metadata"].get("resource_type", "") and doc["metadata"].get(
+            "lb_listeners"
+        ):
             lb_with_ports += 1
 
     print(f"\nTotal docs: {len(docs)}")

--- a/tests/test_build_aws_docs.py
+++ b/tests/test_build_aws_docs.py
@@ -321,17 +321,12 @@ class TestEnrichElb:
         cli, stubber = _stub_client("elbv2")
 
         lb_arn = (
-            f"arn:aws:elasticloadbalancing:{REGION}:{ACCOUNT_ID}"
-            ":loadbalancer/app/my-alb/abc123"
+            f"arn:aws:elasticloadbalancing:{REGION}:{ACCOUNT_ID}:loadbalancer/app/my-alb/abc123"
         )
         listener_arn = (
-            f"arn:aws:elasticloadbalancing:{REGION}:{ACCOUNT_ID}"
-            ":listener/app/my-alb/abc123/def456"
+            f"arn:aws:elasticloadbalancing:{REGION}:{ACCOUNT_ID}:listener/app/my-alb/abc123/def456"
         )
-        tg_arn = (
-            f"arn:aws:elasticloadbalancing:{REGION}:{ACCOUNT_ID}"
-            ":targetgroup/my-tg/xyz789"
-        )
+        tg_arn = f"arn:aws:elasticloadbalancing:{REGION}:{ACCOUNT_ID}:targetgroup/my-tg/xyz789"
 
         # describe_load_balancers page
         stubber.add_response(
@@ -349,7 +344,7 @@ class TestEnrichElb:
                         "AvailabilityZones": [{"ZoneName": "eu-west-1a"}],
                     }
                 ],
-                },
+            },
         )
         # describe_listeners for that LB
         stubber.add_response(
@@ -363,7 +358,7 @@ class TestEnrichElb:
                         "SslPolicy": "ELBSecurityPolicy-2016-08",
                     }
                 ],
-                },
+            },
             expected_params={"LoadBalancerArn": lb_arn},
         )
         # describe_target_groups
@@ -382,7 +377,7 @@ class TestEnrichElb:
                         "LoadBalancerArns": [lb_arn],
                     }
                 ],
-                },
+            },
         )
         stubber.activate()
         return cli, stubber, lb_arn, listener_arn
@@ -563,7 +558,7 @@ class TestEnrichRds:
                         "TagList": [{"Key": "Env", "Value": "prod"}],
                     }
                 ],
-                },
+            },
         )
         stubber.activate()
         return cli, stubber, db_arn
@@ -632,7 +627,7 @@ class TestEnrichEc2:
                         ]
                     }
                 ],
-                },
+            },
         )
         stubber.activate()
         return cli, stubber, inst_arn
@@ -659,9 +654,7 @@ class TestEnrichEc2:
 
     def test_ec2_access_denied_skipped(self) -> None:
         cli, stubber = _stub_client("ec2")
-        stubber.add_client_error(
-            "describe_instances", service_error_code="AccessDenied"
-        )
+        stubber.add_client_error("describe_instances", service_error_code="AccessDenied")
         stubber.activate()
         docs: dict[str, Any] = {}
         with stubber, patch("build_aws_docs._client", return_value=cli):

--- a/tests/test_ingestion_e2e.py
+++ b/tests/test_ingestion_e2e.py
@@ -95,16 +95,22 @@ class _StubEmbedding:
 
 
 class _InMemoryIndexWriter:
-    """Minimal in-memory writer satisfying ``IndexWriterProtocol``.
+    """In-memory orchestrator satisfying ``IndexWriterProtocol``.
 
-    Records every call so the test can assert all three stores received
-    the document without requiring a Postgres container.  Production
-    semantics (content-hash dedup, document-id stability) are
-    preserved.
+    Stands in for the production :class:`omniscience_index.writer.IndexWriter`
+    *Postgres* side only (content-hash dedup + document-id stability kept
+    in memory so the test needs no Postgres container).  The Neo4j and
+    Qdrant fan-out is **not** stubbed: this writer drives the real
+    ``graph_store``/``vector_store`` exactly as the production writer does,
+    so the pipeline's worker-write path (``index_writer.upsert_document``
+    -> Qdrant, ``index_writer.upsert_graph`` -> Neo4j) is exercised
+    end-to-end against live containers.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, graph_store: Any, vector_store: Any) -> None:
         self._documents: dict[tuple[uuid.UUID, str], dict[str, Any]] = {}
+        self._graph_store = graph_store
+        self._vector_store = vector_store
 
     async def upsert_document(
         self,
@@ -115,7 +121,8 @@ class _InMemoryIndexWriter:
         content_hash: str,
         metadata: dict[str, Any],
         chunks: list[Any],
-        ingestion_run_id: uuid.UUID | None,
+        workspace_id: uuid.UUID | None = None,
+        ingestion_run_id: uuid.UUID | None = None,
     ) -> Any:
         from dataclasses import dataclass
 
@@ -128,36 +135,90 @@ class _InMemoryIndexWriter:
 
         key = (source_id, external_id)
         existing = self._documents.get(key)
-        if existing is None:
-            doc_id = uuid.uuid4()
-            self._documents[key] = {
-                "id": doc_id,
-                "content_hash": content_hash,
-                "version": 1,
-            }
-            return _Result(
-                action="created",
-                document_id=doc_id,
-                chunks_written=len(chunks),
-                doc_version=1,
-            )
-        if existing["content_hash"] == content_hash:
+        if existing is not None and existing["content_hash"] == content_hash:
             return _Result(
                 action="unchanged",
                 document_id=existing["id"],
                 chunks_written=0,
                 doc_version=existing["version"],
             )
-        existing["content_hash"] = content_hash
-        existing["version"] += 1
+
+        if existing is None:
+            doc_id = uuid.uuid4()
+            self._documents[key] = {"id": doc_id, "content_hash": content_hash, "version": 1}
+            action = "created"
+        else:
+            existing["content_hash"] = content_hash
+            existing["version"] += 1
+            doc_id = existing["id"]
+            action = "updated"
+
+        # Qdrant fan-out — mirrors IndexWriter.upsert_document.
+        if self._vector_store is not None and workspace_id is not None:
+            vector_metadata = dict(metadata)
+            vector_metadata["workspace_id"] = str(workspace_id)
+            payloads = [
+                {
+                    "ord": c.ord,
+                    "text": c.text,
+                    "embedding": c.embedding,
+                    "symbol": c.symbol,
+                    "metadata": c.metadata,
+                    "embedding_model": c.embedding_model,
+                    "embedding_provider": c.embedding_provider,
+                    "parser_version": c.parser_version,
+                    "chunker_strategy": c.chunker_strategy,
+                }
+                for c in chunks
+            ]
+            await self._vector_store.upsert_chunks(
+                source_id=source_id,
+                external_id=external_id,
+                uri=uri,
+                title=title,
+                content_hash=content_hash,
+                metadata=vector_metadata,
+                chunks=payloads,
+                ingestion_run_id=ingestion_run_id,
+            )
+
         return _Result(
-            action="updated",
-            document_id=existing["id"],
+            action=action,
+            document_id=doc_id,
             chunks_written=len(chunks),
-            doc_version=existing["version"],
+            doc_version=self._documents[key]["version"],
         )
 
-    async def tombstone(self, source_id: uuid.UUID, external_id: str) -> bool:
+    async def upsert_graph(
+        self,
+        source_id: uuid.UUID,
+        document_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+        workspace_id: uuid.UUID | None = None,
+        snapshot_at: Any | None = None,
+    ) -> None:
+        # Neo4j fan-out — mirrors IndexWriter.upsert_graph.
+        if self._graph_store is not None and workspace_id is not None:
+            for ent in entities:
+                if hasattr(ent, "metadata"):
+                    ent.metadata["workspace_id"] = str(workspace_id)
+                elif isinstance(ent, dict):
+                    ent.setdefault("metadata", {})["workspace_id"] = str(workspace_id)
+            await self._graph_store.upsert_graph(
+                source_id=source_id,
+                document_id=document_id,
+                entities=entities,
+                edges=edges,
+                snapshot_at=snapshot_at,
+            )
+
+    async def tombstone(
+        self,
+        source_id: uuid.UUID,
+        external_id: str,
+        workspace_id: uuid.UUID | None = None,
+    ) -> bool:
         key = (source_id, external_id)
         if key in self._documents:
             del self._documents[key]
@@ -174,7 +235,13 @@ class _InMemoryIndexWriter:
 def neo4j_container() -> Any:
     from testcontainers.neo4j import Neo4jContainer
 
-    with Neo4jContainer(image="neo4j:5.20").with_env("NEO4J_AUTH", "neo4j/test_password") as c:
+    # Pass the password through the constructor so the wrapper's _configure()
+    # sets NEO4J_AUTH correctly.  Using .with_env("NEO4J_AUTH", ...) is
+    # silently overridden by the wrapper's own default — the container would
+    # then reject the connection below with an AuthError.  This mirrors every
+    # other testcontainers Neo4j fixture in the suite (e.g.
+    # tests/test_graph_store_contract.py, tests/integration/test_replay.py).
+    with Neo4jContainer("neo4j:5.20", password="test_password") as c:
         yield c
 
 
@@ -279,12 +346,15 @@ async def test_ingestion_writes_to_all_three_stores(
         )
         return [ent], []
 
+    # The pipeline writes to all three stores *through* the index_writer
+    # (the worker-write architecture from #126): Postgres + Qdrant via
+    # upsert_document, Neo4j via upsert_graph.  The pipeline itself does
+    # not take graph_store/vector_store — those live behind the writer.
+    index_writer = _InMemoryIndexWriter(graph_store=neo4j_store, vector_store=qdrant_store)
     pipeline = IngestionPipeline(
         connector=connector,
         embedding_provider=_StubEmbedding(),  # type: ignore[arg-type]
-        index_writer=_InMemoryIndexWriter(),  # type: ignore[arg-type]
-        graph_store=neo4j_store,
-        vector_store=qdrant_store,
+        index_writer=index_writer,  # type: ignore[arg-type]
         graph_extractor=_stub_extractor,
     )
 

--- a/tests/test_unblock_ingestion.py
+++ b/tests/test_unblock_ingestion.py
@@ -60,6 +60,12 @@ def _make_settings() -> Settings:
     )
 
 
+# Shared workspace UUID so the mocked token's workspace_id matches the
+# mocked source's tenant_id — the sync endpoint is workspace-scoped and
+# returns 404 on a tenant mismatch (see rest/sources._get_source_or_404).
+_WORKSPACE_ID: uuid.UUID = uuid.uuid4()
+
+
 def _make_source(
     source_type: SourceType = SourceType.git,
 ) -> Source:
@@ -72,6 +78,7 @@ def _make_source(
     src.status = SourceStatus.active
     src.last_sync_at = None
     src.last_error = None
+    src.tenant_id = _WORKSPACE_ID
     return src
 
 
@@ -136,6 +143,9 @@ def _make_app_with_source(source: Source | None = None) -> FastAPI:
     token.expires_at = None
     token.is_active = True
     token.last_used_at = None
+    # Workspace-scoped token: must match the source's tenant_id so the
+    # workspace-scoped sync endpoint resolves the source (not 404).
+    token.workspace_id = _WORKSPACE_ID
 
     app = create_app(settings=_make_settings())
 


### PR DESCRIPTION
## Why main was red

The most recent push CI run on \`main\` (#27305981187) failed **four** jobs: \`lint\` (ruff format), \`test\` (21 failed + 1 error), and \`typecheck\` (mypy, 2 errors). These are pre-existing failures blocking #313, #317/#323, #319/#322. Each failure was traced to a root cause and fixed with the smallest correct change — no skips, xfails, or weakened assertions.

## Per-failure fixes

### 1. 10× \`PermissionError: forbidden:workspace_required\` (MCP tools + operator endpoint)
Commit \`c2fa94d\` ("fail closed on legacy tokens") changed \`get_workspace_id\` to **raise \`PermissionError\`** instead of returning \`None\`, but ~10 call sites still used the now-dead \`if workspace_id is None: raise ...\` guard. The \`PermissionError\` leaked past the MCP/REST boundary instead of the documented contract (\`ValueError("forbidden:...")\` for MCP tools, \`HTTPException(403)\` for the operator endpoint).
**Fix:** wrap each \`get_workspace_id(token)\` call in \`try/except PermissionError\` and raise the site-specific contract error. Files: \`mcp/server.py\` (8 tools), \`mcp/incident_timeline.py\`, \`rest/operator.py\`.

### 2. 7× \`assert 404 == 202\` on \`POST /sources/{id}/sync\` (\`test_unblock_ingestion.py\`)
The sync endpoint became workspace-scoped (\`_get_source_or_404\` 404s on a tenant mismatch). These tests predated scoping: the mocked token had no \`workspace_id\` and the mocked source no \`tenant_id\`, so every sync 404'd.
**Fix (test only):** give the mocked token and source a shared workspace UUID, mirroring \`tests/test_tenant_isolation_rest.py\`.

### 3. 4× \`botocore.exceptions.NoRegionError\` (\`test_aws_config_connector.py\`)
\`_build_config_client\` built a boto3 \`config\` client with \`region=None\`; with no ambient region (env/profile), as in CI, boto3 raises before any aggregator call.
**Fix (product):** default the Config client's home region to \`us-east-1\` (the aggregator API is region-agnostic for org-wide queries), mirroring the existing \`_ORG_REGION\` pattern for the Organizations client.

### 4. 1× \`neo4j.exceptions.AuthError\` (\`test_ingestion_e2e.py\`, opt-in via \`OMNISCIENCE_RUN_E2E_INGESTION=1\`, run in CI)
Two real bugs:
- **Neo4j container auth:** the fixture used \`Neo4jContainer(...).with_env("NEO4J_AUTH", ...)\`, which the testcontainers wrapper silently overrides with its own default password → AuthError on connect. Pass the password through the constructor, matching all 8 other testcontainers Neo4j fixtures in the suite.
- **Pipeline construction:** the test passed \`graph_store=\`/\`vector_store=\` to \`IngestionPipeline\`, which does not accept them. Per the #126 worker-write architecture the pipeline writes all three stores **through** its \`index_writer\` (Postgres+Qdrant via \`upsert_document\`, Neo4j via \`upsert_graph\`). The in-memory index writer is now a faithful orchestrator that drives the live \`graph_store\`/\`vector_store\` exactly as the production \`IndexWriter\` does. **No \`graph_store\`/\`vector_store\` params were added to \`IngestionPipeline\`.**

### 5. 2× mypy errors (typecheck job)
- \`qdrant_store.py:583\` — dropped a now-unused \`# type: ignore[arg-type]\`.
- \`reconcile_worker.py:389\` — annotated \`point_ids: list[int | str | uuid.UUID]\` so the invariant list matches \`PointIdsList(points=...)\`.

### 6. lint (ruff format)
\`scripts/build_aws_docs.py\` and \`tests/test_build_aws_docs.py\` were committed unformatted in #311; reformatted. (Plus formatting on touched files.)

## Overlap notes
- #1 touches the workspace-scoping area from \`c2fa94d\`/#117.
- #4 touches the #126 worker-write ingestion architecture.
- #3/#6 touch the #311 AWS-enriched-scrape area.

## Validation (local)
- \`uv run ruff check .\` — clean
- \`uv run ruff format --check .\` — clean (432 files)
- \`uv run mypy apps/ packages/\` — Success: no issues found in 255 source files
- \`uv run pytest -q --no-cov\` — **3125 passed, 67 skipped, 13 errors**. All 13 errors are \`DockerException\` (no local Docker) in testcontainers integration tests — infra-missing, not code failures; CI provides service containers so they run there. Zero genuine assertion/type failures.

Expectation: main's CI should be green after this merges (lint + typecheck verified clean locally; the Docker-gated tests, including the e2e fix, run against CI service containers).