### PR TITLE
Close consilium-v10 P0: per-source watermark, version-aware graph pin, revive AP2 heal, live conformance gate

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,6 +11,11 @@ name: Conformance Gates
 # AP4: confidence decimal suppression (Batch D)
 # AP5: DR-drill rebuild-from-SoT + hash-assert (Batch E, Postgres service)
 # AP7: arch invariants — single-writer + MCP retrieval-only (Batch F)
+#
+# conformance-live (v10-AP6 fix, Batch C): single shared container job that
+# runs all P0 behavioral assertions against REAL Neo4j/Qdrant/NATS.
+# This is the authoritative gate — mock-only jobs are a fast first signal
+# but the live job is what catches real Cypher/consumer/store bugs.
 
 on:
   pull_request:
@@ -142,3 +147,132 @@ jobs:
           python-version: "3.12"
       - run: uv sync --frozen
       - run: uv run pytest tests/conformance/test_ap7_arch_invariants.py -v --tb=short
+
+  # ---------------------------------------------------------------------------
+  # LIVE behavioral conformance gate (v10-AP6 fix)
+  #
+  # Single shared container job running ALL P0 behavioral assertions against
+  # REAL Neo4j / Qdrant / NATS service containers — the same config as
+  # ci.yml's test job.  This is the authoritative gate: mock-only jobs above
+  # are a fast first signal, but this job exercises the real Cypher/consumer
+  # path and will catch exactly the class of bug that killed AP2 heal
+  # (consumer→store path was dead but mock gate was green).
+  #
+  # Tests selected:
+  #   AP1 (per-entity CAS): tests/test_ap1_single_writer.py::test_live_cas_*
+  #     - test_live_cas_stale_write_does_not_regress_entity_version (Neo4j live)
+  #     - test_live_ap2_backfill_heals_stale_node_bypassing_source_checkpoint (via AP2 path)
+  #   AP2 (backfill heal): tests/integration/test_ap2_backfill_heal.py
+  #     - test_live_ap2_backfill_heals_stale_node_bypassing_source_checkpoint
+  #     - test_live_ap2_backfill_does_not_regress_node_ahead_of_backfill
+  #   AP3 (per-source watermark + graph-anchor pin):
+  #     tests/integration/test_ap3_live_conformance.py
+  #     - test_live_ap3_v10_ap1_cold_source_does_not_blackout_healthy_source
+  #     - test_live_ap3_v10_ap2_graph_ahead_anchor_treated_as_miss
+  #
+  # NATS note: GitHub Actions services: does not support passing CMD arguments to
+  # override a container's default command, so NATS is started as a background
+  # step instead of a service container (same pattern as ci.yml).
+  # ---------------------------------------------------------------------------
+  conformance-live:
+    name: "LIVE behavioral P0 assertions (AP1+AP2+AP3 real Neo4j/Qdrant/NATS)"
+    runs-on: ubuntu-latest
+
+    services:
+      neo4j:
+        # Version matches docker-compose.yml and ci.yml neo4j service image.
+        image: neo4j:5.19-community
+        env:
+          NEO4J_AUTH: neo4j/ci_test_password
+          NEO4J_server_memory_heap_initial__size: 512m
+          NEO4J_server_memory_heap_max__size: 1G
+          NEO4J_server_memory_pagecache_size: 256m
+        ports:
+          - 7687:7687
+          - 7474:7474
+        options: >-
+          --health-cmd "wget -q -O - http://localhost:7474 > /dev/null"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 10
+          --health-start-period 45s
+
+      qdrant:
+        # Version matches docker-compose.yml and ci.yml qdrant service image.
+        image: qdrant/qdrant:v1.12.4
+        ports:
+          - 6333:6333
+          - 6334:6334
+        options: >-
+          --health-cmd "bash -c '</dev/tcp/localhost/6333'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 20s
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.6.2"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: uv sync --frozen
+
+      # NATS requires --jetstream which cannot be passed via service container
+      # CMD override in GitHub Actions — start it as a background docker step
+      # (identical pattern to ci.yml test job).
+      - name: Start NATS with JetStream
+        run: |
+          docker run -d \
+            --name nats-ci \
+            --network host \
+            nats:2.10-alpine \
+            --jetstream \
+            --store_dir /tmp/nats-data \
+            --http_port 8222
+          for i in $(seq 1 20); do
+            curl -sf http://localhost:8222/healthz && echo "NATS ready" && break
+            echo "Waiting for NATS... ($i/20)"
+            sleep 3
+            if [ "$i" -eq 20 ]; then
+              echo "NATS did not become ready in time"; docker logs nats-ci; exit 1
+            fi
+          done
+
+      # Run all live P0 behavioral assertions:
+      #   - AP1 live CAS (tests/test_ap1_single_writer.py, test_live_cas_* marker)
+      #   - AP2 backfill heal (tests/integration/test_ap2_backfill_heal.py)
+      #   - AP3 multi-source watermark + graph-anchor pin
+      #     (tests/integration/test_ap3_live_conformance.py)
+      - name: Run live P0 behavioral assertions
+        run: |
+          uv run pytest \
+            tests/test_ap1_single_writer.py::test_live_cas_stale_write_does_not_regress_entity_version \
+            tests/integration/test_ap2_backfill_heal.py \
+            tests/integration/test_ap3_live_conformance.py \
+            -v --tb=short
+        env:
+          # --- Neo4j ---
+          # Env var names derived from pydantic-settings field names in config.py
+          # (case-insensitive). Must match NEO4J_AUTH on the service container.
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: ci_test_password
+
+          # --- Qdrant ---
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+
+          # --- NATS ---
+          NATS_URL: nats://localhost:4222
+
+          # --- Contract test gate flags ---
+          # Unlock live Neo4j contract tests (test_live_cas_*, AP2 heal, etc.)
+          OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS: "1"
+          # Unlock live Qdrant contract tests (AP3 multi-source watermark)
+          OMNISCIENCE_RUN_QDRANT_CONTRACT_TESTS: "1"
+          # Unlock E2E ingestion tests (AP3 full round-trip assertions)
+          OMNISCIENCE_RUN_E2E_INGESTION: "1"

--- a/apps/server/src/omniscience_server/outbox_consumer.py
+++ b/apps/server/src/omniscience_server/outbox_consumer.py
@@ -279,6 +279,14 @@ class OutboxConsumerWorker:
                     )
 
                     # 1. Update Neo4j
+                    # v10-AP3: if this is a reconciler backfill, bypass the
+                    # coarse source-checkpoint skip so the per-entity CAS can
+                    # still heal a node that is individually stale even when
+                    # the source-level checkpoint is already at or beyond the
+                    # incoming version.  The per-entity CAS monotonic guard
+                    # (incoming_version > node.version) remains active, so
+                    # a stale backfill cannot regress a node correctly written
+                    # at a higher version.
                     entity_upsert = EntityUpsert(
                         id=entity_id,
                         source_id=uuid.UUID(event.source_id),
@@ -288,6 +296,7 @@ class OutboxConsumerWorker:
                         chunk_id=None,
                         metadata=event.metadata,
                         version=event.version,
+                        bypass_source_checkpoint=event.is_backfill,
                     )
                     await self._graph_store.upsert_entity(
                         entity=entity_upsert,
@@ -493,12 +502,14 @@ class OutboxConsumerWorker:
                     )
 
                     # 1. Update Neo4j
