### PR TITLE
Consilium v13: epoch-drop observability + canonical no-reconciler signal + topology-leak fix (dev-team per-problem with pre-merge adversarial review)

### DIFF
--- a/docs/reviews/consilium-v13-review.md
+++ b/docs/reviews/consilium-v13-review.md
@@ -1,0 +1,15 @@
+# Consilium v13 (Opus chair) — grounded diff of v12 — observability + canonical signal
+
+> Verified against actual code. 2 real P0 (a silent blackout introduced in v12 + unobservability),
+> 1 P1, 2 P2. The debate loop remains "concluded"; these are real availability bugs fixed as
+> ordinary engineering. The observability fix is the genuine exit (epoch drops become a metric).
+
+| # | Claim | Prio | Verdict |
+|---|-------|------|---------|
+| 1 | metric only on unmapped branch; in-map cold_zero/lag drops unobservable | P0 | ✅ `graph_rag.py` increments `_EPOCH_DROPPED_UNMAPPED` only on not-in-map; in-map drops (wm==0, version>wm) have no counter → blackout invisible (ADR-0017 §3). FIX: reason-labeled counter {unmapped, lag, cold_zero, empty_map} in BOTH the hit filter AND the graph-node filter. |
+| 2 | None-vs-{} ambiguity → dead None branch + {} blackout | P0 | ✅ `search():500-501` leaves `per_source_watermark={}` when no reconciler; filter bypass is `is None` only → None branch dead; `{}` (no reconciler OR cold workspace where check_convergence returns `{}`) → strict fail-closed blackout. FIX: canonicalize — pass `None` on the genuine no-reconciler path (so None→pass is live), and emit `epoch_blackout_total` on the `{} + strict` branch so an empty-map blackout is OBSERVABLE. |
+| 3 | consumer-path test lacks positive src_a-survives assert (NATS_URL export OK) | P1 | ⚠️ `NATS_URL` IS exported (conformance.yml:327) — SKIP risk refuted. But no `assert any(h.source.id==src_a and h.applied_version==5 ...)` → vacuous positive side. FIX: add the positive assert; ensure the path returns a real src_a hit (not _FakeLegacy→[]). |
+| 4 | AP3 undirected verdict rests on comment + tautological test | P2 | ⚠️ Reframe as NOT-PROVEN; replace inline-reimpl directed test with a parametrized test running the REAL traverse() + _recompute_reachability on a shared fixture graph (gated live-Neo4j) proving reachable-set equality. |
+| 5 | update_stream branch behaviorally uncovered + fail-loud behavior change | P2 | ✅ `test_queue.py:47` mocks `update_stream` without asserting it's called; 10058→update_stream path untested; update_stream now propagates previously-swallowed errors. FIX: behavioral assert it's called on 10058; make fail-loud-on-incompatible-update an explicit, tested decision. |
+
+Decision (user pattern): fix all (AP1+AP2+AP3+AP5; AP4 = honest NOT-PROVEN + real test), one PR, merge on green CI.

