### PR TITLE
feat(store): lite-mode PostgresOnlyStore and simplify Neo4j/Qdrant bitemporality (#334, #335)

### DIFF
--- a/apps/server/src/omniscience_server/app.py
+++ b/apps/server/src/omniscience_server/app.py
@@ -53,14 +53,14 @@ from omniscience_server.ingestion.worker import IngestionWorker
 from omniscience_server.mcp.mount import create_mcp_asgi_app
 from omniscience_server.mcp.server import mcp_server
 from omniscience_server.middleware import TelemetryMiddleware, TracingMiddleware
+from omniscience_server.outbox_consumer import OutboxConsumerWorker
+from omniscience_server.outbox_worker import OutboxWorker
 from omniscience_server.reconcile_worker import ReconcileWorker
 from omniscience_server.rest import api_v1_router, register_error_handlers
 from omniscience_server.rest.otlp_ingester import OtlpIngester
 from omniscience_server.retention_worker import RetentionWorker
 from omniscience_server.routes import health_router, tokens_router
 from omniscience_server.scheduler import SchedulerWorker
-from omniscience_server.outbox_worker import OutboxWorker
-from omniscience_server.outbox_consumer import OutboxConsumerWorker
 
 log = structlog.get_logger(__name__)
 
@@ -81,8 +81,8 @@ connector_registry._connectors.setdefault(
 # ---------------------------------------------------------------------------
 
 
-_SUPPORTED_GRAPH_BACKENDS: frozenset[str] = frozenset({"neo4j"})
-_SUPPORTED_VECTOR_BACKENDS: frozenset[str] = frozenset({"qdrant"})
+_SUPPORTED_GRAPH_BACKENDS: frozenset[str] = frozenset({"neo4j", "postgres"})
+_SUPPORTED_VECTOR_BACKENDS: frozenset[str] = frozenset({"qdrant", "postgres"})
 
 
 class _UnwiredLegacyService:
@@ -180,28 +180,49 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             "Pgvector was removed at the #105 cutover; see CHANGELOG.md §0.2.0."
         )
 
-    # --- Graph store (Neo4j, ADR-0005) ---
-    neo4j_config = Neo4jStoreConfig.from_settings(settings)
-    neo4j_graph_store = Neo4jGraphStore(config=neo4j_config)
-    await neo4j_graph_store.connect()
-    app.state.graph_store = neo4j_graph_store
-    app.state.neo4j_graph_store = neo4j_graph_store
-    # ADR-0008 §8 phase 2 — bitemporal write-path rollout flag.  Read-only
-    # in this PR (issue #130 lands the schema DDL); the writer that gates
-    # on it lands in #131.  Defaults to "disabled" so PR #104's writer
-    # behaviour is preserved verbatim until #131.
-    app.state.graph_bitemporal_enabled = settings.graph_bitemporal == "enabled"
+    if graph_backend == "postgres" and vector_backend == "postgres":
+        from omniscience_index.stores.postgres_only_store import PostgresOnlyStore
 
-    # --- Vector store (Qdrant, ADR-0006) ---
-    qdrant_store = await _build_qdrant_store(settings, embedding_provider)
-    app.state.vector_store = qdrant_store
-    app.state.qdrant_store = qdrant_store
-    log.info(
-        "storage_adapters_ready",
-        graph_backend=graph_backend,
-        vector_backend=vector_backend,
-        collection=qdrant_store.collection_name,
-    )
+        postgres_only_store = PostgresOnlyStore(
+            session_factory=session_factory,
+            embedding_provider=embedding_provider,
+        )
+        await postgres_only_store.connect()
+        app.state.graph_store = postgres_only_store
+        app.state.vector_store = postgres_only_store
+        app.state.postgres_only_store = postgres_only_store
+        app.state.qdrant_store = postgres_only_store
+        app.state.neo4j_graph_store = postgres_only_store
+        app.state.graph_bitemporal_enabled = False
+        log.info(
+            "storage_adapters_ready",
+            graph_backend=graph_backend,
+            vector_backend=vector_backend,
+            collection="postgres_only",
+        )
+    else:
+        # --- Graph store (Neo4j, ADR-0005) ---
+        neo4j_config = Neo4jStoreConfig.from_settings(settings)
+        neo4j_graph_store = Neo4jGraphStore(config=neo4j_config)
+        await neo4j_graph_store.connect()
+        app.state.graph_store = neo4j_graph_store
+        app.state.neo4j_graph_store = neo4j_graph_store
+        # ADR-0008 §8 phase 2 — bitemporal write-path rollout flag.  Read-only
+        # in this PR (issue #130 lands the schema DDL); the writer that gates
+        # on it lands in #131.  Defaults to "disabled" so PR #104's writer
+        # behaviour is preserved verbatim until #131.
+        app.state.graph_bitemporal_enabled = settings.graph_bitemporal == "enabled"
+
+        # --- Vector store (Qdrant, ADR-0006) ---
+        qdrant_store = await _build_qdrant_store(settings, embedding_provider)
+        app.state.vector_store = qdrant_store
+        app.state.qdrant_store = qdrant_store
+        log.info(
+            "storage_adapters_ready",
+            graph_backend=graph_backend,
+            vector_backend=vector_backend,
+            collection=qdrant_store.collection_name,
+        )
 
     # --- Legacy retrieval handle (unwired after #105) ---
     # The pgvector ``RetrievalService`` is no longer instantiated.
@@ -242,6 +263,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         graph_store=neo4j_graph_store,
         vector_store=qdrant_store,
         legacy_service=federated if federated is not None else _UnwiredLegacyService(),
+        session_factory=session_factory,
     )
     app.state.graph_rag_composer = graph_rag_composer
     log.info(

--- a/packages/index/src/omniscience_index/stores/__init__.py
+++ b/packages/index/src/omniscience_index/stores/__init__.py
@@ -19,5 +19,6 @@ from omniscience_index.stores.neo4j_store import (
     Neo4jGraphStore,
     Neo4jStoreConfig,
 )
+from omniscience_index.stores.postgres_only_store import PostgresOnlyStore
 
-__all__ = ["Neo4jGraphStore", "Neo4jStoreConfig"]
+__all__ = ["Neo4jGraphStore", "Neo4jStoreConfig", "PostgresOnlyStore"]

--- a/packages/index/src/omniscience_index/stores/neo4j/_cypher.py
+++ b/packages/index/src/omniscience_index/stores/neo4j/_cypher.py
@@ -652,7 +652,8 @@ RETURN n.id AS id,
        n.chunk_text AS chunk_text,
        n.valid_from AS valid_from,
        n.valid_to AS valid_to,
-       n.recorded_at AS recorded_at
+       n.recorded_at AS recorded_at,
+       n.metadata AS metadata
 LIMIT 1
 """
 
@@ -669,7 +670,8 @@ RETURN n.id AS id,
        n.chunk_text AS chunk_text,
        s.valid_from AS valid_from,
        s.valid_to AS valid_to,
-       s.recorded_at AS recorded_at
+       s.recorded_at AS recorded_at,
+       s.metadata AS metadata
 LIMIT 1
 """
 
@@ -698,7 +700,8 @@ RETURN n.id AS id,
        n.chunk_text AS chunk_text,
        n.valid_from AS valid_from,
        n.valid_to AS valid_to,
-       n.recorded_at AS recorded_at
+       n.recorded_at AS recorded_at,
+       n.metadata AS metadata
 ORDER BY name
 """
 
@@ -716,7 +719,8 @@ RETURN n.id AS id,
        n.chunk_text AS chunk_text,
        s.valid_from AS valid_from,
        s.valid_to AS valid_to,
-       s.recorded_at AS recorded_at
+       s.recorded_at AS recorded_at,
+       s.metadata AS metadata
 ORDER BY name
 """
 
@@ -744,6 +748,7 @@ _TRAVERSE_CYPHER_TEMPLATE: Final[str] = (
     "    seed.valid_from AS seed_valid_from,\n"
     "    seed.valid_to AS seed_valid_to,\n"
     "    seed.recorded_at AS seed_recorded_at,\n"
+    "    seed.metadata AS seed_metadata,\n"
     "    collect(CASE WHEN neighbour IS NULL THEN NULL ELSE {\n"
     "        id: neighbour.id,\n"
     "        name: neighbour.name,\n"
@@ -754,7 +759,8 @@ _TRAVERSE_CYPHER_TEMPLATE: Final[str] = (
     "        edge_type: rels[-1].edge_type,\n"
     "        valid_from: neighbour.valid_from,\n"
     "        valid_to: neighbour.valid_to,\n"
-    "        recorded_at: neighbour.recorded_at\n"
+    "        recorded_at: neighbour.recorded_at,\n"
+    "        metadata: neighbour.metadata\n"
     "    } END) AS neighbours,\n"
     "    collect(CASE WHEN rels IS NULL THEN NULL ELSE\n"
     "        [startNode(last(rels)).name, endNode(last(rels)).name,"
@@ -796,6 +802,7 @@ _TRAVERSE_AS_OF_CYPHER_TEMPLATE: Final[str] = (
     "    seed_state.valid_from AS seed_valid_from,\n"
     "    seed_state.valid_to AS seed_valid_to,\n"
     "    seed_state.recorded_at AS seed_recorded_at,\n"
+    "    seed_state.metadata AS seed_metadata,\n"
     "    collect(CASE WHEN neighbour IS NULL THEN NULL ELSE {\n"
     "        id: neighbour.id,\n"
     "        name: neighbour.name,\n"
@@ -806,7 +813,8 @@ _TRAVERSE_AS_OF_CYPHER_TEMPLATE: Final[str] = (
     "        edge_type: rels[-1].edge_type,\n"
     "        valid_from: n_state.valid_from,\n"
     "        valid_to: n_state.valid_to,\n"
-    "        recorded_at: n_state.recorded_at\n"
+    "        recorded_at: n_state.recorded_at,\n"
+    "        metadata: coalesce(n_state.metadata, neighbour.metadata)\n"
     "    } END) AS neighbours,\n"
     "    collect(CASE WHEN rels IS NULL THEN NULL ELSE\n"
     "        [startNode(last(rels)).name, endNode(last(rels)).name,"

--- a/packages/index/src/omniscience_index/stores/neo4j/mappers.py
+++ b/packages/index/src/omniscience_index/stores/neo4j/mappers.py
@@ -302,6 +302,7 @@ def _entity_record_to_view(record: dict[str, Any]) -> EntityNodeView:
         valid_from=_optional_datetime(record.get("valid_from")),
         valid_to=_optional_datetime(record.get("valid_to")),
         recorded_at=_optional_datetime(record.get("recorded_at")),
+        metadata=record.get("metadata") or {},
     )
 
 
@@ -318,6 +319,7 @@ def _neighbour_to_view(payload: dict[str, Any]) -> EntityNodeView:
         valid_from=_optional_datetime(payload.get("valid_from")),
         valid_to=_optional_datetime(payload.get("valid_to")),
         recorded_at=_optional_datetime(payload.get("recorded_at")),
+        metadata=payload.get("metadata") or {},
     )
 
 
@@ -349,6 +351,7 @@ def _rows_to_graph_result(row: dict[str, Any]) -> GraphResultView:
         valid_from=_optional_datetime(row.get("seed_valid_from")),
         valid_to=_optional_datetime(row.get("seed_valid_to")),
         recorded_at=_optional_datetime(row.get("seed_recorded_at")),
+        metadata=row.get("seed_metadata") or {},
     )
     related_raw = row.get("neighbours") or []
     related = [_neighbour_to_view(n) for n in related_raw if n and n.get("name")]

--- a/packages/index/src/omniscience_index/stores/neo4j/store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j/store.py
@@ -177,7 +177,7 @@ class Neo4jGraphStore:
             max_transaction_retry_time=(config.max_transaction_retry_time_seconds),
         )
         self._bootstrapped: bool = False
-        self._bitemporal_enabled: bool = bool(config.bitemporal_enabled)
+        self._bitemporal_enabled: bool = False
 
     async def connect(self) -> None:
         """Verify connectivity and run the idempotent schema bootstrap."""
@@ -997,12 +997,229 @@ class Neo4jGraphStore:
                n.name AS name,
                n.kind AS kind,
                n.source_id AS source_id,
-               n.name AS chunk_text,
+               n.chunk_text AS chunk_text,
                n.valid_from AS valid_from,
                n.valid_to AS valid_to,
-               n.recorded_at AS recorded_at
+               n.recorded_at AS recorded_at,
+               n.metadata AS metadata
         """
         params = {"workspace_id": str(workspace_id)}
         async with self._driver.session(database=self._config.database) as session:
             rows = await session.execute_read(_run_read_stmt, cypher, params)
         return [_entity_record_to_view(r) for r in rows]
+
+    async def merge_nodes(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        source_id: uuid.UUID,
+        target_id: uuid.UUID,
+    ) -> bool:
+        """Merge a source node into a target node reversibly."""
+        params = {
+            "workspace_id": str(workspace_id),
+            "source_id": str(source_id),
+            "target_id": str(target_id),
+        }
+
+        async with self._driver.session(database=self._config.database) as session:
+            exist_check_cypher = """
+            MATCH (a:`Entity` {workspace_id: $workspace_id, id: $source_id})
+            MATCH (b:`Entity` {workspace_id: $workspace_id, id: $target_id})
+            RETURN a.id AS aid, b.id AS bid
+            """
+            rows = await session.execute_read(_run_read_stmt, exist_check_cypher, params)
+            if not rows:
+                return False
+
+            async def _merge_tx(tx):
+                merge_rel_cypher = """
+                MATCH (a:`Entity` {workspace_id: $workspace_id, id: $source_id})
+                MATCH (b:`Entity` {workspace_id: $workspace_id, id: $target_id})
+                MERGE (a)-[r:MERGED_INTO {workspace_id: $workspace_id}]->(b)
+                SET a.is_merged = true, a.merged_into = $target_id
+                """
+                await tx.run(merge_rel_cypher, params)
+
+                inc_cypher = """
+                MATCH (x)-[r]->(a:`Entity` {workspace_id: $workspace_id, id: $source_id})
+                WHERE r.workspace_id = $workspace_id 
+                  AND type(r) <> 'MERGED_INTO' 
+                  AND type(r) <> 'HAD_STATE'
+                RETURN id(r) AS rid, type(r) AS rtype, properties(r) AS rprops, x.id AS other_id
+                """
+                inc_res = await tx.run(inc_cypher, params)
+                inc_records = [rec async for rec in inc_res]
+
+                out_cypher = """
+                MATCH (a:`Entity` {workspace_id: $workspace_id, id: $source_id})-[r]->(y)
+                WHERE r.workspace_id = $workspace_id 
+                  AND type(r) <> 'MERGED_INTO' 
+                  AND type(r) <> 'HAD_STATE'
+                RETURN id(r) AS rid, type(r) AS rtype, properties(r) AS rprops, y.id AS other_id
+                """
+                out_res = await tx.run(out_cypher, params)
+                out_records = [rec async for rec in out_res]
+
+                for rec in inc_records:
+                    rtype = rec["rtype"]
+                    other_id = rec["other_id"]
+                    rprops = dict(rec["rprops"])
+                    rprops["original_node_id"] = str(source_id)
+                    redirect_inc_cypher = f"""
+                    MATCH (x {{workspace_id: $workspace_id, id: $other_id}})
+                    MATCH (b:`Entity` {{workspace_id: $workspace_id, id: $target_id}})
+                    CREATE (x)-[r2:`{rtype}` {{workspace_id: $workspace_id}}]->(b)
+                    SET r2 = $rprops
+                    """
+                    await tx.run(
+                        redirect_inc_cypher,
+                        {
+                            "workspace_id": str(workspace_id),
+                            "other_id": str(other_id),
+                            "target_id": str(target_id),
+                            "rprops": rprops,
+                        },
+                    )
+
+                for rec in out_records:
+                    rtype = rec["rtype"]
+                    other_id = rec["other_id"]
+                    rprops = dict(rec["rprops"])
+                    rprops["original_node_id"] = str(source_id)
+                    redirect_out_cypher = f"""
+                    MATCH (b:`Entity` {{workspace_id: $workspace_id, id: $target_id}})
+                    MATCH (y {{workspace_id: $workspace_id, id: $other_id}})
+                    CREATE (b)-[r2:`{rtype}` {{workspace_id: $workspace_id}}]->(y)
+                    SET r2 = $rprops
+                    """
+                    await tx.run(
+                        redirect_out_cypher,
+                        {
+                            "workspace_id": str(workspace_id),
+                            "other_id": str(other_id),
+                            "target_id": str(target_id),
+                            "rprops": rprops,
+                        },
+                    )
+
+                del_cypher = """
+                MATCH (a:`Entity` {workspace_id: $workspace_id, id: $source_id})-[r]-()
+                WHERE r.workspace_id = $workspace_id 
+                  AND type(r) <> 'MERGED_INTO' 
+                  AND type(r) <> 'HAD_STATE'
+                DELETE r
+                """
+                await tx.run(del_cypher, params)
+                return True
+
+            await session.execute_write(_merge_tx)
+            return True
+
+    async def unmerge_node(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        merged_node_id: uuid.UUID,
+    ) -> bool:
+        """Split/unmerge a previously merged node back to its original identity."""
+        params = {
+            "workspace_id": str(workspace_id),
+            "merged_node_id": str(merged_node_id),
+        }
+        async with self._driver.session(database=self._config.database) as session:
+            check_cypher = """
+            MATCH (a:`Entity` {workspace_id: $workspace_id, id: $merged_node_id})
+            WHERE a.is_merged = true
+            RETURN a.merged_into AS target_id
+            """
+            rows = await session.execute_read(_run_read_stmt, check_cypher, params)
+            if not rows or not rows[0].get("target_id"):
+                return False
+
+            target_id = rows[0]["target_id"]
+            params["target_id"] = str(target_id)
+
+            async def _unmerge_tx(tx):
+                inc_cypher = """
+                MATCH (x)-[r]->(b:`Entity` {workspace_id: $workspace_id, id: $target_id})
+                WHERE r.workspace_id = $workspace_id AND r.original_node_id = $merged_node_id
+                RETURN id(r) AS rid, type(r) AS rtype, properties(r) AS rprops, x.id AS other_id
+                """
+                inc_res = await tx.run(inc_cypher, params)
+                inc_records = [rec async for rec in inc_res]
+
+                out_cypher = """
+                MATCH (b:`Entity` {workspace_id: $workspace_id, id: $target_id})-[r]->(y)
+                WHERE r.workspace_id = $workspace_id AND r.original_node_id = $merged_node_id
+                RETURN id(r) AS rid, type(r) AS rtype, properties(r) AS rprops, y.id AS other_id
+                """
+                out_res = await tx.run(out_cypher, params)
+                out_records = [rec async for rec in out_res]
+
+                for rec in inc_records:
+                    rtype = rec["rtype"]
+                    other_id = rec["other_id"]
+                    rprops = dict(rec["rprops"])
+                    rprops.pop("original_node_id", None)
+                    restore_inc_cypher = f"""
+                    MATCH (x {{workspace_id: $workspace_id, id: $other_id}})
+                    MATCH (a:`Entity` {{workspace_id: $workspace_id, id: $merged_node_id}})
+                    CREATE (x)-[r2:`{rtype}` {{workspace_id: $workspace_id}}]->(a)
+                    SET r2 = $rprops
+                    """
+                    await tx.run(
+                        restore_inc_cypher,
+                        {
+                            "workspace_id": str(workspace_id),
+                            "other_id": str(other_id),
+                            "merged_node_id": str(merged_node_id),
+                            "rprops": rprops,
+                        },
+                    )
+
+                for rec in out_records:
+                    rtype = rec["rtype"]
+                    other_id = rec["other_id"]
+                    rprops = dict(rec["rprops"])
+                    rprops.pop("original_node_id", None)
+                    restore_out_cypher = f"""
+                    MATCH (a:`Entity` {{workspace_id: $workspace_id, id: $merged_node_id}})
+                    MATCH (y {{workspace_id: $workspace_id, id: $other_id}})
+                    CREATE (a)-[r2:`{rtype}` {{workspace_id: $workspace_id}}]->(y)
+                    SET r2 = $rprops
+                    """
+                    await tx.run(
+                        restore_out_cypher,
+                        {
+                            "workspace_id": str(workspace_id),
+                            "other_id": str(other_id),
+                            "merged_node_id": str(merged_node_id),
+                            "rprops": rprops,
+                        },
+                    )
+
+                del_cypher = """
+                MATCH (b:`Entity` {workspace_id: $workspace_id, id: $target_id})-[r]-()
+                WHERE r.workspace_id = $workspace_id AND r.original_node_id = $merged_node_id
+                DELETE r
+                """
+                await tx.run(del_cypher, params)
+
+                del_merge_rel = """
+                MATCH (a:`Entity` {workspace_id: $workspace_id, id: $merged_node_id})
+                      -[r:MERGED_INTO]->
+                      (b:`Entity` {workspace_id: $workspace_id, id: $target_id})
+                DELETE r
+                """
+                await tx.run(del_merge_rel, params)
+
+                reset_props = """
+                MATCH (a:`Entity` {workspace_id: $workspace_id, id: $merged_node_id})
+                REMOVE a.is_merged, a.merged_into
+                """
+                await tx.run(reset_props, params)
+                return True
+
+            await session.execute_write(_unmerge_tx)
+            return True

--- a/packages/index/src/omniscience_index/stores/postgres_only_store.py
+++ b/packages/index/src/omniscience_index/stores/postgres_only_store.py
@@ -1,0 +1,999 @@
+"""PostgresOnlyStore: A class implementing GraphStore and VectorStore protocols for Lite-mode."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+from omniscience_core.db.models import Chunk, Document, Edge, Entity, Source
+from omniscience_core.storage.graph import (
+    EdgeUpsert,
+    EntityNodeView,
+    EntityUpsert,
+    GraphEdgeView,
+    GraphResultView,
+)
+from omniscience_core.storage.vector import (
+    ChunkPayload,
+    UpsertOutcome,
+)
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+if TYPE_CHECKING:
+    from omniscience_embeddings.base import EmbeddingProvider
+    from omniscience_retrieval.models import (
+        SearchRequest,
+        SearchResult,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresOnlyStore:
+    """Lite-mode store that bypasses Neo4j and Qdrant entirely.
+    Uses Postgres for both graph relations (recursive CTEs) and vector embeddings (pgvector).
+    """
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        embedding_provider: EmbeddingProvider | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._embedding_provider = embedding_provider
+
+    async def connect(self) -> None:
+        """Dynamically enable pgvector extension and add embedding column to chunks table."""
+        async with self._session_factory() as session:
+            try:
+                await session.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+                await session.execute(
+                    text("ALTER TABLE chunks ADD COLUMN IF NOT EXISTS embedding vector")
+                )
+                await session.commit()
+            except Exception as e:
+                await session.rollback()
+                logger.warning("Failed to initialize vector extension/column: %s", e)
+
+    async def close(self) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # GraphStore Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_graph(
+        self,
+        *,
+        source_id: uuid.UUID,
+        document_id: uuid.UUID,
+        entities: list[Any],
+        edges: list[Any],
+        snapshot_at: datetime | None = None,
+    ) -> None:
+        """Persist a batch of entities and edges for one document/source."""
+        if not entities:
+            return
+
+        # workspace_id can be extracted from the first entity
+        head = entities[0]
+        ws = getattr(head, "workspace_id", None)
+        if ws is None:
+            metadata = getattr(head, "metadata", None) or {}
+            ws = metadata.get("workspace_id")
+        if ws is None:
+            raise ValueError("upsert_graph_missing_workspace_id")
+        uuid.UUID(str(ws)) if not isinstance(ws, uuid.UUID) else ws
+
+        async with self._session_factory() as session, session.begin():
+            # Standard active-state: delete existing entities/edges by source_id
+            # Edge deletion cascades automatically due to FK ondelete CASCADE,
+            # but we can be explicit
+            entity_ids_stmt = select(Entity.id).where(Entity.source_id == source_id)
+            entity_ids_res = await session.execute(entity_ids_stmt)
+            entity_ids = [r[0] for r in entity_ids_res.all()]
+            if entity_ids:
+                await session.execute(
+                    delete(Edge).where(
+                        (Edge.source_entity_id.in_(entity_ids))
+                        | (Edge.target_entity_id.in_(entity_ids))
+                    )
+                )
+                await session.execute(delete(Entity).where(Entity.id.in_(entity_ids)))
+
+            name_to_id: dict[str, uuid.UUID] = {}
+            # Insert entities
+            for ent in entities:
+                ent_id = getattr(ent, "id", None) or uuid.uuid4()
+                ent_type = getattr(ent, "entity_type", None) or getattr(ent, "kind", "entity")
+                name = getattr(ent, "name", "")
+                display_name = getattr(ent, "display_name", name)
+                chunk_id = getattr(ent, "chunk_id", None)
+                metadata = getattr(ent, "metadata", None) or {}
+                if isinstance(metadata, str):
+                    import json
+
+                    try:
+                        metadata = json.loads(metadata)
+                    except ValueError:
+                        metadata = {}
+
+                db_ent = Entity(
+                    id=ent_id,
+                    source_id=source_id,
+                    entity_type=ent_type,
+                    name=name,
+                    display_name=display_name,
+                    chunk_id=chunk_id,
+                    entity_metadata=metadata,
+                )
+                session.add(db_ent)
+                name_to_id[name] = ent_id
+                name_to_id[display_name] = ent_id
+
+            await session.flush()
+
+            # Insert edges
+            for edge in edges:
+                src_id = getattr(edge, "source_entity_id", None)
+                tgt_id = getattr(edge, "target_entity_id", None)
+                tgt_name = getattr(edge, "target_name", None)
+                edge_type = getattr(edge, "edge_type", "calls")
+                metadata = getattr(edge, "metadata", None) or {}
+
+                if src_id is None:
+                    continue
+
+                if tgt_id is None and tgt_name is not None:
+                    tgt_id = name_to_id.get(str(tgt_name))
+
+                # Create stub target if not found
+                if tgt_id is None:
+                    tgt_id = uuid.uuid4()
+                    stub_name = str(tgt_name or "stub")
+                    stub_ent = Entity(
+                        id=tgt_id,
+                        source_id=source_id,
+                        entity_type="stub",
+                        name=stub_name,
+                        display_name=stub_name,
+                        entity_metadata={"is_stub": True},
+                    )
+                    session.add(stub_ent)
+                    await session.flush()
+                    name_to_id[stub_name] = tgt_id
+
+                if src_id == tgt_id:
+                    continue  # skip self loops
+
+                db_edge = Edge(
+                    id=uuid.uuid4(),
+                    source_entity_id=src_id,
+                    target_entity_id=tgt_id,
+                    edge_type=edge_type,
+                    edge_metadata=metadata,
+                )
+                session.add(db_edge)
+
+    async def upsert_entity(self, *, entity: EntityUpsert, workspace_id: uuid.UUID) -> None:
+        async with self._session_factory() as session, session.begin():
+            # Check if exists
+            stmt = select(Entity).where(Entity.id == entity.id)
+            res = await session.execute(stmt)
+            db_ent = res.scalar_one_or_none()
+            if db_ent is None:
+                db_ent = Entity(
+                    id=entity.id,
+                    source_id=entity.source_id,
+                    entity_type=entity.entity_type,
+                    name=entity.name,
+                    display_name=entity.display_name,
+                    chunk_id=entity.chunk_id,
+                    entity_metadata=entity.metadata,
+                )
+                session.add(db_ent)
+            else:
+                db_ent.entity_type = entity.entity_type
+                db_ent.name = entity.name
+                db_ent.display_name = entity.display_name
+                db_ent.chunk_id = entity.chunk_id
+                db_ent.entity_metadata = entity.metadata
+
+    async def upsert_edge(self, *, edge: EdgeUpsert, workspace_id: uuid.UUID) -> None:
+        async with self._session_factory() as session, session.begin():
+            db_edge = Edge(
+                id=uuid.uuid4(),
+                source_entity_id=edge.source_entity_id,
+                target_entity_id=edge.target_entity_id,
+                edge_type=edge.edge_type,
+                edge_metadata=edge.metadata,
+            )
+            session.add(db_edge)
+
+    async def upsert_edge_by_name(
+        self,
+        *,
+        source_entity_id: uuid.UUID,
+        target_name: str,
+        edge_type: str,
+        workspace_id: uuid.UUID,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        async with self._session_factory() as session, session.begin():
+            # Find source entity to get source_id
+            src_ent = await session.get(Entity, source_entity_id)
+            if src_ent is None:
+                return
+
+            # Check if target entity exists in this workspace
+            stmt = (
+                select(Entity)
+                .join(Source)
+                .where(Entity.name == target_name, Source.tenant_id == workspace_id)
+            )
+            res = await session.execute(stmt)
+            tgt_ent = res.scalar_one_or_none()
+            if tgt_ent is None:
+                # Create stub
+                tgt_ent = Entity(
+                    id=uuid.uuid4(),
+                    source_id=src_ent.source_id,
+                    entity_type="stub",
+                    name=target_name,
+                    display_name=target_name,
+                    entity_metadata={"is_stub": True},
+                )
+                session.add(tgt_ent)
+                await session.flush()
+
+            if source_entity_id == tgt_ent.id:
+                return
+
+            db_edge = Edge(
+                id=uuid.uuid4(),
+                source_entity_id=source_entity_id,
+                target_entity_id=tgt_ent.id,
+                edge_type=edge_type,
+                edge_metadata=metadata or {},
+            )
+            session.add(db_edge)
+
+    async def delete_tombstoned_graph(self) -> int:
+        return 0
+
+    async def resolve_pending_stubs(self, *, workspace_id: uuid.UUID) -> int:
+        # Resolve stub nodes that have been replaced by real entities
+        async with self._session_factory() as session, session.begin():
+            stubs_stmt = (
+                select(Entity)
+                .join(Source)
+                .where(Entity.entity_type == "stub", Source.tenant_id == workspace_id)
+            )
+            stubs_res = await session.execute(stubs_stmt)
+            stubs = stubs_res.scalars().all()
+            if not stubs:
+                return 0
+
+            count = 0
+            for stub in stubs:
+                real_stmt = (
+                    select(Entity)
+                    .join(Source)
+                    .where(
+                        Entity.name == stub.name,
+                        Entity.entity_type != "stub",
+                        Source.tenant_id == workspace_id,
+                    )
+                )
+                real_res = await session.execute(real_stmt)
+                real = real_res.scalar_one_or_none()
+                if real:
+                    await session.execute(
+                        text(
+                            "UPDATE edges SET source_entity_id = :real_id "
+                            "WHERE source_entity_id = :stub_id"
+                        ),
+                        {"real_id": real.id, "stub_id": stub.id},
+                    )
+                    await session.execute(
+                        text(
+                            "UPDATE edges SET target_entity_id = :real_id "
+                            "WHERE target_entity_id = :stub_id"
+                        ),
+                        {"real_id": real.id, "stub_id": stub.id},
+                    )
+                    await session.delete(stub)
+                    count += 1
+            return count
+
+    # ------------------------------------------------------------------
+    # GraphStore Read API
+    # ------------------------------------------------------------------
+
+    async def get_entity(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> EntityNodeView | None:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Entity)
+                .join(Source)
+                .where(Entity.name == entity_name, Source.tenant_id == workspace_id)
+            )
+            res = await session.execute(stmt)
+            ent = res.scalar_one_or_none()
+            if ent is None:
+                return None
+
+            chunk_text = None
+            if ent.chunk_id:
+                chk = await session.get(Chunk, ent.chunk_id)
+                if chk:
+                    chunk_text = chk.text
+
+            return EntityNodeView(
+                id=ent.id,
+                name=ent.name,
+                kind=ent.entity_type,
+                source=str(ent.source_id),
+                chunk_text=chunk_text,
+                display_name=ent.display_name,
+            )
+
+    async def find_related(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        return await self.traverse(
+            entity_name=entity_name,
+            workspace_id=workspace_id,
+            as_of=as_of,
+            max_depth=max_depth,
+            edge_types=edge_types,
+        )
+
+    async def traverse(
+        self,
+        *,
+        entity_name: str,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+        max_depth: int = 1,
+        edge_types: list[str] | None = None,
+    ) -> GraphResultView:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Entity)
+                .join(Source)
+                .where(Entity.name == entity_name, Source.tenant_id == workspace_id)
+            )
+            res = await session.execute(stmt)
+            seed_ent = res.scalar_one_or_none()
+            if seed_ent is None:
+                raise ValueError(f"entity_not_found:{entity_name}")
+
+            chunk_text = None
+            if seed_ent.chunk_id:
+                chk = await session.get(Chunk, seed_ent.chunk_id)
+                if chk:
+                    chunk_text = chk.text
+
+            seed_view = EntityNodeView(
+                id=seed_ent.id,
+                name=seed_ent.name,
+                kind=seed_ent.entity_type,
+                source=str(seed_ent.source_id),
+                chunk_text=chunk_text,
+                depth=0,
+                display_name=seed_ent.display_name,
+            )
+
+            edge_types_clause = ""
+            if edge_types:
+                edge_types_clause = "AND edge.edge_type = ANY(:edge_types)"
+
+            sql = """
+            WITH RECURSIVE traverse_cte AS (
+                SELECT
+                    e.id,
+                    e.source_id,
+                    e.entity_type,
+                    e.name,
+                    e.display_name,
+                    e.chunk_id,
+                    0 AS depth
+                FROM entities e
+                WHERE e.id = :seed_id
+
+                UNION ALL
+
+                SELECT
+                    e.id,
+                    e.source_id,
+                    e.entity_type,
+                    e.name,
+                    e.display_name,
+                    e.chunk_id,
+                    tc.depth + 1 AS depth
+                FROM traverse_cte tc
+                JOIN edges edge ON tc.id = edge.source_entity_id
+                JOIN entities e ON edge.target_entity_id = e.id
+                JOIN sources s ON e.source_id = s.id
+                WHERE tc.depth < :max_depth
+                  AND s.tenant_id = :workspace_id
+                  {edge_types_clause}
+            )
+            SELECT DISTINCT ON (id)
+                tc.id,
+                tc.source_id,
+                tc.entity_type,
+                tc.name,
+                tc.display_name,
+                tc.chunk_id,
+                tc.depth,
+                ch.text AS chunk_text
+            FROM traverse_cte tc
+            LEFT JOIN chunks ch ON tc.chunk_id = ch.id
+            ORDER BY id, depth ASC;
+            """
+            sql = sql.replace("{edge_types_clause}", edge_types_clause)
+
+            params = {
+                "seed_id": seed_ent.id,
+                "max_depth": max_depth,
+                "workspace_id": workspace_id,
+            }
+            if edge_types:
+                params["edge_types"] = edge_types
+
+            nodes_res = await session.execute(text(sql), params)
+            rows = nodes_res.all()
+
+            related = []
+            node_ids = [seed_ent.id]
+            for r in rows:
+                if r.id == seed_ent.id:
+                    continue
+                node_ids.append(r.id)
+                related.append(
+                    EntityNodeView(
+                        id=r.id,
+                        name=r.name,
+                        kind=r.entity_type,
+                        source=str(r.source_id),
+                        chunk_text=r.chunk_text,
+                        depth=r.depth,
+                        display_name=r.display_name,
+                    )
+                )
+
+            edges_sql = """
+            SELECT
+                edge.edge_type,
+                src.name AS from_name,
+                tgt.name AS to_name
+            FROM edges edge
+            JOIN entities src ON edge.source_entity_id = src.id
+            JOIN entities tgt ON edge.target_entity_id = tgt.id
+            WHERE edge.source_entity_id = ANY(:node_ids)
+              AND edge.target_entity_id = ANY(:node_ids);
+            """
+            edges_res = await session.execute(text(edges_sql), {"node_ids": node_ids})
+            edge_rows = edges_res.all()
+
+            edges = [
+                GraphEdgeView(
+                    from_entity=er.from_name,
+                    to_entity=er.to_name,
+                    edge_type=er.edge_type,
+                )
+                for er in edge_rows
+            ]
+
+            return GraphResultView(seed=seed_view, related=related, edges=edges)
+
+    async def list_entities(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        kind: str,
+        cluster: str | None = None,
+        name: str | None = None,
+        as_of: datetime | None = None,
+    ) -> list[EntityNodeView]:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Entity)
+                .join(Source)
+                .where(Entity.entity_type == kind, Source.tenant_id == workspace_id)
+            )
+            if name is not None:
+                stmt = stmt.where(Entity.name == name)
+            if cluster is not None:
+                stmt = stmt.where(Entity.entity_metadata["cluster"].astext == cluster)
+
+            res = await session.execute(stmt)
+            entities = res.scalars().all()
+
+            views = []
+            for ent in entities:
+                chunk_text = None
+                if ent.chunk_id:
+                    chk = await session.get(Chunk, ent.chunk_id)
+                    if chk:
+                        chunk_text = chk.text
+
+                views.append(
+                    EntityNodeView(
+                        id=ent.id,
+                        name=ent.name,
+                        kind=ent.entity_type,
+                        source=str(ent.source_id),
+                        chunk_text=chunk_text,
+                        display_name=ent.display_name,
+                    )
+                )
+            return views
+
+    async def find_entities_by_metadata(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        key: str,
+        value: Any,
+    ) -> list[EntityNodeView]:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Entity)
+                .join(Source)
+                .where(
+                    Source.tenant_id == workspace_id,
+                    Entity.entity_metadata[key].astext == str(value),
+                )
+            )
+            res = await session.execute(stmt)
+            entities = res.scalars().all()
+
+            views = []
+            for ent in entities:
+                chunk_text = None
+                if ent.chunk_id:
+                    chk = await session.get(Chunk, ent.chunk_id)
+                    if chk:
+                        chunk_text = chk.text
+                views.append(
+                    EntityNodeView(
+                        id=ent.id,
+                        name=ent.name,
+                        kind=ent.entity_type,
+                        source=str(ent.source_id),
+                        chunk_text=chunk_text,
+                        display_name=ent.display_name,
+                    )
+                )
+            return views
+
+    async def get_all_entities(self, *, workspace_id: uuid.UUID) -> list[EntityNodeView]:
+        async with self._session_factory() as session:
+            stmt = select(Entity).join(Source).where(Source.tenant_id == workspace_id)
+            res = await session.execute(stmt)
+            entities = res.scalars().all()
+            views = []
+            for ent in entities:
+                chunk_text = None
+                if ent.chunk_id:
+                    chk = await session.get(Chunk, ent.chunk_id)
+                    if chk:
+                        chunk_text = chk.text
+                views.append(
+                    EntityNodeView(
+                        id=ent.id,
+                        name=ent.name,
+                        kind=ent.entity_type,
+                        source=str(ent.source_id),
+                        chunk_text=chunk_text,
+                        display_name=ent.display_name,
+                    )
+                )
+            return views
+
+    # ------------------------------------------------------------------
+    # GraphStore Stats API
+    # ------------------------------------------------------------------
+
+    async def count_entities(self, *, workspace_id: uuid.UUID) -> int:
+        async with self._session_factory() as session:
+            stmt = (
+                select(func.count(Entity.id)).join(Source).where(Source.tenant_id == workspace_id)
+            )
+            res = await session.execute(stmt)
+            return res.scalar() or 0
+
+    async def count_entities_by_kind(self, *, workspace_id: uuid.UUID) -> dict[str, int]:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Entity.entity_type, func.count(Entity.id))
+                .join(Source)
+                .where(Source.tenant_id == workspace_id)
+                .group_by(Entity.entity_type)
+            )
+            res = await session.execute(stmt)
+            return {r[0]: r[1] for r in res.all()}
+
+    async def count_edges_by_type(self, *, workspace_id: uuid.UUID) -> dict[str, int]:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Edge.edge_type, func.count(Edge.id))
+                .join(Entity, Edge.source_entity_id == Entity.id)
+                .join(Source)
+                .where(Source.tenant_id == workspace_id)
+                .group_by(Edge.edge_type)
+            )
+            res = await session.execute(stmt)
+            return {r[0]: r[1] for r in res.all()}
+
+    async def count_entities_by_source(self, *, workspace_id: uuid.UUID) -> dict[str, int]:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Entity.source_id, func.count(Entity.id))
+                .join(Source)
+                .where(Source.tenant_id == workspace_id)
+                .group_by(Entity.source_id)
+            )
+            res = await session.execute(stmt)
+            return {str(r[0]): r[1] for r in res.all()}
+
+    # ------------------------------------------------------------------
+    # VectorStore Write API
+    # ------------------------------------------------------------------
+
+    async def upsert_chunks(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+        uri: str,
+        title: str | None,
+        content_hash: str,
+        metadata: dict[str, Any],
+        chunks: list[ChunkPayload],
+        ingestion_run_id: uuid.UUID | None = None,
+    ) -> UpsertOutcome:
+        async with self._session_factory() as session, session.begin():
+            doc_stmt = select(Document).where(
+                Document.source_id == source_id, Document.external_id == external_id
+            )
+            doc_res = await session.execute(doc_stmt)
+            doc = doc_res.scalar_one_or_none()
+            if doc is None:
+                doc = Document(
+                    id=uuid.uuid4(),
+                    source_id=source_id,
+                    external_id=external_id,
+                    uri=uri,
+                    title=title,
+                    content_hash=content_hash,
+                    doc_metadata=metadata,
+                    doc_version=1,
+                )
+                session.add(doc)
+                await session.flush()
+                action = "created"
+            else:
+                doc.uri = uri
+                doc.title = title
+                doc.content_hash = content_hash
+                doc.doc_metadata = metadata
+                doc.doc_version += 1
+                action = "updated"
+
+            if action == "updated":
+                await session.execute(delete(Chunk).where(Chunk.document_id == doc.id))
+
+            for chunk_payload in chunks:
+                chunk = Chunk(
+                    id=uuid.uuid4(),
+                    document_id=doc.id,
+                    ord=chunk_payload["ord"],
+                    text=chunk_payload["text"],
+                    symbol=chunk_payload.get("symbol"),
+                    ingestion_run_id=ingestion_run_id,
+                    embedding_model=chunk_payload.get("embedding_model", ""),
+                    embedding_provider=chunk_payload.get("embedding_provider", ""),
+                    parser_version=chunk_payload.get("parser_version", ""),
+                    chunker_strategy=chunk_payload.get("chunker_strategy", ""),
+                    chunk_metadata=chunk_payload.get("metadata", {}),
+                )
+                session.add(chunk)
+                await session.flush()
+                if chunk_payload.get("embedding"):
+                    emb_str = "[" + ",".join(map(str, chunk_payload["embedding"])) + "]"
+                    await session.execute(
+                        text("UPDATE chunks SET embedding = :emb::vector WHERE id = :cid"),
+                        {"emb": emb_str, "cid": chunk.id},
+                    )
+
+            return UpsertOutcome(
+                action=action,
+                document_id=doc.id,
+                chunks_written=len(chunks),
+                doc_version=doc.doc_version,
+            )
+
+    async def delete_by_document(
+        self,
+        *,
+        source_id: uuid.UUID,
+        external_id: str,
+        workspace_id: uuid.UUID | None = None,
+    ) -> bool:
+        async with self._session_factory() as session, session.begin():
+            stmt = select(Document).where(
+                Document.source_id == source_id, Document.external_id == external_id
+            )
+            res = await session.execute(stmt)
+            doc = res.scalar_one_or_none()
+            if doc is None or doc.tombstoned_at is not None:
+                return False
+            doc.tombstoned_at = datetime.now(UTC)
+            return True
+
+    async def delete_tombstoned(self, older_than: timedelta | None = None) -> int:
+        if older_than is None:
+            return 0
+        cutoff = datetime.now(UTC) - older_than
+        async with self._session_factory() as session, session.begin():
+            stmt = select(Document.id).where(Document.tombstoned_at < cutoff)
+            res = await session.execute(stmt)
+            doc_ids = [r[0] for r in res.all()]
+            if not doc_ids:
+                return 0
+            await session.execute(delete(Chunk).where(Chunk.document_id.in_(doc_ids)))
+            await session.execute(delete(Document).where(Document.id.in_(doc_ids)))
+            return len(doc_ids)
+
+    # ------------------------------------------------------------------
+    # VectorStore Read API
+    # ------------------------------------------------------------------
+
+    async def search(
+        self,
+        *,
+        request: SearchRequest,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> SearchResult:
+        from omniscience_retrieval.models import (
+            ChunkLineage,
+            Citation,
+            QueryStats,
+            SearchHit,
+            SearchResult,
+            SourceInfo,
+        )
+
+        start = time.monotonic()
+        query_vector = await self._embed_query(request.query)
+
+        async with self._session_factory() as session:
+            stmt = (
+                select(
+                    Chunk,
+                    Document,
+                    Source,
+                    Chunk.embedding.op("<=>")(query_vector).label("distance"),
+                )
+                .join(Document, Chunk.document_id == Document.id)
+                .join(Source, Document.source_id == Source.id)
+            )
+
+            stmt = stmt.where(Source.tenant_id == workspace_id)
+
+            if not request.include_tombstoned:
+                stmt = stmt.where(Document.tombstoned_at.is_(None))
+
+            if request.sources:
+                source_uuids = []
+                for s in request.sources:
+                    with contextlib.suppress(ValueError):
+                        source_uuids.append(uuid.UUID(s))
+                if source_uuids:
+                    stmt = stmt.where(Source.id.in_(source_uuids))
+
+            if request.max_age_seconds:
+                cutoff = datetime.now(UTC) - timedelta(seconds=request.max_age_seconds)
+                stmt = stmt.where(Document.indexed_at >= cutoff)
+
+            stmt = stmt.order_by("distance").limit(request.top_k)
+
+            res = await session.execute(stmt)
+            rows = res.all()
+
+            hits = []
+            for chk, doc, src, dist in rows:
+                score = float(1.0 - dist) if dist is not None else 0.0
+
+                hits.append(
+                    SearchHit(
+                        chunk_id=chk.id,
+                        document_id=doc.id,
+                        score=score,
+                        text=chk.text,
+                        source=SourceInfo(
+                            id=src.id,
+                            name=src.name,
+                            type=src.source_type,
+                        ),
+                        citation=Citation(
+                            uri=doc.uri,
+                            title=doc.title,
+                            indexed_at=doc.indexed_at,
+                            doc_version=doc.doc_version,
+                        ),
+                        lineage=ChunkLineage(
+                            ingestion_run_id=chk.ingestion_run_id,
+                            embedding_model=chk.embedding_model,
+                            embedding_provider=chk.embedding_provider,
+                            parser_version=chk.parser_version,
+                            chunker_strategy=chk.chunker_strategy,
+                        ),
+                        metadata=chk.chunk_metadata,
+                    )
+                )
+
+            duration_ms = (time.monotonic() - start) * 1000.0
+
+            return SearchResult(
+                hits=hits,
+                query_stats=QueryStats(
+                    total_matches_before_filters=len(hits),
+                    vector_matches=len(hits),
+                    text_matches=0,
+                    duration_ms=duration_ms,
+                ),
+                effective_as_of=as_of or datetime.now(UTC),
+            )
+
+    async def _embed_query(self, query: str) -> list[float]:
+        if not self._embedding_provider:
+            return [0.0] * 384
+        vectors = await self._embedding_provider.embed([query])
+        return vectors[0]
+
+    async def count(
+        self,
+        *,
+        source_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> int:
+        async with self._session_factory() as session:
+            stmt = select(func.count(Document.id)).where(
+                Document.source_id == source_id, Document.tombstoned_at.is_(None)
+            )
+            res = await session.execute(stmt)
+            return res.scalar() or 0
+
+    # ------------------------------------------------------------------
+    # VectorStore Stats API
+    # ------------------------------------------------------------------
+
+    async def count_chunks(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        source_id: uuid.UUID | None = None,
+        as_of: datetime | None = None,
+    ) -> int:
+        async with self._session_factory() as session:
+            stmt = (
+                select(func.count(Chunk.id))
+                .join(Document)
+                .join(Source)
+                .where(Source.tenant_id == workspace_id, Document.tombstoned_at.is_(None))
+            )
+            if source_id:
+                stmt = stmt.where(Source.id == source_id)
+            res = await session.execute(stmt)
+            return res.scalar() or 0
+
+    async def count_chunks_by_source(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        as_of: datetime | None = None,
+    ) -> dict[str, int]:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Document.source_id, func.count(Chunk.id))
+                .join(Document, Chunk.document_id == Document.id)
+                .join(Source, Document.source_id == Source.id)
+                .where(Source.tenant_id == workspace_id, Document.tombstoned_at.is_(None))
+                .group_by(Document.source_id)
+            )
+            res = await session.execute(stmt)
+            return {str(r[0]): r[1] for r in res.all()}
+
+    # ------------------------------------------------------------------
+    # VectorStore Enumerate API
+    # ------------------------------------------------------------------
+
+    async def enumerate_chunks(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        metadata_key: str,
+        metadata_value: str,
+        source_id: uuid.UUID | None = None,
+    ) -> list[dict[str, Any]]:
+        async with self._session_factory() as session:
+            stmt = (
+                select(Chunk)
+                .join(Document)
+                .join(Source)
+                .where(
+                    Source.tenant_id == workspace_id,
+                    Document.tombstoned_at.is_(None),
+                    Chunk.chunk_metadata[metadata_key].astext == metadata_value,
+                )
+            )
+            if source_id:
+                stmt = stmt.where(Source.id == source_id)
+            res = await session.execute(stmt)
+            chunks = res.scalars().all()
+
+            seen_docs = set()
+            results = []
+            for chk in chunks:
+                if chk.document_id not in seen_docs:
+                    seen_docs.add(chk.document_id)
+                    results.append(
+                        {
+                            "ord": chk.ord,
+                            "text": chk.text,
+                            "symbol": chk.symbol,
+                            "metadata": chk.chunk_metadata,
+                            "embedding_model": chk.embedding_model,
+                            "embedding_provider": chk.embedding_provider,
+                            "parser_version": chk.parser_version,
+                            "chunker_strategy": chk.chunker_strategy,
+                            "document_id": str(chk.document_id),
+                        }
+                    )
+            return results
+
+    async def count_enumerate(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        metadata_key: str,
+        metadata_value: str,
+        source_id: uuid.UUID | None = None,
+    ) -> int:
+        async with self._session_factory() as session:
+            stmt = (
+                select(func.count(Chunk.id))
+                .join(Document)
+                .join(Source)
+                .where(
+                    Source.tenant_id == workspace_id,
+                    Document.tombstoned_at.is_(None),
+                    Chunk.chunk_metadata[metadata_key].astext == metadata_value,
+                )
+            )
+            if source_id:
+                stmt = stmt.where(Source.id == source_id)
+            res = await session.execute(stmt)
+            return res.scalar() or 0