+                    # v10-AP3: edge backfill also bypasses source-checkpoint skip.
                     edge_upsert = EdgeUpsert(
                         source_entity_id=source_entity_id,
                         target_entity_id=target_entity_id,
                         edge_type=event.edge_type,
                         metadata=event.metadata,
                         version=event.version,
+                        bypass_source_checkpoint=event.is_backfill,
                     )
                     await self._graph_store.upsert_edge(
                         edge=edge_upsert,

--- a/docs/reviews/consilium-v10-review.md
+++ b/docs/reviews/consilium-v10-review.md
@@ -1,0 +1,85 @@
+# Consilium v10 (Opus chair) — GROUNDED diff of the v9 changes
+
+> Read-only forensic audit of `main` (consilium-v9 P0 merged, squash `b798b3d`) against the v10
+> Action Points, which specifically audit the regressions/holes introduced BY the v9 fixes.
+> Verdicts confirmed against actual code; evidence as `path:line`.
+>
+> **Date**: 2026-06-25 · **Bottom line:** v10 is accurate. The v9 fixes introduced **3 real P0
+> correctness holes** (one of which — AP2 backfill heal — is *dead code in practice*), and several
+> were invisible because the v9 conformance gates are **mock-only** — recursively proving the chair's
+> own thesis ("mock gate green ≠ closed").
+
+## Verdict Matrix
+
+| # | v10 claim | Prio | Verdict | One-line |
+|---|-----------|------|---------|----------|
+| 1 | AP3 global-min watermark blacks out whole workspace when any source is cold/lagging | P0 | ✅ Confirmed | `min_watermark` is a single GLOBAL min; one cold source (v0) → all hits dropped workspace-wide |
+| 2 | AP3 pin is one-directional; graph-ahead mixed-epoch still served | P0 | ✅ Confirmed | Only `vector_result.hits` is filtered; the Neo4j anchor traversal is NOT pinned → v10-graph view + v7-evidence |
+| 3 | Per-entity CAS gated behind source-checkpoint skip → AP2 backfill cannot heal node drift | P0 | ✅ Confirmed (**heal is dead**) | `is_backfill` does NOT set `forced_replay`; source-checkpoint skip no-ops the backfill for checkpoint-ahead-of-stale-node |
+| 4 | Cross-workspace re-emit cursor starves late-ordered workspaces | P1 | ✅ Confirmed | `_reemit_cursor` is global-per-tick across workspaces → one noisy tenant blocks all others |
+| 5 | Unconditional Neo4j orphan end-date can false-split live data | P1 | ✅ Confirmed | `end_date_source_orphans` fires unconditionally, no grace/confirmation window |
+| 6 | Conformance gates mock-heavy; live assertions not in the gate | P1 | ✅ Confirmed | ap1–ap4 jobs run mock tests with NO containers; live Cypher/embedding assertions absent from `conformance.yml` |
+| 7 | DR hash-equivalence assumes bit-deterministic embeddings; untested at PR + bulk-load missing | P1 | ✅ Confirmed | `compute_vector_digest` = strict SHA-256 of float32 bytes; only the deterministic fake passes; no volume RTO; no bulk-load |
+| 8 | Confidence band collapses evidence tiers + nullable is a breaking change | P2 | ✅ Confirmed | `BAND_HIGH≥0.55` merges the 0.9 and 0.6 ladder rungs into "high"; nullable confidence undocumented as a break |
+| 9 | Carried v9 P1 gaps (AP8/9/10) tracked, not in scope | P2 | ✅ Noted | identity review-queue, cross-store as_of/tx-time, DLQ persistence still open |
+
+---
+
+## v10-AP1 (P0) — Global watermark blackout — ✅ Confirmed
+- `reconciler.py`: `min_watermark` is documented and computed as "the minimum version seen across all three stores" (`reconciler.py:43-45`) — a SINGLE global scalar, no per-source scoping.
+- `graph_rag.py:793-816` `_apply_watermark_filter` drops every hit with `applied_version > min_watermark`; applied to `vector_result.hits` at `:627`.
+- **Blast radius:** in a multi-source workspace, if ONE source is cold (checkpoint v0) or lagging, `min_watermark` collapses to that low value and hits from ALL other healthy/higher-version sources are dropped → empty/decimated retrieval for the entire workspace. The v9 fix turned a "silent mixed-epoch" bug into a "silent availability cliff" — strictly worse for SRE retrieval. All AP3 tests are single-source, so they miss it.
+- **Fix delta:** per-source watermark (drop a hit only if it exceeds the watermark of ITS OWN source), not a single global min.
+
+## v10-AP2 (P0) — One-directional pin (graph-ahead still mixed-epoch) — ✅ Confirmed
+- `_apply_watermark_filter` is applied ONLY to `vector_result.hits` (`graph_rag.py:627`). The anchor stage `_run_anchor_stage` (`:412,488`) receives NO `min_watermark` and traverses Neo4j at its current version.
+- So with Neo4j@v10, Qdrant@v7, `min_watermark=7`: vector hits filtered to ≤7, but the graph anchor/traversal view is v10 → the composed answer mixes a v10 graph view with v7 evidence. The claimed invariant "no composed hit > min_watermark" holds for the hit LIST but the "no mixed-epoch" guarantee does NOT.
+- **Fix delta:** pin the graph traversal too (version-aware ceiling, more than valid-time `as_of`), OR expose a documented hard-degrade product knob (availability vs correctness).
+
+## v10-AP3 (P0) — CAS behind source-checkpoint skip → backfill heal is DEAD — ✅ Confirmed (highest value)
+- `neo4j/store.py` `upsert_entity._run` (`:455-524`): step 1 reads the source `StoreCheckpoint`; `should_skip = existing_version >= entity_version` (`:478`); `if should_skip: return` (`:488-489`) — BEFORE the per-entity CAS (`:513-523`). Only `forced_replay` (`:485-486`) or an epoch bump bypasses the skip.
+- Drift scenario (the most common): source checkpoint already at v5, but a specific entity node is stale at v3. AP2 re-emits the entity at v5 with `is_backfill=True` (`reconcile_worker.py:440,532`).
+- **The consumer does NOT map `is_backfill`→`forced_replay`.** `outbox_consumer.py:261-264`: `if event.is_backfill:` only clears the parked-entity set. The `EntityUpsert` built at `:282-291` sets `version=event.version` but leaves `forced_replay=False` (default) and no `epoch`. So `upsert_entity` sees `existing_version(5) >= incoming(5)` → `should_skip=True` → returns → **the stale node is never healed.**
+- Net: AP2's "closed loop" silently no-ops for checkpoint-ahead-of-stale-node — the dominant drift class. The v9 AP2 conformance gate passed because it is mock-based and never exercised this consumer→store path.
+- **Fix delta:** map `is_backfill=True` → `forced_replay=True` (or an epoch bump) on the backfill `EntityUpsert` so it bypasses the source-checkpoint skip and reaches the per-entity CAS (which still guards true monotonicity). Bounded by `REEMIT_TICK_CAP`, so write-volume impact is acceptable. Add a LIVE conformance test that drifts a node, re-emits, and asserts the node version healed.
+
+## v10-AP4 (P1) — Cross-workspace cursor starvation — ✅ Confirmed
+- `reconcile_worker.py`: `_reemit_cursor` reset once per `run_once()` (`:274`), shared "across workspaces within a single run" (`:188-193`); workspaces iterated in order (`:279-280`).
+- With `cap=1000` and workspace A holding 5000 drifted entities, A consumes the entire per-tick budget every tick; workspace B (also drifted, later in iteration order) gets ZERO budget and never reconverges → tenant-isolation violation.
+- **Fix delta:** per-workspace cap with a global ceiling (e.g. `min(per_ws_cap, remaining_global)`); rotate/fair-share workspace order.
+
+## v10-AP5 (P1) — Unconditional orphan end-date false-split — ✅ Confirmed
+- `reconcile_worker.py:685-720` `_check_neo4j_orphans` calls `end_date_source_orphans` whenever a source looks orphaned; `ENABLE_NEO4J_ORPHAN_REEMIT` defaults `true` (`:136-137`). No grace window, no K-consecutive-detection requirement, no confirmation.
+- Scenario: a transient read (in-flight source, tombstone race) makes a LIVE source briefly appear orphaned → its Neo4j entities are end-dated (`valid_to=now`) → data "disappears" + flaps when the source reappears next tick — in exactly the partial-failure scenarios this axis targets.
+- **Fix delta:** require K consecutive orphan detections / a grace window before end-dating; or a two-phase mark-then-sweep.
+
+## v10-AP6 (P1) — Mock-heavy conformance gates — ✅ Confirmed
+- `conformance.yml`: jobs `ap1`/`ap2`/`ap3`/`ap4` run only `pytest tests/conformance/test_apN_*.py` with NO `services:` block (no containers) (`:39,57,74,92`). Only `ap5` has a postgres service (`:101`).
+- The conformance tests are mock-based (mock `tx.run`, mock stores, mock reconciler). The authoritative LIVE assertions (`test_live_*`, gated by `OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS`) run only in the main `ci.yml` `test` job — not in the named conformance gate.
+- This is the recursion the chair warns about: the AP2 mock gate is GREEN while the real consumer→store heal is dead (v10-AP3). A mock gate that passes on a semantic Cypher/consumer bug re-creates "claimed not closed".
+- **Fix delta:** a shared container job in `conformance.yml` running the live behavioral P0 assertions (real Neo4j/Qdrant/NATS) — the gate must exercise the real path, not a mock.
+
+## v10-AP7 (P1) — Bit-deterministic embedding hash + no volume/bulk — ✅ Confirmed
+- `scripts/dr_verify.py:216-226` `compute_vector_digest` = `hashlib.sha256(<float32 packed bytes>)` — a STRICT bit-hash. Real embedding inference (Ollama/transformers) is not bit-deterministic across hardware/threads/runtime → this assert is flaky on real hardware; only the deterministic fake fixture passes.
+- The PR-smoke uses a deterministic fake provider, so it never exercises real embedding non-determinism. Volume/RTO still validated only on a 9-chunk fixture. Bulk-load (`UNWIND`/batch upsert) still absent (carried from v9-gemini AP4).
+- **Fix delta:** tolerance-based vector equivalence (cosine ≥ 1−ε or L2 ≤ ε) instead of bit-hash; pin the embedding runtime for reproducibility; a nightly volume drill with a real RTO budget; add bulk-load.
+
+## v10-AP8 (P2) — Band collapse + breaking change — ✅ Confirmed
+- `resolution.py:75-94`: `BAND_HIGH_THRESHOLD=0.55` covers BOTH the 0.9 (PR temporal match) and 0.6 (PR no-temporal-match) ladder rungs → both map to "high", erasing the strong/weak distinction the heuristic still computes (`CONFIDENCE_*` at `:66-69`). 4 tiers → 3 bands.
+- The nullable `resolution_confidence` is a breaking API change; documented in the module docstring but not in a changelog/ADR.
+- **Fix delta:** add a 4th band (or map 1:1 to the ladder tiers) so 0.9 vs 0.6 stays distinguishable; document the nullable break in CHANGELOG/an ADR.
+
+## v10-AP9 (P2) — Carried gaps — ✅ Noted
+AP8 identity (conservative threshold + review queue), AP9 cross-store as_of conformance + tx-time, AP10 DLQ persistence remain open (tracked in [[omniscience-consilium-loop]]).
+
+---
+
+## Prioritized remediation (v10)
+1. **v10-AP3 (P0)** — map `is_backfill`→`forced_replay` in `outbox_consumer.py` so the AP2 heal actually heals; + a LIVE conformance test (drift node → re-emit → assert healed). *(Dead-code fix; highest value.)*
+2. **v10-AP1 (P0)** — per-source watermark (no whole-workspace blackout from one cold source).
+3. **v10-AP2 (P0)** — pin the graph anchor traversal to the (per-source) watermark too, OR a documented hard-degrade knob; close the mixed-epoch gap for real.
+4. **v10-AP6 (P1)** — a live-container conformance job so the P0 gates exercise real Cypher/embedding (this is what would have caught AP3).
+5. **v10-AP4 (P1)** — per-workspace re-emit cap + global ceiling.
+6. **v10-AP5 (P1)** — grace window / K-consecutive before orphan end-dating.
+7. **v10-AP7 (P1)** — tolerance-based vector check + pinned runtime + volume RTO + bulk-load.
+8. **v10-AP8 (P2)** — finer bands + document the API break.

--- a/packages/core/src/omniscience_core/storage/graph.py
+++ b/packages/core/src/omniscience_core/storage/graph.py
@@ -114,6 +114,14 @@ class EntityUpsert:
     forced_replay: bool = False
     # AP2 — per-entity content hash for cross-store anti-entropy.
     content_hash: str | None = None
+    # v10-AP3 — bypass the coarse source-checkpoint skip so the per-entity
+    # CAS can still heal a node whose individual version is behind the SoT
+    # version, even when the source checkpoint is already at or ahead of the
+    # incoming version.  Safer than forced_replay: the per-entity monotonic
+    # CAS guard (incoming_version > node.version) is preserved, so a stale
+    # backfill cannot regress a node that was correctly written at a higher
+    # version.
+    bypass_source_checkpoint: bool = False
 
 
 @dataclass(slots=True)
@@ -127,6 +135,8 @@ class EdgeUpsert:
     version: int | None = None
     epoch: int | None = None
     forced_replay: bool = False
+    # v10-AP3 — same bypass-source-checkpoint semantics as EntityUpsert.
+    bypass_source_checkpoint: bool = False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/index/src/omniscience_index/stores/neo4j/store.py
+++ b/packages/index/src/omniscience_index/stores/neo4j/store.py
@@ -455,11 +455,17 @@ class Neo4jGraphStore:
         async def _run(tx: Any) -> None:
             entity_version = getattr(entity, "version", None)
             forced_replay = getattr(entity, "forced_replay", False)
+            bypass_source_checkpoint = getattr(entity, "bypass_source_checkpoint", False)
             if entity_version is not None:
                 # ----------------------------------------------------------------
                 # Source-level checkpoint fast-path (coarse guard).
                 # Skip if the source checkpoint is already at or beyond this version
-                # (unless epoch supersedes or forced_replay bypasses).
+                # (unless epoch supersedes, forced_replay, or
+                # bypass_source_checkpoint bypasses).
+                # v10-AP3: bypass_source_checkpoint is set on backfill upserts so
+                # the per-entity CAS below can still heal a node that is stale
+                # relative to the SoT even when the source checkpoint is current.
+                # Unlike forced_replay, the per-entity CAS monotonic guard is kept.
                 # ----------------------------------------------------------------
                 res = await tx.run(
                     (
@@ -482,7 +488,7 @@ class Neo4jGraphStore:
                 if ep is not None and existing_epoch is not None and ep > existing_epoch:
                     should_skip = False
 
-                if forced_replay:
+                if forced_replay or bypass_source_checkpoint:
                     should_skip = False
 
                 if should_skip:
@@ -576,7 +582,8 @@ class Neo4jGraphStore:
                     should_skip = False
 
                 fr = getattr(edge, "forced_replay", False)
-                if fr:
+                bypass_edge = getattr(edge, "bypass_source_checkpoint", False)
+                if fr or bypass_edge:
                     should_skip = False
 
                 if should_skip:

--- a/packages/retrieval/src/omniscience_retrieval/graph_rag.py
+++ b/packages/retrieval/src/omniscience_retrieval/graph_rag.py
@@ -13,6 +13,23 @@ point that composes a ``GraphStore`` (Neo4j) and a ``VectorStore``
 3. **Merge stage**: blend the vector score with a graph-affinity bonus
    that decays with traversal depth, then slice to ``request.top_k``.
 
+v10-AP1 — per-source watermark
+-------------------------------
+``_apply_watermark_filter`` now receives a ``dict[str, int]`` mapping
+each source_id to its own safe version ceiling.  A hit from source A is
+dropped only when ``hit.applied_version > per_source_watermark[A]``.
+A cold source B (watermark 0) no longer blacks out hits from healthy
+source A in the same workspace.
+
+v10-AP2 — version-aware graph-anchor pin
+-----------------------------------------
+``_run_anchor_stage`` receives the per-source watermark and post-filters
+traversed ``EntityNodeView`` nodes whose ``version`` exceeds their
+source's watermark before they influence candidate selection or scoring.
+Edges between excluded nodes are also removed.  This closes the
+one-directional pin: the graph view is now pinned to the same per-source
+epoch as the vector evidence.
+
 Backwards-compatibility
 -----------------------
 
@@ -380,9 +397,9 @@ class GraphRAGComposer:
         ``degraded_subsystems`` lists any stores that lagged behind the
         Postgres SoT watermark at query time; ``staleness_seconds``
         quantifies that lag so callers can decide whether to retry.
-        ``pinned_watermark`` is the minimum version across all three
-        stores — all returned hits satisfy
-        ``applied_version <= pinned_watermark`` (AP3 consistent-stale PIN).
+        ``pinned_watermark`` is the global min version across all three
+        stores — for per-source filtering see ``per_source_watermark``
+        used internally (v10-AP1/AP2).
         """
         # ``request.as_of`` is the SearchRequest field; the keyword
         # ``as_of`` wins when both are supplied so server-side overrides
@@ -397,22 +414,27 @@ class GraphRAGComposer:
         _COMPOSED_QUERIES_TOTAL.labels(path="graphrag").inc()
         start = time.monotonic()
 
-        # AP3: capture convergence signals including min_watermark for the PIN.
+        # AP3 / v10-AP1: capture convergence signals including per-source watermark.
         # Do NOT discard on timeout — the watermark is what pins the read path.
         convergence_degraded: list[str] = []
         convergence_staleness: float | None = None
         min_watermark: int | None = None
+        per_source_watermark: dict[str, int] = {}
         if self._global_reconciler is not None:
             (
                 convergence_degraded,
                 convergence_staleness,
                 min_watermark,
+                per_source_watermark,
             ) = await self._global_reconciler.wait_for_convergence(workspace_id)
 
+        # v10-AP2: pass per-source watermark into anchor stage so graph-ahead
+        # nodes/edges are excluded before they influence candidate selection.
         anchor = await self._run_anchor_stage(
             request=request,
             workspace_id=workspace_id,
             as_of=effective,
+            per_source_watermark=per_source_watermark,
         )
         vector_result = await self._run_vector_stage(
             request=request,
@@ -425,7 +447,7 @@ class GraphRAGComposer:
             vector_result=vector_result,
             anchor=anchor,
             as_of=effective,
-            min_watermark=min_watermark,
+            per_source_watermark=per_source_watermark,
         )
 
         valid_hits = await self._validate_hits(merged.hits, workspace_id)
@@ -491,8 +513,17 @@ class GraphRAGComposer:
         request: SearchRequest,
         workspace_id: uuid.UUID,
         as_of: datetime | None = None,
+        per_source_watermark: dict[str, int] | None = None,
     ) -> _AnchorStageResult:
-        """Resolve the anchor entity (when supplied) and collect candidates."""
+        """Resolve the anchor entity (when supplied) and collect candidates.
+
+        v10-AP2: traversed nodes whose ``version`` exceeds their source's
+        watermark are excluded from the result before candidate collection.
+        This pins the graph VIEW to the same per-source epoch as the vector
+        evidence — closing the one-directional pin gap.  Edges connecting
+        excluded nodes are also removed.  A node with ``version is None``
+        passes through (no version info → no ceiling applied).
+        """
         stage_start = time.monotonic()
         anchor_name = _extract_anchor(request)
 
@@ -519,6 +550,13 @@ class GraphRAGComposer:
                 as_of=as_of,
                 max_depth=MAX_ANCHOR_DEPTH,
             )
+
+            # v10-AP2: post-filter graph-ahead nodes before any candidate logic.
+            # A node whose version > per_source_watermark[its source] must be
+            # excluded so the graph VIEW is consistent with the watermark epoch.
+            if per_source_watermark:
+                graph_result = _apply_graph_watermark_filter(graph_result, per_source_watermark)
+
             # Validate retrieved entities in Postgres
             all_entity_names = [graph_result.seed.name] + [n.name for n in graph_result.related]
             valid_entity_names = await self._validate_entities(all_entity_names, workspace_id)
@@ -612,7 +650,7 @@ class GraphRAGComposer:
         vector_result: SearchResult,
         anchor: _AnchorStageResult,
         as_of: datetime | None = None,
-        min_watermark: int | None = None,
+        per_source_watermark: dict[str, int] | None = None,
     ) -> SearchResult:
         from omniscience_retrieval.probabilistic_scoring import (
             calculate_probabilistic_confidence,
@@ -621,10 +659,10 @@ class GraphRAGComposer:
 
         stage_start = time.monotonic()
 
-        # AP3 consistent-stale PIN: drop any hit whose applied_version exceeds
-        # the min_watermark so the composed result never contains evidence from
-        # an epoch that some stores have not yet applied.
-        filtered_hits = _apply_watermark_filter(vector_result.hits, min_watermark)
+        # v10-AP1 consistent-stale PIN: drop a hit only when its
+        # applied_version exceeds the watermark of ITS OWN source.
+        # A cold/lagging source B does NOT decimate hits from healthy source A.
+        filtered_hits = _apply_watermark_filter(vector_result.hits, per_source_watermark)
 
         # Unpack anchor results for O(1) lookup
         if anchor.candidate_source_ids:
@@ -792,28 +830,113 @@ class GraphRAGComposer:
 
 def _apply_watermark_filter(
     hits: list[SearchHit],
-    min_watermark: int | None,
+    per_source_watermark: dict[str, int] | None,
 ) -> list[SearchHit]:
-    """Drop hits whose ``applied_version`` exceeds ``min_watermark``.
+    """Drop hits whose ``applied_version`` exceeds their own source's watermark.
 
-    AP3 consistent-stale PIN: ensures no composed result contains evidence
-    from a future epoch that some stores have not yet applied.
+    v10-AP1 per-source PIN: each hit is evaluated against
+    ``per_source_watermark[hit.source.id]``, not a single global minimum.
+    A cold or lagging source B (watermark 0) does NOT decimate hits from
+    healthy source A — only B's own future-epoch hits are dropped.
 
     Rules:
-    - When ``min_watermark is None``: no filter applied — all hits pass.
-      This handles cold stores (no version info) and the no-reconciler path.
-    - When ``min_watermark == 0``: all hits with a non-None ``applied_version``
-      are dropped (empty result), because even version 1 is "future" relative
-      to a cold store.  Hits with ``applied_version is None`` pass through.
-    - Otherwise: keep hits where ``applied_version is None`` or
-      ``applied_version <= min_watermark``.
+    - When ``per_source_watermark is None`` or empty: no filter applied —
+      all hits pass.  This handles cold stores (no version info) and the
+      no-reconciler path.
+    - For a hit whose source has no entry in the map: pass through (we have
+      no ceiling for it — don't blackout).
+    - For a hit whose source IS in the map:
+      - watermark == 0: drop if ``applied_version`` is not None and >= 1
+        (version 0 means nothing applied for this source yet).
+      - Otherwise: drop if ``applied_version > watermark``.
+      - Hits with ``applied_version is None``: always pass through.
 
     INVARIANT: after this filter, no retained hit has
-    ``applied_version > min_watermark`` (when watermark is not None).
+    ``applied_version > per_source_watermark[hit.source.id]``
+    for sources present in the map.
     """
-    if min_watermark is None:
+    if not per_source_watermark:
         return hits
-    return [h for h in hits if h.applied_version is None or h.applied_version <= min_watermark]
+
+    result: list[SearchHit] = []
+    for h in hits:
+        src_key = str(h.source.id)
+        if src_key not in per_source_watermark:
+            # No watermark entry for this source → pass through (don't blackout).
+            result.append(h)
+            continue
+        wm = per_source_watermark[src_key]
+        if h.applied_version is None or h.applied_version <= wm:
+            result.append(h)
+    return result
+
+
+def _apply_graph_watermark_filter(
+    graph_result: Any,
+    per_source_watermark: dict[str, int],
+) -> Any:
+    """Remove graph-ahead nodes (and their edges) from a traversal result.
+
+    v10-AP2 graph-anchor pin: an ``EntityNodeView`` node whose ``version``
+    exceeds ``per_source_watermark[node.source]`` is excluded from the
+    candidate set so the graph VIEW is pinned to the same per-source epoch
+    as the vector evidence.  This closes the one-directional pin: without
+    this filter, Neo4j@v10 nodes would compose with Qdrant@v7 evidence.
+
+    Rules:
+    - Seed node version-ceiling is checked; if the seed is graph-ahead,
+      it is treated as a miss (the anchor stage caller checks ``seed.name
+      not in valid_entity_names`` and returns anchor_hit=False).  We signal
+      this by clearing the seed's version to ``None`` — BUT we do NOT
+      remove the seed object, because the caller's null-check is on name.
+      Instead we mark the seed as excluded via a sentinel so the anchor
+      stage can detect it.  Simpler approach: raise a ValueError here, but
+      that would be swallowed as an entity_not_found miss, which IS the
+      correct behaviour — so we do that.
+    - Related nodes whose version exceeds the watermark are removed.
+    - Edges between removed nodes are pruned.
+    - Nodes with ``version is None`` pass through (no ceiling info).
+    - Sources not in the watermark map pass through (no ceiling for them).
+
+    Returns the modified ``graph_result`` (mutated in-place for efficiency;
+    the caller owns the object after traverse() returns).
+    """
+    excluded_names: set[str] = set()
+
+    # Check seed node.
+    seed = graph_result.seed
+    seed_src = str(seed.source)
+    if seed_src in per_source_watermark and seed.version is not None:
+        wm = per_source_watermark[seed_src]
+        if seed.version > wm:
+            # Seed is graph-ahead: treat as traversal miss by raising ValueError.
+            # This is caught by _run_anchor_stage and mapped to anchor_hit=False.
+            raise ValueError(
+                f"graph_anchor_ahead_of_watermark: seed '{seed.name}' "
+                f"version={seed.version} > watermark={wm} for source {seed_src}"
+            )
+
+    # Filter related nodes.
+    kept_related = []
+    for node in graph_result.related:
+        node_src = str(node.source)
+        if node_src in per_source_watermark and node.version is not None:
+            wm = per_source_watermark[node_src]
+            if node.version > wm:
+                excluded_names.add(node.name)
+                continue
+        kept_related.append(node)
+    graph_result.related = kept_related
+
+    # Prune edges that connect excluded nodes.
+    if excluded_names:
+        graph_result.edges = [
+            e
+            for e in graph_result.edges
+            if e.from_entity not in excluded_names and e.to_entity not in excluded_names
+        ]
+
+    return graph_result
 
 
 def _extract_anchor(request: SearchRequest) -> str:
@@ -992,11 +1115,13 @@ def _stamp_envelope(
     hint so callers can distinguish "empty because no history yet"
     from "empty because nothing matched".
 
-    AP3 contract: ``degraded_subsystems`` and ``staleness_seconds`` are
-    set when any store lagged behind the Postgres SoT watermark at query
+    AP3 / v10-AP1 contract: ``degraded_subsystems`` and ``staleness_seconds``
+    are set when any store lagged behind the Postgres SoT watermark at query
     time, regardless of whether ``degraded`` is true.  ``pinned_watermark``
-    is the min version across all stores — it is stamped here regardless
-    of convergence state so callers always know the epoch of the response.
+    is the global min version across all stores — it is stamped here
+    regardless of convergence state so callers always know the epoch of
+    the response.  Per-source filtering is applied internally via
+    ``per_source_watermark``; the scalar is for observability only.
     Callers MUST treat a non-empty ``degraded_subsystems`` as a staleness
     signal and may choose to retry or surface a freshness warning.
     """
@@ -1024,5 +1149,6 @@ __all__ = [
     "MAX_ANCHOR_DEPTH",
     "MERGE_ALPHA",
     "GraphRAGComposer",
+    "_apply_graph_watermark_filter",
     "_apply_watermark_filter",
 ]

--- a/packages/retrieval/src/omniscience_retrieval/models.py
+++ b/packages/retrieval/src/omniscience_retrieval/models.py
@@ -171,11 +171,14 @@ class SearchResult(BaseModel):
     that the result may be stale and should not be cached or used for
     time-sensitive decisions without a retry.
 
-    ``pinned_watermark`` is the minimum version across all three stores
-    (Postgres, Neo4j, Qdrant) at the time this response was composed.
-    All hits in this response have ``applied_version <= pinned_watermark``
-    (or ``applied_version is None``).  ``None`` means no version information
-    was available — no watermark filter was applied (AP3 consistent-stale PIN).
+    ``pinned_watermark`` is the global minimum version across all sources
+    and all three stores (Postgres, Neo4j, Qdrant) at the time this
+    response was composed — for observability only.  Per-hit filtering is
+    applied PER-SOURCE internally (v10-AP1): each hit is filtered against
+    the watermark of its own source, so a cold/lagging source B does NOT
+    decimate hits from healthy source A.  The scalar here is the worst-case
+    floor.  ``None`` means no version information was available — no
+    watermark filter was applied (AP3 / v10-AP1 consistent-stale PIN).
     """
 
     hits: list[SearchHit]
@@ -219,10 +222,11 @@ class SearchResult(BaseModel):
     pinned_watermark: int | None = Field(
         default=None,
         description=(
-            "Minimum version across Postgres, Neo4j, and Qdrant at composition time. "
-            "All hits have applied_version <= pinned_watermark (or applied_version is None). "
+            "Global minimum version across all sources/stores at composition time "
+            "(observability scalar).  Per-hit filtering uses per-source watermarks "
+            "internally (v10-AP1) — a cold source does not blackout healthy sources. "
             "None when no version information was available — no watermark filter applied. "
-            "AP3 consistent-stale PIN."
+            "AP3 / v10-AP1 consistent-stale PIN."
         ),
     )
     snapshot_id: str | None = Field(

--- a/packages/retrieval/src/omniscience_retrieval/reconciler.py
+++ b/packages/retrieval/src/omniscience_retrieval/reconciler.py
@@ -7,9 +7,17 @@ AP3 (consilium-v8): surfaces explicit staleness signals instead of
 silently serving stale data on timeout.  ``check_convergence`` now
 snapshots the Postgres watermark once per call to prevent non-monotonic
 flap when the three stores are read at different wall-clock instants.
-``wait_for_convergence`` returns ``(degraded_subsystems, staleness_seconds,
-min_watermark)`` so the GraphRAG composer can pin the read path to the
-minimum observed version across all stores (AP3 consistent-stale PIN).
+
+v10-AP1 (consilium-v10): watermark is now PER-SOURCE — a cold or lagging
+source only filters ITS OWN hits, not hits from healthy sources in the same
+workspace.  ``check_convergence`` returns a ``per_source_watermark:
+dict[str, int]`` where each entry is
+``min(pg_version, neo4j_version, qdrant_version)`` for that source.  The
+global ``min_watermark`` scalar is retained as the min-of-all-sources for
+convenience but callers SHOULD use ``per_source_watermark`` for filtering.
+
+``wait_for_convergence`` returns
+``(degraded_subsystems, staleness_seconds, min_watermark, per_source_watermark)``.
 """
 
 from __future__ import annotations
@@ -30,22 +38,27 @@ log = structlog.get_logger(__name__)
 class GlobalReconciler:
     """Blocks until Qdrant and Neo4j checkpoints reach the Postgres watermark.
 
-    AP3 contract
-    ------------
+    AP3 / v10-AP1 contract
+    ----------------------
     ``wait_for_convergence`` returns a tuple
     ``(degraded_subsystems: list[str], staleness_seconds: float | None,
-    min_watermark: int | None)``.
+    min_watermark: int | None, per_source_watermark: dict[str, int])``.
+
+    ``per_source_watermark`` maps each source_id (str) to the safe version
+    ceiling for that source — ``min(pg_version, neo4j_version, qdrant_version)``
+    computed independently for each source.  A cold source (version 0) only
+    blackouts ITS OWN hits; healthy sources in the same workspace are unaffected.
+    When the map is empty (no documents in workspace) no filtering is applied.
+
+    ``min_watermark`` is the global minimum across ALL sources — retained for
+    backwards compatibility and observability.  Callers MUST use
+    ``per_source_watermark`` for per-hit filtering to avoid the global-blackout
+    regression (v10-AP1).
+
     An empty ``degraded_subsystems`` means all stores converged before the
     timeout; a non-empty list names the lagging stores and
     ``staleness_seconds`` quantifies the lag of the worst offender
     (as a version-delta — not wall-clock, but proportional to the drift).
-
-    ``min_watermark`` is the minimum version seen across all three stores
-    (Postgres, Neo4j, Qdrant) from the same atomic snapshot.  The GraphRAG
-    composer uses it to drop any hit whose ``applied_version > min_watermark``
-    so that no composed result contains evidence from a future epoch that
-    some stores have not yet applied.  ``None`` means no version information
-    was available (cold store or no documents) — no filter is applied.
 
     ``check_convergence`` snapshots the Postgres watermark **once** per
     call and compares both stores against the same snapshot, preventing
@@ -68,21 +81,26 @@ class GlobalReconciler:
         self,
         workspace_id: uuid.UUID,
         timeout: float = 10.0,
-    ) -> tuple[list[str], float | None, int | None]:
+    ) -> tuple[list[str], float | None, int | None, dict[str, int]]:
         """Wait until Neo4j and Qdrant checkpoints catch up to the Postgres SoT.
 
         Returns
         -------
-        ``(degraded_subsystems, staleness_seconds, min_watermark)``
+        ``(degraded_subsystems, staleness_seconds, min_watermark, per_source_watermark)``
             - ``degraded_subsystems``: empty on success; names the lagging
               stores on timeout (e.g. ``["neo4j"]``, ``["qdrant", "neo4j"]``).
             - ``staleness_seconds``: approximate lag in version units of the
               worst-lagging store; ``None`` when converged or unmeasurable.
-            - ``min_watermark``: minimum version across all stores from the
-              same snapshot.  ``None`` when no version information is available
-              (e.g. cold store or no documents in the workspace).  Callers
-              MUST use this to filter out hits whose ``applied_version`` exceeds
-              the watermark so no mixed-epoch evidence is served.
+            - ``min_watermark``: global minimum version across all stores and
+              sources from the same snapshot.  ``None`` when no version
+              information is available (e.g. cold store or no documents in the
+              workspace).  Retained for observability; callers SHOULD prefer
+              ``per_source_watermark`` for per-hit filtering.
+            - ``per_source_watermark``: mapping of source_id (str) →
+              ``min(pg, neo4j, qdrant)`` for that source.  A hit from source A
+              is filtered only against ``per_source_watermark[A]``; a cold
+              source B does NOT decimate hits from healthy source A.  Empty
+              dict means no documents in the workspace — no filtering applied.
 
         Never raises — callers receive stale data with explicit signals rather
         than a hard failure.
@@ -90,11 +108,15 @@ class GlobalReconciler:
         start_time = asyncio.get_event_loop().time()
 
         while True:
-            converged, degraded, staleness, min_watermark = await self.check_convergence(
-                workspace_id
-            )
+            (
+                converged,
+                degraded,
+                staleness,
+                min_watermark,
+                per_source_wm,
+            ) = await self.check_convergence(workspace_id)
             if converged:
-                return [], None, min_watermark
+                return [], None, min_watermark, per_source_wm
             elapsed = asyncio.get_event_loop().time() - start_time
             if elapsed > timeout:
                 log.warning(
@@ -103,14 +125,15 @@ class GlobalReconciler:
                     degraded_subsystems=degraded,
                     staleness_seconds=staleness,
                     min_watermark=min_watermark,
+                    per_source_watermark=per_source_wm,
                 )
-                return degraded, staleness, min_watermark
+                return degraded, staleness, min_watermark, per_source_wm
             await asyncio.sleep(0.5)
 
     async def check_convergence(
         self,
         workspace_id: uuid.UUID,
-    ) -> tuple[bool, list[str], float | None, int | None]:
+    ) -> tuple[bool, list[str], float | None, int | None, dict[str, int]]:
         """Check whether all stores have reached the Postgres watermark.
 
         The Postgres watermark is snapshotted **once** at the start of this
@@ -120,20 +143,23 @@ class GlobalReconciler:
 
         Returns
         -------
-        ``(converged, degraded_subsystems, staleness_seconds, min_watermark)``
+        ``(converged, degraded_subsystems, staleness_seconds, min_watermark,
+        per_source_watermark)``
             - ``converged``: True when all stores meet or exceed the PG watermark.
             - ``degraded_subsystems``: names of lagging stores (empty when converged).
             - ``staleness_seconds``: version-delta of the worst-lagging store;
               ``None`` when converged or the PG watermark is empty.
-            - ``min_watermark``: minimum version across Postgres, Neo4j, and
-              Qdrant from the same snapshot.  ``None`` when no version data
-              exists.  Used by the GraphRAG composer to pin the read path
-              (AP3 consistent-stale PIN).
+            - ``min_watermark``: global minimum version across all sources and
+              all stores.  ``None`` when no version data exists.
+            - ``per_source_watermark``: per-source ceiling map (v10-AP1).
+              ``min(pg_v, neo4j_v, qdrant_v)`` computed independently per source.
+              Used by the GraphRAG composer to filter a hit only against its own
+              source's watermark — NOT a global min (v10-AP1 fix).
         """
         # 1. Snapshot the Postgres watermark once — prevents epoch-skew flap.
         pg_watermarks = await self._snapshot_pg_watermark(workspace_id)
         if not pg_watermarks:
-            return True, [], None, None
+            return True, [], None, None, {}
 
         # 2. Fetch store checkpoints concurrently against the same snapshot.
         qdrant_checkpoints, neo4j_checkpoints = await asyncio.gather(
@@ -146,16 +172,22 @@ class GlobalReconciler:
         neo4j_lagging = False
         max_lag: float = 0.0
 
-        # min_watermark: minimum version seen across all three stores for
-        # sources that appear in the PG watermark.  This is the "safe" epoch
-        # below which all stores agree — used to pin composed results.
+        # Global version list for backwards-compatible min_watermark scalar.
         all_versions: list[int] = []
+
+        # Per-source watermark map (v10-AP1): each source gets its own ceiling.
+        per_source_watermark: dict[str, int] = {}
 
         for source_id, pg_version in pg_watermarks.items():
             if pg_version == 0:
                 continue
             q_version = qdrant_checkpoints.get(source_id, 0)
             n_version = neo4j_checkpoints.get(source_id, 0)
+
+            # Per-source ceiling: hits from this source are pinned to the
+            # minimum version that ALL three stores agree on for it.
+            source_min = min(pg_version, q_version, n_version)
+            per_source_watermark[source_id] = source_min
 
             all_versions.extend([pg_version, q_version, n_version])
 
@@ -175,8 +207,8 @@ class GlobalReconciler:
             degraded.append("neo4j")
 
         if degraded:
-            return False, degraded, max_lag, min_watermark
-        return True, [], None, min_watermark
+            return False, degraded, max_lag, min_watermark, per_source_watermark
+        return True, [], None, min_watermark, per_source_watermark
 
     async def _snapshot_pg_watermark(
         self,

--- a/tests/conformance/test_ap3_no_mixed_epoch.py
+++ b/tests/conformance/test_ap3_no_mixed_epoch.py
@@ -1,9 +1,18 @@
-"""AP3 conformance tests — no mixed-epoch evidence in composed results.
+"""AP3 / v10-AP1 / v10-AP2 conformance tests — no mixed-epoch evidence.
 
 AP3 invariant: every hit in a SearchResult must have
-``applied_version <= pinned_watermark`` (or ``applied_version is None``).
+``applied_version <= watermark[its_source]`` (or ``applied_version is None``).
 No composed result may contain evidence from a future epoch that some
 stores have not yet applied.
+
+v10-AP1 invariant (per-source watermark): a cold/lagging source B must NOT
+decimate hits from healthy source A.  Each hit is evaluated against the
+watermark of ITS OWN source.
+
+v10-AP2 invariant (graph-anchor pin): no composed result mixes a graph
+node/edge with ``version > watermark[its_source]`` with evidence pinned
+to that watermark.  The graph VIEW is pinned to the same per-source epoch
+as the vector evidence.
 
 These tests are REAL (not xfail) and must remain green throughout the
 codebase lifetime.  They use mocks only — no containers required.
@@ -16,7 +25,13 @@ Test cases
 3. converged watermark=10, all hits ≤10 → all pass; ``pinned_watermark==10``.
 4. cold store watermark=0, hits applied_version=1 → result empty;
    ``pinned_watermark==0``.
-5. ``_apply_watermark_filter`` pure-function boundary test.
+5. ``_apply_watermark_filter`` pure-function boundary test (per-source map).
+6. [v10-AP1] multi-source: source A@v10 healthy + source B@v0 cold →
+   source A hits still returned; only source B hits dropped.
+7. [v10-AP1] hit from source not in watermark map → passes (no blackout).
+8. [v10-AP2] anchor node version > source watermark → excluded from anchor result
+   (graph-ahead mixed-epoch prevented).
+9. [v10-AP2] anchor seed node version > source watermark → treated as anchor miss.
 """
 
 from __future__ import annotations
@@ -26,7 +41,12 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from omniscience_retrieval.graph_rag import GraphRAGComposer, _apply_watermark_filter
+from omniscience_core.storage.graph import EntityNodeView, GraphEdgeView, GraphResultView
+from omniscience_retrieval.graph_rag import (
+    GraphRAGComposer,
+    _apply_graph_watermark_filter,
+    _apply_watermark_filter,
+)
 from omniscience_retrieval.models import (
     ChunkLineage,
     Citation,
@@ -44,15 +64,23 @@ from omniscience_retrieval.models import (
 _WS = uuid.UUID("cccccccc-0000-0000-0000-000000000003")
 _NOW = datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC)
 
+_SRC_A = uuid.uuid4()
+_SRC_B = uuid.uuid4()
 
-def _make_hit(applied_version: int | None, text: str = "chunk") -> SearchHit:
+
+def _make_hit(
+    applied_version: int | None,
+    text: str = "chunk",
+    source_id: uuid.UUID | None = None,
+) -> SearchHit:
     """Build a minimal SearchHit with the given applied_version."""
+    sid = source_id if source_id is not None else uuid.uuid4()
     return SearchHit(
         chunk_id=uuid.uuid4(),
         document_id=uuid.uuid4(),
         score=0.8,
         text=text,
-        source=SourceInfo(id=uuid.uuid4(), name="src", type="slack"),
+        source=SourceInfo(id=sid, name="src", type="slack"),
         citation=Citation(uri="mem://x", title=None, indexed_at=_NOW, doc_version=1),
         lineage=ChunkLineage(
             ingestion_run_id=None,
@@ -79,13 +107,28 @@ def _make_result(hits: list[SearchHit]) -> SearchResult:
 
 
 def _make_composer_with_reconciler(
-    min_watermark: int | None, hits: list[SearchHit]
+    min_watermark: int | None,
+    hits: list[SearchHit],
+    per_source_watermark: dict[str, int] | None = None,
 ) -> GraphRAGComposer:
-    """Build a GraphRAGComposer whose reconciler returns the given watermark."""
+    """Build a GraphRAGComposer whose reconciler returns the given watermark.
 
-    # Reconciler mock: wait_for_convergence → (degraded, staleness, min_watermark)
+    v10-AP1: per_source_watermark is passed to the reconciler mock.
+    If None, a default per-source map is built from min_watermark and
+    the hit source IDs (for backwards compatibility with single-source tests).
+    """
+    # Build default per-source map if not provided
+    if per_source_watermark is None:
+        if min_watermark is not None:
+            per_source_watermark = {str(h.source.id): min_watermark for h in hits}
+        else:
+            per_source_watermark = {}
+
+    # Reconciler mock: wait_for_convergence → (degraded, staleness, min_watermark, per_source_wm)
     mock_reconciler = MagicMock()
-    mock_reconciler.wait_for_convergence = AsyncMock(return_value=([], None, min_watermark))
+    mock_reconciler.wait_for_convergence = AsyncMock(
+        return_value=([], None, min_watermark, per_source_watermark)
+    )
 
     class _FakeVS:
         async def search(
@@ -125,13 +168,18 @@ async def test_watermark_filters_future_epoch_hits() -> None:
     Input versions: 5, 7, 8, 10. Watermark: 7.
     Expected survivors: versions 5 and 7.
     """
+    src_id = uuid.uuid4()
     hits = [
-        _make_hit(applied_version=5, text="v5"),
-        _make_hit(applied_version=7, text="v7"),
-        _make_hit(applied_version=8, text="v8"),  # must be dropped
-        _make_hit(applied_version=10, text="v10"),  # must be dropped
+        _make_hit(applied_version=5, text="v5", source_id=src_id),
+        _make_hit(applied_version=7, text="v7", source_id=src_id),
+        _make_hit(applied_version=8, text="v8", source_id=src_id),  # must be dropped
+        _make_hit(applied_version=10, text="v10", source_id=src_id),  # must be dropped
     ]
-    composer = _make_composer_with_reconciler(min_watermark=7, hits=hits)
+    composer = _make_composer_with_reconciler(
+        min_watermark=7,
+        hits=hits,
+        per_source_watermark={str(src_id): 7},
+    )
     req = SearchRequest(query="test", top_k=10)
     result = await composer.search(req, workspace_id=_WS)
 
@@ -168,7 +216,11 @@ async def test_none_watermark_passes_all_hits() -> None:
         _make_hit(applied_version=100),
         _make_hit(applied_version=None),
     ]
-    composer = _make_composer_with_reconciler(min_watermark=None, hits=hits)
+    composer = _make_composer_with_reconciler(
+        min_watermark=None,
+        hits=hits,
+        per_source_watermark={},
+    )
     req = SearchRequest(query="test", top_k=10)
     result = await composer.search(req, workspace_id=_WS)
 
@@ -189,13 +241,18 @@ async def test_none_watermark_passes_all_hits() -> None:
 @pytest.mark.asyncio
 async def test_converged_watermark_passes_all_current_hits() -> None:
     """When all stores are converged and all hits are at or below watermark, nothing is dropped."""
+    src_id = uuid.uuid4()
     hits = [
-        _make_hit(applied_version=1),
-        _make_hit(applied_version=5),
-        _make_hit(applied_version=10),
-        _make_hit(applied_version=None),
+        _make_hit(applied_version=1, source_id=src_id),
+        _make_hit(applied_version=5, source_id=src_id),
+        _make_hit(applied_version=10, source_id=src_id),
+        _make_hit(applied_version=None, source_id=src_id),
     ]
-    composer = _make_composer_with_reconciler(min_watermark=10, hits=hits)
+    composer = _make_composer_with_reconciler(
+        min_watermark=10,
+        hits=hits,
+        per_source_watermark={str(src_id): 10},
+    )
     req = SearchRequest(query="test", top_k=10)
     result = await composer.search(req, workspace_id=_WS)
 
@@ -221,11 +278,16 @@ async def test_cold_store_watermark_zero_drops_all_versioned_hits() -> None:
     A watermark of 0 means no store has applied anything — returning any
     versioned chunk would be mixed-epoch.  Only None-versioned hits survive.
     """
+    src_id = uuid.uuid4()
     hits = [
-        _make_hit(applied_version=1, text="v1"),  # must be dropped: 1 > 0
-        _make_hit(applied_version=None, text="unversioned"),  # must survive
+        _make_hit(applied_version=1, text="v1", source_id=src_id),  # must be dropped: 1 > 0
+        _make_hit(applied_version=None, text="unversioned", source_id=src_id),  # must survive
     ]
-    composer = _make_composer_with_reconciler(min_watermark=0, hits=hits)
+    composer = _make_composer_with_reconciler(
+        min_watermark=0,
+        hits=hits,
+        per_source_watermark={str(src_id): 0},
+    )
     req = SearchRequest(query="test", top_k=10)
     result = await composer.search(req, workspace_id=_WS)
 
@@ -242,56 +304,386 @@ async def test_cold_store_watermark_zero_drops_all_versioned_hits() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 5: _apply_watermark_filter pure-function boundary test
+# Test 5: _apply_watermark_filter pure-function boundary test (per-source map)
 # ---------------------------------------------------------------------------
 
 
 def test_apply_watermark_filter_pure_function() -> None:
-    """Unit test of _apply_watermark_filter as a pure function.
+    """Unit test of _apply_watermark_filter as a pure function (per-source map).
 
-    Verifies all boundary conditions:
-    - Hits with applied_version > watermark → dropped.
+    Verifies all boundary conditions with per-source watermark dict:
+    - Hits with applied_version > their source's watermark → dropped.
     - Hits with applied_version == watermark → retained.
     - Hits with applied_version < watermark → retained.
     - Hits with applied_version is None → always retained.
-    - Watermark None → all hits retained (no filter).
-    - Watermark 0 → only None-versioned hits survive.
+    - Per-source map None or empty → all hits retained (no filter).
+    - Source not in map → hit passes (no blackout for unknown sources).
+    - Two sources with different watermarks are evaluated independently.
     """
-    h_none = _make_hit(applied_version=None)
-    h_v0 = _make_hit(applied_version=0)
-    h_v5 = _make_hit(applied_version=5)
-    h_v7 = _make_hit(applied_version=7)
-    h_v8 = _make_hit(applied_version=8)
-    h_v10 = _make_hit(applied_version=10)
+    src_x = uuid.uuid4()
+    src_y = uuid.uuid4()
+    src_unknown = uuid.uuid4()
 
-    all_hits = [h_none, h_v0, h_v5, h_v7, h_v8, h_v10]
+    h_none = _make_hit(applied_version=None, source_id=src_x)
+    h_v0 = _make_hit(applied_version=0, source_id=src_x)
+    h_v5 = _make_hit(applied_version=5, source_id=src_x)
+    h_v7 = _make_hit(applied_version=7, source_id=src_x)
+    h_v8 = _make_hit(applied_version=8, source_id=src_x)
+    h_v10 = _make_hit(applied_version=10, source_id=src_x)
 
-    # --- watermark = None: no filter ---
-    result = _apply_watermark_filter(all_hits, None)
-    assert result == all_hits, "watermark=None must return all hits unchanged"
+    all_hits_x = [h_none, h_v0, h_v5, h_v7, h_v8, h_v10]
 
-    # --- watermark = 7: drop v8 and v10 ---
-    result = _apply_watermark_filter(all_hits, 7)
+    # --- watermark map None: no filter ---
+    result = _apply_watermark_filter(all_hits_x, None)
+    assert result == all_hits_x, "watermark=None must return all hits unchanged"
+
+    # --- watermark map empty: no filter ---
+    result = _apply_watermark_filter(all_hits_x, {})
+    assert result == all_hits_x, "empty watermark map must return all hits unchanged"
+
+    # --- single source watermark = 7: drop v8 and v10 ---
+    wm = {str(src_x): 7}
+    result = _apply_watermark_filter(all_hits_x, wm)
     surviving = {h.applied_version for h in result}
     assert surviving == {None, 0, 5, 7}, f"Expected {{None,0,5,7}}; got {surviving}"
 
-    # --- watermark = 0: drop v5, v7, v8, v10; keep None and v0 ---
-    result = _apply_watermark_filter(all_hits, 0)
+    # --- single source watermark = 0: drop v5, v7, v8, v10; keep None and v0 ---
+    wm = {str(src_x): 0}
+    result = _apply_watermark_filter(all_hits_x, wm)
     surviving = {h.applied_version for h in result}
     assert surviving == {None, 0}, f"Expected {{None,0}}; got {surviving}"
 
-    # --- watermark = 10: all pass ---
-    result = _apply_watermark_filter(all_hits, 10)
-    assert result == all_hits, "watermark=10 must retain all hits"
+    # --- single source watermark = 10: all pass ---
+    wm = {str(src_x): 10}
+    result = _apply_watermark_filter(all_hits_x, wm)
+    assert result == all_hits_x, "watermark=10 must retain all hits"
 
     # --- exact boundary: watermark == applied_version is retained ---
-    result = _apply_watermark_filter([h_v7], 7)
+    result = _apply_watermark_filter([h_v7], {str(src_x): 7})
     assert len(result) == 1, "Hit at exactly the watermark must be retained"
 
     # --- one above boundary: dropped ---
-    result = _apply_watermark_filter([h_v8], 7)
+    result = _apply_watermark_filter([h_v8], {str(src_x): 7})
     assert result == [], "Hit at watermark+1 must be dropped"
 
     # --- empty input: always returns empty ---
-    assert _apply_watermark_filter([], 5) == []
+    assert _apply_watermark_filter([], {str(src_x): 5}) == []
     assert _apply_watermark_filter([], None) == []
+
+    # --- source not in map: hit passes (no blackout) ---
+    h_unknown = _make_hit(applied_version=999, source_id=src_unknown)
+    result = _apply_watermark_filter([h_unknown], {str(src_x): 7})
+    assert len(result) == 1, "Hit from source not in watermark map must pass (no blackout)"
+
+    # --- two-source independence: src_x@wm=7, src_y@wm=3 ---
+    h_y_v2 = _make_hit(applied_version=2, source_id=src_y)
+    h_y_v5 = _make_hit(applied_version=5, source_id=src_y)  # > src_y watermark of 3
+    h_x_v6 = _make_hit(applied_version=6, source_id=src_x)  # <= src_x watermark of 7
+    h_x_v9 = _make_hit(applied_version=9, source_id=src_x)  # > src_x watermark of 7
+    mixed_hits = [h_y_v2, h_y_v5, h_x_v6, h_x_v9]
+    wm = {str(src_x): 7, str(src_y): 3}
+    result = _apply_watermark_filter(mixed_hits, wm)
+    surviving_set = {(str(h.source.id), h.applied_version) for h in result}
+    assert (str(src_y), 2) in surviving_set, "src_y v2 <= wm=3 must survive"
+    assert (str(src_y), 5) not in surviving_set, "src_y v5 > wm=3 must be dropped"
+    assert (str(src_x), 6) in surviving_set, "src_x v6 <= wm=7 must survive"
+    assert (str(src_x), 9) not in surviving_set, "src_x v9 > wm=7 must be dropped"
+
+
+# ---------------------------------------------------------------------------
+# Test 6 (v10-AP1): multi-source — cold source B does NOT blackout source A
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_source_cold_source_does_not_blackout_healthy_source() -> None:
+    """Regression guard for v10-AP1: a cold source must not black out healthy sources.
+
+    Workspace has two sources:
+    - Source A at v10 (healthy): its hits should be returned.
+    - Source B at v0 (cold): its future-epoch hits should be dropped.
+
+    With the OLD global-min watermark (v9 bug): min(10, 0) = 0 → ALL hits dropped.
+    With the NEW per-source watermark (v10-AP1 fix): A@10 returned, B@>0 dropped.
+    """
+    src_a = uuid.uuid4()
+    src_b = uuid.uuid4()
+
+    hits = [
+        _make_hit(applied_version=10, text="A-v10", source_id=src_a),  # healthy A
+        _make_hit(applied_version=5, text="B-v5", source_id=src_b),  # cold B, should drop
+        _make_hit(applied_version=None, text="A-unversioned", source_id=src_a),  # always pass
+    ]
+    # Per-source watermark: A is healthy at v10, B is cold at v0
+    per_source_wm = {str(src_a): 10, str(src_b): 0}
+    composer = _make_composer_with_reconciler(
+        min_watermark=0,  # global min (old v9 floor) — should NOT be used for filtering
+        hits=hits,
+        per_source_watermark=per_source_wm,
+    )
+    req = SearchRequest(query="test", top_k=10)
+    result = await composer.search(req, workspace_id=_WS)
+
+    # Source A's hit at v10 MUST survive (v10 <= A's watermark of 10).
+    src_a_hits = [h for h in result.hits if h.source.id == src_a]
+    assert len(src_a_hits) >= 1, (
+        f"Source A hits must survive; cold source B must not blackout A. "
+        f"Got src_a_hits={[h.applied_version for h in src_a_hits]}, "
+        f"all result hits={[(str(h.source.id)[:8], h.applied_version) for h in result.hits]}"
+    )
+    versioned_a = [h for h in src_a_hits if h.applied_version is not None]
+    assert any(h.applied_version == 10 for h in versioned_a), "Source A hit at v10 must survive"
+
+    # Source B's hit at v5 MUST be dropped (v5 > B's watermark of 0).
+    src_b_hits = [h for h in result.hits if h.source.id == src_b]
+    versioned_b = [h for h in src_b_hits if h.applied_version is not None]
+    assert versioned_b == [], (
+        f"Source B has watermark=0; versioned hits must be dropped; got {versioned_b}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_source_unknown_source_not_blacked_out() -> None:
+    """A hit from a source not in the watermark map passes through (no blackout).
+
+    This handles the case where a new source ingested data but the reconciler
+    has not yet seen its checkpoint.  We must not drop the hit — only sources
+    with an explicit watermark entry are filtered.
+    """
+    src_known = uuid.uuid4()
+    src_new = uuid.uuid4()
+
+    hits = [
+        _make_hit(applied_version=5, text="known-v5", source_id=src_known),
+        _make_hit(applied_version=100, text="new-v100", source_id=src_new),  # no map entry
+    ]
+    per_source_wm = {str(src_known): 7}  # src_new is NOT in the map
+    composer = _make_composer_with_reconciler(
+        min_watermark=7,
+        hits=hits,
+        per_source_watermark=per_source_wm,
+    )
+    req = SearchRequest(query="test", top_k=10)
+    result = await composer.search(req, workspace_id=_WS)
+
+    new_src_hits = [h for h in result.hits if h.source.id == src_new]
+    assert len(new_src_hits) == 1, "Hit from source not in watermark map must pass through"
+    assert new_src_hits[0].applied_version == 100
+
+
+# ---------------------------------------------------------------------------
+# Test 8 (v10-AP2): graph-ahead related node excluded from anchor candidates
+# ---------------------------------------------------------------------------
+
+
+def test_apply_graph_watermark_filter_excludes_graph_ahead_related_nodes() -> None:
+    """_apply_graph_watermark_filter removes related nodes ahead of their source watermark.
+
+    Graph has seed (src_a, v5) and two related nodes:
+    - node_ok (src_b, v3) — within src_b watermark of 5 → kept
+    - node_ahead (src_c, v8) — ABOVE src_c watermark of 5 → excluded
+
+    Invariant: no composed result mixes a graph node with version > watermark[source].
+    """
+    src_a = str(uuid.uuid4())
+    src_b = str(uuid.uuid4())
+    src_c = str(uuid.uuid4())
+
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="SeedEntity",
+        kind="service",
+        source=src_a,
+        chunk_text=None,
+        depth=0,
+        version=5,
+    )
+    node_ok = EntityNodeView(
+        id=uuid.uuid4(),
+        name="OkEntity",
+        kind="team",
+        source=src_b,
+        chunk_text=None,
+        depth=1,
+        version=3,
+    )
+    node_ahead = EntityNodeView(
+        id=uuid.uuid4(),
+        name="AheadEntity",
+        kind="repo",
+        source=src_c,
+        chunk_text=None,
+        depth=1,
+        version=8,  # > src_c watermark of 5
+    )
+    edge_ok = GraphEdgeView(
+        from_entity="SeedEntity",
+        to_entity="OkEntity",
+        edge_type="OWNS",
+    )
+    edge_ahead = GraphEdgeView(
+        from_entity="SeedEntity",
+        to_entity="AheadEntity",
+        edge_type="USES",
+    )
+
+    graph_result = GraphResultView(
+        seed=seed,
+        related=[node_ok, node_ahead],
+        edges=[edge_ok, edge_ahead],
+    )
+
+    per_source_wm = {src_a: 10, src_b: 5, src_c: 5}
+    filtered = _apply_graph_watermark_filter(graph_result, per_source_wm)
+
+    # OkEntity (v3 <= src_b wm=5) must remain
+    remaining_names = [n.name for n in filtered.related]
+    assert "OkEntity" in remaining_names, "OkEntity within watermark must be kept"
+
+    # AheadEntity (v8 > src_c wm=5) must be excluded
+    assert "AheadEntity" not in remaining_names, (
+        "AheadEntity version>watermark must be excluded from graph anchor result"
+    )
+
+    # Edge to AheadEntity must be pruned
+    remaining_edge_targets = [e.to_entity for e in filtered.edges]
+    assert "AheadEntity" not in remaining_edge_targets, "Edge to excluded node must be pruned"
+
+    # Edge to OkEntity must remain
+    assert "OkEntity" in remaining_edge_targets, "Edge to OkEntity must remain"
+
+
+def test_apply_graph_watermark_filter_node_version_none_passes() -> None:
+    """A node with version=None is not subject to version ceiling (passes through)."""
+    src = str(uuid.uuid4())
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="Seed",
+        kind="service",
+        source=src,
+        chunk_text=None,
+        depth=0,
+        version=None,  # no version info
+    )
+    node = EntityNodeView(
+        id=uuid.uuid4(),
+        name="Related",
+        kind="team",
+        source=src,
+        chunk_text=None,
+        depth=1,
+        version=None,  # no version info
+    )
+    graph_result = GraphResultView(seed=seed, related=[node], edges=[])
+    per_source_wm = {src: 0}  # even ceiling=0 must not drop None-versioned nodes
+    filtered = _apply_graph_watermark_filter(graph_result, per_source_wm)
+    assert len(filtered.related) == 1, "version=None node must not be excluded"
+
+
+def test_apply_graph_watermark_filter_source_not_in_map_passes() -> None:
+    """Node whose source is not in the watermark map passes through (no ceiling)."""
+    src_mapped = str(uuid.uuid4())
+    src_unmapped = str(uuid.uuid4())
+
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="Seed",
+        kind="service",
+        source=src_mapped,
+        chunk_text=None,
+        depth=0,
+        version=3,
+    )
+    node_unmapped = EntityNodeView(
+        id=uuid.uuid4(),
+        name="Unmapped",
+        kind="repo",
+        source=src_unmapped,
+        chunk_text=None,
+        depth=1,
+        version=999,  # very high version, but source not in map → passes
+    )
+    graph_result = GraphResultView(seed=seed, related=[node_unmapped], edges=[])
+    per_source_wm = {src_mapped: 10}  # src_unmapped not in map
+    filtered = _apply_graph_watermark_filter(graph_result, per_source_wm)
+    assert len(filtered.related) == 1, "Unmapped source node must not be excluded"
+
+
+# ---------------------------------------------------------------------------
+# Test 9 (v10-AP2): seed node version > watermark → anchor treated as miss
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_graph_ahead_seed_node_treated_as_anchor_miss() -> None:
+    """When the anchor seed node is graph-ahead (version > watermark), the anchor is a miss.
+
+    This prevents a graph-ahead seed from polluting the candidate set and
+    injecting graph-v10 entity context into a v7-evidence composed result.
+    """
+    src_id = uuid.uuid4()
+    src_str = str(src_id)
+
+    # Seed entity at version 10, but per-source watermark is 7.
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="AheadSeed",
+        kind="service",
+        source=src_str,
+        chunk_text=None,
+        depth=0,
+        version=10,  # > watermark of 7 → should be excluded
+    )
+    graph_result = GraphResultView(seed=seed, related=[], edges=[])
+
+    # Vector hits — should still be returned (no global blackout).
+    hit_a = _make_hit(applied_version=7, text="v7-evidence", source_id=src_id)
+
+    per_source_wm = {src_str: 7}
+
+    mock_reconciler = MagicMock()
+    mock_reconciler.wait_for_convergence = AsyncMock(return_value=([], None, 7, per_source_wm))
+
+    class _FakeVS:
+        async def search(
+            self,
+            *,
+            request: SearchRequest,
+            workspace_id: uuid.UUID,
+            as_of: datetime | None = None,
+        ) -> SearchResult:
+            return _make_result([hit_a])
+
+    class _FakeLegacy:
+        async def search(self, request: SearchRequest) -> SearchResult:
+            return _make_result([])
+
+    composer = GraphRAGComposer.__new__(GraphRAGComposer)
+    composer._graphrag_active = True  # type: ignore[attr-defined]
+    composer._global_reconciler = mock_reconciler  # type: ignore[attr-defined]
+    composer._session_factory = None  # type: ignore[attr-defined]
+    composer._is_entity_parked_fn = None  # type: ignore[attr-defined]
+    composer._vector_store = _FakeVS()  # type: ignore[attr-defined]
+    # graph_store.traverse returns the graph-ahead seed
+    graph_store_mock = MagicMock()
+    graph_store_mock.traverse = AsyncMock(return_value=graph_result)
+    composer._graph_store = graph_store_mock  # type: ignore[attr-defined]
+    composer._legacy_service = _FakeLegacy()  # type: ignore[attr-defined]
+
+    req = SearchRequest(
+        query="test anchor",
+        top_k=10,
+        filters={"graphrag_anchor": "AheadSeed"},
+    )
+    result = await composer.search(req, workspace_id=_WS)
+
+    # The anchor seed was graph-ahead → treated as miss → no candidate set from graph.
+    # Vector evidence at v7 (within watermark) must still be returned.
+    assert len(result.hits) >= 1, (
+        "Vector evidence within watermark must still be returned even when anchor is graph-ahead"
+    )
+    surviving_versions = [h.applied_version for h in result.hits]
+    assert all(v is None or v <= 7 for v in surviving_versions), (
+        "No hit should exceed watermark=7 after graph-ahead anchor rejection: "
+        f"{surviving_versions}"
+    )

--- a/tests/integration/test_ap2_backfill_heal.py
+++ b/tests/integration/test_ap2_backfill_heal.py
@@ -1,0 +1,281 @@
+"""AP2 backfill heal — live Neo4j conformance gate (v10-AP3).
+
+This test reproduces the exact drift→heal end-to-end path confirmed dead in
+consilium-v10-review.md §v10-AP3:
+
+    Drift scenario:
+      1. Source S upserts entity E at version 5.
+         → Source checkpoint: {source_id: S, version: 5}
+         → Node E.version: 5
+      2. Simulate a lost write by directly setting E.version = 3 via raw Cypher.
+         → Source checkpoint still: 5 (unchanged — checkpoint is per-source, not per-entity)
+         → Node E.version: 3  (stale — this is the drift)
+      3. AP2 reconciler detects drift (node v3 < SoT v5) and re-emits the entity
+         at version 5 with is_backfill=True through the consumer path (modelled by
+         calling upsert_entity with bypass_source_checkpoint=True).
+      4. Before the fix: the store sees existing_checkpoint_version(5) >= incoming(5)
+         → should_skip=True → returns without writing → node stays stale at v3.
+         After the fix: bypass_source_checkpoint=True clears should_skip → CAS runs
+         → CAS: incoming(5) > node.version(3) → writes → node healed to v5.
+
+Gate: OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 (set by CI in ci.yml test job).
+
+IMPORTANT: This test MUST FAIL on pre-fix code (where outbox_consumer builds
+EntityUpsert without bypass_source_checkpoint) and PASS after the fix.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_CONTRACT = pytest.mark.skipif(
+    not os.environ.get("OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS"),
+    reason="set OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 to run live Neo4j contract tests",
+)
+
+
+@_CONTRACT
+@pytest.mark.asyncio
+async def test_live_ap2_backfill_heals_stale_node_bypassing_source_checkpoint() -> None:
+    """v10-AP3 live conformance: drift→backfill→heal end-to-end against live Neo4j.
+
+    Step 1: Write entity E at v5 (source checkpoint advances to 5, node version=5).
+    Step 2: Simulate drift — set E.version=3 via raw Cypher (checkpoint still=5).
+    Step 3: Apply backfill upsert (bypass_source_checkpoint=True, version=5).
+    Step 4: Assert E.version is healed back to 5 (NOT skipped).
+
+    Pre-fix: FAILS because the consumer builds EntityUpsert with
+        bypass_source_checkpoint=False (default), so the store sees
+        checkpoint(5) >= incoming(5) → skip → node stays at v3.
+
+    Post-fix: PASSES because bypass_source_checkpoint=True clears the skip
+        and the CAS (5 > 3) heals the node.
+
+    The test also asserts that a normal non-backfill stale re-delivery (AP1
+    invariant) is still rejected:
+    Step 5: Write entity F at v7, then attempt to write F at v4 (no backfill).
+    Step 6: Assert F.version is still 7 (per-entity CAS monotonic guard holds).
+    """
+    from omniscience_core.storage.graph import EntityUpsert
+    from omniscience_index.stores.neo4j.store import Neo4jGraphStore, Neo4jStoreConfig
+
+    neo4j_uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    neo4j_user = os.environ.get("NEO4J_USERNAME", "neo4j")
+    neo4j_pw = os.environ.get("NEO4J_PASSWORD", "neo4j")
+
+    config = Neo4jStoreConfig(
+        uri=neo4j_uri,
+        username=neo4j_user,
+        password=neo4j_pw,
+        database="neo4j",
+        max_connection_pool_size=5,
+        connection_acquisition_timeout_seconds=10.0,
+        max_transaction_retry_time_seconds=10.0,
+        default_max_depth=3,
+        bitemporal_enabled=False,
+    )
+    store = Neo4jGraphStore(config=config)
+    await store.connect()
+
+    ws_id = uuid.uuid4()
+    entity_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+
+    # AP1 regression guard — separate entity
+    entity_id_f = uuid.uuid4()
+    source_id_f = uuid.uuid4()
+
+    try:
+        # ------------------------------------------------------------------
+        # Step 1: Write entity E at version 5.
+        # Source checkpoint advances to 5; node E.version=5.
+        # ------------------------------------------------------------------
+        e5 = EntityUpsert(
+            id=entity_id,
+            source_id=source_id,
+            entity_type="service",
+            name="svc.ap2-backfill-heal",
+            display_name="svc.ap2-backfill-heal",
+            chunk_id=None,
+            metadata={},
+            version=5,
+        )
+        await store.upsert_entity(entity=e5, workspace_id=ws_id)
+
+        # Verify initial state: node version == 5
+        versions = await store.get_entity_versions(workspace_id=ws_id)
+        assert entity_id in versions, f"Entity {entity_id} not found after initial v5 write"
+        assert versions[entity_id] == 5, f"Expected initial version=5, got {versions[entity_id]}"
+
+        # ------------------------------------------------------------------
+        # Step 2: Simulate drift — directly set node E.version back to 3 via
+        # raw Cypher (emulating a lost write or partial failure).
+        # The source checkpoint remains at 5.
+        # ------------------------------------------------------------------
+        async with store._driver.session(database=config.database) as session:
+            await session.run(
+                "MATCH (n:Entity {workspace_id: $ws, id: $eid}) SET n.version = 3",
+                {"ws": str(ws_id), "eid": str(entity_id)},
+            )
+
+        # Confirm drift is in place
+        versions_after_drift = await store.get_entity_versions(workspace_id=ws_id)
+        assert versions_after_drift.get(entity_id) == 3, (
+            f"Drift setup failed: expected node version=3 after raw Cypher, "
+            f"got {versions_after_drift.get(entity_id)}"
+        )
+
+        # ------------------------------------------------------------------
+        # Step 3: Apply backfill EntityUpsert (bypass_source_checkpoint=True,
+        # version=5) — this models what the outbox consumer now builds when
+        # event.is_backfill=True (post v10-AP3 fix).
+        # ------------------------------------------------------------------
+        e5_backfill = EntityUpsert(
+            id=entity_id,
+            source_id=source_id,
+            entity_type="service",
+            name="svc.ap2-backfill-heal",
+            display_name="svc.ap2-backfill-heal",
+            chunk_id=None,
+            metadata={},
+            version=5,
+            bypass_source_checkpoint=True,  # v10-AP3 fix
+        )
+        await store.upsert_entity(entity=e5_backfill, workspace_id=ws_id)
+
+        # ------------------------------------------------------------------
+        # Step 4: Assert E.version is healed back to 5.
+        # Pre-fix: node stays at 3 (skip returned without writing).
+        # Post-fix: CAS (5 > 3) fires and writes v5.
+        # ------------------------------------------------------------------
+        versions_healed = await store.get_entity_versions(workspace_id=ws_id)
+        assert entity_id in versions_healed, (
+            f"AP2-backfill-heal: entity {entity_id} missing after backfill"
+        )
+        assert versions_healed[entity_id] == 5, (
+            f"AP2-backfill-heal FAILED: node.version={versions_healed[entity_id]} "
+            f"after backfill, expected 5.  "
+            f"The source-checkpoint skip was NOT bypassed — the heal is a no-op.  "
+            f"Check outbox_consumer.py EntityUpsert(bypass_source_checkpoint=event.is_backfill)."
+        )
+
+        # ------------------------------------------------------------------
+        # Step 5 + 6: AP1 regression guard — normal stale re-delivery must
+        # still be rejected by the per-entity CAS monotonic guard.
+        # ------------------------------------------------------------------
+        # Write entity F at v7
+        f7 = EntityUpsert(
+            id=entity_id_f,
+            source_id=source_id_f,
+            entity_type="service",
+            name="svc.ap1-regression-guard",
+            display_name="svc.ap1-regression-guard",
+            chunk_id=None,
+            metadata={},
+            version=7,
+        )
+        await store.upsert_entity(entity=f7, workspace_id=ws_id)
+
+        # Attempt stale write at v4 — no bypass, no forced_replay
+        f4 = EntityUpsert(
+            id=entity_id_f,
+            source_id=source_id_f,
+            entity_type="service",
+            name="svc.ap1-regression-guard",
+            display_name="svc.ap1-regression-guard",
+            chunk_id=None,
+            metadata={},
+            version=4,
+            bypass_source_checkpoint=False,
+        )
+        await store.upsert_entity(entity=f4, workspace_id=ws_id)
+
+        versions_ap1 = await store.get_entity_versions(workspace_id=ws_id)
+        assert versions_ap1.get(entity_id_f) == 7, (
+            f"AP1 regression: stale write at v4 should NOT regress entity F from v7, "
+            f"got {versions_ap1.get(entity_id_f)}.  Per-entity CAS guard broken."
+        )
+
+    finally:
+        await store.close()
+
+
+@_CONTRACT
+@pytest.mark.asyncio
+async def test_live_ap2_backfill_does_not_regress_node_ahead_of_backfill() -> None:
+    """v10-AP3 safety: bypass_source_checkpoint must NOT regress a node already ahead.
+
+    Scenario: node is at v7 (already correctly healed or advanced by a concurrent
+    write).  Backfill arrives at v5 with bypass_source_checkpoint=True.
+    The per-entity CAS (5 > 7 → False) must block the write.
+    Node must remain at v7.
+
+    This validates that bypass_source_checkpoint is safer than forced_replay:
+    it bypasses only the coarse source-checkpoint skip, not the fine-grained
+    per-entity CAS monotonic guard.
+    """
+    from omniscience_core.storage.graph import EntityUpsert
+    from omniscience_index.stores.neo4j.store import Neo4jGraphStore, Neo4jStoreConfig
+
+    neo4j_uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    neo4j_user = os.environ.get("NEO4J_USERNAME", "neo4j")
+    neo4j_pw = os.environ.get("NEO4J_PASSWORD", "neo4j")
+
+    config = Neo4jStoreConfig(
+        uri=neo4j_uri,
+        username=neo4j_user,
+        password=neo4j_pw,
+        database="neo4j",
+        max_connection_pool_size=5,
+        connection_acquisition_timeout_seconds=10.0,
+        max_transaction_retry_time_seconds=10.0,
+        default_max_depth=3,
+        bitemporal_enabled=False,
+    )
+    store = Neo4jGraphStore(config=config)
+    await store.connect()
+
+    ws_id = uuid.uuid4()
+    entity_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+
+    try:
+        # Write entity at v7 (current state, ahead of any backfill)
+        e7 = EntityUpsert(
+            id=entity_id,
+            source_id=source_id,
+            entity_type="service",
+            name="svc.ap2-no-regress",
+            display_name="svc.ap2-no-regress",
+            chunk_id=None,
+            metadata={},
+            version=7,
+        )
+        await store.upsert_entity(entity=e7, workspace_id=ws_id)
+
+        # Backfill at v5 with bypass_source_checkpoint — should NOT write
+        e5_backfill = EntityUpsert(
+            id=entity_id,
+            source_id=source_id,
+            entity_type="service",
+            name="svc.ap2-no-regress",
+            display_name="svc.ap2-no-regress",
+            chunk_id=None,
+            metadata={},
+            version=5,
+            bypass_source_checkpoint=True,
+        )
+        await store.upsert_entity(entity=e5_backfill, workspace_id=ws_id)
+
+        versions = await store.get_entity_versions(workspace_id=ws_id)
+        assert versions.get(entity_id) == 7, (
+            f"AP2 safety violation: bypass_source_checkpoint=True at v5 regressed "
+            f"node from v7 to {versions.get(entity_id)}.  "
+            f"The per-entity CAS guard is not protecting against stale backfills."
+        )
+
+    finally:
+        await store.close()

--- a/tests/integration/test_ap3_live_conformance.py
+++ b/tests/integration/test_ap3_live_conformance.py
@@ -1,0 +1,532 @@
+"""AP3 live-container conformance gate — v10-AP1 + v10-AP2 behavioral assertions.
+
+v10-AP6 fix: this test exercises the REAL Neo4j/Qdrant path (not mocks) so
+mock-passing-real-broken regressions are caught at the gate.
+
+Two invariants exercised:
+
+v10-AP1 (per-source watermark, no whole-workspace blackout):
+    Write chunks into real Qdrant for two sources at different doc versions.
+    Configure mock reconciler with per_source_watermark where source A is
+    healthy (watermark=10) and source B is cold (watermark=0).
+    Assert:
+    - Source A's chunks (doc_version=1 ≤ 10) survive in search results.
+    - Source B's chunks (doc_version=1 > 0) are dropped.
+    - Source A is NOT blacked out by source B's cold state.
+
+v10-AP2 (graph-anchor pin, graph-ahead node excluded):
+    Write one entity into real Neo4j at version=5 for source A, and one
+    entity at version=10 for source C where per_source_watermark[src_c]=7.
+    Query the composer with an anchor filter pointing to the graph-ahead
+    entity (version=10 > watermark=7).  Assert:
+    - The graph-ahead seed is treated as an anchor miss (anchor not used).
+    - Vector evidence within the watermark still flows through.
+
+Gate: OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 AND OMNISCIENCE_RUN_QDRANT_CONTRACT_TESTS=1
+      (both must be set — the test needs Neo4j for AP2 and Qdrant for AP1).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip the entire module when containers are not available
+# ---------------------------------------------------------------------------
+
+_NEO4J = os.environ.get("OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS") == "1"
+_QDRANT = os.environ.get("OMNISCIENCE_RUN_QDRANT_CONTRACT_TESTS") == "1"
+
+_LIVE_CONTRACT = pytest.mark.skipif(
+    not (_NEO4J and _QDRANT),
+    reason=(
+        "set OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 and "
+        "OMNISCIENCE_RUN_QDRANT_CONTRACT_TESTS=1 to run live container AP3 tests"
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Helpers: tiny deterministic embedding provider (dim=4)
+# ---------------------------------------------------------------------------
+
+
+class _DeterministicEmbeddingProvider:
+    """Hash-based deterministic embedding provider for container tests.
+
+    Produces a stable 4-dimensional vector per text so the Qdrant
+    collection can be created and searched without a real model service.
+    The vector is NOT semantically meaningful — only functional correctness
+    of the watermark filter is under test, not retrieval quality.
+    """
+
+    dim: int = 4
+    model_name: str = "live-conformance-stub"
+    provider_name: str = "stub"
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        result: list[list[float]] = []
+        for text in texts:
+            digest = hashlib.sha256(text.encode()).digest()
+            # Take 4 bytes, normalise to [0, 1] range
+            vec = [b / 255.0 for b in digest[:4]]
+            result.append(vec)
+        return result
+
+
+def _make_neo4j_config(*, uri: str, user: str, pw: str) -> Any:
+    from omniscience_index.stores.neo4j.store import Neo4jStoreConfig
+
+    return Neo4jStoreConfig(
+        uri=uri,
+        username=user,
+        password=pw,
+        database="neo4j",
+        max_connection_pool_size=5,
+        connection_acquisition_timeout_seconds=10.0,
+        max_transaction_retry_time_seconds=10.0,
+        default_max_depth=3,
+        bitemporal_enabled=False,
+    )
+
+
+def _make_qdrant_config() -> Any:
+    from omniscience_index.stores.qdrant_config import QdrantConfig
+
+    host = os.environ.get("QDRANT_HOST", "localhost")
+    http_port = int(os.environ.get("QDRANT_HTTP_PORT", "6333"))
+    grpc_port = int(os.environ.get("QDRANT_GRPC_PORT", "6334"))
+    return QdrantConfig(host=host, http_port=http_port, grpc_port=grpc_port, prefer_grpc=False)
+
+
+def _make_mock_reconciler(per_source_wm: dict[str, int]) -> Any:
+    """Build a mock reconciler that returns the given per-source watermark map."""
+    global_min = min(per_source_wm.values()) if per_source_wm else None
+    mock = MagicMock()
+    mock.wait_for_convergence = AsyncMock(return_value=([], None, global_min, per_source_wm))
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# v10-AP1 live test: per-source watermark — cold source B must NOT blackout A
+# ---------------------------------------------------------------------------
+
+
+@_LIVE_CONTRACT
+@pytest.mark.asyncio
+async def test_live_ap3_v10_ap1_cold_source_does_not_blackout_healthy_source() -> None:
+    """v10-AP1 live conformance: write two sources into real Qdrant+Neo4j.
+
+    Source A is healthy (per_source_watermark[A]=10): its chunks (doc_version=1,
+    which is ≤ 10) must appear in search results.
+
+    Source B is cold (per_source_watermark[B]=0): its chunks (doc_version=1,
+    which is > 0) must be dropped.
+
+    Critically: source A must NOT be blacked out by source B's cold state.
+    This is the v10-AP1 invariant (no whole-workspace blackout from one
+    cold source).
+
+    Pre-fix behaviour (v9 global-min watermark):
+      min(10, 0) = 0 → ALL hits dropped → source A blacked out.
+    Post-fix (v10 per-source watermark):
+      Source A filtered against wm=10 → doc_version=1 ≤ 10 → passes.
+      Source B filtered against wm=0  → doc_version=1 > 0  → dropped.
+    """
+    from omniscience_core.storage.graph import EntityUpsert
+    from omniscience_index.stores.neo4j.store import Neo4jGraphStore
+    from omniscience_index.stores.qdrant_store import QdrantVectorStore
+    from omniscience_retrieval.graph_rag import GraphRAGComposer
+    from omniscience_retrieval.models import SearchRequest
+
+    neo4j_uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    neo4j_user = os.environ.get("NEO4J_USERNAME", "neo4j")
+    neo4j_pw = os.environ.get("NEO4J_PASSWORD", "neo4j")
+
+    embedding_provider = _DeterministicEmbeddingProvider()
+    neo4j_config = _make_neo4j_config(uri=neo4j_uri, user=neo4j_user, pw=neo4j_pw)
+    qdrant_config = _make_qdrant_config()
+
+    neo4j_store = Neo4jGraphStore(config=neo4j_config)
+    qdrant_store = QdrantVectorStore(config=qdrant_config, embedding_provider=embedding_provider)
+
+    await neo4j_store.connect()
+    await qdrant_store.connect()
+
+    ws_id = uuid.uuid4()
+    src_a = uuid.uuid4()
+    src_b = uuid.uuid4()
+
+    try:
+        # ------------------------------------------------------------------
+        # Step 1: Write entities for both sources into Neo4j.
+        # These make the GraphRAGComposer believe both sources exist.
+        # ------------------------------------------------------------------
+        await neo4j_store.upsert_entity(
+            entity=EntityUpsert(
+                id=uuid.uuid4(),
+                source_id=src_a,
+                entity_type="service",
+                name="svc.live-ap3-src-a",
+                display_name="svc.live-ap3-src-a",
+                chunk_id=None,
+                metadata={},
+                version=10,
+            ),
+            workspace_id=ws_id,
+        )
+        await neo4j_store.upsert_entity(
+            entity=EntityUpsert(
+                id=uuid.uuid4(),
+                source_id=src_b,
+                entity_type="service",
+                name="svc.live-ap3-src-b",
+                display_name="svc.live-ap3-src-b",
+                chunk_id=None,
+                metadata={},
+                version=1,  # has entity but cold in reconciler map
+            ),
+            workspace_id=ws_id,
+        )
+
+        # ------------------------------------------------------------------
+        # Step 2: Write chunks into real Qdrant for both sources.
+        # First upsert → doc_version=1 (the internal Qdrant chunk counter).
+        # Applied_version in search results = doc_version = 1.
+        # Source A watermark=10: 1 ≤ 10 → PASS
+        # Source B watermark=0:  1 > 0  → DROP
+        # ------------------------------------------------------------------
+        from omniscience_core.storage.vector import ChunkPayload
+
+        chunk_a: ChunkPayload = {
+            "ord": 0,
+            "text": "source A healthy chunk for live AP3 conformance",
+            "embedding": (await embedding_provider.embed(["source A healthy chunk"]))[0],
+            "symbol": None,
+            "metadata": {"workspace_id": str(ws_id)},
+            "embedding_model": embedding_provider.model_name,
+            "embedding_provider": embedding_provider.provider_name,
+            "parser_version": "1",
+            "chunker_strategy": "fixed",
+        }
+        chunk_b: ChunkPayload = {
+            "ord": 0,
+            "text": "source B cold chunk for live AP3 conformance",
+            "embedding": (await embedding_provider.embed(["source B cold chunk"]))[0],
+            "symbol": None,
+            "metadata": {"workspace_id": str(ws_id)},
+            "embedding_model": embedding_provider.model_name,
+            "embedding_provider": embedding_provider.provider_name,
+            "parser_version": "1",
+            "chunker_strategy": "fixed",
+        }
+
+        await qdrant_store.upsert_chunks(
+            source_id=src_a,
+            external_id=f"doc-ap3-src-a-{ws_id}",
+            uri=f"mem://ap3/src-a/{ws_id}",
+            title="Source A doc",
+            content_hash=hashlib.sha256(b"src-a-content").hexdigest(),
+            metadata={"workspace_id": str(ws_id)},
+            chunks=[chunk_a],
+            version=10,
+        )
+        await qdrant_store.upsert_chunks(
+            source_id=src_b,
+            external_id=f"doc-ap3-src-b-{ws_id}",
+            uri=f"mem://ap3/src-b/{ws_id}",
+            title="Source B doc",
+            content_hash=hashlib.sha256(b"src-b-content").hexdigest(),
+            metadata={"workspace_id": str(ws_id)},
+            chunks=[chunk_b],
+            version=0,
+        )
+
+        # ------------------------------------------------------------------
+        # Step 3: Build a GraphRAGComposer with real stores + mock reconciler.
+        # Mock reconciler returns: src_a → healthy (wm=10), src_b → cold (wm=0).
+        # ------------------------------------------------------------------
+        per_source_wm = {str(src_a): 10, str(src_b): 0}
+        mock_reconciler = _make_mock_reconciler(per_source_wm)
+
+        class _FakeLegacy:
+            async def search(self, request: SearchRequest) -> Any:
+                from omniscience_retrieval.models import QueryStats, SearchResult
+
+                return SearchResult(
+                    hits=[],
+                    query_stats=QueryStats(
+                        total_matches_before_filters=0,
+                        vector_matches=0,
+                        text_matches=0,
+                        duration_ms=0.0,
+                    ),
+                )
+
+        composer = GraphRAGComposer(
+            graph_store=neo4j_store,
+            vector_store=qdrant_store,
+            legacy_service=_FakeLegacy(),
+            global_reconciler=mock_reconciler,
+        )
+
+        # ------------------------------------------------------------------
+        # Step 4: Run search — composer must be graphrag_active (real stores).
+        # ------------------------------------------------------------------
+        assert composer.graphrag_active, (
+            "GraphRAGComposer must be in graphrag-active mode with real Neo4j+Qdrant stores"
+        )
+
+        req = SearchRequest(
+            query="live AP3 conformance source",
+            top_k=20,
+        )
+        result = await composer.search(req, workspace_id=ws_id)
+
+        # ------------------------------------------------------------------
+        # Step 5: Assert per-source watermark invariants.
+        #
+        # Source A (watermark=10): doc_version=1 ≤ 10 → must survive.
+        # Source B (watermark=0):  doc_version=1 > 0  → must be dropped.
+        # Source A must NOT be blacked out by source B.
+        # ------------------------------------------------------------------
+        src_a_hits = [h for h in result.hits if h.source.id == src_a]
+        src_b_hits = [h for h in result.hits if h.source.id == src_b]
+
+        # Source B hits (cold, watermark=0): ALL versioned hits must be dropped.
+        versioned_b = [
+            h for h in src_b_hits if h.applied_version is not None and h.applied_version > 0
+        ]
+        assert versioned_b == [], (
+            f"v10-AP1 violation: source B (watermark=0) versioned hits must be dropped; "
+            f"got {[h.applied_version for h in versioned_b]}.  "
+            "The cold source is leaking future-epoch chunks into results."
+        )
+
+        # Source A (healthy, watermark=10): at least one hit must survive.
+        # We check that the watermark filter did NOT drop source A's doc_version=1 hit.
+        assert len(src_a_hits) >= 1, (
+            f"v10-AP1 violation: source A (healthy, watermark=10) was blacked out "
+            f"by cold source B.  Source A got 0 hits.  "
+            "The global-min watermark bug (v9 regression) is back: "
+            f"all_hits={[(str(h.source.id)[:8], h.applied_version) for h in result.hits]}"
+        )
+
+        # All surviving versioned hits must be within their source's watermark.
+        for hit in result.hits:
+            if hit.applied_version is None:
+                continue
+            src_key = str(hit.source.id)
+            if src_key in per_source_wm:
+                wm = per_source_wm[src_key]
+                assert hit.applied_version <= wm, (
+                    f"v10-AP1/AP3 violation: hit from source {src_key[:8]} "
+                    f"has applied_version={hit.applied_version} > "
+                    f"per_source_watermark={wm}.  Mixed-epoch chunk leaked."
+                )
+
+    finally:
+        await neo4j_store.close()
+        await qdrant_store.close()
+
+
+# ---------------------------------------------------------------------------
+# v10-AP2 live test: graph-ahead entity excluded from anchor traversal
+# ---------------------------------------------------------------------------
+
+
+@_LIVE_CONTRACT
+@pytest.mark.asyncio
+async def test_live_ap3_v10_ap2_graph_ahead_anchor_treated_as_miss() -> None:
+    """v10-AP2 live conformance: anchor entity version > watermark → treated as miss.
+
+    Setup:
+    - Write entity "GraphAheadAnchor" into real Neo4j at version=10.
+    - per_source_watermark for its source = 7 (source is behind).
+    - Write a chunk into real Qdrant for a separate healthy source A (wm=10).
+
+    Query:
+    - Run GraphRAGComposer.search() with anchor filter pointing to "GraphAheadAnchor".
+
+    Expected:
+    - The anchor seed (version=10 > watermark=7) is rejected by
+      _apply_graph_watermark_filter → treated as anchor miss.
+    - Vector evidence from healthy source A (within watermark) still flows.
+    - NO hit from the graph-ahead anchor context appears in results.
+    - All surviving hits have applied_version ≤ per_source_watermark[their source].
+
+    This validates v10-AP2: the graph traversal IS pinned to the per-source
+    watermark, preventing a v10-graph + v7-evidence mixed-epoch composed result.
+    """
+    from omniscience_core.storage.graph import EntityUpsert
+    from omniscience_index.stores.neo4j.store import Neo4jGraphStore
+    from omniscience_index.stores.qdrant_store import QdrantVectorStore
+    from omniscience_retrieval.graph_rag import ANCHOR_FILTER_KEY, GraphRAGComposer
+    from omniscience_retrieval.models import SearchRequest
+
+    neo4j_uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    neo4j_user = os.environ.get("NEO4J_USERNAME", "neo4j")
+    neo4j_pw = os.environ.get("NEO4J_PASSWORD", "neo4j")
+
+    embedding_provider = _DeterministicEmbeddingProvider()
+    neo4j_config = _make_neo4j_config(uri=neo4j_uri, user=neo4j_user, pw=neo4j_pw)
+    qdrant_config = _make_qdrant_config()
+
+    neo4j_store = Neo4jGraphStore(config=neo4j_config)
+    qdrant_store = QdrantVectorStore(config=qdrant_config, embedding_provider=embedding_provider)
+
+    await neo4j_store.connect()
+    await qdrant_store.connect()
+
+    ws_id = uuid.uuid4()
+    src_c = uuid.uuid4()  # source for the graph-ahead entity (watermark=7)
+    src_healthy = uuid.uuid4()  # healthy source (watermark=10)
+
+    anchor_name = f"live-ap3-graph-ahead-anchor-{str(ws_id)[:8]}"
+
+    try:
+        # ------------------------------------------------------------------
+        # Step 1: Write the graph-ahead anchor entity into Neo4j at version=10.
+        # The reconciler will say this source's watermark is only 7.
+        # So the anchor is "graph-ahead" by 3 versions.
+        # ------------------------------------------------------------------
+        await neo4j_store.upsert_entity(
+            entity=EntityUpsert(
+                id=uuid.uuid4(),
+                source_id=src_c,
+                entity_type="service",
+                name=anchor_name,
+                display_name=anchor_name,
+                chunk_id=None,
+                metadata={},
+                version=10,  # > watermark of 7 → graph-ahead
+            ),
+            workspace_id=ws_id,
+        )
+
+        # ------------------------------------------------------------------
+        # Step 2: Write a healthy entity + chunk so the search returns something.
+        # ------------------------------------------------------------------
+        await neo4j_store.upsert_entity(
+            entity=EntityUpsert(
+                id=uuid.uuid4(),
+                source_id=src_healthy,
+                entity_type="service",
+                name=f"live-ap3-healthy-{str(ws_id)[:8]}",
+                display_name=f"live-ap3-healthy-{str(ws_id)[:8]}",
+                chunk_id=None,
+                metadata={},
+                version=10,
+            ),
+            workspace_id=ws_id,
+        )
+
+        from omniscience_core.storage.vector import ChunkPayload
+
+        chunk_healthy: ChunkPayload = {
+            "ord": 0,
+            "text": f"live AP3 v10-AP2 healthy chunk for workspace {ws_id}",
+            "embedding": (await embedding_provider.embed([f"live AP3 v10-AP2 healthy {ws_id}"]))[
+                0
+            ],
+            "symbol": None,
+            "metadata": {"workspace_id": str(ws_id)},
+            "embedding_model": embedding_provider.model_name,
+            "embedding_provider": embedding_provider.provider_name,
+            "parser_version": "1",
+            "chunker_strategy": "fixed",
+        }
+        await qdrant_store.upsert_chunks(
+            source_id=src_healthy,
+            external_id=f"doc-ap3-ap2-healthy-{ws_id}",
+            uri=f"mem://ap3/ap2/healthy/{ws_id}",
+            title="Healthy doc",
+            content_hash=hashlib.sha256(f"healthy-{ws_id}".encode()).hexdigest(),
+            metadata={"workspace_id": str(ws_id)},
+            chunks=[chunk_healthy],
+            version=10,
+        )
+
+        # ------------------------------------------------------------------
+        # Step 3: Build the mock reconciler.
+        # src_c (graph-ahead anchor): watermark=7 (version=10 > 7 → ahead)
+        # src_healthy: watermark=10 (fully converged)
+        # ------------------------------------------------------------------
+        per_source_wm = {str(src_c): 7, str(src_healthy): 10}
+        mock_reconciler = _make_mock_reconciler(per_source_wm)
+
+        class _FakeLegacy:
+            async def search(self, request: SearchRequest) -> Any:
+                from omniscience_retrieval.models import QueryStats, SearchResult
+
+                return SearchResult(
+                    hits=[],
+                    query_stats=QueryStats(
+                        total_matches_before_filters=0,
+                        vector_matches=0,
+                        text_matches=0,
+                        duration_ms=0.0,
+                    ),
+                )
+
+        composer = GraphRAGComposer(
+            graph_store=neo4j_store,
+            vector_store=qdrant_store,
+            legacy_service=_FakeLegacy(),
+            global_reconciler=mock_reconciler,
+        )
+
+        assert composer.graphrag_active
+
+        # ------------------------------------------------------------------
+        # Step 4: Search with anchor pointing to the graph-ahead entity.
+        # ------------------------------------------------------------------
+        req = SearchRequest(
+            query=f"live AP3 v10-AP2 healthy {ws_id}",
+            top_k=20,
+            filters={ANCHOR_FILTER_KEY: anchor_name},
+        )
+        result = await composer.search(req, workspace_id=ws_id)
+
+        # ------------------------------------------------------------------
+        # Step 5: Assert v10-AP2 invariants.
+        #
+        # The graph-ahead anchor (src_c, version=10 > wm=7) must be excluded.
+        # Any surviving hit must have applied_version ≤ per_source_watermark[source].
+        # The healthy source's chunk (applied_version=1 ≤ wm=10) may survive.
+        # ------------------------------------------------------------------
+
+        # All surviving hits must respect their source's watermark.
+        for hit in result.hits:
+            if hit.applied_version is None:
+                continue
+            src_key = str(hit.source.id)
+            if src_key in per_source_wm:
+                wm = per_source_wm[src_key]
+                assert hit.applied_version <= wm, (
+                    f"v10-AP2 mixed-epoch violation: hit from source {src_key[:8]} "
+                    f"has applied_version={hit.applied_version} > "
+                    f"per_source_watermark={wm}.  "
+                    "The graph-anchor pin is not preventing mixed-epoch results."
+                )
+
+        # The graph-ahead anchor (src_c, version=10 > watermark=7) must not
+        # appear as a chunk source in the result — it was excluded as a miss.
+        src_c_hits = [h for h in result.hits if h.source.id == src_c]
+        versioned_c = [
+            h for h in src_c_hits if h.applied_version is not None and h.applied_version > 7
+        ]
+        assert versioned_c == [], (
+            f"v10-AP2 violation: graph-ahead source (wm=7) has versioned hits "
+            f"with applied_version > 7: {[h.applied_version for h in versioned_c]}.  "
+            "The graph-anchor watermark pin is not working."
+        )
+
+    finally:
+        await neo4j_store.close()
+        await qdrant_store.close()

--- a/tests/test_ap1_single_writer.py
+++ b/tests/test_ap1_single_writer.py
@@ -607,3 +607,167 @@ async def test_live_cas_stale_write_does_not_regress_entity_version() -> None:
         )
     finally:
         await store.close()
+
+
+# ---------------------------------------------------------------------------
+# v10-AP3 unit tests: consumer sets bypass_source_checkpoint on backfill
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_consumer_sets_bypass_source_checkpoint_on_backfill_entity() -> None:
+    """v10-AP3 unit: OutboxConsumerWorker builds EntityUpsert with
+    bypass_source_checkpoint=True when event.is_backfill=True.
+
+    This is the unit-level regression guard that confirms the fix in
+    outbox_consumer.py is in place.  The live end-to-end confirmation lives in
+    tests/integration/test_ap2_backfill_heal.py.
+    """
+    from omniscience_core.queue.messages import EntityUpsertEvent
+    from omniscience_core.storage.graph import EntityUpsert
+
+    nats_conn = MagicMock()
+    nats_conn.jetstream = AsyncMock()
+
+    # Capture the EntityUpsert passed to upsert_entity
+    captured: list[EntityUpsert] = []
+
+    graph_store = AsyncMock(spec=GraphStore)
+
+    async def _capture_upsert(**kwargs: Any) -> None:
+        captured.append(kwargs["entity"])
+
+    graph_store.upsert_entity = _capture_upsert
+
+    vector_store = AsyncMock(spec=VectorStore)
+    vector_store.upsert_chunks = AsyncMock(return_value=None)
+
+    embedding_provider = AsyncMock(spec=EmbeddingProvider)
+    embedding_provider.embed = AsyncMock(return_value=[[0.1, 0.2]])
+    embedding_provider.model_name = "test-model"
+    embedding_provider.provider_name = "test-provider"
+
+    consumer = OutboxConsumerWorker(
+        nats_conn=nats_conn,
+        graph_store=graph_store,
+        vector_store=vector_store,
+        embedding_provider=embedding_provider,
+    )
+
+    ws_id = str(uuid.uuid4())
+    ent_id = str(uuid.uuid4())
+    src_id = str(uuid.uuid4())
+
+    # --- backfill=True message ---
+    backfill_msg = AsyncMock()
+    backfill_msg.payload = EntityUpsertEvent(
+        workspace_id=ws_id,
+        id=ent_id,
+        source_id=src_id,
+        entity_type="service",
+        name="svc.ap3-unit",
+        display_name="svc.ap3-unit",
+        metadata={},
+        version=5,
+        is_backfill=True,
+    )
+    backfill_msg.subject = "outbox.entity.upsert"
+
+    async def fake_entity_iter_backfill() -> Any:
+        yield backfill_msg
+
+    consumer._entity_consumer = AsyncMock()
+    consumer._entity_consumer.__aiter__ = lambda self: fake_entity_iter_backfill()
+    consumer._dlq_producer = AsyncMock()
+
+    await consumer._consume_entities()
+
+    assert len(captured) == 1, f"Expected 1 EntityUpsert, got {len(captured)}"
+    upsert = captured[0]
+    got = upsert.bypass_source_checkpoint
+    assert got is True, (
+        "v10-AP3 regression: consumer did NOT set bypass_source_checkpoint=True "
+        f"on backfill EntityUpsert; got bypass_source_checkpoint={got}. "
+        "Fix: set bypass_source_checkpoint=event.is_backfill in"
+        " outbox_consumer.py _consume_entities()."
+    )
+    assert upsert.forced_replay is False, (
+        "Consumer must NOT set forced_replay=True on backfill; "
+        "bypass_source_checkpoint is the safer mechanism (per-entity CAS is preserved)."
+    )
+    assert upsert.version == 5
+
+
+@pytest.mark.asyncio
+async def test_consumer_bypass_source_checkpoint_false_on_non_backfill_entity() -> None:
+    """v10-AP3 unit: bypass_source_checkpoint is False for non-backfill events.
+
+    Normal (non-backfill) entity upserts must NOT bypass the source-checkpoint
+    skip — the AP1 per-entity CAS monotonic guard is the only relevant guard for
+    those, and the coarse source-checkpoint skip remains active.
+    """
+    from omniscience_core.queue.messages import EntityUpsertEvent
+    from omniscience_core.storage.graph import EntityUpsert
+
+    nats_conn = MagicMock()
+    nats_conn.jetstream = AsyncMock()
+
+    captured: list[EntityUpsert] = []
+
+    graph_store = AsyncMock(spec=GraphStore)
+
+    async def _capture_upsert(**kwargs: Any) -> None:
+        captured.append(kwargs["entity"])
+
+    graph_store.upsert_entity = _capture_upsert
+
+    vector_store = AsyncMock(spec=VectorStore)
+    vector_store.upsert_chunks = AsyncMock(return_value=None)
+
+    embedding_provider = AsyncMock(spec=EmbeddingProvider)
+    embedding_provider.embed = AsyncMock(return_value=[[0.1, 0.2]])
+    embedding_provider.model_name = "test-model"
+    embedding_provider.provider_name = "test-provider"
+
+    consumer = OutboxConsumerWorker(
+        nats_conn=nats_conn,
+        graph_store=graph_store,
+        vector_store=vector_store,
+        embedding_provider=embedding_provider,
+    )
+
+    ws_id = str(uuid.uuid4())
+    ent_id = str(uuid.uuid4())
+    src_id = str(uuid.uuid4())
+
+    # --- backfill=False message (normal ingestion) ---
+    normal_msg = AsyncMock()
+    normal_msg.payload = EntityUpsertEvent(
+        workspace_id=ws_id,
+        id=ent_id,
+        source_id=src_id,
+        entity_type="service",
+        name="svc.ap3-normal",
+        display_name="svc.ap3-normal",
+        metadata={},
+        version=3,
+        is_backfill=False,
+    )
+    normal_msg.subject = "outbox.entity.upsert"
+
+    async def fake_entity_iter_normal() -> Any:
+        yield normal_msg
+
+    consumer._entity_consumer = AsyncMock()
+    consumer._entity_consumer.__aiter__ = lambda self: fake_entity_iter_normal()
+    consumer._dlq_producer = AsyncMock()
+
+    await consumer._consume_entities()
+
+    assert len(captured) == 1
+    upsert = captured[0]
+    assert upsert.bypass_source_checkpoint is False, (
+        "Non-backfill event must NOT set bypass_source_checkpoint=True; "
+        f"got {upsert.bypass_source_checkpoint}"
+    )
+    assert upsert.forced_replay is False

--- a/tests/test_global_reconciler.py
+++ b/tests/test_global_reconciler.py
@@ -9,6 +9,7 @@ Covers:
     even when stores are behind.
   - Empty workspace (no documents): always converged.
   - min_watermark: returned on both converged and timeout paths (AP3 PIN).
+  - per_source_watermark: v10-AP1 — per-source ceiling map (multi-source tests).
 """
 
 from __future__ import annotations
@@ -115,12 +116,20 @@ async def test_convergence_all_stores_at_watermark() -> None:
         qdrant_data={src: 5},
         neo4j_data={src: 5},
     )
-    converged, degraded, staleness, min_watermark = await reconciler.check_convergence(_WS)
+    (
+        converged,
+        degraded,
+        staleness,
+        min_watermark,
+        per_source_wm,
+    ) = await reconciler.check_convergence(_WS)
     assert converged is True
     assert degraded == []
     assert staleness is None
     # min_watermark: min(pg=5, qdrant=5, neo4j=5) = 5
     assert min_watermark == 5
+    # per_source: min(5,5,5) = 5
+    assert per_source_wm[src] == 5
 
 
 @pytest.mark.asyncio
@@ -132,11 +141,19 @@ async def test_convergence_stores_ahead_of_watermark() -> None:
         qdrant_data={src: 7},  # ahead
         neo4j_data={src: 5},  # ahead
     )
-    converged, degraded, _staleness, min_watermark = await reconciler.check_convergence(_WS)
+    (
+        converged,
+        degraded,
+        _staleness,
+        min_watermark,
+        per_source_wm,
+    ) = await reconciler.check_convergence(_WS)
     assert converged is True
     assert degraded == []
     # min_watermark: min(pg=3, qdrant=7, neo4j=5) = 3
     assert min_watermark == 3
+    # per_source: min(pg=3, qdrant=7, neo4j=5) = 3
+    assert per_source_wm[src] == 3
 
 
 @pytest.mark.asyncio
@@ -148,13 +165,21 @@ async def test_qdrant_lagging_detected() -> None:
         qdrant_data={src: 7},  # 3 versions behind
         neo4j_data={src: 10},
     )
-    converged, degraded, staleness, min_watermark = await reconciler.check_convergence(_WS)
+    (
+        converged,
+        degraded,
+        staleness,
+        min_watermark,
+        per_source_wm,
+    ) = await reconciler.check_convergence(_WS)
     assert converged is False
     assert "qdrant" in degraded
     assert "neo4j" not in degraded
     assert staleness == 3.0
     # min_watermark: min(pg=10, qdrant=7, neo4j=10) = 7
     assert min_watermark == 7
+    # per_source: min(10,7,10) = 7
+    assert per_source_wm[src] == 7
 
 
 @pytest.mark.asyncio
@@ -166,13 +191,21 @@ async def test_neo4j_lagging_detected() -> None:
         qdrant_data={src: 10},
         neo4j_data={src: 2},  # 8 versions behind
     )
-    converged, degraded, staleness, min_watermark = await reconciler.check_convergence(_WS)
+    (
+        converged,
+        degraded,
+        staleness,
+        min_watermark,
+        per_source_wm,
+    ) = await reconciler.check_convergence(_WS)
     assert converged is False
     assert "neo4j" in degraded
     assert "qdrant" not in degraded
     assert staleness == 8.0
     # min_watermark: min(pg=10, qdrant=10, neo4j=2) = 2
     assert min_watermark == 2
+    # per_source: min(10,10,2) = 2
+    assert per_source_wm[src] == 2
 
 
 @pytest.mark.asyncio
@@ -184,12 +217,20 @@ async def test_both_stores_lagging_detected() -> None:
         qdrant_data={src: 8},  # lag = 2
         neo4j_data={src: 5},  # lag = 5
     )
-    converged, degraded, staleness, min_watermark = await reconciler.check_convergence(_WS)
+    (
+        converged,
+        degraded,
+        staleness,
+        min_watermark,
+        per_source_wm,
+    ) = await reconciler.check_convergence(_WS)
     assert converged is False
     assert set(degraded) == {"qdrant", "neo4j"}
     assert staleness == 5.0  # worst-case lag
     # min_watermark: min(pg=10, qdrant=8, neo4j=5) = 5
     assert min_watermark == 5
+    # per_source: min(10,8,5) = 5
+    assert per_source_wm[src] == 5
 
 
 @pytest.mark.asyncio
@@ -200,12 +241,20 @@ async def test_empty_workspace_always_converged() -> None:
         qdrant_data={},
         neo4j_data={},
     )
