### PR TITLE
spec: Set sources.tenant_id from the token workspace on create (closes #355)

### DIFF
--- a/docs/specs/gh-issue-355-set-sources-tenant-id-from-the-token-workspace-on-create.md
+++ b/docs/specs/gh-issue-355-set-sources-tenant-id-from-the-token-workspace-on-create.md
@@ -1,0 +1,18 @@
+---
+title: "Set sources.tenant_id from the token workspace on create"
+status: ready
+source: { kind: github, ref: "355", url: "https://github.com/100rd/Omniscience/issues/355" }
+repo: "/Users/lord/Develop/multi-team-agentic/project/Omniscience"
+acceptanceCriteria:
+  - "POST /api/v1/sources sets tenant_id from the authenticated token workspace (never NULL)"
+  - "a regression test proves a created source is visible to a workspace-scoped sync"
+---
+
+## Problem
+`create_source` leaves `sources.tenant_id` NULL, so the source is invisible to workspace-scoped sync.
+
+## Scope
+TBD
+
+## Out of scope
+None specified.


### PR DESCRIPTION
Track-1 auto-produced spec for issue #355.

This spec was generated from the linked GitHub issue by the factory's Track-1 intake.
Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.

Closes #355