### PR TITLE
fix(api): derive source tenant from authenticated workspace

### DIFF
--- a/apps/server/src/omniscience_server/rest/sources.py
+++ b/apps/server/src/omniscience_server/rest/sources.py
@@ -222,12 +222,14 @@ async def list_sources(
 async def create_source(
     payload: SourceCreate,
     request: Request,
+    token: ApiToken = _write_scope_dep,
 ) -> SourceRead:
     """Create a new ingestion source.
 
     Body is validated as a SourceCreate (type, name, config, optional secrets_ref).
     Requires scope: ``sources:write``
     """
+    workspace_id = _require_workspace(token)
     factory = _get_db_factory(request)
 
     db: AsyncSession
@@ -239,7 +241,7 @@ async def create_source(
             secrets_ref=payload.secrets_ref,
             status=payload.status,
             freshness_sla_seconds=payload.freshness_sla_seconds,
-            tenant_id=payload.tenant_id,
+            tenant_id=workspace_id,
         )
         db.add(source)
         await db.flush()

--- a/tests/test_tenant_isolation_rest.py
+++ b/tests/test_tenant_isolation_rest.py
@@ -5,6 +5,7 @@ delete resources that belong to workspace B.
 
 Endpoints under test:
   GET    /api/v1/sources            — list_sources
+  POST   /api/v1/sources            — create_source
   GET    /api/v1/sources/{id}       — get_source
   PATCH  /api/v1/sources/{id}       — update_source
   DELETE /api/v1/sources/{id}       — delete_source
@@ -20,6 +21,7 @@ Security invariants tested:
   6. Token for workspace A gets 404 for a document whose parent source is in workspace B.
   7. Legacy token (workspace_id=None) is rejected fail-closed with 403 on
      all read and write source endpoints, and on the document endpoint.
+  8. Source creation derives tenant_id from the token and ignores caller claims.
 """
 
 from __future__ import annotations
@@ -182,6 +184,22 @@ def _make_data_session(
     return session
 
 
+def _make_create_session() -> AsyncMock:
+    """Return a data session that simulates database-generated source fields."""
+    session = _make_data_session()
+
+    async def _refresh(source: Source) -> None:
+        source.id = source.id or uuid.uuid4()
+        source.last_sync_at = None
+        source.last_error = None
+        source.last_error_at = None
+        source.created_at = datetime.now(tz=UTC)
+        source.updated_at = datetime.now(tz=UTC)
+
+    session.refresh = AsyncMock(side_effect=_refresh)
+    return session
+
+
 def _build_app(
     token: ApiToken,
     data_session: AsyncMock,
@@ -202,6 +220,50 @@ def _build_app(
 async def _get_client(app: FastAPI) -> AsyncClient:
     transport = ASGITransport(app=app)
     return AsyncClient(transport=transport, base_url="http://test")
+
+
+# ---------------------------------------------------------------------------
+# create_source — server-derived workspace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_source_uses_token_workspace_not_caller_tenant() -> None:
+    """POST /sources ignores a foreign tenant_id claimed by the request body."""
+    tok, pt = _make_token(workspace_id=_WS_A, scopes=["sources:write"])
+    data_session = _make_create_session()
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.post(
+            "/api/v1/sources",
+            json={"type": "git", "name": "owned-source", "tenant_id": str(_WS_B)},
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 201
+    created = data_session.add.call_args.args[0]
+    assert created.tenant_id == _WS_A
+    assert resp.json()["tenant_id"] == str(_WS_A)
+
+
+@pytest.mark.asyncio
+async def test_create_source_legacy_token_rejected_before_write() -> None:
+    """POST /sources rejects a token without workspace_id before persistence."""
+    tok, pt = _make_token(workspace_id=None, scopes=["sources:write"])
+    data_session = _make_create_session()
+    app = _build_app(tok, data_session)
+
+    async with await _get_client(app) as client:
+        resp = await client.post(
+            "/api/v1/sources",
+            json={"type": "git", "name": "unscoped-source"},
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "forbidden"
+    data_session.add.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Task contract

- task: `gh-issue-355`
- governing merge revision: `0922853ca6ee953b49441dbd59c30725c00da0ae`
- pinned task blob: `360c877c07f411fa70a2d427d6871212dac315ff`
- SDD mode: Full
- governing contracts: accepted ADR-0019, ready SPEC-IN and SPEC-ACL

## Change

- inject the authenticated write-scope token into `create_source`
- fail closed when the token has no workspace
- persist the server-derived token workspace even when the caller claims another `tenant_id`
- add API regressions for foreign tenant override and legacy unscoped tokens

## Probe evidence

- RED before implementation: 2 failed, 15 passed
- GREEN after implementation: 17 passed
- broader REST/tenant/schema suite: 102 passed
- ruff check/format: clean
- strict mypy for endpoint: clean

Local macOS coverage instrumentation hits a Numpy duplicate-load issue when it imports the app twice; repository CI runs the standard Linux coverage gate and is required by branch protection.

Closes #355