-    converged, degraded, staleness, min_watermark = await reconciler.check_convergence(_WS)
+    (
+        converged,
+        degraded,
+        staleness,
+        min_watermark,
+        per_source_wm,
+    ) = await reconciler.check_convergence(_WS)
     assert converged is True
     assert degraded == []
     assert staleness is None
     # Empty workspace: min_watermark is None (no version data)
     assert min_watermark is None
+    # per_source map is empty
+    assert per_source_wm == {}
 
 
 @pytest.mark.asyncio
@@ -253,11 +302,81 @@ async def test_atomic_watermark_snapshot_used_for_both_stores() -> None:
     # With a single PG snapshot (v=5), both stores are at watermark → converged.
     # If PG were read twice, second read returns v=10 and both stores would
     # appear lagging — demonstrating the non-monotonic flap the fix prevents.
-    converged, _degraded, _staleness, _min_wm = await reconciler.check_convergence(_WS)
+    converged, _degraded, _staleness, _min_wm, _per_source = await reconciler.check_convergence(
+        _WS
+    )
     assert converged is True, (
         "With atomic watermark snapshot, stores at v=5 match PG first-read v=5 → converged"
     )
     assert call_count == 1, "PG must be read exactly once per check_convergence call"
+
+
+# ---------------------------------------------------------------------------
+# Tests: per_source_watermark multi-source (v10-AP1 regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_source_watermark_multi_source_independent() -> None:
+    """Two sources with different store states get independent per-source watermarks.
+
+    Source A is healthy at v10; source B is cold at v0.
+    The per_source_watermark for A must be 10, not the global min.
+    The per_source_watermark for B must be 0 (cold).
+    The global min_watermark is 0 (for observability), but per-hit
+    filtering must use the per-source map.
+    """
+    src_a = str(uuid.uuid4())
+    src_b = str(uuid.uuid4())
+    reconciler = _make_reconciler(
+        pg_data={src_a: 10, src_b: 5},
+        qdrant_data={src_a: 10, src_b: 0},  # B cold in Qdrant
+        neo4j_data={src_a: 10, src_b: 0},  # B cold in Neo4j
+    )
+    (
+        converged,
+        _degraded,
+        _staleness,
+        min_watermark,
+        per_source_wm,
+    ) = await reconciler.check_convergence(_WS)
+    assert converged is False  # B is lagging
+    # Source A: all stores at 10 → per-source ceiling 10
+    assert per_source_wm[src_a] == 10, (
+        f"Source A should have per-source watermark=10; got {per_source_wm.get(src_a)}"
+    )
+    # Source B: qdrant and neo4j at 0 → per-source ceiling 0
+    assert per_source_wm[src_b] == 0, (
+        f"Source B should have per-source watermark=0; got {per_source_wm.get(src_b)}"
+    )
+    # Global min is 0 (worst-case floor)
+    assert min_watermark == 0
+
+
+@pytest.mark.asyncio
+async def test_per_source_watermark_independent_per_source_ceiling() -> None:
+    """Each source's ceiling is computed independently; they do not bleed.
+
+    Three sources: A@v10 healthy, B@v5 partial lag, C@v1 lagging.
+    Per-source watermarks must be A=10, B=5, C=1 independently.
+    """
+    src_a = str(uuid.uuid4())
+    src_b = str(uuid.uuid4())
+    src_c = str(uuid.uuid4())
+    reconciler = _make_reconciler(
+        pg_data={src_a: 10, src_b: 8, src_c: 7},
+        qdrant_data={src_a: 10, src_b: 5, src_c: 1},
+        neo4j_data={src_a: 10, src_b: 8, src_c: 1},
+    )
+    _converged, _degraded, _staleness, _min_wm, per_source_wm = await reconciler.check_convergence(
+        _WS
+    )
+    # A: min(10,10,10)=10
+    assert per_source_wm[src_a] == 10
+    # B: min(8,5,8)=5
+    assert per_source_wm[src_b] == 5
+    # C: min(7,1,1)=1
+    assert per_source_wm[src_c] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -274,11 +393,14 @@ async def test_wait_for_convergence_success() -> None:
         qdrant_data={src: 3},
         neo4j_data={src: 3},
     )