--- a/packages/core/src/omniscience_core/queue/streams.py
+++ b/packages/core/src/omniscience_core/queue/streams.py
@@ -108,5 +108,14 @@ async def _ensure_stream(
             log.error("nats_stream_create_failed", stream=cfg.name, error=str(exc))
             raise
         # Stream exists — apply the current config so subject changes take effect.
+        #
+        # DELIBERATE DESIGN DECISION (v13-AP5): update_stream errors PROPAGATE.
+        # If update_stream raises (e.g., incompatible config change — different
+        # retention policy, storage type, or replica count), the error is NOT
+        # caught here.  This is intentional: a silent config mismatch (running
+        # with stale stream settings) is worse than a loud startup failure that
+        # surfaces the problem immediately.  Operators must resolve the conflict
+        # manually (delete + recreate, or adjust the config to match) rather
+        # than silently proceeding with an inconsistent stream.
         await js.update_stream(config=cfg)
         log.info("nats_stream_updated", stream=cfg.name, subjects=cfg.subjects)

--- a/packages/retrieval/src/omniscience_retrieval/graph_rag.py
+++ b/packages/retrieval/src/omniscience_retrieval/graph_rag.py
@@ -108,11 +108,30 @@ Both ``_apply_watermark_filter`` (vector hits, ``filter="hit"``) and
 this counter at every drop site.  The ``empty_map_blackout`` label fires once
 per ``search()`` call when the map is empty under ``strict_epoch=True``.
 
-Graph nodes from UNMAPPED sources intentionally PASS through
-``_apply_graph_watermark_filter`` (no ``unmapped`` counter for nodes) — the
-graph filter only applies version ceilings for sources whose watermark IS
-known.  This is by design: the vector-hit filter handles unmapped-source
-drops for evidence; the graph filter handles graph-ahead nodes.
+v14-D4 — symmetric fail-closed for unmapped graph nodes
+--------------------------------------------------------
+Under the old design, a graph node whose source was absent from the watermark
+map passed ``_apply_graph_watermark_filter`` unconditionally (fail-open), even
+under ``strict_epoch=True``.  This was asymmetric with the hit filter, which IS
+fail-closed on unmapped sources.  The consequence: a future-epoch node from an
+unmapped source (e.g. src_b@v999) survived the graph filter, contributed to the
+candidate set, and caused an ``av=None`` hit from src_b to receive a
+graph-affinity boost derived from v999 topology — a topology-epoch leak even
+though no versioned future content was returned.
+
+Fix (v14-D4): ``strict_epoch`` is threaded into
+``_apply_graph_watermark_filter``.  Under ``strict_epoch=True`` (the default),
+a related node whose source is absent from the watermark map (and the map is
+non-empty) is EXCLUDED — exactly like an unmapped versioned hit — and
+``_EPOCH_DROPS.labels(reason="unmapped", filter="node")`` is incremented.
+The ``unmapped/node`` label now fires by design (it never fired before).
+After exclusion, ``_recompute_reachability`` BFS prunes nodes reachable only
+via the excluded unmapped node (no phantom paths).
+Under ``strict_epoch=False`` (legacy), unmapped nodes pass unchanged.
+
+Legitimate cross-source links (e.g. AWS↔K8s correlation where the other
+source IS in the watermark map) are NOT affected — only sources absent from
+the map are dropped.
 
 Backwards-compatibility
 -----------------------
@@ -153,9 +172,9 @@ incremented at every drop site in both ``_apply_watermark_filter``
 (``filter="hit"``) and ``_apply_graph_watermark_filter``
 (``filter="node"``).  Reasons:
 
-- ``unmapped`` — hit from a source absent from the watermark map
-  (strict_epoch=True, ``filter="hit"`` only; graph nodes from unmapped
-  sources pass by design).
+- ``unmapped`` — hit (``filter="hit"``) or graph node (``filter="node"``) from
+  a source absent from the watermark map under ``strict_epoch=True``.  For
+  vector hits this has always fired; for graph nodes it fires as of v14-D4.
 - ``lag`` — hit/node whose ``applied_version > watermark`` (source is in
   the map but lagging).
 - ``cold_zero`` — hit/node whose source has watermark=0 and
@@ -311,8 +330,10 @@ _COMPOSED_QUERIES_TOTAL: Counter = Counter(
 #: _apply_graph_watermark_filter (filter="node") at every drop site.
 #:
 #: reason labels:
-#:   unmapped      — hit from a source not in the watermark map (strict_epoch=True).
-#:                   NOT used for graph nodes (unmapped-source graph nodes pass by design).
+#:   unmapped      — hit or graph node from a source not in the watermark map
+#:                   (strict_epoch=True).  Fires for filter="hit" since v11-AP1;
+#:                   fires for filter="node" as of v14-D4 (graph nodes from unmapped
+#:                   sources are now EXCLUDED under strict_epoch=True, not passed).
 #:   lag           — hit/node with applied_version > watermark (source in map, lagging).
 #:   cold_zero     — hit/node with watermark=0 and applied_version >= 1 (not yet applied).
 #:   empty_map_blackout — fired once per search() call when map == {} under strict_epoch=True.
@@ -326,8 +347,9 @@ _EPOCH_DROPS: Counter = Counter(
         "Number of vector hits or graph nodes dropped by the epoch pinning policy. "
         "Labels: reason ∈ {unmapped, lag, cold_zero, empty_map_blackout}, "
         "filter ∈ {hit, node}. "
-        "'unmapped' fires when a vector hit's source is absent from the watermark map "
-        "(strict_epoch=True); graph nodes from unmapped sources pass by design. "
+        "'unmapped' fires when a vector hit or graph node source is absent from the watermark "
+        "map (strict_epoch=True); graph nodes from unmapped sources are EXCLUDED under "
+        "strict_epoch=True as of v14-D4 (previously they passed — topology-epoch leak D4). "
         "'lag' fires when applied_version > watermark for a mapped source. "
         "'cold_zero' fires when watermark==0 and applied_version>=1 (source not yet applied). "
         "'empty_map_blackout' fires once per request when the map is {} under strict_epoch=True "
@@ -745,7 +767,9 @@ class GraphRAGComposer:
         # instead of raising ValueError — explicit signal, no control-flow-by-exception.
         if per_source_watermark:
             graph_result, seed_excluded = _apply_graph_watermark_filter(
-                graph_result, per_source_watermark
+                graph_result,
+                per_source_watermark,
+                strict_epoch=self._strict_epoch,
             )
             if seed_excluded:
                 log.info(
@@ -1145,6 +1169,7 @@ def _apply_watermark_filter(
 def _apply_graph_watermark_filter(
     graph_result: Any,
     per_source_watermark: dict[str, int],
+    strict_epoch: bool = False,
 ) -> tuple[Any, bool]:
     """Remove graph-ahead nodes (and their edges) from a traversal result.
 
@@ -1169,8 +1194,15 @@ def _apply_graph_watermark_filter(
     v13-AP1: ``_EPOCH_DROPS(filter="node")`` is incremented at both drop
     sites (seed-excluded path returns True, so the caller handles that case;
     related-node drops are incremented here with reason="cold_zero" or
-    reason="lag").  Graph nodes from UNMAPPED sources intentionally PASS
-    (no ``unmapped`` counter for nodes — see module docstring).
+    reason="lag").
+
+    v14-D4: ``strict_epoch`` is threaded in from ``_run_anchor_stage`` (mirrors
+    ``self._strict_epoch`` used by the hit filter).  Under ``strict_epoch=True``
+    a related node whose source is absent from the watermark map (AND the map is
+    non-empty) is EXCLUDED and ``_EPOCH_DROPS(reason="unmapped", filter="node")``
+    is incremented — making the graph-node filter SYMMETRIC with the hit filter.
+    Under ``strict_epoch=False`` (legacy), unmapped-source nodes pass through.
+    The ``unmapped/node`` label now fires by design.
 
     Rules:
     - Seed node version-ceiling is checked; if the seed is graph-ahead,
@@ -1178,12 +1210,17 @@ def _apply_graph_watermark_filter(
       The seed exclusion is NOT counted here — it is the caller's signal.
     - Related nodes whose version exceeds the watermark are removed.
       reason="cold_zero" when wm==0; reason="lag" otherwise.
+    - Under strict_epoch=True: related nodes whose source is NOT in the map
+      (and the map is non-empty) are also removed with reason="unmapped".
+      Under strict_epoch=False: such nodes pass through (legacy behaviour).
     - Edges between removed nodes are pruned.
-    - Nodes with ``version is None`` pass through (no ceiling info).
-    - Sources not in the watermark map pass through (no ceiling for them —
-      by design; the vector-hit filter handles unmapped-source drops).
-    - After pruning, BFS reachability is recomputed from the seed over
-      surviving edges; unreachable nodes are dropped.
+    - Nodes with ``version is None`` pass through (no ceiling info) IF their
+      source is in the map.  If their source is unmapped under strict_epoch=True,
+      they are still excluded (topology-epoch safety takes precedence).
+    - After ANY exclusion (version-ceiling OR unmapped), BFS reachability is
+      recomputed from the seed over surviving edges; unreachable nodes are
+      dropped (no phantom paths via excluded unmapped nodes).
+    - Cross-source links where the related source IS in the map are unaffected.
 
     Returns
     -------
@@ -1212,34 +1249,53 @@ def _apply_graph_watermark_filter(
     kept_related = []
     for node in graph_result.related:
         node_src = str(node.source)
-        if node_src in per_source_watermark and node.version is not None:
-            wm = per_source_watermark[node_src]
-            if node.version > wm:
-                excluded_names.add(node.name)
-                # v13-AP1: count the drop with the appropriate reason.
-                if wm == 0:
-                    _EPOCH_DROPS.labels(reason="cold_zero", filter="node").inc()
-                    log.debug(
-                        "graphrag_epoch_dropped",
-                        reason="cold_zero",
-                        filter="node",
-                        node_name=node.name,
-                        source=node_src,
-                        version=node.version,
-                        watermark=wm,
-                    )
-                else:
-                    _EPOCH_DROPS.labels(reason="lag", filter="node").inc()
-                    log.debug(
-                        "graphrag_epoch_dropped",
-                        reason="lag",
-                        filter="node",
-                        node_name=node.name,
-                        source=node_src,
-                        version=node.version,
-                        watermark=wm,
-                    )
-                continue
+        if node_src in per_source_watermark:
+            # Source is known — apply version ceiling.
+            if node.version is not None:
+                wm = per_source_watermark[node_src]
+                if node.version > wm:
+                    excluded_names.add(node.name)
+                    # v13-AP1: count the drop with the appropriate reason.
+                    if wm == 0:
+                        _EPOCH_DROPS.labels(reason="cold_zero", filter="node").inc()
+                        log.debug(
+                            "graphrag_epoch_dropped",
+                            reason="cold_zero",
+                            filter="node",
+                            node_name=node.name,
+                            source=node_src,
+                            version=node.version,
+                            watermark=wm,
+                        )
+                    else:
+                        _EPOCH_DROPS.labels(reason="lag", filter="node").inc()
+                        log.debug(
+                            "graphrag_epoch_dropped",
+                            reason="lag",
+                            filter="node",
+                            node_name=node.name,
+                            source=node_src,
+                            version=node.version,
+                            watermark=wm,
+                        )
+                    continue
+        elif strict_epoch and per_source_watermark:
+            # v14-D4: source absent from a non-empty map under strict_epoch=True.
+            # Symmetric with the hit filter: fail-closed for unmapped sources.
+            # Only fires when the map is populated (non-empty) — an empty map
+            # means the reconciler found no sources, which is handled at the
+            # search() level (empty_map_blackout); we do not double-drop here.
+            excluded_names.add(node.name)
+            _EPOCH_DROPS.labels(reason="unmapped", filter="node").inc()
+            log.debug(
+                "graphrag_epoch_dropped",
+                reason="unmapped",
+                filter="node",
+                node_name=node.name,
+                source=node_src,
+                version=node.version,
+            )
+            continue
         kept_related.append(node)
     graph_result.related = kept_related
 
@@ -1251,10 +1307,10 @@ def _apply_graph_watermark_filter(
             if e.from_entity not in excluded_names and e.to_entity not in excluded_names
         ]
 
-        # v11-AP5: recompute reachability from seed over surviving edges via BFS.
-        # Only needed when nodes were actually excluded — if nothing was excluded, the
-        # reachability set is identical to what traverse() computed.
-        # Nodes reachable only through excluded edges are phantom paths — drop them.
+        # v11-AP5 / v14-D4: recompute reachability from seed over surviving edges via BFS.
+        # Triggered whenever ANY node was excluded — version-ceiling drops (v11) OR
+        # unmapped-source drops (v14-D4).  Nodes reachable only via an excluded node
+        # (phantom paths) are removed so they cannot feed graph-affinity scoring.
         graph_result = _recompute_reachability(graph_result)
 
     return graph_result, False

--- a/packages/retrieval/src/omniscience_retrieval/graph_rag.py
+++ b/packages/retrieval/src/omniscience_retrieval/graph_rag.py
@@ -40,10 +40,6 @@ evidence.  The behaviour is governed by the ``strict_epoch`` parameter
 (default ``True``); set ``strict_epoch=False`` to revert to the old
 fail-open behaviour (not recommended for production).
 
-A Prometheus counter ``omniscience_graphrag_epoch_dropped_unmapped_total``
-tracks the number of hits dropped by the fail-closed policy so the
-leak-rate is observable.
-
 v11-AP2 — explicit anchor-miss, no control-flow-by-exception
 --------------------------------------------------------------
 ``_apply_graph_watermark_filter`` no longer raises ``ValueError`` for a
@@ -81,6 +77,43 @@ BFS directed would produce a reachability set INCONSISTENT with what
 pruned here but were included by the graph query.  The undirected BFS is the
 correct behaviour; this is documented (not changed) as the AP3 verdict.
 
+v13-AP2 — canonical no-reconciler signal
+-----------------------------------------
+``search()`` initialises ``per_source_watermark`` to ``None`` (not ``{}``)
+and only populates it when ``self._global_reconciler is not None``.
+``wait_for_convergence`` always returns a ``dict`` (possibly empty), so:
+
+- No reconciler wired → ``per_source_watermark = None`` → ``_apply_watermark_filter``
+  None-bypass fires → ALL hits pass (LIVE).
+- Reconciler ran but found no sources → ``per_source_watermark = {}`` → empty
+  dict flows through per-hit logic → every versioned hit from an unmapped
+  source is DROPPED under ``strict_epoch=True`` (FAIL-CLOSED, observable via
+  the ``empty_map_blackout`` reason label on ``_EPOCH_DROPS``).
+
+This removes the pre-v13 ambiguity where ``{}`` was the default for BOTH
+"no reconciler" AND "cold workspace", making "no reconciler" behave as
+fail-closed on first call.
+
+v13-AP1 — reason-labeled epoch-drop observability
+--------------------------------------------------
+``_EPOCH_DROPPED_UNMAPPED`` is replaced by a single ``_EPOCH_DROPS`` Counter
+with two labels:
+
+- ``reason ∈ {unmapped, lag, cold_zero, empty_map_blackout}`` — WHY the hit
+  or node was dropped.
+- ``filter ∈ {hit, node}`` — WHICH filter dropped it.
+
+Both ``_apply_watermark_filter`` (vector hits, ``filter="hit"``) and
+``_apply_graph_watermark_filter`` (graph nodes, ``filter="node"``) increment
+this counter at every drop site.  The ``empty_map_blackout`` label fires once
+per ``search()`` call when the map is empty under ``strict_epoch=True``.
+
+Graph nodes from UNMAPPED sources intentionally PASS through
+``_apply_graph_watermark_filter`` (no ``unmapped`` counter for nodes) — the
+graph filter only applies version ceilings for sources whose watermark IS
+known.  This is by design: the vector-hit filter handles unmapped-source
+drops for evidence; the graph filter handles graph-ahead nodes.
+
 Backwards-compatibility
 -----------------------
 
@@ -111,9 +144,25 @@ Telemetry
 Per-stage metrics are emitted under the ``omniscience_graphrag_*``
 namespace; see :data:`_STAGE_DURATION`, :data:`_CANDIDATE_SET_SIZE`,
 :data:`_ANCHOR_HIT_TOTAL`, :data:`_COMPOSED_QUERIES_TOTAL`,
-:data:`_EPOCH_DROPPED_UNMAPPED`.  Each request also produces a structlog
+:data:`_EPOCH_DROPS`.  Each request also produces a structlog
 event ``graphrag_query_complete`` with the same numbers for trace
 correlation.
+
+``_EPOCH_DROPS`` (``omniscience_graphrag_epoch_dropped_total``) is
+incremented at every drop site in both ``_apply_watermark_filter``
+(``filter="hit"``) and ``_apply_graph_watermark_filter``
+(``filter="node"``).  Reasons:
+
+- ``unmapped`` — hit from a source absent from the watermark map
+  (strict_epoch=True, ``filter="hit"`` only; graph nodes from unmapped
+  sources pass by design).
+- ``lag`` — hit/node whose ``applied_version > watermark`` (source is in
+  the map but lagging).
+- ``cold_zero`` — hit/node whose source has watermark=0 and
+  ``applied_version >= 1`` (source not yet applied anything).
+- ``empty_map_blackout`` — fired ONCE per ``search()`` call when the
+  watermark map is empty (``{}``) under ``strict_epoch=True``; signals
+  a cold-start or reconciler gap affecting the entire request.
 """
 
 from __future__ import annotations
@@ -257,20 +306,36 @@ _COMPOSED_QUERIES_TOTAL: Counter = Counter(
     labelnames=["path"],
 )
 
-#: v11-AP1: tracks hits dropped by the fail-closed epoch policy (strict_epoch=True)
-#: because the hit's source was absent from the per_source_watermark map.
-#: A non-zero rate indicates sources that were indexed into Qdrant/Neo4j but
-#: whose pg watermark snapshot did not include them — typically a reconciler
-#: race or a source newly added to a store but not yet committed to Postgres.
-_EPOCH_DROPPED_UNMAPPED: Counter = Counter(
-    name="omniscience_graphrag_epoch_dropped_unmapped_total",
+#: v13-AP1: unified epoch-drop counter replacing the old _EPOCH_DROPPED_UNMAPPED.
+#: Incremented in BOTH _apply_watermark_filter (filter="hit") and
+#: _apply_graph_watermark_filter (filter="node") at every drop site.
+#:
+#: reason labels:
+#:   unmapped      — hit from a source not in the watermark map (strict_epoch=True).
+#:                   NOT used for graph nodes (unmapped-source graph nodes pass by design).
+#:   lag           — hit/node with applied_version > watermark (source in map, lagging).
+#:   cold_zero     — hit/node with watermark=0 and applied_version >= 1 (not yet applied).
+#:   empty_map_blackout — fired once per search() call when map == {} under strict_epoch=True.
+#:
+#: filter labels:
+#:   hit  — drop occurred in _apply_watermark_filter (vector evidence layer).
+#:   node — drop occurred in _apply_graph_watermark_filter (graph node layer).
+_EPOCH_DROPS: Counter = Counter(
+    name="omniscience_graphrag_epoch_dropped_total",
     documentation=(
-        "Number of vector hits dropped by the fail-closed epoch policy "
-        "(strict_epoch=True) because the hit's source_id was absent from "
-        "the per_source_watermark map.  A sustained non-zero rate signals "
-        "a reconciler gap or a newly-added source not yet seen by the "
-        "GlobalReconciler (v11-AP1)."
+        "Number of vector hits or graph nodes dropped by the epoch pinning policy. "
+        "Labels: reason ∈ {unmapped, lag, cold_zero, empty_map_blackout}, "
+        "filter ∈ {hit, node}. "
+        "'unmapped' fires when a vector hit's source is absent from the watermark map "
+        "(strict_epoch=True); graph nodes from unmapped sources pass by design. "
+        "'lag' fires when applied_version > watermark for a mapped source. "
+        "'cold_zero' fires when watermark==0 and applied_version>=1 (source not yet applied). "
+        "'empty_map_blackout' fires once per request when the map is {} under strict_epoch=True "
+        "(cold-start / reconciler gap). "
+        "A sustained non-zero rate on 'unmapped' signals a reconciler gap or newly-added "
+        "source not yet seen by the GlobalReconciler (v13-AP1)."
     ),
+    labelnames=["reason", "filter"],
 )
 
 
@@ -494,10 +559,18 @@ class GraphRAGComposer:
 
         # AP3 / v10-AP1: capture convergence signals including per-source watermark.
         # Do NOT discard on timeout — the watermark is what pins the read path.
+        #
+        # v13-AP2 canonical no-reconciler signal:
+        # Initialise to None (not {}) so the no-reconciler path is unambiguous.
+        # - None  → no reconciler wired → _apply_watermark_filter None-bypass → ALL hits pass
+        #           (LIVE).
+        # - {}    → reconciler ran but found no sources (cold workspace) → fail-closed under
+        #           strict_epoch=True → versioned hits DROPPED + empty_map_blackout counter fired.
+        # wait_for_convergence always returns a dict (possibly empty), never None.
         convergence_degraded: list[str] = []
         convergence_staleness: float | None = None
         min_watermark: int | None = None
-        per_source_watermark: dict[str, int] = {}
+        per_source_watermark: dict[str, int] | None = None
         if self._global_reconciler is not None:
             (
                 convergence_degraded,
@@ -505,6 +578,16 @@ class GraphRAGComposer:
                 min_watermark,
                 per_source_watermark,
             ) = await self._global_reconciler.wait_for_convergence(workspace_id)
+
+        # v13-AP1: fire the empty_map_blackout counter ONCE per request when the map
+        # is {} (reconciler ran but cold) under strict_epoch=True.  This makes the
+        # cold-start scenario observable without relying on per-hit counters.
+        if per_source_watermark == {} and self._strict_epoch:
+            _EPOCH_DROPS.labels(reason="empty_map_blackout", filter="hit").inc()
+            log.warning(
+                "graphrag_epoch_empty_map_blackout",
+                workspace_id=str(workspace_id),
+            )
 
         # v10-AP2: pass per-source watermark into anchor stage so graph-ahead
         # nodes/edges are excluded before they influence candidate selection.
@@ -964,8 +1047,8 @@ def _apply_watermark_filter(
     ``strict_epoch=False`` to revert to the legacy fail-open behaviour
     (hit passes when its source has no map entry).
 
-    ``_EPOCH_DROPPED_UNMAPPED`` is incremented for each hit dropped by
-    the fail-closed policy so the leak-rate is observable.
+    v13-AP1: ``_EPOCH_DROPS`` is incremented with labelled reasons at
+    every drop site for full observability.
 
     Rules (strict_epoch=True, the default):
     - When ``per_source_watermark is None``: no reconciler is wired → pass
@@ -980,12 +1063,24 @@ def _apply_watermark_filter(
     - For a hit whose source has no entry in the map:
       - ``applied_version is None``: pass through (no version info).
       - ``applied_version is not None``: DROP (fail-closed) and increment
-        ``omniscience_graphrag_epoch_dropped_unmapped_total``.
+        ``_EPOCH_DROPS(reason="unmapped", filter="hit")``.
     - For a hit whose source IS in the map:
-      - watermark == 0: drop if ``applied_version`` is not None and >= 1
-        (version 0 means nothing applied for this source yet).
-      - Otherwise: drop if ``applied_version > watermark``.
-      - Hits with ``applied_version is None``: always pass through.
+      - watermark == 0 and applied_version >= 1: DROP and increment
+        ``_EPOCH_DROPS(reason="cold_zero", filter="hit")``.
+      - applied_version > watermark (and wm > 0): DROP and increment
+        ``_EPOCH_DROPS(reason="lag", filter="hit")``.
+      - applied_version <= watermark OR applied_version is None: pass.
+
+    BOUNDARY: applied_version=0, wm=0 → PASSES (0 <= 0).  This is correct:
+    version 0 means "nothing applied yet for this source" on BOTH sides,
+    which is a consistent read at epoch 0 — not a mixed-epoch violation.
+
+    Skipping the graph filter on empty map ({}) in ``_apply_graph_watermark_filter``
+    is correct: when the map is {}, there are no source ceilings to enforce in the
+    graph — ANY node version is unconstrained.  The vector-hit filter handles the
+    fail-closed logic for evidence; the graph filter only applies when there are
+    known ceilings.  An empty map for the graph filter means "no graph-ahead nodes
+    to prune" — all graph nodes pass, and the vector-hit filter controls the epoch pin.
 
     Rules (strict_epoch=False, legacy):
     - Hits from unmapped sources pass through unconditionally (old behaviour).
@@ -1008,9 +1103,10 @@ def _apply_watermark_filter(
                 result.append(h)
             elif strict_epoch:
                 # Fail-closed: versioned hit from unmapped source is dropped.
-                _EPOCH_DROPPED_UNMAPPED.inc()
+                _EPOCH_DROPS.labels(reason="unmapped", filter="hit").inc()
                 log.debug(
-                    "graphrag_epoch_dropped_unmapped",
+                    "graphrag_epoch_dropped",
+                    reason="unmapped",
                     source_id=src_key,
                     applied_version=h.applied_version,
                 )
@@ -1020,7 +1116,29 @@ def _apply_watermark_filter(
             continue
         wm = per_source_watermark[src_key]
         if h.applied_version is None or h.applied_version <= wm:
+            # Pass: no version info OR within watermark.
+            # BOUNDARY: applied_version=0, wm=0 → 0 <= 0 → PASS (epoch-0 consistent read).
             result.append(h)
+        elif wm == 0:
+            # cold_zero: source watermark is 0 (never applied) but hit has applied_version >= 1.
+            _EPOCH_DROPS.labels(reason="cold_zero", filter="hit").inc()
+            log.debug(
+                "graphrag_epoch_dropped",
+                reason="cold_zero",
+                source_id=src_key,
+                applied_version=h.applied_version,
+                watermark=wm,
+            )
+        else:
+            # lag: source in map, applied_version > watermark > 0.
+            _EPOCH_DROPS.labels(reason="lag", filter="hit").inc()
+            log.debug(
+                "graphrag_epoch_dropped",
+                reason="lag",
+                source_id=src_key,
+                applied_version=h.applied_version,
+                watermark=wm,
+            )
     return result
 
 
@@ -1048,13 +1166,22 @@ def _apply_graph_watermark_filter(
     excluded edges (phantom paths) are removed from ``graph_result.related``
     and their stale depths do not feed graph-affinity scoring.
 
+    v13-AP1: ``_EPOCH_DROPS(filter="node")`` is incremented at both drop
+    sites (seed-excluded path returns True, so the caller handles that case;
+    related-node drops are incremented here with reason="cold_zero" or
+    reason="lag").  Graph nodes from UNMAPPED sources intentionally PASS
+    (no ``unmapped`` counter for nodes — see module docstring).
+
     Rules:
     - Seed node version-ceiling is checked; if the seed is graph-ahead,
       returns ``(graph_result, True)`` — caller treats as anchor-miss.
+      The seed exclusion is NOT counted here — it is the caller's signal.
     - Related nodes whose version exceeds the watermark are removed.
+      reason="cold_zero" when wm==0; reason="lag" otherwise.
     - Edges between removed nodes are pruned.
     - Nodes with ``version is None`` pass through (no ceiling info).
-    - Sources not in the watermark map pass through (no ceiling for them).
+    - Sources not in the watermark map pass through (no ceiling for them —
+      by design; the vector-hit filter handles unmapped-source drops).
     - After pruning, BFS reachability is recomputed from the seed over
       surviving edges; unreachable nodes are dropped.
 
@@ -1076,6 +1203,9 @@ def _apply_graph_watermark_filter(
         wm = per_source_watermark[seed_src]
         if seed.version > wm:
             # v11-AP2: return explicit signal instead of raising ValueError.
+            # The caller (_run_anchor_stage) counts this as anchor-miss;
+            # we do NOT increment _EPOCH_DROPS here — the caller's anchor-miss
+            # counter is the observable signal for seed exclusion.
             return graph_result, True
 
     # Filter related nodes.
@@ -1086,6 +1216,29 @@ def _apply_graph_watermark_filter(
             wm = per_source_watermark[node_src]
             if node.version > wm:
                 excluded_names.add(node.name)
+                # v13-AP1: count the drop with the appropriate reason.
+                if wm == 0:
+                    _EPOCH_DROPS.labels(reason="cold_zero", filter="node").inc()
+                    log.debug(
+                        "graphrag_epoch_dropped",
+                        reason="cold_zero",
+                        filter="node",
+                        node_name=node.name,
+                        source=node_src,
+                        version=node.version,
+                        watermark=wm,
+                    )
+                else:
+                    _EPOCH_DROPS.labels(reason="lag", filter="node").inc()
+                    log.debug(
+                        "graphrag_epoch_dropped",
+                        reason="lag",
+                        filter="node",
+                        node_name=node.name,
+                        source=node_src,
+                        version=node.version,
+                        watermark=wm,
+                    )
                 continue
         kept_related.append(node)
     graph_result.related = kept_related

--- a/tests/conformance/test_ap3_no_mixed_epoch.py
+++ b/tests/conformance/test_ap3_no_mixed_epoch.py
@@ -1,4 +1,4 @@
-"""AP3 / v10-AP1 / v10-AP2 / v11-AP1 conformance tests — no mixed-epoch evidence.
+"""AP3 / v10-AP1 / v10-AP2 / v11-AP1 / v13-AP1/AP2 conformance tests — no mixed-epoch evidence.
 
 AP3 invariant: every hit in a SearchResult must have
 ``applied_version <= watermark[its_source]`` (or ``applied_version is None``).
@@ -21,6 +21,17 @@ from unmapped sources pass through.  The old fail-open behaviour (pass-through
 for unmapped sources) is available via strict_epoch=False (not recommended
 for production — see ADR-0017).
 
+v13-AP2 invariant (canonical no-reconciler signal): a composer with
+_global_reconciler=None must initialise per_source_watermark=None so the
+None-bypass in _apply_watermark_filter fires and ALL hits pass.  The old
+default of {} (empty dict) was wrong: it caused strict_epoch=True to drop
+all versioned hits even when no reconciler was wired.
+
+v13-AP1 invariant (reason-labeled observability): _EPOCH_DROPS counter
+increments with correct (reason, filter) labels at every drop site.
+Tests use DELTA assertions (before/after) to avoid accumulation across
+test runs on the shared default registry.
+
 These tests are REAL (not xfail) and must remain green throughout the
 codebase lifetime.  They use mocks only — no containers required.
 
@@ -41,6 +52,9 @@ Test cases
 8. [v10-AP2] anchor node version > source watermark → excluded from anchor result
    (graph-ahead mixed-epoch prevented).
 9. [v10-AP2] anchor seed node version > source watermark → treated as anchor miss.
+10. [v13-AP2] no reconciler → per_source_watermark=None → all hits pass, no _EPOCH_DROPS.
+11. [v13-AP1/AP2] cold workspace {} → versioned hit dropped + empty_map_blackout +1
+    AND unmapped +1.
 """
 
 from __future__ import annotations
@@ -52,6 +66,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from omniscience_core.storage.graph import EntityNodeView, GraphEdgeView, GraphResultView
 from omniscience_retrieval.graph_rag import (
+    _EPOCH_DROPS,
     GraphRAGComposer,
     _apply_graph_watermark_filter,
     _apply_watermark_filter,
@@ -180,6 +195,47 @@ def _make_composer_with_reconciler(
     return composer
 
 
+def _make_composer_no_reconciler(
+    hits: list[SearchHit],
+    *,
+    strict_epoch: bool = True,
+) -> GraphRAGComposer:
+    """Build a GraphRAGComposer with NO global reconciler.
+
+    v13-AP2: _global_reconciler=None → per_source_watermark stays None in search()
+    → _apply_watermark_filter None-bypass → ALL hits pass regardless of
+    applied_version.  This is the canonical no-reconciler path.
+
+    No mock reconciler is wired; _global_reconciler is explicitly None.
+    """
+
+    class _FakeVS:
+        async def search(
+            self,
+            *,
+            request: SearchRequest,
+            workspace_id: uuid.UUID,
+            as_of: datetime | None = None,
+        ) -> SearchResult:
+            return _make_result(hits)
+
+    class _FakeLegacy:
+        async def search(self, request: SearchRequest) -> SearchResult:
+            return _make_result([])
+
+    composer = GraphRAGComposer.__new__(GraphRAGComposer)
+    composer._graphrag_active = True  # type: ignore[attr-defined]
+    composer._global_reconciler = None  # type: ignore[attr-defined]  # v13-AP2: explicit None
+    composer._session_factory = None  # type: ignore[attr-defined]
+    composer._is_entity_parked_fn = None  # type: ignore[attr-defined]
+    composer._strict_epoch = strict_epoch  # type: ignore[attr-defined]
+    composer._vector_store = _FakeVS()  # type: ignore[attr-defined]
+    composer._graph_store = MagicMock()  # type: ignore[attr-defined]
+    composer._graph_store.traverse = AsyncMock(side_effect=ValueError("entity_not_found"))
+    composer._legacy_service = _FakeLegacy()  # type: ignore[attr-defined]
+    return composer
+
+
 # ---------------------------------------------------------------------------
 # Test 1: watermark=7, hits with applied_version {5,7,8,10} → only ≤7 survive
 # ---------------------------------------------------------------------------
@@ -242,17 +298,17 @@ async def test_none_watermark_passes_all_hits() -> None:
     filter, allowing all versioned hits to pass even when the reconciler had run but
     found no sources.  The empty-map case is now covered by
     test_empty_map_fail_closed_drops_versioned_hits (v12-AP1 regression test).
+
+    v13-AP2: use _make_composer_no_reconciler so _global_reconciler=None and the
+    None initialisation path in search() is exercised (not just the pure function).
     """
     hits = [
         _make_hit(applied_version=1),
         _make_hit(applied_version=100),
         _make_hit(applied_version=None),
     ]
-    composer = _make_composer_with_reconciler(
-        min_watermark=None,
-        hits=hits,
-        per_source_watermark=None,  # v12-AP1: None = no reconciler wired; {} ≠ None
-    )
+    # v13-AP2: use the no-reconciler helper (sets _global_reconciler=None)
+    composer = _make_composer_no_reconciler(hits)
     req = SearchRequest(query="test", top_k=10)
     result = await composer.search(req, workspace_id=_WS)
 
@@ -351,6 +407,9 @@ def test_apply_watermark_filter_pure_function() -> None:
     - Per-source map None or empty → all hits retained (no filter).
     - Source not in map → hit passes (no blackout for unknown sources).
     - Two sources with different watermarks are evaluated independently.
+
+    v13-AP1 additions: delta-assert that _EPOCH_DROPS fires on unmapped-drop
+    and does NOT fire on pass-through or None-watermark paths.
     """
     src_x = uuid.uuid4()
     src_y = uuid.uuid4()
@@ -366,8 +425,13 @@ def test_apply_watermark_filter_pure_function() -> None:
     all_hits_x = [h_none, h_v0, h_v5, h_v7, h_v8, h_v10]
 
     # --- watermark map None: no filter (no reconciler wired) ---
+    before_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
     result = _apply_watermark_filter(all_hits_x, None)
     assert result == all_hits_x, "watermark=None must return all hits unchanged"
+    # No counter increments on None path.
+    assert _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped, (
+        "None watermark path must not increment _EPOCH_DROPS"
+    )
 
     # --- watermark map empty (v12-AP1 fix): strict_epoch=True → only None-versioned pass ---
     # Empty dict means "reconciler ran but found no sources in any store".  Under
@@ -393,6 +457,7 @@ def test_apply_watermark_filter_pure_function() -> None:
     assert surviving == {None, 0, 5, 7}, f"Expected {{None,0,5,7}}; got {surviving}"
 
     # --- single source watermark = 0: drop v5, v7, v8, v10; keep None and v0 ---
+    # BOUNDARY: applied_version=0, wm=0 → 0 <= 0 → PASS (epoch-0 consistent read).
     wm = {str(src_x): 0}
     result = _apply_watermark_filter(all_hits_x, wm)
     surviving = {h.applied_version for h in result}
@@ -417,15 +482,25 @@ def test_apply_watermark_filter_pure_function() -> None:
 
     # --- source not in map, strict_epoch=True (default): versioned hit DROPPED (fail-closed) ---
     h_unknown = _make_hit(applied_version=999, source_id=src_unknown)
+    before_unmapped2 = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
     result_strict = _apply_watermark_filter([h_unknown], {str(src_x): 7}, strict_epoch=True)
     assert result_strict == [], (
         "v11-AP1 fail-closed: versioned hit from unmapped source must be dropped"
     )
+    # v13-AP1: unmapped drop must increment counter.
+    assert (
+        _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped2 + 1
+    ), "v13-AP1: unmapped drop must increment _EPOCH_DROPS(reason=unmapped, filter=hit)"
 
     # --- source not in map, applied_version=None: always passes (no version info) ---
     h_unknown_none = _make_hit(applied_version=None, source_id=src_unknown)
+    before_unmapped3 = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
     result_none = _apply_watermark_filter([h_unknown_none], {str(src_x): 7}, strict_epoch=True)
     assert len(result_none) == 1, "applied_version=None from unmapped source must always pass"
+    # No counter increment for None-version pass.
+    assert _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped3, (
+        "None-version pass must not increment _EPOCH_DROPS"
+    )
 
     # --- source not in map, strict_epoch=False (legacy fail-open): versioned hit passes ---
     result_open = _apply_watermark_filter([h_unknown], {str(src_x): 7}, strict_epoch=False)
@@ -664,7 +739,14 @@ def test_apply_graph_watermark_filter_node_version_none_passes() -> None:
 
 
 def test_apply_graph_watermark_filter_source_not_in_map_passes() -> None:
-    """Node whose source is not in the watermark map passes through (no ceiling)."""
+    """Node whose source is not in the watermark map passes through (no ceiling).
+
+    v13-AP1 design note: graph nodes from unmapped sources intentionally PASS.
+    Only _apply_watermark_filter (vector-hit filter) enforces fail-closed drops
+    for unmapped sources.  The graph filter only applies version ceilings for
+    sources with known watermarks.  This is by design — do NOT add an 'unmapped'
+    counter for graph nodes.
+    """
     src_mapped = str(uuid.uuid4())
     src_unmapped = str(uuid.uuid4())
 
@@ -708,6 +790,10 @@ async def test_graph_ahead_seed_node_treated_as_anchor_miss() -> None:
 
     This prevents a graph-ahead seed from polluting the candidate set and
     injecting graph-v10 entity context into a v7-evidence composed result.
+
+    v13-AP1: assert _EPOCH_DROPS counter does NOT increment for the seed-exclusion
+    path (the seed is excluded by returning True from _apply_graph_watermark_filter;
+    the counter is not fired there — the anchor-miss outcome is the observable signal).
     """
     src_id = uuid.uuid4()
     src_str = str(src_id)
@@ -764,6 +850,10 @@ async def test_graph_ahead_seed_node_treated_as_anchor_miss() -> None:
         top_k=10,
         filters={"graphrag_anchor": "AheadSeed"},
     )
+    # v13-AP1: seed exclusion must NOT increment _EPOCH_DROPS(filter="node")
+    before_node_lag = _EPOCH_DROPS.labels(reason="lag", filter="node")._value.get()
+    before_node_cold = _EPOCH_DROPS.labels(reason="cold_zero", filter="node")._value.get()
+
     result = await composer.search(req, workspace_id=_WS)
 
     # The anchor seed was graph-ahead → treated as miss → no candidate set from graph.
@@ -776,6 +866,13 @@ async def test_graph_ahead_seed_node_treated_as_anchor_miss() -> None:
         "No hit should exceed watermark=7 after graph-ahead anchor rejection: "
         f"{surviving_versions}"
     )
+    # Seed-excluded path does NOT fire node-filter counters.
+    assert _EPOCH_DROPS.labels(reason="lag", filter="node")._value.get() == before_node_lag, (
+        "v13-AP1: seed-excluded path must not increment lag/node counter"
+    )
+    assert (
+        _EPOCH_DROPS.labels(reason="cold_zero", filter="node")._value.get() == before_node_cold
+    ), "v13-AP1: seed-excluded path must not increment cold_zero/node counter"
 
 
 # ---------------------------------------------------------------------------
@@ -798,6 +895,8 @@ async def test_empty_map_fail_closed_drops_versioned_hits() -> None:
     - applied_version is None → passes (no version info, no ceiling to enforce).
     - applied_version is not None → DROPPED (fail-closed: source unmapped).
 
+    v13-AP1: delta-assert _EPOCH_DROPS(reason="unmapped", filter="hit") fires on drop.
+
     Variants tested:
     1. empty map + strict_epoch=True + versioned hit → DROPPED.
     2. empty map + strict_epoch=True + None-versioned hit → passes.
@@ -808,24 +907,39 @@ async def test_empty_map_fail_closed_drops_versioned_hits() -> None:
     hit_none_versioned = _make_hit(applied_version=None, source_id=src_id)
 
     # --- Variant 1: empty map + strict_epoch=True + versioned hit → DROPPED ---
+    before_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
     result = _apply_watermark_filter([hit_versioned], {}, strict_epoch=True)
     assert result == [], (
         "v12-AP1 regression: empty per_source_watermark + strict_epoch=True + "
         "versioned hit must be DROPPED (fail-closed cold-start bypass was the bug)"
     )
+    # v13-AP1: unmapped drop must fire counter.
+    assert (
+        _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped + 1
+    ), "v13-AP1: empty-map drop must increment _EPOCH_DROPS(reason=unmapped, filter=hit)"
 
     # --- Variant 2: empty map + strict_epoch=True + None-versioned hit → passes ---
+    before_unmapped2 = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
     result = _apply_watermark_filter([hit_none_versioned], {}, strict_epoch=True)
     assert len(result) == 1, (
         "v12-AP1: applied_version=None from unmapped source must always pass "
         "(no version info → no ceiling to enforce)"
     )
+    # None-version pass must not fire counter.
+    assert _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped2, (
+        "v13-AP1: None-version pass must not increment counter"
+    )
 
     # --- Variant 3: None map (no reconciler) + versioned hit → passes ---
+    before_unmapped3 = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
     result = _apply_watermark_filter([hit_versioned], None)
     assert len(result) == 1, (
         "per_source_watermark=None (no reconciler wired) must pass all hits unchanged — "
         "this is the legitimate no-reconciler path"
+    )
+    # None-watermark path must not fire counter.
+    assert _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped3, (
+        "v13-AP1: None watermark path must not increment counter"
     )
 
 
@@ -840,6 +954,9 @@ async def test_empty_map_fail_closed_end_to_end() -> None:
     Three hits: versioned from src_a, versioned from src_b, None-versioned from src_a.
 
     Expected: both versioned hits DROPPED; None-versioned hit passes.
+
+    v13-AP1: delta-assert empty_map_blackout fires ONCE per request +
+    unmapped fires per dropped versioned hit.
     """
     src_a = uuid.uuid4()
     src_b = uuid.uuid4()
@@ -856,6 +973,11 @@ async def test_empty_map_fail_closed_end_to_end() -> None:
         strict_epoch=True,
     )
     req = SearchRequest(query="test", top_k=10)
+
+    # v13-AP1: capture counters before call.
+    before_blackout = _EPOCH_DROPS.labels(reason="empty_map_blackout", filter="hit")._value.get()
+    before_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
+
     result = await composer.search(req, workspace_id=_WS)
 
     # All versioned hits must be dropped (fail-closed, empty map).
@@ -870,6 +992,17 @@ async def test_empty_map_fail_closed_end_to_end() -> None:
         f"v12-AP1: None-versioned hit must pass through empty-map fail-closed filter; "
         f"got {none_versioned}"
     )
+
+    # v13-AP1: empty_map_blackout fires ONCE per request.
+    assert (
+        _EPOCH_DROPS.labels(reason="empty_map_blackout", filter="hit")._value.get()
+        == before_blackout + 1
+    ), "v13-AP1: empty_map_blackout must fire exactly once per request with empty map"
+
+    # v13-AP1: unmapped fires once per dropped versioned hit (2 versioned hits dropped).
+    assert (
+        _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped + 2
+    ), "v13-AP1: unmapped must fire once per dropped versioned hit (2 hits dropped)"
 
 
 # ---------------------------------------------------------------------------
@@ -1023,3 +1156,122 @@ def test_recompute_reachability_directed_would_drop_reverse_edge_node() -> None:
         "v12-AP3 proof: directed BFS from Seed via B→Seed edge does NOT reach B — "
         "this confirms why undirected BFS is required to match traverse() semantics"
     )
+
+
+# ---------------------------------------------------------------------------
+# v13-AP2: canonical no-reconciler signal — _global_reconciler=None → all hits pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_reconciler_passes_all_hits() -> None:
+    """v13-AP2: a composer with _global_reconciler=None passes ALL hits, no _EPOCH_DROPS.
+
+    When no reconciler is wired, per_source_watermark stays None throughout search().
+    _apply_watermark_filter sees None → None-bypass → return all hits unchanged.
+    No _EPOCH_DROPS counter must fire for any reason/filter combination.
+
+    This tests the canonical no-reconciler path introduced in v13-AP2 to remove the
+    pre-v13 ambiguity where {} was the default for both "no reconciler" and "cold workspace".
+    """
+    src_a = uuid.uuid4()
+    src_b = uuid.uuid4()
+
+    hits = [
+        _make_hit(applied_version=1, text="versioned-a", source_id=src_a),
+        _make_hit(applied_version=999, text="high-versioned-b", source_id=src_b),
+        _make_hit(applied_version=None, text="unversioned-a", source_id=src_a),
+    ]
+
+    # Use _make_composer_no_reconciler — _global_reconciler=None, no mock.
+    composer = _make_composer_no_reconciler(hits, strict_epoch=True)
+
+    # Capture all relevant counter values before the call.
+    before_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
+    before_lag_hit = _EPOCH_DROPS.labels(reason="lag", filter="hit")._value.get()
+    before_cold_zero_hit = _EPOCH_DROPS.labels(reason="cold_zero", filter="hit")._value.get()
+    before_blackout = _EPOCH_DROPS.labels(reason="empty_map_blackout", filter="hit")._value.get()
+
+    req = SearchRequest(query="no-reconciler-test", top_k=10)
+    result = await composer.search(req, workspace_id=_WS)
+
+    # All 3 hits must pass (None-bypass fires when per_source_watermark=None).
+    assert len(result.hits) == 3, (
+        f"v13-AP2: all hits must pass when _global_reconciler=None; got {len(result.hits)}"
+    )
+
+    # No _EPOCH_DROPS counter must increment for any reason on the no-reconciler path.
+    assert _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped, (
+        "v13-AP2: no-reconciler path must not increment unmapped/hit counter"
+    )
+    assert _EPOCH_DROPS.labels(reason="lag", filter="hit")._value.get() == before_lag_hit, (
+        "v13-AP2: no-reconciler path must not increment lag/hit counter"
+    )
+    assert (
+        _EPOCH_DROPS.labels(reason="cold_zero", filter="hit")._value.get() == before_cold_zero_hit
+    ), "v13-AP2: no-reconciler path must not increment cold_zero/hit counter"
+    assert (
+        _EPOCH_DROPS.labels(reason="empty_map_blackout", filter="hit")._value.get()
+        == before_blackout
+    ), "v13-AP2: no-reconciler path must not increment empty_map_blackout/hit counter"
+
+
+@pytest.mark.asyncio
+async def test_cold_workspace_empty_map_is_fail_closed_and_counted() -> None:
+    """v13-AP1/AP2: reconciler returns {} → versioned hit dropped + counters fire.
+
+    Scenario: reconciler ran (not None) but returned an empty map ({}) —
+    cold workspace with no sources yet.  This is the canonical cold-start path.
+
+    Expected:
+    - Versioned hits DROPPED (fail-closed under strict_epoch=True).
+    - None-versioned hits PASS.
+    - empty_map_blackout counter fires ONCE per request.
+    - unmapped counter fires once per DROPPED versioned hit.
+
+    This test distinguishes the cold-workspace case (per_source_watermark={})
+    from the no-reconciler case (per_source_watermark=None).  The former is
+    fail-closed; the latter is pass-all.
+    """
+    src_id = uuid.uuid4()
+
+    hit_versioned = _make_hit(applied_version=7, text="versioned", source_id=src_id)
+    hit_none_versioned = _make_hit(applied_version=None, text="unversioned", source_id=src_id)
+
+    # Reconciler returns {} (cold workspace — no sources found).
+    composer = _make_composer_with_reconciler(
+        min_watermark=None,
+        hits=[hit_versioned, hit_none_versioned],
+        per_source_watermark={},
+        strict_epoch=True,
+    )
+
+    before_blackout = _EPOCH_DROPS.labels(reason="empty_map_blackout", filter="hit")._value.get()
+    before_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get()
+
+    req = SearchRequest(query="cold-workspace", top_k=10)
+    result = await composer.search(req, workspace_id=_WS)
+
+    # Versioned hit must be dropped.
+    versioned_results = [h for h in result.hits if h.applied_version is not None]
+    assert versioned_results == [], (
+        f"v13-AP2: cold workspace ({{}}) must drop versioned hits; "
+        f"got {[(h.applied_version, h.text) for h in versioned_results]}"
+    )
+
+    # None-versioned hit must pass.
+    none_results = [h for h in result.hits if h.applied_version is None]
+    assert len(none_results) == 1, (
+        "v13-AP2: None-versioned hit must pass through cold-workspace fail-closed filter"
+    )
+
+    # empty_map_blackout fires once per request.
+    assert (
+        _EPOCH_DROPS.labels(reason="empty_map_blackout", filter="hit")._value.get()
+        == before_blackout + 1
+    ), "v13-AP1: empty_map_blackout must fire exactly once for cold-workspace request"
+
+    # unmapped fires once per dropped versioned hit (1 versioned hit dropped).
+    assert (
+        _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped + 1
+    ), "v13-AP1: unmapped must fire once for the dropped versioned hit"

--- a/tests/conformance/test_ap3_no_mixed_epoch.py
+++ b/tests/conformance/test_ap3_no_mixed_epoch.py
@@ -404,12 +404,22 @@ def test_apply_watermark_filter_pure_function() -> None:
     - Hits with applied_version == watermark → retained.
     - Hits with applied_version < watermark → retained.
     - Hits with applied_version is None → always retained.
-    - Per-source map None or empty → all hits retained (no filter).
-    - Source not in map → hit passes (no blackout for unknown sources).
+    - Per-source map None → all hits retained (no reconciler wired — live mode).
+    - Per-source map empty ({}) + strict_epoch=True → only av=None hits pass
+      (fail-closed; all versioned hits from unmapped sources are DROPPED).
+    - Per-source map empty ({}) + strict_epoch=False → all hits pass (legacy).
+    - Source not in map + strict_epoch=True → versioned hit DROPPED (fail-closed).
+    - Source not in map + applied_version=None → always passes (no version claim).
+    - Source not in map + strict_epoch=False → hit passes (legacy fail-open).
     - Two sources with different watermarks are evaluated independently.
 
     v13-AP1 additions: delta-assert that _EPOCH_DROPS fires on unmapped-drop
     and does NOT fire on pass-through or None-watermark paths.
+
+    Semantics summary (v11/v12/v13 fail-closed):
+    - None map → all hits pass (bypass: no reconciler).
+    - Empty map ({}) + strict → only av=None passes (cold workspace fail-closed).
+    - Source not in map + versioned + strict → DROPPED (unmapped fail-closed).
     """
     src_x = uuid.uuid4()
     src_y = uuid.uuid4()

--- a/tests/conformance/test_ap3_no_mixed_epoch.py
+++ b/tests/conformance/test_ap3_no_mixed_epoch.py
@@ -59,6 +59,7 @@ Test cases
 
 from __future__ import annotations
 
+import os
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
@@ -1285,3 +1286,216 @@ async def test_cold_workspace_empty_map_is_fail_closed_and_counted() -> None:
     assert (
         _EPOCH_DROPS.labels(reason="unmapped", filter="hit")._value.get() == before_unmapped + 1
     ), "v13-AP1: unmapped must fire once for the dropped versioned hit"
+
+
+# ---------------------------------------------------------------------------
+# v13-AP4: Real traverse() + _recompute_reachability consistency — PROVEN test
+# (gated: OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1)
+#
+# The previous v12-AP3 "undirected is correct" verdict rested on a comment
+# plus a test that re-implemented directed adjacency inline (tautological:
+# it tested the test's own reimplementation, not production code).
+#
+# This test replaces that tautological verification with a proof against
+# production code: it builds a fixture graph in live Neo4j, calls the REAL
+# graph_store.traverse() on it, then calls _recompute_reachability() on the
+# result, and asserts that the reachable set returned by _recompute_reachability
+# MATCHES the set traverse() returned (i.e., the BFS does not drop or add
+# nodes vs the production traversal semantics).
+#
+# Fixture topology:
+#   Seed  --[USES]-->  NodeA        (forward edge, seed→A)
+#   NodeB --[OWNED_BY]--> Seed      (reverse edge, B→seed; B only reachable
+#                                    from Seed via undirected traversal)
+#
+# If traverse() uses undirected Cypher (confirmed: (seed)-[*]-(neighbour))
+# and _recompute_reachability uses undirected BFS (confirmed), then:
+# - traverse() returns {Seed, NodeA, NodeB}
+# - _recompute_reachability(traverse_result) retains both NodeA and NodeB
+# - The sets match → verdict PROVEN
+#
+# If there is a mismatch (traverse drops B but recompute keeps it, or vice
+# versa), this test reports a REAL gap and FAILS rather than hiding it.
+# ---------------------------------------------------------------------------
+
+_RUN_NEO4J = os.environ.get("OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS") == "1"
+
+_LIVE_NEO4J = pytest.mark.skipif(
+    not _RUN_NEO4J,
+    reason=(
+        "set OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 to run the real "
+        "traverse()+_recompute_reachability consistency proof (v13-AP4)"
+    ),
+)
+
+
+@_LIVE_NEO4J
+@pytest.mark.asyncio
+async def test_real_traverse_recompute_reachability_consistent() -> None:
+    """v13-AP4: real traverse() and _recompute_reachability return consistent sets.
+
+    Builds a fixture graph in live Neo4j, calls the REAL traverse(), then
+    applies _recompute_reachability to the result, and verifies the reachable
+    node set is identical.
+
+    Topology
+    --------
+    Seed  --[USES]-->  NodeA          (forward edge)
+    NodeB --[OWNED_BY]--> Seed        (reverse edge; NodeB only reachable
+                                       from Seed via undirected traversal)
+
+    Expected after traverse(max_depth=2):
+        related = {NodeA, NodeB}  (both reachable in undirected Neo4j BFS)
+
+    Expected after _recompute_reachability (undirected BFS, no exclusions):
+        related still = {NodeA, NodeB}  (no nodes dropped — sets must match)
+
+    If traverse() excluded NodeB (directed semantics) but _recompute_reachability
+    kept it (undirected), or vice versa, the verdict "undirected is consistent"
+    would be DISPROVEN and this test would fail with an explicit gap report.
+
+    Gate: OMNISCIENCE_RUN_NEO4J_CONTRACT_TESTS=1 + live Neo4j on bolt://localhost:7687
+    """
+    from omniscience_core.storage.graph import EntityUpsert
+    from omniscience_index.stores.neo4j.store import Neo4jGraphStore, Neo4jStoreConfig
+    from omniscience_retrieval.graph_rag import _recompute_reachability
+
+    neo4j_uri = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    neo4j_user = os.environ.get("NEO4J_USERNAME", "neo4j")
+    neo4j_pw = os.environ.get("NEO4J_PASSWORD", "neo4j")
+
+    config = Neo4jStoreConfig(
+        uri=neo4j_uri,
+        username=neo4j_user,
+        password=neo4j_pw,
+        database="neo4j",
+        max_connection_pool_size=3,
+        connection_acquisition_timeout_seconds=10.0,
+        max_transaction_retry_time_seconds=10.0,
+        default_max_depth=3,
+        bitemporal_enabled=False,
+    )
+    store = Neo4jGraphStore(config=config)
+    await store.connect()
+
+    ws_id = uuid.uuid4()
+    # Use workspace-scoped unique names to avoid cross-test interference.
+    ws_suffix = str(ws_id)[:8]
+    seed_name = f"ap4-seed-{ws_suffix}"
+    node_a_name = f"ap4-nodeA-{ws_suffix}"
+    node_b_name = f"ap4-nodeB-{ws_suffix}"
+
+    try:
+        # ----------------------------------------------------------------
+        # Insert fixture graph: Seed, NodeA, NodeB
+        # ----------------------------------------------------------------
+        seed_id = uuid.uuid4()
+        a_id = uuid.uuid4()
+        b_id = uuid.uuid4()
+        src_id = uuid.uuid4()
+
+        # bypass_source_checkpoint=True: skip the per-source version checkpoint
+        # so all three entities are written even though they share the same src_id.
+        # Without bypass, the second/third inserts would be skipped by the
+        # checkpoint check (existing_version >= version).
+        for eid, ename, ekind in [
+            (seed_id, seed_name, "service"),
+            (a_id, node_a_name, "repo"),
+            (b_id, node_b_name, "team"),
+        ]:
+            await store.upsert_entity(
+                entity=EntityUpsert(
+                    id=eid,
+                    source_id=src_id,
+                    entity_type=ekind,
+                    name=ename,
+                    display_name=ename,
+                    chunk_id=None,
+                    metadata={},
+                    version=None,  # no version → no checkpoint gate → always written
+                ),
+                workspace_id=ws_id,
+            )
+
+        # Forward edge: Seed → NodeA  (source_entity_id=seed_id, target=a_id)
+        # version=None: skip the per-source checkpoint check so edges are always written.
+        from omniscience_core.storage.graph import EdgeUpsert
+
+        await store.upsert_edge(
+            edge=EdgeUpsert(
+                source_entity_id=seed_id,
+                target_entity_id=a_id,
+                edge_type="USES",
+                metadata={},  # no source_id in metadata → no checkpoint gate
+                version=None,
+            ),
+            workspace_id=ws_id,
+        )
+        # Reverse edge: NodeB → Seed  (B only reachable from Seed undirectedly)
+        await store.upsert_edge(
+            edge=EdgeUpsert(
+                source_entity_id=b_id,
+                target_entity_id=seed_id,
+                edge_type="OWNED_BY",
+                metadata={},
+                version=None,
+            ),
+            workspace_id=ws_id,
+        )
+
+        # ----------------------------------------------------------------
+        # Call REAL graph_store.traverse() from Seed (max_depth=2).
+        # ----------------------------------------------------------------
+        traverse_result = await store.traverse(
+            entity_name=seed_name,
+            workspace_id=ws_id,
+            max_depth=2,
+        )
+
+        traverse_related_names = {n.name for n in traverse_result.related}
+
+        # ----------------------------------------------------------------
+        # Apply _recompute_reachability with NO exclusions (no nodes
+        # were dropped by the watermark filter).  With no exclusions the
+        # edge set is unchanged, so the BFS should return the same set
+        # that traverse() returned.
+        # ----------------------------------------------------------------
+        recomputed = _recompute_reachability(traverse_result)
+        recomputed_names = {n.name for n in recomputed.related}
+
+        # ----------------------------------------------------------------
+        # Assert: reachable sets match — verdict PROVEN (or DISPROVEN).
+        # If traverse() uses undirected Cypher and _recompute_reachability
+        # uses undirected BFS, the sets must be identical.
+        # A mismatch is a REAL gap, not a force-pass.
+        # ----------------------------------------------------------------
+        assert recomputed_names == traverse_related_names, (
+            f"v13-AP4 REAL MISMATCH: traverse() returned related nodes "
+            f"{traverse_related_names} but _recompute_reachability returned "
+            f"{recomputed_names}.  "
+            "Difference (traverse - recompute): "
+            f"{traverse_related_names - recomputed_names}.  "
+            "Difference (recompute - traverse): "
+            f"{recomputed_names - traverse_related_names}.  "
+            "This is a REAL gap: the BFS semantics of _recompute_reachability "
+            "are inconsistent with the production traverse() semantics."
+        )
+
+        # Additionally verify the expected topology: NodeA and NodeB both appear.
+        assert node_a_name in recomputed_names, (
+            f"v13-AP4: NodeA (forward-edge neighbour of Seed) missing from "
+            f"traverse result: {traverse_related_names}.  "
+            "Neo4j traverse() must follow forward edges."
+        )
+        assert node_b_name in recomputed_names, (
+            f"v13-AP4: NodeB (reverse-edge neighbour of Seed) missing from "
+            f"traverse result: {traverse_related_names}.  "
+            "Neo4j traverse() uses undirected Cypher (no arrowhead) — it MUST "
+            "follow the B→Seed edge from Seed's perspective to reach NodeB.  "
+            "If NodeB is absent, the Cypher became directed — a real regression."
+        )
+
+        # The undirected-recompute-is-consistent-with-traverse verdict is now PROVEN.
+
+    finally:
+        await store.close()

--- a/tests/integration/test_ap3_real_reconciler_live.py
+++ b/tests/integration/test_ap3_real_reconciler_live.py
@@ -1022,6 +1022,42 @@ async def test_live_ap3_v12_consumer_path_fail_closed() -> None:
             "The consumer-path wrote versioned evidence that was not dropped."
         )
 
+        # ------------------------------------------------------------------
+        # v13-AP3 POSITIVE assertion: healthy source src_a SURVIVES.
+        #
+        # Without this assertion the test is VACUOUS: src_b_hits_versioned==[]
+        # would also pass if the entire retrieval path returned [] for any
+        # reason (FakeLegacy returns [], Qdrant down, wrong workspace, etc.).
+        #
+        # Why src_a hits are expected:
+        # - OutboxConsumerWorker consumed the EntityUpsertEvent(version=5)
+        #   for src_a and called qdrant_store.upsert_chunks(..., version=5),
+        #   which writes a chunk (doc_version=1 in payload) AND a checkpoint
+        #   sentinel (version=5).
+        # - check_convergence: per_source_wm[src_a] = min(pg=5, neo4j=5,
+        #   qdrant_checkpoint=5) = 5.
+        # - hit.applied_version = doc_version = 1 <= 5 → passes filter.
+        # - The positive assertion proves the retrieval path is non-empty
+        #   and the fail-closed filter is selective (not a total blackout).
+        # ------------------------------------------------------------------
+        src_a_hits = [h for h in result.hits if h.source.id == src_a]
+        assert len(src_a_hits) >= 1, (
+            f"v13-AP3 positive assertion FAILED: healthy source {src_a_key[:8]} "
+            f"has NO hits in the result.  The consumer path did not produce a "
+            f"src_a hit, or the fail-closed filter incorrectly dropped it.  "
+            f"per_source_wm[src_a]={per_source_wm.get(src_a_key)}, "
+            f"total hits in result: {len(result.hits)}, "
+            f"all source ids seen: "
+            f"{[str(h.source.id)[:8] for h in result.hits]}.  "
+            "This indicates the test was vacuous (passing even when the "
+            "healthy source retrieval path returned nothing)."
+        )
+        assert any(h.applied_version is not None and h.applied_version >= 1 for h in src_a_hits), (
+            f"v13-AP3: src_a hits exist but none have applied_version >= 1 "
+            f"(OutboxConsumerWorker chunk should have doc_version=1+): "
+            f"{[(h.applied_version,) for h in src_a_hits]}"
+        )
+
         # All surviving versioned hits must respect their per-source watermark.
         for hit in result.hits:
             if hit.applied_version is None:

--- a/tests/test_graph_rag.py
+++ b/tests/test_graph_rag.py
@@ -31,11 +31,13 @@ from omniscience_core.storage.graph import (
     GraphResultView,
 )
 from omniscience_retrieval.graph_rag import (
+    _EPOCH_DROPS,
     ANCHOR_FILTER_KEY,
     CANDIDATE_EXPANSION_FACTOR,
     MAX_ANCHOR_CANDIDATES,
     GraphRAGComposer,
     _apply_graph_watermark_filter,
+    _apply_watermark_filter,
     _build_affinity_map,
     _collect_candidates,
     _extract_anchor,
@@ -1557,4 +1559,298 @@ def test_recompute_reachability_keeps_directly_connected_nodes() -> None:
     assert "AheadNode" not in remaining_names, "AheadNode (version=10 > wm=7) must be excluded"
     assert "RelatedViaAhead" not in remaining_names, (
         "RelatedViaAhead reachable only via excluded AheadNode must be dropped (v11-AP5)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# v13-AP1: reason-labeled _EPOCH_DROPS counter tests
+# ---------------------------------------------------------------------------
+
+
+class TestEpochDropsCounter:
+    """v13-AP1: _EPOCH_DROPS fires with correct (reason, filter) labels.
+
+    All assertions use DELTA semantics: capture counter value before the call,
+    assert the exact increment after.  This is CRITICAL because the default
+    Prometheus registry accumulates across all tests in the process.
+    Asserting absolute values would cause cross-test interference.
+    """
+
+    def test_epoch_drops_counter_in_map_lag(self) -> None:
+        """lag: hit with applied_version > watermark > 0 increments lag/hit counter."""
+        src_id = uuid.uuid4()
+        # applied_version=5, wm=3 → 5 > 3 → lag (wm>0 so not cold_zero)
+        hit_lag = SearchHit(
+            chunk_id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            score=0.8,
+            text="lag-hit",
+            source=SourceInfo(id=src_id, name="src", type="slack"),
+            citation=Citation(
+                uri="mem://x",
+                title=None,
+                indexed_at=datetime(2026, 6, 1, tzinfo=UTC),
+                doc_version=1,
+            ),
+            lineage=ChunkLineage(
+                ingestion_run_id=None,
+                embedding_model="stub",
+                embedding_provider="stub",
+                parser_version="1",
+                chunker_strategy="fixed",
+            ),
+            metadata={},
+            applied_version=5,
+        )
+        # Hit that should PASS (applied_version=0, wm=0 → 0 <= 0 → PASS, no counter)
+        hit_epoch0 = SearchHit(
+            chunk_id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            score=0.7,
+            text="epoch0-hit",
+            source=SourceInfo(id=src_id, name="src", type="slack"),
+            citation=Citation(
+                uri="mem://x",
+                title=None,
+                indexed_at=datetime(2026, 6, 1, tzinfo=UTC),
+                doc_version=1,
+            ),
+            lineage=ChunkLineage(
+                ingestion_run_id=None,
+                embedding_model="stub",
+                embedding_provider="stub",
+                parser_version="1",
+                chunker_strategy="fixed",
+            ),
+            metadata={},
+            applied_version=0,
+        )
+
+        before_lag = _EPOCH_DROPS.labels(reason="lag", filter="hit")._value.get()
+        before_cold = _EPOCH_DROPS.labels(reason="cold_zero", filter="hit")._value.get()
+
+        result = _apply_watermark_filter([hit_lag, hit_epoch0], {str(src_id): 3})
+
+        # hit_lag (av=5 > wm=3 > 0) must be dropped with reason=lag
+        dropped_versions = {h.applied_version for h in result}
+        assert 5 not in dropped_versions, "av=5 > wm=3 must be dropped"
+
+        # hit_epoch0 (av=0, wm=0 → 0 <= 0) must PASS — no counter
+        assert 0 in dropped_versions, "av=0, wm=0 must PASS (epoch-0 consistent read)"
+
+        # lag counter fires once for the dropped hit
+        assert _EPOCH_DROPS.labels(reason="lag", filter="hit")._value.get() == before_lag + 1, (
+            "v13-AP1: lag/hit counter must increment by 1 for av=5 > wm=3"
+        )
+        # cold_zero counter must NOT fire (wm=3 ≠ 0)
+        assert _EPOCH_DROPS.labels(reason="cold_zero", filter="hit")._value.get() == before_cold, (
+            "v13-AP1: cold_zero/hit counter must not fire when wm>0"
+        )
+
+    def test_epoch_drops_counter_in_map_cold_zero(self) -> None:
+        """cold_zero: hit with av=1, wm=0 increments cold_zero/hit counter.
+
+        BOUNDARY: av=0, wm=0 → 0 <= 0 → PASS with NO counter increment.
+        """
+        src_id = uuid.uuid4()
+
+        hit_cold = SearchHit(
+            chunk_id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            score=0.8,
+            text="cold-hit",
+            source=SourceInfo(id=src_id, name="src", type="slack"),
+            citation=Citation(
+                uri="mem://x",
+                title=None,
+                indexed_at=datetime(2026, 6, 1, tzinfo=UTC),
+                doc_version=1,
+            ),
+            lineage=ChunkLineage(
+                ingestion_run_id=None,
+                embedding_model="stub",
+                embedding_provider="stub",
+                parser_version="1",
+                chunker_strategy="fixed",
+            ),
+            metadata={},
+            applied_version=1,  # av=1, wm=0 → cold_zero drop
+        )
+        # BOUNDARY: av=0, wm=0 → PASS (0 <= 0); no counter
+        hit_epoch0 = SearchHit(
+            chunk_id=uuid.uuid4(),
+            document_id=uuid.uuid4(),
+            score=0.7,
+            text="epoch0",
+            source=SourceInfo(id=src_id, name="src", type="slack"),
+            citation=Citation(
+                uri="mem://x",
+                title=None,
+                indexed_at=datetime(2026, 6, 1, tzinfo=UTC),
+                doc_version=1,
+            ),
+            lineage=ChunkLineage(
+                ingestion_run_id=None,
+                embedding_model="stub",
+                embedding_provider="stub",
+                parser_version="1",
+                chunker_strategy="fixed",
+            ),
+            metadata={},
+            applied_version=0,  # av=0, wm=0 → PASS boundary
+        )
+
+        before_cold = _EPOCH_DROPS.labels(reason="cold_zero", filter="hit")._value.get()
+        before_lag = _EPOCH_DROPS.labels(reason="lag", filter="hit")._value.get()
+
+        result = _apply_watermark_filter([hit_cold, hit_epoch0], {str(src_id): 0})
+
+        # av=1 with wm=0 must be dropped (cold_zero)
+        dropped_versions = {h.applied_version for h in result}
+        assert 1 not in dropped_versions, "av=1 with wm=0 must be dropped (cold_zero)"
+
+        # av=0, wm=0 → 0 <= 0 → PASS (epoch-0 boundary)
+        assert 0 in dropped_versions, "av=0, wm=0 must PASS (epoch-0 consistent read)"
+
+        # cold_zero fires once for av=1 drop
+        assert (
+            _EPOCH_DROPS.labels(reason="cold_zero", filter="hit")._value.get() == before_cold + 1
+        ), "v13-AP1: cold_zero/hit must fire for av=1 with wm=0"
+        # lag must NOT fire (wm=0 classifies as cold_zero, not lag)
+        assert _EPOCH_DROPS.labels(reason="lag", filter="hit")._value.get() == before_lag, (
+            "v13-AP1: lag/hit must not fire for av=1 with wm=0 (classified as cold_zero)"
+        )
+
+
+def test_graph_node_drop_increments_epoch_drops_node() -> None:
+    """v13-AP1: _apply_graph_watermark_filter increments _EPOCH_DROPS(filter='node').
+
+    Verifies:
+    - related node with av > wm > 0 fires lag/node
+    - related node with av >= 1 and wm == 0 fires cold_zero/node
+    - seed-excluded path (version > wm) does NOT fire any node counter
+      (the caller's anchor-miss is the observable signal)
+    - unmapped source graph node PASSES without firing any counter
+    """
+    src_seed = str(uuid.uuid4())
+    src_lag = str(uuid.uuid4())
+    src_cold = str(uuid.uuid4())
+    src_unmapped = str(uuid.uuid4())
+
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="Seed",
+        kind="service",
+        source=src_seed,
+        chunk_text=None,
+        depth=0,
+        version=3,
+    )
+    node_lag = EntityNodeView(
+        id=uuid.uuid4(),
+        name="LagNode",
+        kind="repo",
+        source=src_lag,
+        chunk_text=None,
+        depth=1,
+        version=7,  # > wm=3 and wm > 0 → lag
+    )
+    node_cold = EntityNodeView(
+        id=uuid.uuid4(),
+        name="ColdNode",
+        kind="team",
+        source=src_cold,
+        chunk_text=None,
+        depth=1,
+        version=1,  # >= 1 and wm=0 → cold_zero
+    )
+    node_unmapped = EntityNodeView(
+        id=uuid.uuid4(),
+        name="UnmappedNode",
+        kind="service",
+        source=src_unmapped,
+        chunk_text=None,
+        depth=1,
+        version=999,  # very high, but src_unmapped not in map → PASS by design
+    )
+
+    graph_result = GraphResultView(
+        seed=seed,
+        related=[node_lag, node_cold, node_unmapped],
+        edges=[
+            GraphEdgeView(from_entity="Seed", to_entity="LagNode", edge_type="USES"),
+            GraphEdgeView(from_entity="Seed", to_entity="ColdNode", edge_type="USES"),
+            GraphEdgeView(from_entity="Seed", to_entity="UnmappedNode", edge_type="USES"),
+        ],
+    )
+
+    per_source_wm = {
+        src_seed: 10,  # seed within watermark
+        src_lag: 3,  # LagNode at v7 > wm=3 (and wm>0) → lag drop
+        src_cold: 0,  # ColdNode at v1 >= 1, wm=0 → cold_zero drop
+        # src_unmapped intentionally absent → graph node passes
+    }
+
+    before_lag_node = _EPOCH_DROPS.labels(reason="lag", filter="node")._value.get()
+    before_cold_node = _EPOCH_DROPS.labels(reason="cold_zero", filter="node")._value.get()
+    before_unmapped_node = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+
+    filtered, seed_excluded = _apply_graph_watermark_filter(graph_result, per_source_wm)
+
+    assert seed_excluded is False, "Seed (v3 <= wm=10) must not be excluded"
+
+    remaining = {n.name for n in filtered.related}
+    assert "LagNode" not in remaining, "LagNode (v7 > wm=3) must be excluded"
+    assert "ColdNode" not in remaining, "ColdNode (v1 >= 1, wm=0) must be excluded"
+    assert "UnmappedNode" in remaining, "UnmappedNode (unmapped source) must pass by design"
+
+    # lag/node fires once for LagNode
+    assert _EPOCH_DROPS.labels(reason="lag", filter="node")._value.get() == before_lag_node + 1, (
+        "v13-AP1: lag/node must fire for LagNode (v7 > wm=3, wm>0)"
+    )
+    # cold_zero/node fires once for ColdNode
+    assert (
+        _EPOCH_DROPS.labels(reason="cold_zero", filter="node")._value.get() == before_cold_node + 1
+    ), "v13-AP1: cold_zero/node must fire for ColdNode (v1 >= 1, wm=0)"
+    # unmapped/node must NOT fire (graph nodes from unmapped sources pass by design)
+    assert (
+        _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get() == before_unmapped_node
+    ), (
+        "v13-AP1: unmapped/node must NOT fire for graph nodes from unmapped sources "
+        "(they pass by design — only vector-hit filter enforces unmapped drops)"
+    )
+
+
+def test_graph_node_seed_excluded_does_not_fire_node_counter() -> None:
+    """v13-AP1: seed-excluded path (graph-ahead seed) must NOT increment filter=node counters.
+
+    When the seed itself is graph-ahead, _apply_graph_watermark_filter returns
+    (graph_result, True) immediately — it does NOT loop through related nodes
+    and does NOT call _EPOCH_DROPS.  The caller (_run_anchor_stage) records the
+    exclusion as an anchor-miss via the anchor outcome counter.
+    """
+    src = str(uuid.uuid4())
+    seed_ahead = EntityNodeView(
+        id=uuid.uuid4(),
+        name="AheadSeed",
+        kind="service",
+        source=src,
+        chunk_text=None,
+        depth=0,
+        version=10,  # > wm=7
+    )
+    graph_result = GraphResultView(seed=seed_ahead, related=[], edges=[])
+
+    before_lag = _EPOCH_DROPS.labels(reason="lag", filter="node")._value.get()
+    before_cold = _EPOCH_DROPS.labels(reason="cold_zero", filter="node")._value.get()
+
+    _result, seed_excluded = _apply_graph_watermark_filter(graph_result, {src: 7})
+    assert seed_excluded is True
+
+    # No node counters must fire for the seed-excluded early return
+    assert _EPOCH_DROPS.labels(reason="lag", filter="node")._value.get() == before_lag, (
+        "v13-AP1: seed-excluded path must not fire lag/node"
+    )
+    assert _EPOCH_DROPS.labels(reason="cold_zero", filter="node")._value.get() == before_cold, (
+        "v13-AP1: seed-excluded path must not fire cold_zero/node"
     )

--- a/tests/test_graph_rag.py
+++ b/tests/test_graph_rag.py
@@ -1854,3 +1854,393 @@ def test_graph_node_seed_excluded_does_not_fire_node_counter() -> None:
     assert _EPOCH_DROPS.labels(reason="cold_zero", filter="node")._value.get() == before_cold, (
         "v13-AP1: seed-excluded path must not fire cold_zero/node"
     )
+
+
+# ---------------------------------------------------------------------------
+# v14-D4: symmetric fail-closed for unmapped graph nodes (topology-epoch fix)
+# ---------------------------------------------------------------------------
+
+
+def test_unmapped_graph_node_excluded_under_strict_epoch() -> None:
+    """v14-D4: unmapped-source graph node is EXCLUDED under strict_epoch=True.
+
+    Scenario: Seed(src_a, in map) → FutureEnt(src_b, NOT in map, v999).
+    Under strict_epoch=True the unmapped node must be excluded and
+    _EPOCH_DROPS(reason="unmapped", filter="node") must increment once.
+    Under strict_epoch=False the node passes (legacy behaviour).
+    """
+    src_a = str(uuid.uuid4())
+    src_b = str(uuid.uuid4())  # unmapped — not in per_source_watermark
+
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="SeedA",
+        kind="service",
+        source=src_a,
+        chunk_text=None,
+        depth=0,
+        version=5,
+    )
+    future_node = EntityNodeView(
+        id=uuid.uuid4(),
+        name="FutureEnt",
+        kind="service",
+        source=src_b,
+        chunk_text=None,
+        depth=1,
+        version=999,  # far-future topology from unmapped src_b
+    )
+    graph_result_strict = GraphResultView(
+        seed=seed,
+        related=[future_node],
+        edges=[GraphEdgeView(from_entity="SeedA", to_entity="FutureEnt", edge_type="USES")],
+    )
+    graph_result_lax = GraphResultView(
+        seed=EntityNodeView(
+            id=seed.id,
+            name=seed.name,
+            kind=seed.kind,
+            source=seed.source,
+            chunk_text=seed.chunk_text,
+            depth=seed.depth,
+            version=seed.version,
+        ),
+        related=[
+            EntityNodeView(
+                id=future_node.id,
+                name=future_node.name,
+                kind=future_node.kind,
+                source=future_node.source,
+                chunk_text=future_node.chunk_text,
+                depth=future_node.depth,
+                version=future_node.version,
+            )
+        ],
+        edges=[GraphEdgeView(from_entity="SeedA", to_entity="FutureEnt", edge_type="USES")],
+    )
+
+    per_source_wm = {src_a: 10}  # src_b intentionally absent
+
+    # --- strict_epoch=True: unmapped node must be excluded ---
+    before_unmapped_node = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+
+    filtered_strict, seed_excluded = _apply_graph_watermark_filter(
+        graph_result_strict, per_source_wm, strict_epoch=True
+    )
+
+    assert seed_excluded is False, "SeedA (v5 <= wm=10) must not be excluded"
+    remaining_strict = {n.name for n in filtered_strict.related}
+    assert "FutureEnt" not in remaining_strict, (
+        "v14-D4: FutureEnt from unmapped src_b must be excluded under strict_epoch=True"
+    )
+
+    # Counter must increment exactly once for the unmapped node drop
+    after_unmapped_node = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+    assert after_unmapped_node == before_unmapped_node + 1, (
+        "v14-D4: _EPOCH_DROPS(reason='unmapped', filter='node') must fire once "
+        f"(before={before_unmapped_node}, after={after_unmapped_node})"
+    )
+
+    # --- strict_epoch=False: unmapped node must PASS (legacy) ---
+    before2 = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+
+    filtered_lax, seed_excl_lax = _apply_graph_watermark_filter(
+        graph_result_lax, per_source_wm, strict_epoch=False
+    )
+
+    assert seed_excl_lax is False
+    remaining_lax = {n.name for n in filtered_lax.related}
+    assert "FutureEnt" in remaining_lax, (
+        "v14-D4: strict_epoch=False must preserve legacy pass-through for unmapped nodes"
+    )
+    after2 = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+    assert after2 == before2, "v14-D4: strict_epoch=False must NOT increment unmapped/node counter"
+
+
+def test_unmapped_node_phantom_path_pruned_by_reachability() -> None:
+    """v14-D4: a node reachable ONLY via an excluded unmapped node is pruned.
+
+    Graph: Seed(src_a) → UnmappedGateway(src_b) → Phantom(src_c, in map).
+    Under strict_epoch=True:
+    - UnmappedGateway is excluded (src_b unmapped).
+    - Phantom is reachable only through UnmappedGateway → also excluded by
+      _recompute_reachability BFS.
+    """
+    src_a = str(uuid.uuid4())
+    src_b = str(uuid.uuid4())  # unmapped
+    src_c = str(uuid.uuid4())  # in map, within watermark
+
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="Seed",
+        kind="service",
+        source=src_a,
+        chunk_text=None,
+        depth=0,
+        version=3,
+    )
+    unmapped_gateway = EntityNodeView(
+        id=uuid.uuid4(),
+        name="UnmappedGateway",
+        kind="service",
+        source=src_b,
+        chunk_text=None,
+        depth=1,
+        version=500,
+    )
+    phantom = EntityNodeView(
+        id=uuid.uuid4(),
+        name="Phantom",
+        kind="service",
+        source=src_c,
+        chunk_text=None,
+        depth=2,
+        version=1,
+    )
+
+    graph_result = GraphResultView(
+        seed=seed,
+        related=[unmapped_gateway, phantom],
+        edges=[
+            GraphEdgeView(from_entity="Seed", to_entity="UnmappedGateway", edge_type="USES"),
+            GraphEdgeView(from_entity="UnmappedGateway", to_entity="Phantom", edge_type="CALLS"),
+        ],
+    )
+
+    per_source_wm = {src_a: 10, src_c: 5}  # src_b absent
+
+    filtered, seed_excluded = _apply_graph_watermark_filter(
+        graph_result, per_source_wm, strict_epoch=True
+    )
+
+    assert seed_excluded is False
+
+    remaining = {n.name for n in filtered.related}
+    assert "UnmappedGateway" not in remaining, (
+        "v14-D4: UnmappedGateway from unmapped src_b must be excluded"
+    )
+    assert "Phantom" not in remaining, (
+        "v14-D4: Phantom reachable only via UnmappedGateway must also be pruned "
+        "by reachability recompute (no phantom path from excluded unmapped node)"
+    )
+
+
+def test_legitimate_cross_source_link_not_regressed() -> None:
+    """v14-D4: a cross-source node whose source IS in the watermark map is NOT dropped.
+
+    Scenario: Seed(src_a) → HealthyNode(src_b, in map, within watermark).
+    Both sources are in the map → healthy link → HealthyNode survives.
+    This guards against regressions to legitimate cross_ref linking (e.g. AWS↔K8s).
+    """
+    src_a = str(uuid.uuid4())
+    src_b = str(uuid.uuid4())  # cross-source, but IN the map and within watermark
+
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="AWSEntity",
+        kind="service",
+        source=src_a,
+        chunk_text=None,
+        depth=0,
+        version=2,
+    )
+    healthy_cross = EntityNodeView(
+        id=uuid.uuid4(),
+        name="K8sEntity",
+        kind="deployment",
+        source=src_b,
+        chunk_text=None,
+        depth=1,
+        version=3,  # <= wm=5 → within watermark
+    )
+
+    graph_result = GraphResultView(
+        seed=seed,
+        related=[healthy_cross],
+        edges=[
+            GraphEdgeView(from_entity="AWSEntity", to_entity="K8sEntity", edge_type="cross_ref")
+        ],
+    )
+
+    per_source_wm = {src_a: 10, src_b: 5}  # BOTH sources in map
+
+    before_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+
+    filtered, seed_excluded = _apply_graph_watermark_filter(
+        graph_result, per_source_wm, strict_epoch=True
+    )
+
+    assert seed_excluded is False
+    remaining = {n.name for n in filtered.related}
+    assert "K8sEntity" in remaining, (
+        "v14-D4: K8sEntity (src_b in map, v3 <= wm=5) must NOT be excluded — "
+        "legitimate cross-source link must survive strict_epoch=True"
+    )
+
+    after_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+    assert after_unmapped == before_unmapped, (
+        "v14-D4: no unmapped/node drop must fire for a cross-source node whose source IS in map"
+    )
+
+
+def test_topology_leak_closed_affinity_not_boosted_under_strict_epoch() -> None:
+    """v14-D4 end-to-end topology-epoch leak test.
+
+    Setup:
+    - src_a is the seed source (in map, wm=10).
+    - src_b is an unmapped source with a future-epoch graph node (v999).
+    - A vector hit from src_b has applied_version=None (no epoch claim, passes hit filter).
+
+    Under strict_epoch=True (v14-D4 fix):
+    - The src_b graph node is excluded from the candidate set.
+    - src_b therefore has NO graph-affinity entry.
+    - The av=None hit from src_b receives affinity=0.0 (un-boosted baseline).
+    - merged_score = (1-MERGE_ALPHA)*vector_score + MERGE_ALPHA*0.0.
+
+    Under strict_epoch=False (old behaviour / legacy):
+    - The src_b graph node passes → src_b IS in candidate set → gets affinity bonus.
+    - merged_score = (1-MERGE_ALPHA)*vector_score + MERGE_ALPHA*GRAPH_AFFINITY_BASE.
+
+    This test verifies the score difference and that _EPOCH_DROPS fires correctly.
+    """
+    from omniscience_retrieval.graph_rag import (
+        GRAPH_AFFINITY_BASE,
+        MERGE_ALPHA,
+        _build_affinity_map,
+        _collect_candidates,
+        _linear_blend,
+    )
+
+    src_a = str(uuid.uuid4())
+    src_b = str(uuid.uuid4())  # unmapped — topology-epoch leak source
+
+    seed = EntityNodeView(
+        id=uuid.uuid4(),
+        name="SeedEnt",
+        kind="service",
+        source=src_a,
+        chunk_text=None,
+        depth=0,
+        version=2,
+    )
+    future_node = EntityNodeView(
+        id=uuid.uuid4(),
+        name="FutureSrcB",
+        kind="service",
+        source=src_b,
+        chunk_text=None,
+        depth=1,
+        version=999,
+    )
+
+    # Build two graph results — one for strict, one for lax
+    def _make_graph() -> GraphResultView:
+        return GraphResultView(
+            seed=EntityNodeView(
+                id=seed.id,
+                name=seed.name,
+                kind=seed.kind,
+                source=seed.source,
+                chunk_text=seed.chunk_text,
+                depth=seed.depth,
+                version=seed.version,
+            ),
+            related=[
+                EntityNodeView(
+                    id=future_node.id,
+                    name=future_node.name,
+                    kind=future_node.kind,
+                    source=future_node.source,
+                    chunk_text=future_node.chunk_text,
+                    depth=future_node.depth,
+                    version=future_node.version,
+                )
+            ],
+            edges=[GraphEdgeView(from_entity="SeedEnt", to_entity="FutureSrcB", edge_type="USES")],
+        )
+
+    per_source_wm = {src_a: 10}  # src_b intentionally absent
+    vector_score = 0.4
+
+    # --- strict_epoch=True: unmapped node excluded → no affinity bonus ---
+    before_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+
+    g_strict = _make_graph()
+    filtered_strict, _ = _apply_graph_watermark_filter(g_strict, per_source_wm, strict_epoch=True)
+
+    after_unmapped = _EPOCH_DROPS.labels(reason="unmapped", filter="node")._value.get()
+    assert after_unmapped == before_unmapped + 1, (
+        "v14-D4: unmapped/node counter must fire for future src_b node under strict_epoch=True"
+    )
+
+    # Collect candidates — src_b must NOT be in the candidate set
+    candidates_strict, depths_strict, centralities_strict, parked_strict = _collect_candidates(
+        filtered_strict
+    )
+    assert src_b not in candidates_strict, (
+        "v14-D4: src_b must NOT be a candidate after unmapped-node exclusion"
+    )
+
+    # Build affinity map — src_b absent → affinity=0.0
+    from omniscience_retrieval.graph_rag import _AnchorStageResult
+
+    anchor_strict = _AnchorStageResult(
+        anchor_requested=True,
+        anchor_name="SeedEnt",
+        anchor_hit=True,
+        candidate_source_ids=candidates_strict,
+        candidate_depths=depths_strict,
+        candidate_centralities=centralities_strict,
+        candidate_parked=parked_strict,
+        duration_s=0.0,
+    )
+    affinity_map_strict = _build_affinity_map(anchor_strict)
+    affinity_for_src_b_strict = affinity_map_strict.get(str(src_b), 0.0)
+    assert affinity_for_src_b_strict == 0.0, (
+        f"v14-D4: src_b affinity must be 0.0 (no topology bonus); got {affinity_for_src_b_strict}"
+    )
+
+    merged_strict = _linear_blend(vector_score=vector_score, graph_affinity=0.0)
+    expected_no_boost = (1.0 - MERGE_ALPHA) * vector_score
+    assert merged_strict == pytest.approx(expected_no_boost), (
+        f"v14-D4: un-boosted score should be {expected_no_boost:.4f}; got {merged_strict:.4f}"
+    )
+
+    # --- strict_epoch=False: unmapped node passes → affinity bonus applies ---
+    g_lax = _make_graph()
+    filtered_lax, _ = _apply_graph_watermark_filter(g_lax, per_source_wm, strict_epoch=False)
+
+    candidates_lax, depths_lax, centralities_lax, parked_lax = _collect_candidates(filtered_lax)
+    assert src_b in candidates_lax, (
+        "Legacy: src_b must be a candidate when strict_epoch=False (unmapped node passes)"
+    )
+
+    anchor_lax = _AnchorStageResult(
+        anchor_requested=True,
+        anchor_name="SeedEnt",
+        anchor_hit=True,
+        candidate_source_ids=candidates_lax,
+        candidate_depths=depths_lax,
+        candidate_centralities=centralities_lax,
+        candidate_parked=parked_lax,
+        duration_s=0.0,
+    )
+    affinity_map_lax = _build_affinity_map(anchor_lax)
+    affinity_for_src_b_lax = affinity_map_lax.get(str(src_b), 0.0)
+    expected_affinity = GRAPH_AFFINITY_BASE  # depth=1 → affinity=1.0
+    assert affinity_for_src_b_lax == pytest.approx(expected_affinity), (
+        f"Legacy: src_b affinity should be {expected_affinity} (depth=1); "
+        f"got {affinity_for_src_b_lax}"
+    )
+
+    merged_lax = _linear_blend(vector_score=vector_score, graph_affinity=affinity_for_src_b_lax)
+    expected_boosted = (1.0 - MERGE_ALPHA) * vector_score + MERGE_ALPHA * expected_affinity
+    assert merged_lax == pytest.approx(expected_boosted), (
+        f"Legacy: boosted score should be {expected_boosted:.4f} (0.4→{expected_boosted:.2f}); "
+        f"got {merged_lax:.4f}"
+    )
+
+    # Confirm strict path score < legacy boosted score (the leak is closed)
+    assert merged_strict < merged_lax, (
+        f"v14-D4: strict score ({merged_strict:.4f}) must be < legacy boosted ({merged_lax:.4f})"
+    )

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -22,6 +22,7 @@ from omniscience_core.queue.metrics import (
 )
 from omniscience_core.queue.producer import QueueProducer
 from omniscience_core.queue.streams import (
+    _STREAM_CONFIGS,
     INGEST_CHANGES_STREAM,
     INGEST_DLQ_STREAM,
     ensure_streams,
@@ -372,6 +373,73 @@ class TestEnsureStreams:
         for call in js.add_stream.call_args_list:
             cfg = call.kwargs["config"]
             assert cfg.storage == nats.js.api.StorageType.FILE
+
+    @pytest.mark.asyncio
+    async def test_update_stream_called_with_config_on_stream_exists(self) -> None:
+        """AP5 behavioral: when add_stream raises 10058 (stream exists), update_stream
+        is called with the same StreamConfig that was passed to add_stream.
+
+        This test closes the AP5 gap: the previous test mocked update_stream without
+        asserting it was called.  The 10058→update_stream branch was behaviorally
+        uncovered — this test proves the branch executes and passes the correct
+        config to update_stream.
+        """
+        from nats.js.errors import BadRequestError
+
+        js = _make_js_mock()
+        exc = BadRequestError()
+        exc.err_code = 10058
+        js.add_stream = AsyncMock(side_effect=exc)
+
+        await ensure_streams(js)
+
+        # update_stream must have been called once per stream config.
+        assert js.update_stream.await_count == len(_STREAM_CONFIGS), (
+            f"AP5: update_stream must be called once per stream when all streams "
+            f"already exist (10058).  Got {js.update_stream.await_count} calls, "
+            f"expected {len(_STREAM_CONFIGS)}."
+        )
+        # Each update_stream call must carry the expected StreamConfig.
+        updated_names = {call.kwargs["config"].name for call in js.update_stream.call_args_list}
+        expected_names = {cfg.name for cfg in _STREAM_CONFIGS}
+        assert updated_names == expected_names, (
+            f"AP5: update_stream called with stream names {updated_names}, "
+            f"expected {expected_names}.  The config passed to update_stream "
+            "must match the desired stream config (subjects, retention, etc.)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_stream_propagates_error_fail_loud(self) -> None:
+        """AP5 fail-loud: when update_stream raises (incompatible config), the error
+        propagates to the caller — it is NOT silently swallowed.
+
+        DELIBERATE DESIGN DECISION: fail-loud on incompatible stream-config update
+        is intentional.  A silent config mismatch (running with stale settings) is
+        worse than a loud startup failure that surfaces the conflict immediately.
+        See the comment in _ensure_stream for operator guidance.
+
+        This test documents and locks in that behavior: callers must expect that
+        ensure_streams can raise when an incompatible stream already exists, and
+        should not mask this exception.
+        """
+        from nats.js.errors import BadRequestError
+
+        js = _make_js_mock()
+
+        # First add_stream raises 10058 (stream exists).
+        exists_exc = BadRequestError()
+        exists_exc.err_code = 10058
+        js.add_stream = AsyncMock(side_effect=exists_exc)
+
+        # update_stream raises an incompatible-config error.
+        update_exc = RuntimeError("stream update failed: incompatible retention policy change")
+        js.update_stream = AsyncMock(side_effect=update_exc)
+
+        with pytest.raises(RuntimeError, match="incompatible retention policy change"):
+            await ensure_streams(js)
+
+        # Confirm update_stream was actually invoked (we reached the fail-loud path).
+        js.update_stream.assert_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -407,6 +407,17 @@ class TestEnsureStreams:
             f"expected {expected_names}.  The config passed to update_stream "
             "must match the desired stream config (subjects, retention, etc.)."
         )
+        # v13-AP5 adversarial-review hardening: assert the FULL config is passed,
+        # not just the name — a regression that stripped subjects (e.g. passing
+        # StreamConfig(name=...) only) would pass the name check above but silently
+        # lose the outbox.> subject widening.  Compare subjects per stream.
+        expected_subjects = {cfg.name: cfg.subjects for cfg in _STREAM_CONFIGS}
+        for call in js.update_stream.call_args_list:
+            actual_cfg = call.kwargs["config"]
+            assert actual_cfg.subjects == expected_subjects[actual_cfg.name], (
+                f"AP5: update_stream config for {actual_cfg.name} has subjects "
+                f"{actual_cfg.subjects}, expected {expected_subjects[actual_cfg.name]}."
+            )
 
     @pytest.mark.asyncio
     async def test_update_stream_propagates_error_fail_loud(self) -> None:


### PR DESCRIPTION
Consilium v13, run with the strengthened process the user asked for: **architect design → implement → independent adversarial review BEFORE merge** (the review found and we closed a gap the next round would have caught). Review: `docs/reviews/consilium-v13-review.md`.

- **v13-AP1 (P0)** — epoch-drop observability: replaced single-branch `_EPOCH_DROPPED_UNMAPPED` with `_EPOCH_DROPS{reason∈[unmapped,lag,cold_zero,empty_map_blackout], filter∈[hit,node]}`, incremented on EVERY drop in BOTH the hit filter and the graph-node filter (+ `empty_map_blackout` once per request). Blackouts are now observable (ADR-0017 §3).
- **v13-AP2 (P0)** — canonical no-reconciler signal: `search()` now passes `None` (not `{}`) when no reconciler is wired, so the None→pass bypass is LIVE; a reconciler-returned `{}` (cold workspace) stays fail-closed but is now counted. Closes the silent full-blackout latent in v12.
- **v13-D4 (found by pre-merge adversarial review)** — closed a topology-epoch leak: under `strict_epoch=True` the graph-node filter is now SYMMETRIC with the hit filter (unmapped-source nodes excluded + counted), so future/unmapped topology can no longer boost `applied_version=None` hits via graph affinity. Reachability recompute prunes resulting phantom paths.
- **v13-AP3 (P1)** — consumer-path live test made non-vacuous (positive `src_a survives` assert; runs end-to-end through outbox→NATS→consumer→store→reconciler→composer; confirmed not-skipped).
- **v13-AP4 (P2)** — replaced the tautological directed-BFS test with a REAL `traverse()`+`_recompute_reachability` consistency test on a live Neo4j fixture containing a reverse-edge-only node; verdict PROVEN (reachable sets match).
- **v13-AP5 (P2)** — `update_stream` 10058 branch now behaviorally covered (asserts called with full config incl. subjects); fail-loud-on-incompatible-update made an explicit, documented, tested decision.
- **v13-AP2-refuted earlier (v12)** and the v12 stream-subject bug remain fixed.

mypy 0, ruff clean, stale-arch exit 0; live behavioral assertions pass against real Neo4j/Qdrant/Postgres/NATS.