### PR TITLE
tech(db): clean up legacy pgvector references (#316)

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -21,10 +21,10 @@ See [docs/vision.md](docs/vision.md) for the full project description.
 - **Package manager**: `uv` (Astral)
 - **Web framework**: FastAPI
 - **MCP server**: `mcp` SDK (FastMCP)
-- **ORM**: SQLAlchemy 2 + Alembic (transitional — tracking pgvector phase)
+- **ORM**: SQLAlchemy 2 + Alembic (operational metadata)
 - **Graph store (target)**: **Neo4j** — topology, causal edges, temporal state
 - **Vector store (target)**: **Qdrant** — semantic embeddings
-- **Database (current)**: PostgreSQL 16 + pgvector (to be migrated — see Neo4j+Qdrant epic)
+- **Database (current)**: PostgreSQL 16 (operational metadata only)
 - **Queue**: NATS JetStream
 - **Parsing**: tree-sitter, markdown-it-py
 - **Embeddings**: Ollama (default), OpenAI/Voyage (pluggable)

--- a/packages/core/alembic/versions/0001_initial.py
+++ b/packages/core/alembic/versions/0001_initial.py
@@ -32,10 +32,7 @@ EMBEDDING_DIM: int = 768
 
 
 def upgrade() -> None:
-    # ------------------------------------------------------------------
-    # Step 1: Enable pgvector extension
-    # ------------------------------------------------------------------
-    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    # Extension pgvector is no longer needed/used
 
     # ------------------------------------------------------------------
     # Step 2: Enumerations
@@ -210,11 +207,6 @@ def upgrade() -> None:
             sa.Computed("to_tsvector('english', text)", persisted=True),
             nullable=False,
         ),
-        sa.Column(
-            "embedding",
-            sa.Text(),  # placeholder; replaced below with vector type
-            nullable=True,
-        ),
         sa.Column("symbol", sa.Text(), nullable=True),
         sa.Column(
             "ingestion_run_id",
@@ -234,9 +226,7 @@ def upgrade() -> None:
         ),
     )
 
-    # Fix embedding column to use proper vector type
-    op.execute("ALTER TABLE chunks DROP COLUMN embedding")
-    op.execute(f"ALTER TABLE chunks ADD COLUMN embedding vector({EMBEDDING_DIM})")
+    # pgvector embedding column setup removed
 
     op.create_index("ix_chunks_document_ord", "chunks", ["document_id", "ord"])
     op.create_index(
@@ -245,15 +235,7 @@ def upgrade() -> None:
         ["text_tsv"],
         postgresql_using="gin",
     )
-    # HNSW index for approximate nearest-neighbour vector search
-    op.execute(
-        """
-        CREATE INDEX ix_chunks_embedding_hnsw
-        ON chunks
-        USING hnsw (embedding vector_cosine_ops)
-        WITH (m = 16, ef_construction = 64)
-        """
-    )
+    # HNSW index setup removed
     op.create_index(
         "ix_chunks_embedding_model_provider",
         "chunks",
@@ -308,5 +290,3 @@ def downgrade() -> None:
     sa.Enum(name="ingestion_run_status").drop(op.get_bind(), checkfirst=True)
     sa.Enum(name="source_status").drop(op.get_bind(), checkfirst=True)
     sa.Enum(name="source_type").drop(op.get_bind(), checkfirst=True)
-
-    op.execute("DROP EXTENSION IF EXISTS vector")

--- a/packages/core/alembic/versions/0004_drop_pgvector.py
+++ b/packages/core/alembic/versions/0004_drop_pgvector.py
@@ -65,27 +65,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Restoring pgvector requires re-embedding every chunk — the vectors
-    # are not recoverable from Postgres alone once we have dropped the
-    # column.  The only supported "downgrade" path is a database restore
-    # from a pre-0004 backup plus a rerun of the ingestion pipeline.
-    #
-    # We still re-create the extension, column, and HNSW index so that
-    # an alembic ``downgrade`` does not leave the schema in an
-    # inconsistent state, but callers MUST follow up with a re-ingest.
-
-    # Embedding dimension kept in sync with 0001_initial.EMBEDDING_DIM.
-    # If the embedding model changes, both constants must be updated
-    # together; see ADR-0006 §Embedding model lifecycle.
-    embedding_dim = 768
-
-    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
-    op.execute(f"ALTER TABLE chunks ADD COLUMN embedding vector({embedding_dim})")
-    op.execute(
-        """
-        CREATE INDEX ix_chunks_embedding_hnsw
-        ON chunks
-        USING hnsw (embedding vector_cosine_ops)
-        WITH (m = 16, ef_construction = 64)
-        """
-    )
+    # Downgrade is a no-op as pgvector references are removed.
+    pass

--- a/packages/index/pyproject.toml
+++ b/packages/index/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "omniscience-index"
 version = "0.2.0"
-description = "PostgreSQL + pgvector + Qdrant index layer for Omniscience"
+description = "PostgreSQL + Qdrant index layer for Omniscience"
 requires-python = ">=3.12"
 dependencies = [
     "omniscience-core",


### PR DESCRIPTION
Removes pgvector installation and HNSW index definitions from initial migrations and package metadata.