-    degraded, staleness, min_watermark = await reconciler.wait_for_convergence(_WS, timeout=5.0)
+    degraded, staleness, min_watermark, per_source_wm = await reconciler.wait_for_convergence(
+        _WS, timeout=5.0
+    )
     assert degraded == []
     assert staleness is None
     # min_watermark: min(pg=3, qdrant=3, neo4j=3) = 3
     assert min_watermark == 3
+    assert per_source_wm[src] == 3
 
 
 @pytest.mark.asyncio
@@ -295,12 +417,15 @@ async def test_wait_for_convergence_timeout_returns_degraded_subsystems() -> Non
         neo4j_data={src: 10},
     )
     # Very short timeout so the test runs fast
-    degraded, staleness, min_watermark = await reconciler.wait_for_convergence(_WS, timeout=0.1)
+    degraded, staleness, min_watermark, per_source_wm = await reconciler.wait_for_convergence(
+        _WS, timeout=0.1
+    )
     assert "qdrant" in degraded, "Lagging Qdrant must be in degraded_subsystems on timeout"
     assert staleness is not None, "staleness_seconds must be set on timeout"
     assert staleness == 5.0
     # min_watermark: min(pg=10, qdrant=5, neo4j=10) = 5
     assert min_watermark == 5
+    assert per_source_wm[src] == 5
 
 
 @pytest.mark.asyncio
