### PR TITLE
Consilium round 1: open action points

### DIFF
--- a/CONSILIUM_ROUND_1.md
+++ b/CONSILIUM_ROUND_1.md
@@ -1,0 +1,6 @@
+# Consilium round 1 — open action points
+
+Open action points from the consilium verdict. Implement and merge to close the round.
+
+- [ ] (P0) Внедрить глобальный LSN и epoch‑tagged reads
+- [ ] (P0) Добавить периодический reconciler между Postgres‑SoT и проекциями (anti‑entropy)


### PR DESCRIPTION
# Consilium round 1 — open action points

Open action points from the consilium verdict. Implement and merge to close the round.

- [ ] (P0) Внедрить глобальный LSN и epoch‑tagged reads
- [ ] (P0) Добавить периодический reconciler между Postgres‑SoT и проекциями (anti‑entropy)
