### PR TITLE
Consilium round 1: open action points

### DIFF
--- a/CONSILIUM_ROUND_1.md
+++ b/CONSILIUM_ROUND_1.md
@@ -1,0 +1,7 @@
+# Consilium round 1 — open action points
+
+Open action points from the consilium verdict. Implement and merge to close the round.
+
+- [ ] (P0) Ввести cross-store watermark floor & per-query gating
+- [ ] (P0) Реализовать anti-entropy reconciler (Postgres-SoT <-> Neo4j/Qdrant)
+- [ ] (P0) Пробрасывать состояние parked-entity в retrieval


### PR DESCRIPTION
# Consilium round 1 — open action points

Open action points from the consilium verdict. Implement and merge to close the round.

- [ ] (P0) Ввести cross-store watermark floor & per-query gating
- [ ] (P0) Реализовать anti-entropy reconciler (Postgres-SoT <-> Neo4j/Qdrant)
- [ ] (P0) Пробрасывать состояние parked-entity в retrieval