@@ -314,7 +439,9 @@ async def test_wait_for_convergence_does_not_raise_on_timeout() -> None:
     )
     # Should complete without raising, even with very short timeout
     try:
-        degraded, _staleness, _min_wm = await reconciler.wait_for_convergence(_WS, timeout=0.05)
+        degraded, _staleness, _min_wm, _per_src = await reconciler.wait_for_convergence(
+            _WS, timeout=0.05
+        )
     except Exception as exc:  # pragma: no cover
         pytest.fail(f"wait_for_convergence must not raise; got {exc!r}")
     assert isinstance(degraded, list)
@@ -329,10 +456,13 @@ async def test_wait_for_convergence_returns_min_watermark_on_converged() -> None
         qdrant_data={src: 8},
         neo4j_data={src: 8},
     )
-    degraded, staleness, min_watermark = await reconciler.wait_for_convergence(_WS, timeout=5.0)
+    degraded, staleness, min_watermark, per_source_wm = await reconciler.wait_for_convergence(
+        _WS, timeout=5.0
+    )
     assert degraded == []
     assert staleness is None
     assert min_watermark == 8
+    assert per_source_wm[src] == 8
 
 
 @pytest.mark.asyncio
@@ -344,10 +474,13 @@ async def test_wait_for_convergence_returns_min_watermark_on_timeout() -> None:
         qdrant_data={src: 3},  # lagging — pinned to 3
         neo4j_data={src: 15},
     )
