### PR TITLE
feat(mcp): consumer-severance conformance kit (issue #350 slice 2)

### DIFF
--- a/docs/integrations/omnius-sre-severance.md
+++ b/docs/integrations/omnius-sre-severance.md
@@ -1,0 +1,118 @@
+# Consumer severance: how Omnius and the SRE harness must react to `meta`
+
+> This page is for engineers implementing or reviewing severance/fallback
+> handling in a consumer of the Omniscience MCP v1 contract (Omnius, the
+> SRE harness, or any other agent that calls Omniscience tools). It
+> describes the decision procedure a conformant consumer must follow, not
+> how Omniscience computes `meta` internally.
+>
+> Producer-side conformance evidence (the fixture matrix every state below
+> is pinned against, and the read-only verifier that checks a receipt
+> against it) lives in
+> [`docs/runbooks/consumer-severance.md`](../runbooks/consumer-severance.md).
+
+Every successful Omniscience MCP tool response carries a `meta` block
+(see [`docs/api/mcp.md`](../api/mcp.md) for the full wire shape). Three of
+its fields drive every severance decision: `freshness.status`,
+`consistency.status`, and `fallback.{required,reason}`. `fallback.reason`
+is the authoritative signal — it is the OR of the freshness and consistency
+reasons, with a contract-pin mismatch always overriding both.
+
+## The decision procedure
+
+```
+1. Is the response even parseable and does it carry a valid `meta` block?
+   NO  -> planning_only. The response cannot gate anything (REQ-MCP-4).
+   YES -> continue.
+
+2. Is meta.fallback.required true?
+   NO  -> use. Continue with the response as one input among several.
+          (This is NOT authorization to skip step 4.)
+   YES -> continue.
+
+3. Is a direct, authoritative source (git, K8s, cloud API, incident
+   system) reachable right now?
+   YES -> direct_source_fallback. Query it instead of trusting this
+          response.
+   NO  -> park. Do not invent context from a stale/degraded/unverifiable
+          response just because the direct source is also down.
+
+4. Regardless of the outcome above — even `use` on perfectly fresh,
+   converged, contract-pinned evidence — does this decision merge code,
+   apply infrastructure, take an incident action, or make any other
+   terminal decision?
+   YES -> independent authority is required. Omniscience output, at any
+          fitness level, is never a sufficient correctness or
+          authorization oracle on its own (REQ-KP-3).
+```
+
+Step 4 is the part consumers most often get wrong: a `use` decision means
+the evidence *passed the fitness gate*, not that it *passed an
+authorization gate*. The two gates are orthogonal and both must be
+satisfied independently before any terminal action.
+
+## `fallback.reason` → decision table
+
+| `fallback.reason` | What it means | Decision (direct source up) | Decision (direct source also down) |
+|---|---|---|---|
+| `null` (`fallback.required = false`) | Fresh, converged, contract-pinned evidence | `use` | n/a |
+| `missing_lineage` | No source lineage extracted, or a used source is missing from the snapshot / synced after the evaluation boundary | `direct_source_fallback` | `park` |
+| `never_synced` | A used source has never completed a sync | `direct_source_fallback` | `park` |
+| `stale_source` | A used source's age exceeds its freshness SLA | `direct_source_fallback` | `park` |
+| `source_degraded` | A used source's status is `error` | `direct_source_fallback` | `park` |
+| `freshness_sla_unknown` | A used source has no configured freshness SLA | `direct_source_fallback` | `park` |
+| `consistency_unknown` | No lag or watermark evidence for a projection-reading tool | `direct_source_fallback` | `park` |
+| `projection_divergence` | Degraded subsystems reported, or non-zero projection lag | `direct_source_fallback` | `park` |
+| `contract_mismatch` | Caller-signalled contract mismatch, or the source commit is not pinnable (dev sentinel / unparsed) — always overrides any freshness/consistency state | `direct_source_fallback` | `park` |
+| *(any string not in this table)* | Schema/enum drift — a future Omniscience release added a reason your consumer doesn't recognize yet | `direct_source_fallback` (treat as `contract_mismatch`) | `park` |
+
+The last row matters as much as the first eight: **never** treat an
+unrecognized `fallback.reason` as safe-to-ignore. Fail closed, the same way
+you would for `contract_mismatch`.
+
+## REQ-MCP-4 payload-shape failures (before you even reach `meta`)
+
+These never produce a `meta.fallback` state — they mean the response
+itself is unusable:
+
+| Condition | Decision |
+|---|---|
+| Response body is not finite JSON (`response_invalid`) | `direct_source_fallback` — never accept a truncated/invalid success |
+| Response exceeds the fixed 80,000-byte budget (`response_too_large`) | `direct_source_fallback` |
+| `meta` is missing from an otherwise successful payload | `planning_only` — usable for planning, never for a gate/terminal decision |
+| `meta` is present but fails `meta.schema.json` validation | `planning_only` |
+
+## Contract-pin verification failures (canary-class)
+
+If your consumer runs its own release-pin verification against
+Omniscience's MCP v1 contract bundle (mirroring what
+`apps/server/src/omniscience_server/mcp/canary.py` does for Omniscience's
+own CI), *any* fail-closed code from that verification — a manifest hash
+mismatch, a tool-schema drift, a `contract_info` field mismatch, and so on
+— means the contract identity itself cannot be trusted. Treat it exactly
+like `contract_mismatch`: `direct_source_fallback` if a direct source is
+reachable, `park` if not. Do not attempt to interpret *which* pin field
+drifted as a reason to partially trust the response.
+
+## Verifying your own severance conformance
+
+Producer-side ground truth for every row above — plus an exhaustiveness
+gate that fails if `fallback.reason`'s enum ever grows — lives in
+[`tests/conformance/consumer_severance/`](../../tests/conformance/consumer_severance/)
+in this repository. If you can build a receipt that runs your consumer's
+actual decision logic against that matrix, the read-only verifier at
+`scripts/check_consumer_severance.py` will tell you GREEN or RED; see
+[`docs/runbooks/consumer-severance.md`](../runbooks/consumer-severance.md)
+for the receipt format and how to run it.
+
+## What this page does not cover
+
+Live conformance checks against a real Omnius or SRE-harness revision
+(AC-SEV-2), and a live severance drill proving already-materialized work
+survives Omniscience being removed (AC-SEV-3), are **blocked on external
+inputs not present in the Omniscience repository** — a real consumer git
+revision, a real receipt, owner approval, and a named safe drill
+environment. See
+[AC-SEV-2/3 blocked-on-external](../runbooks/consumer-severance.md#ac-sev-23-blocked-on-external)
+in the runbook for the full explanation and what has to arrive from
+outside this repository before those can move.

--- a/docs/runbooks/consumer-severance.md
+++ b/docs/runbooks/consumer-severance.md
@@ -1,0 +1,155 @@
+# Consumer-severance runbook
+
+> Status: fixture matrix + verifier shipped (AC-SEV-1, AC-SEV-5) — issue
+> [#350](https://github.com/100rd/Omniscience/issues/350),
+> [`gh-issue-350-consumer-severance`](../specs/gh-issue-350-consumer-severance.md).
+> AC-SEV-2 and AC-SEV-3 are **blocked on external inputs** — see
+> [AC-SEV-2/3 blocked-on-external](#ac-sev-23-blocked-on-external) below.
+
+This runbook documents how to run the producer-owned consumer-severance
+conformance kit: the fixture matrix that pins every MCP v1 evidence-fitness
+and contract-pin failure to a deterministic consumer decision
+(`scripts/check_consumer_severance.py`, `tests/conformance/consumer_severance/`),
+and the read-only verifier that checks a consumer's (Omnius, the SRE
+harness) severance receipt against it.
+
+## What this kit proves, and what it doesn't
+
+- **Proves (AC-SEV-1, in this repo, GREEN today):** for every value of the
+  closed `meta.fallback.reason` enum, every REQ-MCP-4 payload-shape
+  failure, and a representative set of `canary.py` contract-pin fail-closed
+  codes, there is exactly one correct consumer decision
+  (`use` / `direct_source_fallback` / `park` / `planning_only`), and the
+  matrix covers the enum 1:1 (an exhaustiveness gate re-reads
+  `meta.schema.json` at test time and fails if the enum drifts).
+- **Proves (AC-SEV-5, in this repo, GREEN today):** the verifier itself
+  never edits, creates, commits, or pushes anything — on the GREEN path or
+  any RED path — and it never accepts a live checkout of a consumer
+  repository, only a revision string and a receipt file.
+- **Does not prove:** that Omnius or the SRE harness actually implement this
+  decision rule (AC-SEV-2), or that a live severance drill succeeds
+  (AC-SEV-3). Those require real receipts from those repositories, which do
+  not exist in this workspace — see below.
+
+## Running the verifier against a real consumer revision
+
+```bash
+uv run python scripts/check_consumer_severance.py \
+  --consumer-revision <40-hex immutable git commit from Omnius or the SRE harness> \
+  --receipt <path to that consumer's severance-receipt.json>
+```
+
+Exit code `0` and `consumer-severance verification: GREEN` on stdout means
+the receipt fully and correctly covers the fixture matrix at the exact
+pinned revision. Any other outcome is exit code `1` and
+`consumer-severance verification: RED (decision-return)` on stderr, followed
+by one or more machine-readable reason codes (`revision_not_immutable:...`,
+`receipt_absent`, `receipt_partial:missing=[...]`,
+`decision_mismatch:<id>:expected=...:observed=...`, etc.).
+
+The verifier is **read-only by construction**: it takes no path into a
+consumer repository at all, only a revision string (data) and a receipt
+file (data). It never shells out to `git`, never opens a network
+connection, and never writes, creates, or deletes a file anywhere. This is
+proven in `tests/test_consumer_severance_verifier.py` by fingerprinting the
+verifier's own directory tree and the receipt's directory before and after
+every GREEN and every RED run and asserting byte-for-byte equality.
+
+## Severance receipt format
+
+A consumer produces this JSON object by running the fixture matrix (either
+by porting `tests/conformance/consumer_severance/fixtures.py`'s decision
+table into its own test suite, or by calling this producer's
+`fixture_matrix_sha256()` / `expected_decisions()` / `all_ids()` helpers
+directly if it can import this repo) and recording, per fixture id, the
+decision its own severance logic actually produced:
+
+```json
+{
+  "consumer_revision": "9c8b7a6d5e4f3c2b1a0f9e8d7c6b5a4938271605",
+  "fixture_matrix_sha256": "<sha256 of tests/conformance/consumer_severance/fixtures.py's canonical matrix>",
+  "command": "uv run pytest tests/severance/test_omniscience_fitness_matrix.py -q",
+  "results": [
+    {"id": "fresh-converged-use", "decision": "use"},
+    {"id": "missing-lineage-no-source-ids", "decision": "direct_source_fallback"}
+  ]
+}
+```
+
+| Field | Requirement |
+|---|---|
+| `consumer_revision` | Exact 40-hex git commit SHA. No `-dirty` suffix, no branch name, no working-tree state — an immutable, pinned revision only. Must match the `--consumer-revision` the verifier was invoked with. |
+| `fixture_matrix_sha256` | Must equal this producer's current `fixture_matrix_sha256()` (content-addressed — a stale or hand-edited receipt fails closed rather than passing silently). |
+| `command` | Non-empty string documenting exactly how the consumer ran the matrix — for audit trail, not machine-checked beyond presence. |
+| `results` | Must cover every id in `all_ids()` exactly once — no partial coverage, no unexpected extra ids — each with the consumer's observed `decision` string. |
+
+## What GREEN and RED mean
+
+- **GREEN** — the full fitness matrix passed at an exact, immutable,
+  pinned consumer revision. This is evidence the consumer's severance
+  behavior conforms *as of that commit*. It is not evidence that any later
+  commit still conforms — re-run against the new revision.
+- **RED is a decision return, not a crash.** The verifier never raises an
+  uncaught exception; every failure mode (absent receipt, dirty/mutable
+  revision, stale digest, partial coverage, a single wrong decision)
+  resolves to an explicit `RED` with a specific reason code. Treat RED the
+  same way you would treat a failed CI gate: it blocks trusting that
+  consumer's severance posture until fixed, but it is itself a successful,
+  informative run of the verifier — not a bug in the verifier.
+
+## Escalation
+
+A RED receipt from Omnius or the SRE harness is **not** something this
+Omniscience task (or any Omniscience agent) is authorized to fix directly —
+per the task's own out-of-scope list, writing, committing, or pushing
+changes in Omnius or the SRE repository is explicitly excluded. A RED
+receipt should become a human-ready task spec filed in the *consumer's own
+repository*, scoped to fixing that consumer's severance-decision logic
+against this producer's fixture matrix, cross-referencing this runbook and
+the exact RED reason codes from the verifier's stderr output.
+
+## AC-SEV-2/3: blocked-on-external
+
+Per `docs/specs/gh-issue-350-consumer-severance.md`:
+
+> A missing consumer revision, direct-source profile, owner approval, or
+> safe drill target produces a decision return and RED receipt. It does not
+> authorize this agent to edit another repository.
+
+This repository (Omniscience) has **no** Omnius or SRE-harness checkout, no
+consumer git revision, and no consumer-produced receipt anywhere in its
+tree. Concretely:
+
+- **AC-SEV-2** ("Omnius and the SRE harness are checked from exact
+  immutable consumer revisions... absent, dirty, mutable, or partial
+  evidence is RED") cannot be exercised against real consumers from this
+  workspace — there is nothing to point `--consumer-revision` /
+  `--receipt` at. The verifier that *would* run this check is built and
+  proven read-only (AC-SEV-5); running it against Omnius/SRE is a
+  cross-repo, human-scheduled action.
+- **AC-SEV-3** ("Removing Omniscience does not stop already materialized
+  work... live Omnius and SRE harness drill traces") requires a named safe
+  environment with an already-materialized task or incident and verified
+  direct-source access. No such environment exists in this repo, and
+  `PLATFORM.md` explicitly forbids an Omniscience-scoped agent from editing
+  `genai-enablement` or `omnius`.
+
+Both are therefore **decision-return / RED**, not GREEN, not a test
+failure — the correct outcome given the evidence available. Do not
+interpret a fixture-only conformance pass (this runbook's "Running the
+verifier" section) as satisfying AC-SEV-2 or AC-SEV-3; it satisfies only
+AC-SEV-1 and AC-SEV-5. Owner approval, a real consumer revision + receipt,
+or a safe live-drill target must arrive from outside this repository before
+either can move.
+
+## Reference
+
+- Fixture matrix and decision model:
+  [`tests/conformance/consumer_severance/`](../../tests/conformance/consumer_severance/)
+- Conformance tests: [`tests/test_consumer_severance_matrix.py`](../../tests/test_consumer_severance_matrix.py),
+  [`tests/test_consumer_severance_verifier.py`](../../tests/test_consumer_severance_verifier.py)
+- Verifier: [`scripts/check_consumer_severance.py`](../../scripts/check_consumer_severance.py)
+- Consumer-facing decision procedure: [`docs/integrations/omnius-sre-severance.md`](../integrations/omnius-sre-severance.md)
+- Ground-truth schemas (read-only, never imported as Python by this kit):
+  `apps/server/src/omniscience_server/mcp/contracts/v1/schemas/meta.schema.json`,
+  `response.schema.json`

--- a/scripts/check_consumer_severance.py
+++ b/scripts/check_consumer_severance.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Read-only producer-side verifier for MCP v1 consumer-severance receipts.
+
+AC-SEV-5: "verification accepts only explicit revision and receipt inputs
+and cannot edit, commit, push, or broaden scope in Omnius or SRE." This
+script never opens, clones, or writes to a consumer repository — it takes
+two pieces of data only: an exact 40-hex consumer git revision string, and
+a path to a JSON "severance receipt" file the consumer produced elsewhere.
+It never writes, creates, or deletes any file, and never shells out to git,
+network, or any subprocess. Every code path that lacks a usable input
+returns a RED decision-return (see `VerificationResult`) — it never raises
+an uncaught exception and never fabricates a GREEN.
+
+Severance receipt format (JSON object)
+---------------------------------------
+    {
+      "consumer_revision":    "<40-hex immutable git commit>",
+      "fixture_matrix_sha256": "<64-hex sha256 of the producer fixture matrix>",
+      "command":               "<exact command the consumer ran>",
+      "results": [
+        {"id": "<fixture id>", "decision": "<consumer's observed decision>"},
+        ...
+      ]
+    }
+
+A receipt is GREEN only if:
+  1. `consumer_revision` is a 40-hex string (no "-dirty"/uncommitted marker)
+     and matches the `--consumer-revision` the caller supplied — immutable,
+     pinned evidence, not a mutable working tree.
+  2. `fixture_matrix_sha256` matches this producer's current fixture matrix
+     digest (`tests/conformance/consumer_severance/fixtures.py`) —
+     content-addressed, so a stale/tampered receipt cannot pass silently.
+  3. `results` covers every fixture id in the matrix exactly (no partial
+     coverage, no unexpected extra ids).
+  4. Every result's `decision` matches this producer's expected decision
+     for that fixture id.
+
+Absent, dirty, mutable, or partial evidence is RED — a decision return, per
+docs/specs/gh-issue-350-consumer-severance.md ("A missing consumer
+revision, direct-source profile, owner approval, or safe drill target
+produces a decision return and RED receipt. It does not authorize this
+agent to edit another repository.").
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tests.conformance.consumer_severance.fixtures import (  # noqa: E402
+    all_ids,
+    expected_decisions,
+    fixture_matrix_sha256,
+)
+
+_REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# A well-formed receipt (fixture-matrix results plus a handful of scalar
+# fields) is a few KB. 1,000,000 bytes is generous headroom over any real
+# receipt while still bounding a truncated/corrupted or adversarial read —
+# mirrors the MCP contract's own fixed 80,000-byte response budget
+# (server.py:158) in spirit, scaled up since a receipt legitimately embeds
+# the full fixture matrix.
+_MAX_RECEIPT_BYTES = 1_000_000
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """A decision return — never an exception, always GREEN or RED."""
+
+    status: str  # "GREEN" | "RED"
+    reasons: tuple[str, ...] = ()
+
+    @property
+    def is_green(self) -> bool:
+        return self.status == "GREEN"
+
+
+def _load_receipt(receipt_path: Path) -> tuple[dict[str, object] | None, str | None]:
+    try:
+        size = receipt_path.stat().st_size
+    except OSError as exc:
+        return None, f"receipt_unreadable:{exc}"
+    if size > _MAX_RECEIPT_BYTES:
+        return None, f"receipt_too_large:{size}>{_MAX_RECEIPT_BYTES}"
+    try:
+        raw_bytes = receipt_path.read_bytes()
+    except OSError as exc:
+        return None, f"receipt_unreadable:{exc}"
+    try:
+        raw = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return None, f"receipt_not_utf8:{exc}"
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"receipt_malformed:{exc}"
+    if not isinstance(parsed, dict):
+        return None, "receipt_malformed:not_an_object"
+    return parsed, None
+
+
+def verify(*, consumer_revision: str | None, receipt_path: Path | None) -> VerificationResult:
+    """Pure, read-only check. Never touches the filesystem except one read."""
+    if not consumer_revision or not _REVISION_RE.fullmatch(consumer_revision):
+        return VerificationResult("RED", (f"revision_not_immutable:{consumer_revision!r}",))
+
+    if receipt_path is None:
+        return VerificationResult("RED", ("receipt_absent",))
+    if not receipt_path.is_file():
+        return VerificationResult("RED", (f"receipt_absent:{receipt_path}",))
+
+    receipt, load_error = _load_receipt(receipt_path)
+    if receipt is None:
+        return VerificationResult("RED", (load_error or "receipt_malformed:unknown",))
+
+    receipt_revision = receipt.get("consumer_revision")
+    if receipt_revision != consumer_revision:
+        return VerificationResult(
+            "RED",
+            (f"revision_mismatch:expected={consumer_revision}:receipt={receipt_revision!r}",),
+        )
+    if not isinstance(receipt_revision, str) or not _REVISION_RE.fullmatch(receipt_revision):
+        return VerificationResult("RED", (f"revision_not_immutable:receipt={receipt_revision!r}",))
+
+    command = receipt.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return VerificationResult("RED", ("receipt_command_missing",))
+
+    expected_digest = fixture_matrix_sha256()
+    receipt_digest = receipt.get("fixture_matrix_sha256")
+    if receipt_digest != expected_digest:
+        return VerificationResult(
+            "RED",
+            (f"fixture_digest_mismatch:expected={expected_digest}:receipt={receipt_digest!r}",),
+        )
+
+    results = receipt.get("results")
+    if not isinstance(results, list):
+        return VerificationResult("RED", ("receipt_malformed:results_not_list",))
+
+    observed: dict[str, object] = {}
+    for row in results:
+        if not isinstance(row, dict) or "id" not in row or "decision" not in row:
+            return VerificationResult("RED", ("receipt_malformed:result_row_shape",))
+        row_id = row["id"]
+        if not isinstance(row_id, str) or not row_id:
+            return VerificationResult("RED", ("receipt_malformed:result_row_shape",))
+        observed[row_id] = row["decision"]
+
+    expected_ids = all_ids()
+    observed_ids = set(observed)
+    missing = expected_ids - observed_ids
+    unexpected = observed_ids - expected_ids
+    if missing or unexpected:
+        reasons: list[str] = []
+        if missing:
+            reasons.append(f"receipt_partial:missing={sorted(missing)}")
+        if unexpected:
+            reasons.append(f"receipt_partial:unexpected={sorted(unexpected)}")
+        return VerificationResult("RED", tuple(reasons))
+
+    expected = expected_decisions()
+    mismatches = tuple(
+        f"decision_mismatch:{fixture_id}:expected={expected[fixture_id]}:"
+        f"observed={observed[fixture_id]!r}"
+        for fixture_id in sorted(expected_ids)
+        if observed[fixture_id] != expected[fixture_id]
+    )
+    if mismatches:
+        return VerificationResult("RED", mismatches)
+
+    return VerificationResult("GREEN")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--consumer-revision",
+        default=None,
+        help="Exact 40-hex immutable consumer git revision the receipt must pin against.",
+    )
+    parser.add_argument(
+        "--receipt",
+        type=Path,
+        default=None,
+        help="Path to the consumer's content-addressed severance receipt (JSON).",
+    )
+    args = parser.parse_args(argv)
+
+    result = verify(consumer_revision=args.consumer_revision, receipt_path=args.receipt)
+    if result.is_green:
+        print("consumer-severance verification: GREEN")
+        return 0
+
+    print("consumer-severance verification: RED (decision-return)", file=sys.stderr)
+    for reason in result.reasons:
+        print(f"- {reason}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conformance/consumer_severance/fixtures.py
+++ b/tests/conformance/consumer_severance/fixtures.py
@@ -1,0 +1,467 @@
+"""Producer-owned MCP v1 consumer-severance fixture matrix (AC-SEV-1).
+
+This module is the single source of truth for the fixture matrix consumed
+by both the pytest suite (`tests/test_consumer_severance_matrix.py`) and
+the read-only verifier (`scripts/check_consumer_severance.py`). It never
+imports `omniscience_server.mcp.metadata` / `.canary` — those, plus the
+JSON schemas under `apps/server/src/omniscience_server/mcp/contracts/v1/
+schemas/`, are the oracle this kit conforms to. Ground truth was extracted
+by hand-reading that code and is re-derived from the schema at test time
+(see the exhaustiveness gate in `tests/test_consumer_severance_matrix.py`),
+never by calling it.
+
+Three fixture categories, matching the three failure classes a consumer
+must switch on:
+
+1. ``REASON_FIXTURES`` — every value of the closed `meta.fallback.reason`
+   enum (schema: `meta.schema.json#/properties/fallback/properties/reason`
+   — 8 non-null reasons + null), each paired with the `freshness`/
+   `consistency` substate that produces it (`metadata.py::_freshness` /
+   `::_consistency` / `build_response_meta`'s contract-override clause).
+2. ``PAYLOAD_SHAPE_FIXTURES`` — REQ-MCP-4 transport-level failures that
+   never reach a `meta.fallback` state at all (oversized/non-finite
+   response, missing/invalid `meta`).
+3. ``CONTRACT_PIN_FIXTURES`` — the full, exhaustiveness-gated set of
+   `canary.py` fail-closed codes (contract-pin mismatch / drift), modelled
+   as "any of these means the contract identity is unverifiable" rather
+   than re-testing `canary.py` itself (that belongs to
+   `tests/test_mcp_canary.py`, out of this kit's scope). Completeness is
+   enforced by a source-derived gate (see
+   `test_contract_pin_fixtures_cover_every_canary_fail_closed_code` in
+   `tests/test_consumer_severance_matrix.py`), mirroring the reason-enum
+   gate below.
+
+Decision vocabulary is defined in `reference_consumer.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+_CONTRACT_COMMIT = "a" * 40
+_CONTRACT_SCHEMA_SHA256 = "b" * 64
+_WORKSPACE_ID = "11111111-2222-4333-8444-555555555555"
+_TIMESTAMP = "2026-07-18T00:00:00Z"
+
+
+@dataclass(frozen=True)
+class ReasonFixture:
+    """One `meta.fallback.reason` state plus its expected consumer decision."""
+
+    id: str
+    freshness_status: str
+    freshness_reason: str | None
+    consistency_status: str
+    consistency_reason: str | None
+    fallback_reason: str | None
+    expected_decision: str
+    direct_source_available: bool = True
+    note: str = ""
+
+    def meta(self) -> dict[str, Any]:
+        freshness: dict[str, Any] = {
+            "status": self.freshness_status,
+            "evaluated_at": _TIMESTAMP,
+            "oldest_source_age_seconds": None if self.freshness_status == "unknown" else 42,
+            "stale_source_ids": (
+                ["22222222-3333-4444-8888-666666666666"]
+                if self.freshness_status == "stale"
+                else []
+            ),
+        }
+        if self.freshness_reason is not None:
+            freshness["reason"] = self.freshness_reason
+        consistency: dict[str, Any] = {
+            "status": self.consistency_status,
+            "degraded_subsystems": (
+                ["neo4j-projection"] if self.consistency_status == "degraded" else []
+            ),
+            "projection_lag_versions": 3 if self.consistency_status == "degraded" else 0,
+        }
+        return {
+            "contract": {
+                "version": "1.0.0",
+                "commit": _CONTRACT_COMMIT,
+                "schema_sha256": _CONTRACT_SCHEMA_SHA256,
+            },
+            "workspace_id": _WORKSPACE_ID,
+            "generated_at": _TIMESTAMP,
+            "effective_as_of": _TIMESTAMP,
+            "freshness": freshness,
+            "consistency": consistency,
+            "fallback": {
+                "required": self.fallback_reason is not None,
+                "reason": self.fallback_reason,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class PayloadShapeFixture:
+    """A REQ-MCP-4 transport-level failure — no `meta.fallback` state exists."""
+
+    id: str
+    condition: str
+    error_code: str | None
+    expected_decision: str
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class ContractPinFixture:
+    """One `canary.py` fail-closed code (§2 of the taxonomy) and its decision."""
+
+    id: str
+    canary_code: str
+    expected_decision: str
+    note: str = ""
+
+
+# ---------------------------------------------------------------------------
+# 1. meta.fallback.reason closed enum — 8 non-null + null (9 rows; two rows
+#    share the "missing_lineage" reason string because metadata.py collapses
+#    two distinct triggers onto it — see metadata.py:136,152-155,174-176).
+# ---------------------------------------------------------------------------
+
+REASON_FIXTURES: tuple[ReasonFixture, ...] = (
+    ReasonFixture(
+        id="fresh-converged-use",
+        freshness_status="fresh",
+        freshness_reason=None,
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason=None,
+        expected_decision="use",
+        note="metadata.py:177-179 — no reason, fallback.required=False.",
+    ),
+    ReasonFixture(
+        id="missing-lineage-no-source-ids",
+        freshness_status="unknown",
+        freshness_reason="missing_lineage",
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="missing_lineage",
+        expected_decision="direct_source_fallback",
+        note="metadata.py:127-134 — no lineage extracted at all.",
+    ),
+    ReasonFixture(
+        id="missing-lineage-snapshot-absent-or-post-boundary",
+        freshness_status="unknown",
+        freshness_reason="missing_lineage",
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="missing_lineage",
+        expected_decision="direct_source_fallback",
+        note=(
+            "metadata.py:136,152-155,174-176 — used source id missing from "
+            "snapshots, or its last_sync_at is after the evaluation boundary. "
+            "Same reason string, distinct trigger from the row above."
+        ),
+    ),
+    ReasonFixture(
+        id="source-degraded",
+        freshness_status="degraded",
+        freshness_reason="source_degraded",
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="source_degraded",
+        expected_decision="direct_source_fallback",
+        note="metadata.py:147-148,165-167 — a used source's status == 'error'.",
+    ),
+    ReasonFixture(
+        id="stale-source",
+        freshness_status="stale",
+        freshness_reason="stale_source",
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="stale_source",
+        expected_decision="direct_source_fallback",
+        note="metadata.py:158-161,168-170 — age exceeds freshness_sla_seconds.",
+    ),
+    ReasonFixture(
+        id="never-synced",
+        freshness_status="unknown",
+        freshness_reason="never_synced",
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="never_synced",
+        expected_decision="direct_source_fallback",
+        note="metadata.py:149-151,171-173 — last_sync_at is None.",
+    ),
+    ReasonFixture(
+        id="freshness-sla-unknown",
+        freshness_status="unknown",
+        freshness_reason="freshness_sla_unknown",
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="freshness_sla_unknown",
+        expected_decision="direct_source_fallback",
+        note="metadata.py:158-159,174-176 — freshness_sla_seconds is None.",
+    ),
+    ReasonFixture(
+        id="projection-divergence",
+        freshness_status="fresh",
+        freshness_reason=None,
+        consistency_status="degraded",
+        consistency_reason="projection_divergence",
+        fallback_reason="projection_divergence",
+        expected_decision="direct_source_fallback",
+        note="metadata.py:203-221 — degraded_subsystems non-empty or lag > 0.",
+    ),
+    ReasonFixture(
+        id="consistency-unknown",
+        freshness_status="fresh",
+        freshness_reason=None,
+        consistency_status="unknown",
+        consistency_reason="consistency_unknown",
+        fallback_reason="consistency_unknown",
+        expected_decision="direct_source_fallback",
+        note="metadata.py:228-232 — no lag/watermark evidence, projection-reading tool.",
+    ),
+    ReasonFixture(
+        id="contract-mismatch-overrides-clean-evidence",
+        freshness_status="fresh",
+        freshness_reason=None,
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="contract_mismatch",
+        expected_decision="direct_source_fallback",
+        note=(
+            "metadata.py:258-259 — contract_match=False or unpinnable commit "
+            "always overrides an otherwise-clean freshness/consistency read."
+        ),
+    ),
+    ReasonFixture(
+        id="fallback-required-direct-source-also-unavailable-parks",
+        freshness_status="degraded",
+        freshness_reason="source_degraded",
+        consistency_status="converged",
+        consistency_reason=None,
+        fallback_reason="source_degraded",
+        expected_decision="park",
+        direct_source_available=False,
+        note="REQ-MCP-11 / REQ-KP-5 fallback clause — never invent context.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# 2. REQ-MCP-4 payload-shape failures (server.py:156,158; response.schema.json:8)
+# ---------------------------------------------------------------------------
+
+PAYLOAD_SHAPE_FIXTURES: tuple[PayloadShapeFixture, ...] = (
+    PayloadShapeFixture(
+        id="response-invalid-not-finite-json",
+        condition="response_invalid",
+        error_code="response_invalid:MCP tool response is not finite JSON",
+        expected_decision="direct_source_fallback",
+        note="server.py:156 — never accept a truncated/invalid success.",
+    ),
+    PayloadShapeFixture(
+        id="response-too-large",
+        condition="response_too_large",
+        error_code="response_too_large:MCP tool response exceeds the fixed byte budget",
+        expected_decision="direct_source_fallback",
+        note="server.py:158 — fixed 80,000-byte UTF-8 budget exceeded.",
+    ),
+    PayloadShapeFixture(
+        id="missing-meta-block",
+        condition="missing_meta",
+        error_code=None,
+        expected_decision="planning_only",
+        note="response.schema.json:8 required:[meta] — planning-only, ties to REQ-KP-4.",
+    ),
+    PayloadShapeFixture(
+        id="invalid-meta-block",
+        condition="invalid_meta",
+        error_code=None,
+        expected_decision="planning_only",
+        note="meta present but fails meta.schema.json validation — planning-only.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# 3. canary.py contract-pin fail-closed codes (taxonomy §2) — the full set
+#    spanning load_release_pin, verify_runtime_observation, and
+#    transport/input validation. Every code means the contract identity
+#    cannot be trusted, regardless of which stage raised it.
+#    `decide_on_contract_pin_failure` is uniform (any non-empty code ->
+#    direct_source_fallback), so these are data rows, not new branches to
+#    test. Completeness against `canary.py`'s actual `_fail(...)` call
+#    sites is enforced by
+#    `test_contract_pin_fixtures_cover_every_canary_fail_closed_code`
+#    (tests/test_consumer_severance_matrix.py).
+# ---------------------------------------------------------------------------
+
+# Every code raised via a literal `_fail("<code>")` call site in canary.py
+# (`load_release_pin` static verification, `verify_runtime_observation`
+# runtime checks, and endpoint/token/workspace/transport validation).
+# Two of these (`manifest_invalid`, `schema_json_invalid`) are raised only
+# via `_fail(code)` with `code` bound through a `code=` keyword argument to
+# `_safe_read`/`_strict_object`, so a literal-only source scan of canary.py
+# cannot see them — included here for genuine completeness even though the
+# gate (a superset check) does not require it.
+_STATIC_CONTRACT_PIN_CODES: tuple[str, ...] = (
+    "json_value_invalid",
+    "schema_path_invalid",
+    "bundle_artifact_invalid",
+    "bundle_file_set_invalid",
+    "bundle_directory_invalid",
+    "bundle_address_invalid",
+    "manifest_invalid",
+    "manifest_address_mismatch",
+    "manifest_not_canonical",
+    "manifest_shape_invalid",
+    "manifest_contract_invalid",
+    "tool_registry_record_invalid",
+    "tool_registry_sha256_mismatch",
+    "tool_registry_shape_invalid",
+    "tool_registry_invalid",
+    "schema_index_invalid",
+    "schema_record_invalid",
+    "schema_json_invalid",
+    "schema_sha256_mismatch",
+    "schema_index_not_sorted",
+    "schema_set_sha256_mismatch",
+    "tool_registry_schema_binding_invalid",
+    "contract_info_timestamp_invalid",
+    "contract_info_meta_shape_mismatch",
+    "contract_info_meta_contract_mismatch",
+    "contract_info_workspace_mismatch",
+    "contract_info_timestamp_mismatch",
+    "contract_info_freshness_mismatch",
+    "contract_info_consistency_mismatch",
+    "contract_info_fallback_required",
+    "contract_info_fallback_mismatch",
+    "contract_info_call_failed",
+    "contract_info_structured_content_missing",
+    "contract_info_content_mismatch",
+    "runtime_tools_capability_missing",
+    "runtime_tool_surface_mismatch",
+    "runtime_input_schema_mismatch",
+    "contract_info_shape_mismatch",
+    "contract_info_manifest_mismatch",
+    "endpoint_invalid",
+    "token_invalid",
+    "runtime_tool_surface_unbounded",
+    "runtime_tool_pagination_invalid",
+    "runtime_tool_pagination_unbounded",
+    "transport_failed",
+    "workspace_id_invalid",
+)
+
+# canary.py:531-543 interpolates `f"contract_info_{field}_mismatch"` for
+# each key of the `expected_values` dict in `verify_runtime_observation` —
+# not a string literal, so a source scan for `_fail("...")` can't see
+# these 8 codes. Field names hardcoded here as ground truth.
+_CONTRACT_INFO_FIELD_MISMATCH_FIELDS: tuple[str, ...] = (
+    "version",
+    "commit",
+    "manifest_sha256",
+    "schema_sha256",
+    "schema_digests",
+    "tool_registry_sha256",
+    "token_profile_id",
+    "capabilities",
+)
+
+CONTRACT_PIN_FIXTURES: tuple[ContractPinFixture, ...] = tuple(
+    ContractPinFixture(
+        id=f"contract-pin-{code}",
+        canary_code=code,
+        expected_decision="direct_source_fallback",
+    )
+    for code in (
+        *_STATIC_CONTRACT_PIN_CODES,
+        *(f"contract_info_{field}_mismatch" for field in _CONTRACT_INFO_FIELD_MISMATCH_FIELDS),
+    )
+)
+
+
+def all_ids() -> frozenset[str]:
+    return frozenset(
+        f.id for f in (*REASON_FIXTURES, *PAYLOAD_SHAPE_FIXTURES, *CONTRACT_PIN_FIXTURES)
+    )
+
+
+def expected_decisions() -> dict[str, str]:
+    decisions: dict[str, str] = {}
+    for fixture in (*REASON_FIXTURES, *PAYLOAD_SHAPE_FIXTURES, *CONTRACT_PIN_FIXTURES):
+        decisions[fixture.id] = fixture.expected_decision
+    return decisions
+
+
+def fixture_matrix_canonical_json() -> str:
+    """Deterministic, content-addressable serialization of the full matrix.
+
+    Consumers reproduce this exact byte sequence to compute the
+    `fixture_matrix_sha256` their severance receipt must pin against.
+    """
+    payload = {
+        "reason_fixtures": sorted(
+            (
+                {
+                    "id": f.id,
+                    "fallback_reason": f.fallback_reason,
+                    "direct_source_available": f.direct_source_available,
+                    "expected_decision": f.expected_decision,
+                }
+                for f in REASON_FIXTURES
+            ),
+            key=lambda row: row["id"],
+        ),
+        "payload_shape_fixtures": sorted(
+            (
+                {
+                    "id": f.id,
+                    "condition": f.condition,
+                    "expected_decision": f.expected_decision,
+                }
+                for f in PAYLOAD_SHAPE_FIXTURES
+            ),
+            key=lambda row: row["id"],
+        ),
+        "contract_pin_fixtures": sorted(
+            (
+                {
+                    "id": f.id,
+                    "canary_code": f.canary_code,
+                    "expected_decision": f.expected_decision,
+                }
+                for f in CONTRACT_PIN_FIXTURES
+            ),
+            key=lambda row: row["id"],
+        ),
+    }
+    return (
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+
+
+def fixture_matrix_sha256() -> str:
+    return hashlib.sha256(fixture_matrix_canonical_json().encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "CONTRACT_PIN_FIXTURES",
+    "PAYLOAD_SHAPE_FIXTURES",
+    "REASON_FIXTURES",
+    "ContractPinFixture",
+    "PayloadShapeFixture",
+    "ReasonFixture",
+    "all_ids",
+    "expected_decisions",
+    "fixture_matrix_canonical_json",
+    "fixture_matrix_sha256",
+]

--- a/tests/conformance/consumer_severance/reference_consumer.py
+++ b/tests/conformance/consumer_severance/reference_consumer.py
@@ -1,0 +1,136 @@
+"""Reference consumer decision rules for MCP v1 consumer-severance (AC-SEV-1/4).
+
+Omniscience does not own or ship any real consumer (Omnius, the SRE
+harness); this module is the producer's own encoding of the *consumer-side*
+decision rule described in SPEC-MCP's Interfaces block, REQ-MCP-11,
+REQ-KP-5, and SPEC-EV REQ-EV-7/REQ-EV-9 — the model the fixture matrix in
+`fixtures.py` is asserted against. It never imports
+`omniscience_server.mcp.metadata` / `.canary`.
+
+Decision vocabulary
+--------------------
+- ``"use"`` — continue with the Omniscience response as one input among
+  several (never as a sole oracle — see `is_sole_oracle`).
+- ``"direct_source_fallback"`` — Omniscience evidence is unusable; consult
+  the authoritative direct source (git/K8s/cloud/incident system) instead.
+- ``"park"`` — both Omniscience and the direct source are unavailable;
+  never invent context.
+- ``"planning_only"`` (payload-shape failures only) — the response could
+  not even be parsed for a fitness verdict; it may inform planning but can
+  never gate anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+Decision = str
+
+KNOWN_FALLBACK_REASONS: frozenset[str | None] = frozenset(
+    {
+        None,
+        "consistency_unknown",
+        "contract_mismatch",
+        "freshness_sla_unknown",
+        "missing_lineage",
+        "never_synced",
+        "projection_divergence",
+        "source_degraded",
+        "stale_source",
+    }
+)
+
+TERMINAL_ACTIONS: tuple[str, ...] = ("merge", "apply", "incident_action", "terminal_decision")
+
+
+def decide(*, fallback_required: bool, direct_source_available: bool = True) -> Decision:
+    """SPEC-MCP Interfaces + REQ-MCP-11 + REQ-KP-5 decision rule (taxonomy §1g)."""
+    if not fallback_required:
+        return "use"
+    return "direct_source_fallback" if direct_source_available else "park"
+
+
+def decide_from_meta(
+    meta: Mapping[str, Any],
+    *,
+    direct_source_available: bool = True,
+) -> Decision:
+    """Apply `decide` to a full MCP v1 `meta` block, failing closed on drift.
+
+    An unrecognised `fallback.reason` (schema/enum drift) or a malformed/
+    missing `fallback` block is treated the same as `contract_mismatch`:
+    SPEC-EV REQ-EV-9 ("unknown major versions fail closed").
+    """
+    fallback = meta.get("fallback") if isinstance(meta, Mapping) else None
+    if not isinstance(fallback, Mapping) or "required" not in fallback:
+        return decide(fallback_required=True, direct_source_available=direct_source_available)
+    required = bool(fallback["required"])
+    reason = fallback.get("reason")
+    # Fail closed on: unrecognised reason (schema/enum drift), or `required`
+    # disagreeing with a known `reason` (defense-in-depth — a real producer
+    # never emits a contradictory shape; metadata.py:271 enforces
+    # `"required": reason is not None`, but this doesn't trust that in
+    # isolation).
+    if (
+        reason not in KNOWN_FALLBACK_REASONS
+        or (reason is not None and not required)
+        or (reason is None and required)
+    ):
+        required = True
+    return decide(fallback_required=required, direct_source_available=direct_source_available)
+
+
+def decide_on_contract_pin_failure(
+    canary_code: str,
+    *,
+    direct_source_available: bool = True,
+) -> Decision:
+    """Any canary fail-closed code (taxonomy §2) makes the contract unverifiable."""
+    if not canary_code:
+        raise ValueError("canary_code must be a non-empty fail-closed code")
+    return decide(fallback_required=True, direct_source_available=direct_source_available)
+
+
+def decide_on_payload_shape(condition: str) -> Decision:
+    """REQ-MCP-4 payload-shape failures — never a `meta.fallback` state (taxonomy §1e)."""
+    if condition in {"response_invalid", "response_too_large"}:
+        return "direct_source_fallback"
+    if condition in {"missing_meta", "invalid_meta"}:
+        return "planning_only"
+    raise ValueError(f"unknown payload-shape condition: {condition!r}")
+
+
+def is_sole_oracle() -> bool:
+    """AC-SEV-4 / REQ-KP-3: no decision, not even `use`, is ever a sole oracle.
+
+    This documents *intent*, not enforced behavior: it is a constant-return
+    stub, not a check against real Omnius/SRE gate logic (which lives
+    outside this repo and cannot be verified here — same limitation as
+    AC-SEV-2/3). No decision value ever changes the answer, so the
+    function intentionally takes none.
+    """
+    return False
+
+
+def requires_independent_authority(action: str) -> bool:
+    """AC-SEV-4: merge/apply/incident-action/terminal decisions always need it.
+
+    Also documents intent, not enforced behavior — see `is_sole_oracle`.
+    """
+    if action not in TERMINAL_ACTIONS:
+        raise ValueError(f"unknown terminal action: {action!r}")
+    return True
+
+
+__all__ = [
+    "KNOWN_FALLBACK_REASONS",
+    "TERMINAL_ACTIONS",
+    "Decision",
+    "decide",
+    "decide_from_meta",
+    "decide_on_contract_pin_failure",
+    "decide_on_payload_shape",
+    "is_sole_oracle",
+    "requires_independent_authority",
+]

--- a/tests/test_consumer_severance_matrix.py
+++ b/tests/test_consumer_severance_matrix.py
@@ -1,0 +1,314 @@
+"""AC-SEV-1 conformance tests — MCP v1 consumer-severance fixture matrix.
+
+Invariant: every value of the closed `meta.fallback.reason` enum, every
+REQ-MCP-4 payload-shape failure, and a representative set of `canary.py`
+contract-pin fail-closed codes must deterministically select the correct
+consumer decision (`use` / `direct_source_fallback` / `park` /
+`planning_only`), and AC-SEV-4's oracle-boundary must hold for every one of
+them: no decision is ever a sole correctness/authorization oracle.
+
+Ground truth: `tests/conformance/consumer_severance/fixtures.py` (fixture
+data, hand-derived from `metadata.py`/`canary.py`/`server.py`) and
+`apps/server/src/omniscience_server/mcp/contracts/v1/schemas/meta.schema.json`
+(read as JSON, never imported as Python — see the exhaustiveness gate
+below). This kit does not import `omniscience_server.mcp.metadata` or
+`.canary`; those live under `apps/**`, out of this task's scope.
+
+Test categories
+----------------
+1. Reason-fixture matrix — `(meta fixture) -> expected decision`.
+2. Exhaustiveness gate — every non-null `fallback.reason` schema enum value
+   is covered by exactly the fixture set, 1:1, both directions.
+3. Payload-shape matrix (REQ-MCP-4) — transport-level failures.
+4. Contract-pin matrix (canary.py fail-closed codes, taxonomy §2).
+5. Fail-closed behaviour on `fallback.reason` schema/enum drift.
+6. AC-SEV-4 oracle-boundary — no decision, and no terminal action, ever
+   collapses the fitness gate into an authorization gate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.conformance.consumer_severance.fixtures import (
+    CONTRACT_PIN_FIXTURES,
+    PAYLOAD_SHAPE_FIXTURES,
+    REASON_FIXTURES,
+    ContractPinFixture,
+    PayloadShapeFixture,
+    ReasonFixture,
+)
+from tests.conformance.consumer_severance.reference_consumer import (
+    TERMINAL_ACTIONS,
+    decide_from_meta,
+    decide_on_contract_pin_failure,
+    decide_on_payload_shape,
+    is_sole_oracle,
+    requires_independent_authority,
+)
+
+META_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "apps"
+    / "server"
+    / "src"
+    / "omniscience_server"
+    / "mcp"
+    / "contracts"
+    / "v1"
+    / "schemas"
+    / "meta.schema.json"
+)
+
+CANARY_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "apps"
+    / "server"
+    / "src"
+    / "omniscience_server"
+    / "mcp"
+    / "canary.py"
+)
+
+_FAIL_CALL_RE = re.compile(r'_fail\(\s*"([a-z_0-9]+)"\s*\)')
+
+# canary.py:531-543 interpolates f"contract_info_{field}_mismatch" per key
+# of the `expected_values` dict in `verify_runtime_observation` — a
+# dynamic f-string, not a string literal, so `_FAIL_CALL_RE` can't see
+# these 8 codes. Field names hardcoded here as ground truth (mirrors
+# `fixtures._CONTRACT_INFO_FIELD_MISMATCH_FIELDS`).
+_DYNAMIC_CONTRACT_INFO_FIELDS: tuple[str, ...] = (
+    "version",
+    "commit",
+    "manifest_sha256",
+    "schema_sha256",
+    "schema_digests",
+    "tool_registry_sha256",
+    "token_profile_id",
+    "capabilities",
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Reason-fixture matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    REASON_FIXTURES,
+    ids=[f.id for f in REASON_FIXTURES],
+)
+def test_reason_fixture_selects_expected_decision(fixture: ReasonFixture) -> None:
+    decision = decide_from_meta(
+        fixture.meta(),
+        direct_source_available=fixture.direct_source_available,
+    )
+    assert decision == fixture.expected_decision
+
+
+def test_reason_fixture_ids_are_unique() -> None:
+    ids = [f.id for f in REASON_FIXTURES]
+    assert len(ids) == len(set(ids))
+
+
+# ---------------------------------------------------------------------------
+# 2. Exhaustiveness gate — 1:1 coverage of the closed fallback.reason enum
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_reason_enum_is_covered_exactly_by_fixtures() -> None:
+    schema = json.loads(META_SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_enum = set(schema["properties"]["fallback"]["properties"]["reason"]["enum"])
+
+    covered = {f.fallback_reason for f in REASON_FIXTURES}
+
+    assert covered == schema_enum, (
+        "fixtures.REASON_FIXTURES must cover exactly the fallback.reason enum "
+        f"in meta.schema.json — missing={schema_enum - covered} "
+        f"unexpected={covered - schema_enum}"
+    )
+
+
+def test_freshness_reason_is_deliberately_not_schema_constrained() -> None:
+    """Taxonomy §3: freshness.reason rides along via additionalProperties, not an enum.
+
+    Only `fallback.reason` is the closed set this kit's exhaustiveness gate
+    binds to; asserting the schema shape here documents why the ground
+    truth for freshness/consistency reasons is `metadata.py`'s code (read
+    by hand into fixtures.py), not the schema.
+    """
+    schema = json.loads(META_SCHEMA_PATH.read_text(encoding="utf-8"))
+    freshness_schema = schema["properties"]["freshness"]
+    assert freshness_schema.get("additionalProperties") is True
+    assert "reason" not in freshness_schema.get("properties", {})
+    assert "reason" not in freshness_schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# 3. Payload-shape matrix (REQ-MCP-4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    PAYLOAD_SHAPE_FIXTURES,
+    ids=[f.id for f in PAYLOAD_SHAPE_FIXTURES],
+)
+def test_payload_shape_fixture_selects_expected_decision(fixture: PayloadShapeFixture) -> None:
+    assert decide_on_payload_shape(fixture.condition) == fixture.expected_decision
+
+
+def test_payload_shape_covers_all_four_req_mcp_4_conditions() -> None:
+    conditions = {f.condition for f in PAYLOAD_SHAPE_FIXTURES}
+    assert conditions == {
+        "response_invalid",
+        "response_too_large",
+        "missing_meta",
+        "invalid_meta",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. Contract-pin matrix (canary.py fail-closed codes)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    CONTRACT_PIN_FIXTURES,
+    ids=[f.id for f in CONTRACT_PIN_FIXTURES],
+)
+def test_contract_pin_fixture_selects_direct_source_fallback(
+    fixture: ContractPinFixture,
+) -> None:
+    assert decide_on_contract_pin_failure(fixture.canary_code) == fixture.expected_decision
+    assert fixture.expected_decision == "direct_source_fallback"
+
+
+def test_contract_pin_failure_parks_when_direct_source_also_unavailable() -> None:
+    decision = decide_on_contract_pin_failure(
+        "contract_info_commit_mismatch",
+        direct_source_available=False,
+    )
+    assert decision == "park"
+
+
+def test_contract_pin_fixture_ids_are_unique() -> None:
+    ids = [f.id for f in CONTRACT_PIN_FIXTURES]
+    assert len(ids) == len(set(ids))
+
+
+def test_contract_pin_fixtures_cover_every_canary_fail_closed_code() -> None:
+    """AC-SEV-1 exhaustiveness gate for contract-pin codes (bp-review finding 1).
+
+    Mirrors `test_fallback_reason_enum_is_covered_exactly_by_fixtures`:
+    source-derived ground truth read from `canary.py` at test time (never
+    imported as Python — out of this kit's scope), asserted against
+    `CONTRACT_PIN_FIXTURES`. Must fail loudly, not pass silently, if
+    `canary.py` is missing/unreadable or the regex sweep finds nothing —
+    an empty derived set would otherwise trivially satisfy a superset
+    check and mask the gate breaking.
+    """
+    text = CANARY_PATH.read_text(encoding="utf-8")
+    literal_codes = set(_FAIL_CALL_RE.findall(text))
+    assert literal_codes, (
+        f'regex sweep of {CANARY_PATH} found zero literal _fail("...") '
+        "call sites -- parsing broke or the file moved; this gate must "
+        "fail loudly, not pass silently"
+    )
+    dynamic_codes = {f"contract_info_{field}_mismatch" for field in _DYNAMIC_CONTRACT_INFO_FIELDS}
+    derived = literal_codes | dynamic_codes
+
+    covered = {f.canary_code for f in CONTRACT_PIN_FIXTURES}
+    missing = derived - covered
+    assert not missing, (
+        "CONTRACT_PIN_FIXTURES is missing canary.py fail-closed codes: "
+        f"{sorted(missing)} -- add a ContractPinFixture entry for each"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Fail-closed behaviour on schema/enum drift
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_fallback_reason_string_fails_closed() -> None:
+    """SPEC-EV REQ-EV-9 analogue: enum drift must never silently resolve to `use`."""
+    meta = {
+        "fallback": {"required": False, "reason": "some_future_reason_not_in_the_enum_yet"},
+    }
+    assert decide_from_meta(meta) == "direct_source_fallback"
+
+
+def test_missing_fallback_block_fails_closed() -> None:
+    assert decide_from_meta({}) == "direct_source_fallback"
+
+
+def test_malformed_fallback_block_fails_closed() -> None:
+    assert decide_from_meta({"fallback": "not-an-object"}) == "direct_source_fallback"
+
+
+def test_required_false_with_known_nonnull_reason_fails_closed() -> None:
+    """Defense-in-depth: `metadata.py:271` enforces `required == (reason is not None)`
+
+    at the producer, so a real response can never emit this shape — but
+    `decide_from_meta` must not trust `required` in isolation when it
+    contradicts a known `reason`.
+    """
+    meta = {"fallback": {"required": False, "reason": "stale_source"}}
+    assert decide_from_meta(meta) == "direct_source_fallback"
+
+
+def test_required_true_with_null_reason_fails_closed() -> None:
+    """Symmetric contradiction case — see the `required=False` test above."""
+    meta = {"fallback": {"required": True, "reason": None}}
+    assert decide_from_meta(meta) == "direct_source_fallback"
+
+
+# ---------------------------------------------------------------------------
+# 6. AC-SEV-4 oracle-boundary — these tests document *intent* (what a
+#    conformant consumer must never do), not enforced behavior: real
+#    enforcement lives in Omnius/SRE gate logic outside this repo and is
+#    not verifiable here, same limitation as AC-SEV-2/3. `is_sole_oracle`
+#    and `requires_independent_authority` are constant-return stubs; these
+#    tests assert exactly the constant each is hardcoded to return.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "decision",
+    ["use", "direct_source_fallback", "park", "planning_only"],
+)
+def test_no_decision_is_ever_a_sole_oracle_by_intent(decision: str) -> None:
+    """`is_sole_oracle` takes no argument — the invariant it documents is
+    decision-independent by construction. Parametrizing over `decision`
+    here only records that every value in the vocabulary is covered by
+    that same intent, not that the function inspects it."""
+    del decision
+    assert is_sole_oracle() is False
+
+
+@pytest.mark.parametrize("action", TERMINAL_ACTIONS)
+def test_terminal_actions_always_require_independent_authority_by_intent(action: str) -> None:
+    assert requires_independent_authority(action) is True
+
+
+def test_use_decision_does_not_bypass_the_authorization_gate() -> None:
+    """The fitness gate (`decide_from_meta`) and the authorization gate are orthogonal.
+
+    A conformant consumer reaching `use` on the fittest possible evidence
+    (fresh, converged, pinnable contract) still may not merge, apply, act
+    on an incident, or make any terminal decision from that alone — by
+    intent, not verified enforcement (see the module comment above).
+    """
+    fresh_fixture = next(f for f in REASON_FIXTURES if f.expected_decision == "use")
+    decision = decide_from_meta(fresh_fixture.meta())
+    assert decision == "use"
+    assert is_sole_oracle() is False
+    for action in TERMINAL_ACTIONS:
+        assert requires_independent_authority(action) is True

--- a/tests/test_consumer_severance_verifier.py
+++ b/tests/test_consumer_severance_verifier.py
@@ -1,0 +1,370 @@
+"""AC-SEV-5 conformance tests — the consumer-severance verifier is read-only.
+
+Invariant: `scripts/check_consumer_severance.py` accepts only an explicit
+consumer revision string and a receipt file path; it never edits, creates,
+commits, or pushes anything, in this repository or any other, on any code
+path (GREEN or RED). Absent, dirty, mutable, or partial evidence returns an
+explicit RED decision return — never an uncaught exception, never a
+fabricated GREEN.
+
+Test categories
+----------------
+1. Read-only proof — directory fingerprint identical before/after, on both
+   the GREEN and every RED path.
+2. Negative RED paths: absent receipt, dirty/mutable/malformed revision,
+   malformed JSON, stale fixture digest, partial coverage, decision
+   mismatch, revision mismatch.
+3. Positive GREEN path: a receipt built from this producer's own current
+   fixture matrix passes.
+4. CLI (`main`) exit-code and stdout/stderr contract.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from tests.conformance.consumer_severance.fixtures import (
+    all_ids,
+    expected_decisions,
+    fixture_matrix_sha256,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER_PATH = ROOT / "scripts" / "check_consumer_severance.py"
+_SPEC = importlib.util.spec_from_file_location("check_consumer_severance", VERIFIER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+verifier = importlib.util.module_from_spec(_SPEC)
+# Register before exec: `verify`'s frozen dataclass needs `cls.__module__` to
+# resolve via sys.modules during class creation (Python 3.12+ dataclasses).
+sys.modules[_SPEC.name] = verifier
+_SPEC.loader.exec_module(verifier)
+
+VALID_REVISION = "9" * 40
+OTHER_VALID_REVISION = "8" * 40
+WATCHED_DIRS: tuple[Path, ...] = (
+    ROOT / "scripts",
+    ROOT / "tests" / "conformance" / "consumer_severance",
+)
+
+
+def _fingerprint(paths: Iterable[Path]) -> dict[str, str]:
+    fingerprint: dict[str, str] = {}
+    for base in paths:
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if path.is_file():
+                fingerprint[str(path)] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return fingerprint
+
+
+def _valid_receipt(*, revision: str = VALID_REVISION) -> dict[str, object]:
+    decisions = expected_decisions()
+    return {
+        "consumer_revision": revision,
+        "fixture_matrix_sha256": fixture_matrix_sha256(),
+        "command": "uv run pytest tests/severance/test_omniscience_fitness_matrix.py -q",
+        "results": [
+            {"id": fixture_id, "decision": decision} for fixture_id, decision in decisions.items()
+        ],
+    }
+
+
+def _write_receipt(tmp_path: Path, payload: object, *, name: str = "receipt.json") -> Path:
+    receipt_path = tmp_path / name
+    receipt_path.write_text(json.dumps(payload), encoding="utf-8")
+    return receipt_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Read-only proof
+# ---------------------------------------------------------------------------
+
+
+def test_green_path_never_writes_or_mutates_any_file(tmp_path: Path) -> None:
+    receipt_path = _write_receipt(tmp_path, _valid_receipt())
+    watched = (*WATCHED_DIRS, tmp_path)
+    before = _fingerprint(watched)
+
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+
+    after = _fingerprint(watched)
+    assert result.is_green
+    assert before == after
+
+
+@pytest.mark.parametrize(
+    "build_case",
+    [
+        lambda tmp_path: (None, None),
+        lambda tmp_path: (VALID_REVISION, None),
+        lambda tmp_path: (VALID_REVISION + "-dirty", _write_receipt(tmp_path, _valid_receipt())),
+        lambda tmp_path: (
+            VALID_REVISION,
+            _write_receipt(tmp_path, {**_valid_receipt(), "results": []}),
+        ),
+        lambda tmp_path: (VALID_REVISION, _write_receipt(tmp_path, "not-json-object")),
+    ],
+    ids=["all-absent", "receipt-absent", "dirty-revision", "partial-results", "malformed-shape"],
+)
+def test_red_paths_never_write_or_mutate_any_file(tmp_path: Path, build_case: object) -> None:
+    consumer_revision, receipt_path = build_case(tmp_path)  # type: ignore[operator]
+    watched = (*WATCHED_DIRS, tmp_path)
+    before = _fingerprint(watched)
+
+    result = verifier.verify(consumer_revision=consumer_revision, receipt_path=receipt_path)
+
+    after = _fingerprint(watched)
+    assert result.status == "RED"
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# 2. Negative RED paths
+# ---------------------------------------------------------------------------
+
+
+def test_absent_receipt_is_red_decision_return_not_a_crash() -> None:
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=None)
+    assert result.status == "RED"
+    assert result.reasons == ("receipt_absent",)
+
+
+def test_nonexistent_receipt_path_is_red(tmp_path: Path) -> None:
+    result = verifier.verify(
+        consumer_revision=VALID_REVISION,
+        receipt_path=tmp_path / "does-not-exist.json",
+    )
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("receipt_absent")
+
+
+@pytest.mark.parametrize(
+    "bad_revision",
+    [
+        None,
+        "",
+        "9" * 39,  # too short
+        "9" * 41,  # too long
+        "9" * 40 + "-dirty",  # mutable working tree marker
+        "g" * 40,  # not hex
+        "9" * 39 + "G",  # not hex (uppercase disallowed)
+    ],
+)
+def test_non_immutable_revision_is_red(tmp_path: Path, bad_revision: str | None) -> None:
+    receipt_path = _write_receipt(tmp_path, _valid_receipt())
+    result = verifier.verify(consumer_revision=bad_revision, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("revision_not_immutable")
+
+
+def test_malformed_json_receipt_is_red(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_text("{not valid json", encoding="utf-8")
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("receipt_malformed")
+
+
+def test_receipt_that_is_not_a_json_object_is_red(tmp_path: Path) -> None:
+    receipt_path = _write_receipt(tmp_path, [1, 2, 3])
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons == ("receipt_malformed:not_an_object",)
+
+
+def test_revision_mismatch_between_arg_and_receipt_is_red(tmp_path: Path) -> None:
+    receipt_path = _write_receipt(tmp_path, _valid_receipt(revision=OTHER_VALID_REVISION))
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("revision_mismatch")
+
+
+def test_stale_fixture_matrix_digest_is_red(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    receipt["fixture_matrix_sha256"] = "0" * 64
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("fixture_digest_mismatch")
+
+
+def test_missing_command_field_is_red(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    del receipt["command"]
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons == ("receipt_command_missing",)
+
+
+def test_partial_coverage_receipt_is_red(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    receipt["results"] = receipt["results"][:-1]  # type: ignore[index]
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert any(reason.startswith("receipt_partial:missing") for reason in result.reasons)
+
+
+def test_extra_unexpected_ids_receipt_is_red(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    receipt["results"] = [
+        *receipt["results"],  # type: ignore[list-item]
+        {"id": "not-a-real-fixture", "decision": "use"},
+    ]
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert any(reason.startswith("receipt_partial:unexpected") for reason in result.reasons)
+
+
+def test_single_decision_mismatch_is_red(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    results = copy.deepcopy(receipt["results"])
+    results[0]["decision"] = "use-a-wrong-decision"  # type: ignore[index]
+    receipt["results"] = results
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert any(reason.startswith("decision_mismatch:") for reason in result.reasons)
+
+
+def test_malformed_result_row_is_red(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    receipt["results"] = [{"id": "missing-decision-key"}]
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons == ("receipt_malformed:result_row_shape",)
+
+
+def test_non_string_result_id_is_red_not_a_crash(tmp_path: Path) -> None:
+    """A JSON array/object `id` deserializes to an unhashable Python type.
+
+    Using it directly as a dict key would raise an uncaught
+    `TypeError: unhashable type`, not a RED decision-return.
+    """
+    receipt = _valid_receipt()
+    receipt["results"] = [{"id": ["not", "a", "string"], "decision": "use"}]
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons == ("receipt_malformed:result_row_shape",)
+
+
+def test_empty_string_result_id_is_red(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    receipt["results"] = [{"id": "", "decision": "use"}]
+    receipt_path = _write_receipt(tmp_path, receipt)
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons == ("receipt_malformed:result_row_shape",)
+
+
+def test_non_utf8_receipt_bytes_is_red_not_a_crash(tmp_path: Path) -> None:
+    """Invalid UTF-8 bytes raise `UnicodeDecodeError` (a `ValueError`
+
+    subclass), not `OSError` — must be caught alongside `OSError` in
+    `_load_receipt`, or this crashes instead of returning RED.
+    """
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_bytes(b'{"consumer_revision": "\xff\xfe invalid utf8 bytes here"}')
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("receipt_not_utf8")
+
+
+def test_oversized_receipt_is_red_not_a_crash(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "receipt.json"
+    padding = "x" * (verifier._MAX_RECEIPT_BYTES + 1)
+    receipt_path.write_text(padding, encoding="utf-8")
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("receipt_too_large")
+
+
+def test_cli_main_prints_red_marker_not_traceback_on_unhashable_id(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    receipt = _valid_receipt()
+    receipt["results"] = [{"id": ["not", "a", "string"], "decision": "use"}]
+    receipt_path = _write_receipt(tmp_path, receipt)
+    exit_code = verifier.main(
+        ["--consumer-revision", VALID_REVISION, "--receipt", str(receipt_path)]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "RED" in captured.err
+    assert "Traceback" not in captured.err
+    assert "Traceback" not in captured.out
+
+
+def test_cli_main_prints_red_marker_not_traceback_on_non_utf8_receipt(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    receipt_path = tmp_path / "receipt.json"
+    receipt_path.write_bytes(b'{"consumer_revision": "\xff\xfe invalid utf8 bytes here"}')
+    exit_code = verifier.main(
+        ["--consumer-revision", VALID_REVISION, "--receipt", str(receipt_path)]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "RED" in captured.err
+    assert "Traceback" not in captured.err
+    assert "Traceback" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# 3. Positive GREEN path
+# ---------------------------------------------------------------------------
+
+
+def test_full_valid_receipt_against_producer_fixture_matrix_is_green(tmp_path: Path) -> None:
+    receipt_path = _write_receipt(tmp_path, _valid_receipt())
+    result = verifier.verify(consumer_revision=VALID_REVISION, receipt_path=receipt_path)
+    assert result.status == "GREEN"
+    assert result.reasons == ()
+    receipt_ids = {entry["id"] for entry in _valid_receipt()["results"]}  # type: ignore[union-attr]
+    assert receipt_ids == all_ids()
+
+
+# ---------------------------------------------------------------------------
+# 4. CLI contract
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_zero_and_prints_green_on_success(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    receipt_path = _write_receipt(tmp_path, _valid_receipt())
+    exit_code = verifier.main(
+        ["--consumer-revision", VALID_REVISION, "--receipt", str(receipt_path)]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "GREEN" in captured.out
+
+
+def test_main_returns_one_and_does_not_crash_on_no_args() -> None:
+    exit_code = verifier.main([])
+    assert exit_code == 1
+
+
+def test_main_returns_one_on_absent_receipt(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = verifier.main(["--consumer-revision", VALID_REVISION])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "RED" in captured.err
+    assert "receipt_absent" in captured.err


### PR DESCRIPTION
Implements the ready task SPEC `docs/specs/gh-issue-350-consumer-severance.md` — slice 2 of issue #350. **Stacked on #361** (`agent/issue-350-mcp-contract-v1`); review/merge #361 first. This PR's diff will shrink to only the kit once #361 merges.

## What ships (AC-SEV-1, AC-SEV-5 — GREEN, in-repo)

A **producer-owned** severance conformance kit (touches only `scripts/`, `tests/conformance/consumer_severance/`, `tests/test_consumer_severance*.py`, `docs/runbooks/`, `docs/integrations/` — no `apps/**`/`packages/**`, by scope).

- **AC-SEV-1 — fixture matrix**: every `fallback.reason` enum value (9), every REQ-MCP-4 payload-shape failure, and the full `canary.py` contract-pin code set → each mapped to the deterministic consumer decision (`use` / `direct_source_fallback` / `park`). Two **source-derived exhaustiveness gates** fail loudly on drift: `fallback.reason` read from `meta.schema.json`, and contract-pin codes parsed from `canary.py` (`_fail("...")` + the 8 dynamic `contract_info_{field}_mismatch`). Contract-pin coverage 54 codes.
- **AC-SEV-5 — read-only verifier** (`scripts/check_consumer_severance.py`): accepts only explicit `--consumer-revision` + `--receipt`; never writes/subprocesses/networks (proven by directory-fingerprint tests); **fails closed to RED, never an uncaught exception**, on absent/dirty/mutable/partial/oversized/non-UTF8/malformed receipts.
- **AC-SEV-4** (Omniscience-side half): no decision — including `use` — is ever a sole oracle; terminal actions require independent authority.

## Review hardening (3 passes: recon + security + best-practices)

- **Security (BLOCKING):** `verify()` crashed instead of returning RED on a non-string `id` (`TypeError`) and non-UTF8 receipt bytes (`UnicodeDecodeError` past `except OSError`) → both now fail closed; negative tests added; receipt size bounded (`_MAX_RECEIPT_BYTES`).
- **Best-practices (BLOCKING):** contract-pin fixtures had no drift gate (21 of ~49 codes) → expanded to 54 with a source-derived gate mirroring the reason-enum gate.
- Polish: oracle-boundary tests relabelled as intent (not enforcement); `decide_from_meta` fails closed on a self-contradictory `fallback` block.

## Not in this slice — AC-SEV-2 / AC-SEV-3 stay RED by design

No Omnius/SRE checkout, consumer revision, receipt, or safe drill environment exists in this repo, and the task must not edit Omnius/SRE. Both are documented as **blocked-on-external** in `docs/runbooks/consumer-severance.md`. The fixture-only pass does **not** satisfy them.

## Verification

- Kit suite: **124 passed** (81 → 124, +43 from review fixes).
- Broad slice (`-k "conformance or severance"`): **168 passed, 5 skipped** (pre-existing env-gated live tests).
- `ruff check` + `ruff format --check` on all touched files: **clean**.
- Verifier manually run on both malformed inputs → RED, exit 1, no traceback.

## Test plan

- [ ] Merge #361 first (this is stacked on it)
- [ ] CI green
- [ ] Reviewer confirms AC-SEV-2/3 remain out-of-scope until real Omnius/SRE receipts + a named safe drill env exist