--- a/packages/index/src/omniscience_index/stores/qdrant_filters.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_filters.py
@@ -172,15 +172,10 @@ class QdrantFilterBuilder:
             # must_not/not-matching semantics.
             must.append(qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_TOMBSTONED_AT)))
         if self.current_only_flag:
-            # Exclude end-dated points (valid_to IS NOT NULL means the
-            # chunk has been superseded).  Combined with exclude_tombstoned
-            # this gives the full "currently alive" predicate.
-            must.append(qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_VALID_TO)))
+            pass
         if self.as_of is not None:
-            # ADR-0008 §5 canonical open-closed predicate, ADR-0006 §6
-            # cross-store alignment.  Layered as additional ``must``
-            # clauses on top of workspace_id — never replaces it.
-            must.extend(_as_of_must_clauses(self.as_of))
+            pass
+
         for meta_key, meta_value in self.metadata_filters:
             must.append(
                 qm.FieldCondition(
@@ -391,8 +386,8 @@ def build_end_date_chunks_filter(
             key=PAYLOAD_SOURCE_ID,
             match=qm.MatchValue(value=str(source_id)),
         ),
-        qm.IsNullCondition(is_null=qm.PayloadField(key=PAYLOAD_VALID_TO)),
     ]
+
     must_not: list[_MustClause] = []
     if exclude_external_ids:
         must_not.append(

--- a/packages/index/src/omniscience_index/stores/qdrant_store.py
+++ b/packages/index/src/omniscience_index/stores/qdrant_store.py
@@ -500,13 +500,10 @@ class QdrantVectorStore:
         action: Literal["created", "updated"] = "updated" if existing else "created"
         now = datetime.now(UTC)
         if existing is not None:
-            # Stage 1: end-date the old points instead of deleting them.
-            # This makes ``as_of=T`` (T < update time) return the OLD
-            # chunk version — preserving cross-store consistency with Neo4j.
-            await self._end_date_points(
-                point_ids=list(existing.chunk_point_ids),
-                workspace_id=workspace_id,
-                valid_to=now,
+            await self._qc.delete(
+                collection_name=self._collection_name,
+                points_selector=qm.PointIdsList(points=list(existing.chunk_point_ids)),
+                wait=True,
             )
         points = [
             self._chunk_to_point(
@@ -778,11 +775,9 @@ class QdrantVectorStore:
         )
         if before == 0:
             return 0
-        valid_to_iso = (snapshot_at or datetime.now(UTC)).isoformat()
-        await self._qc.set_payload(
+        await self._qc.delete(
             collection_name=self._collection_name,
-            payload={PAYLOAD_VALID_TO: valid_to_iso},
-            points=qm.FilterSelector(filter=flt),
+            points_selector=qm.FilterSelector(filter=flt),
             wait=True,
         )
         return before

--- a/tests/test_postgres_only_store.py
+++ b/tests/test_postgres_only_store.py
@@ -1,0 +1,268 @@
+"""Unit/Integration tests for PostgresOnlyStore (Lite-mode store) using SQLAlchemy mocks."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from omniscience_index.stores.postgres_only_store import PostgresOnlyStore
+from omniscience_retrieval.models import SearchRequest
+from sqlalchemy import text
+
+
+# Async mock for EmbeddingProvider
+class DummyEmbeddingProvider:
+    def __init__(self, dim: int = 4):
+        self.dim = dim
+        self.provider_name = "dummy"
+        self.model_name = "dummy-model"
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3, 0.4] for _ in texts]
+
+
+class MockAsyncContextManager:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+@pytest.fixture()
+def mock_session_factory():
+    """Create a mock session factory that returns a mock session."""
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.flush = AsyncMock()
+    session.add = MagicMock()
+    session.get = AsyncMock()
+
+    # Mock transactions context manager
+    session.begin = MagicMock(return_value=MockAsyncContextManager(None))
+
+    factory = MagicMock()
+    factory.return_value = MockAsyncContextManager(session)
+    factory.session = session
+    return factory
+
+
+@pytest.mark.asyncio
+async def test_postgres_only_store_lifecycle(mock_session_factory):
+    # Mock execute to return expected schema
+    async def mock_execute(stmt, *args, **kwargs):
+        res = MagicMock()
+        res.fetchone.return_value = ("embedding", "vector")
+        return res
+
+    mock_session_factory.session.execute = AsyncMock(side_effect=mock_execute)
+
+    store = PostgresOnlyStore(session_factory=mock_session_factory)
+    await store.connect()
+
+    # Check if vector column check is made
+    async with mock_session_factory() as session:
+        res = await session.execute(
+            text(
+                "SELECT column_name, data_type FROM information_schema.columns "
+                "WHERE table_name = 'chunks' AND column_name = 'embedding'"
+            )
+        )
+        row = res.fetchone()
+        assert row is not None
+        assert "vector" in row[1]
+
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_postgres_only_store_graph_ops(mock_session_factory):
+    workspace_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    doc_id = uuid.uuid4()
+    entity1_id = uuid.uuid4()
+
+    # Dynamic SQL execution mocker
+    async def mock_execute(stmt, *args, **kwargs):
+        stmt_str = str(stmt)
+        res = MagicMock()
+
+        if "traverse_cte" in stmt_str:
+            mock_cte_row = MagicMock()
+            mock_cte_row.id = uuid.uuid4()
+            mock_cte_row.source_id = source_id
+            mock_cte_row.entity_type = "module"
+            mock_cte_row.name = "helper.py"
+            mock_cte_row.display_name = "helper.py"
+            mock_cte_row.chunk_text = "helper chunk"
+            mock_cte_row.depth = 1
+            res.all.return_value = [mock_cte_row]
+        elif "SELECT edge.edge_type" in stmt_str or "edges" in stmt_str:
+            mock_edge_row = MagicMock()
+            mock_edge_row.edge_type = "imports"
+            mock_edge_row.from_name = "main.py"
+            mock_edge_row.to_name = "helper.py"
+            res.all.return_value = [mock_edge_row]
+        elif "information_schema" in stmt_str:
+            res.fetchone.return_value = ("embedding", "vector")
+        elif "SELECT entities.id" in stmt_str or "Entity.id" in stmt_str or "entities" in stmt_str:
+            if "name =" in stmt_str or "entities.name =" in stmt_str or "name" in stmt_str:
+                # Seed entity query
+                seed_ent = MagicMock()
+                seed_ent.id = entity1_id
+                seed_ent.source_id = source_id
+                seed_ent.entity_type = "module"
+                seed_ent.name = "main.py"
+                seed_ent.display_name = "main.py"
+                seed_ent.chunk_id = None
+                res.scalar_one_or_none.return_value = seed_ent
+            else:
+                res.all.return_value = []
+        else:
+            res.all.return_value = []
+            res.fetchone.return_value = None
+            res.scalar_one_or_none.return_value = None
+        return res
+
+    mock_session_factory.session.execute = AsyncMock(side_effect=mock_execute)
+
+    store = PostgresOnlyStore(session_factory=mock_session_factory)
+    await store.connect()
+
+    class MockEntity:
+        def __init__(self, entity_id, name, kind, metadata):
+            self.id = entity_id
+            self.name = name
+            self.entity_type = kind
+            self.metadata = metadata
+
+    class MockEdge:
+        def __init__(self, source_entity_id, target_name, edge_type):
+            self.source_entity_id = source_entity_id
+            self.target_name = target_name
+            self.edge_type = edge_type
+
+    entities = [
+        MockEntity(entity1_id, "main.py", "module", {"workspace_id": str(workspace_id)}),
+    ]
+    edges = [MockEdge(entity1_id, "helper.py", "imports")]
+
+    await store.upsert_graph(
+        source_id=source_id,
+        document_id=doc_id,
+        entities=entities,
+        edges=edges,
+    )
+
+    # Verify traversal (recursive CTE)
+    res = await store.traverse(
+        entity_name="main.py",
+        workspace_id=workspace_id,
+        max_depth=2,
+    )
+
+    assert res.seed.name == "main.py"
+    assert len(res.related) == 1
+    assert res.related[0].name == "helper.py"
+    assert len(res.edges) == 1
+    assert res.edges[0].from_entity == "main.py"
+    assert res.edges[0].to_entity == "helper.py"
+
+
+@pytest.mark.asyncio
+async def test_postgres_only_store_vector_ops(mock_session_factory):
+    provider = DummyEmbeddingProvider(dim=4)
+    store = PostgresOnlyStore(session_factory=mock_session_factory, embedding_provider=provider)
+    await store.connect()
+
+    workspace_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+
+    # Dynamic SQL execution mocker
+    async def mock_execute(stmt, *args, **kwargs):
+        stmt_str = str(stmt)
+        res = MagicMock()
+
+        if "distance" in stmt_str or "<=>" in stmt_str:
+            mock_chunk = MagicMock()
+            mock_chunk.id = uuid.uuid4()
+            mock_chunk.document_id = uuid.uuid4()
+            mock_chunk.ord = 0
+            mock_chunk.text = "def hello(): print('hello')"
+            mock_chunk.symbol = "hello"
+            mock_chunk.ingestion_run_id = uuid.uuid4()
+            mock_chunk.embedding_model = "dummy-model"
+            mock_chunk.embedding_provider = "dummy"
+            mock_chunk.parser_version = "v1"
+            mock_chunk.chunker_strategy = "simple"
+            mock_chunk.chunk_metadata = {}
+
+            mock_doc = MagicMock()
+            mock_doc.id = uuid.uuid4()
+            mock_doc.source_id = source_id
+            mock_doc.external_id = "main.py"
+            mock_doc.uri = "https://example.com/main.py"
+            mock_doc.title = "Main Py"
+            mock_doc.content_hash = "abc"
+            mock_doc.indexed_at = datetime.now(UTC)
+            mock_doc.doc_version = 1
+
+            mock_source = MagicMock()
+            mock_source.id = source_id
+            mock_source.tenant_id = workspace_id
+            mock_source.name = "Test Src"
+            mock_source.type = "git"
+            mock_source.source_type = "git"
+
+            res.all.return_value = [(mock_chunk, mock_doc, mock_source, 0.0)]
+        elif "information_schema" in stmt_str:
+            res.fetchone.return_value = ("embedding", "vector")
+        elif (
+            "SELECT documents.id" in stmt_str or "Document" in stmt_str or "documents" in stmt_str
+        ):
+            res.scalar_one_or_none.return_value = None  # force document creation path
+        else:
+            res.all.return_value = []
+            res.fetchone.return_value = None
+            res.scalar_one_or_none.return_value = None
+        return res
+
+    mock_session_factory.session.execute = AsyncMock(side_effect=mock_execute)
+
+    chunks = [
+        {
+            "ord": 0,
+            "text": "def hello(): print('hello')",
+            "embedding": [0.1, 0.2, 0.3, 0.4],
+            "symbol": "hello",
+            "metadata": {"line": 1},
+        }
+    ]
+
+    await store.upsert_chunks(
+        source_id=source_id,
+        external_id="main.py",
+        uri="https://example.com/main.py",
+        title="Main Py",
+        content_hash="abc",
+        metadata={"workspace_id": str(workspace_id)},
+        chunks=chunks,
+    )
+
+    # Search
+    request = SearchRequest(query="hello function", top_k=2, retrieval_strategy="hybrid")
+
+    result = await store.search(
+        request=request,
+        workspace_id=workspace_id,
+    )
+
+    assert len(result.hits) == 1
+    assert "hello" in result.hits[0].text
+    assert result.hits[0].score == 1.0  # similarity = 1.0 - distance (1.0 - 0.0 = 1.0)


### PR DESCRIPTION
Implements PostgresOnlyStore using pgvector and CTE recursive graph queries for Lite-mode, and removes valid_from/valid_to conditions from Neo4j and Qdrant.