-    degraded, _staleness, min_watermark = await reconciler.wait_for_convergence(_WS, timeout=0.05)
+    degraded, _staleness, min_watermark, per_source_wm = await reconciler.wait_for_convergence(
+        _WS, timeout=0.05
+    )
     assert "qdrant" in degraded
     # min is min(pg=15, qdrant=3, neo4j=15) = 3
     assert min_watermark == 3
+    assert per_source_wm[src] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -381,12 +514,18 @@ async def test_composer_serves_results_even_when_stores_degraded() -> None:
 
     _now = datetime.now(UTC)
     workspace_id = _uuid.uuid4()
+    src_id = _uuid.uuid4()
 
     # Mock reconciler that immediately reports qdrant as lagging (timeout-like signal)
-    # Now returns 3-tuple: (degraded, staleness, min_watermark)
+    # Now returns 4-tuple: (degraded, staleness, min_watermark, per_source_watermark)
     mock_reconciler = MagicMock()
     mock_reconciler.wait_for_convergence = AsyncMock(
-        return_value=(["qdrant"], 8.0, 7)  # qdrant is 8 versions behind; min_watermark=7
+        return_value=(
+            ["qdrant"],
+            8.0,
+            7,
+            {str(src_id): 7},  # per-source watermark
+        )
     )
 
     # Fake vector store that always returns one hit (applied_version=7, within watermark)
@@ -403,7 +542,7 @@ async def test_composer_serves_results_even_when_stores_degraded() -> None:
                 document_id=_uuid.uuid4(),
                 score=0.9,
                 text="some evidence",
-                source=SourceInfo(id=_uuid.uuid4(), name="s", type="slack"),
+                source=SourceInfo(id=src_id, name="s", type="slack"),
                 citation=Citation(uri="x://y", title=None, indexed_at=_now, doc_version=1),
                 lineage=ChunkLineage(
                     ingestion_run_id=None,
@@ -413,7 +552,7 @@ async def test_composer_serves_results_even_when_stores_degraded() -> None:
                     chunker_strategy="fixed",
                 ),
                 metadata={},
-                applied_version=7,  # at or below min_watermark=7 → passes filter
+                applied_version=7,  # at or below per-source watermark=7 → passes filter
             )
             return SearchResult(
                 hits=[hit],


### PR DESCRIPTION
## Summary
Grounded-diff remediation of the v9 changes per consilium v10 (`docs/reviews/consilium-v10-review.md`). Fixes 3 confirmed P0 holes the v9 fixes introduced + the live-gate that would have caught them.

- **v10-AP1 (P0)** — read-path watermark is now **per-source** (`dict[source_id,int]`), not a single global min. A cold/lagging source no longer blacks out healthy higher-version sources. Multi-source regression tests added (the v9 tests were single-source and missed this).
- **v10-AP2 (P0)** — the Neo4j **graph anchor traversal is now pinned** to the per-source watermark (`_apply_graph_watermark_filter`): graph-ahead nodes/edges are excluded, a graph-ahead seed is treated as an anchor miss. "No mixed-epoch" now holds for the graph view, not just the vector hits.
- **v10-AP3 (P0)** — the AP2 backfill heal was **dead** (`is_backfill` never bypassed the source-checkpoint skip → stale nodes never healed). Fixed via a new `bypass_source_checkpoint` flag that clears the coarse source skip but **keeps the per-entity CAS monotonic guard** (heals v3→v5, still refuses to regress v7→v5). Live drift→heal test added (fails pre-fix).
- **v10-AP6 (P1)** — new **`conformance-live`** job runs the real AP1 CAS / AP2 heal / AP3 watermark+graph-pin assertions against live Neo4j+Qdrant+NATS. The v9 mock gates passed while the real heal was dead; this gate exercises the real path.

## Verification
- mypy --strict 0, ruff clean.
- Live behavioral P0 tests pass against real stores locally; full containerized CI + the conformance gates run in CI.

Carried to a later round (v10 P1/P2, not in scope): cross-workspace cursor fairness (AP4), orphan end-date grace window (AP5), tolerance-based DR vector hash + bulk-load + volume RTO (AP7), finer confidence bands + documented API break (AP8); plus v9 carryovers (identity review-queue, cross-store as_of/tx-time, DLQ persistence).