### PR TITLE
feat(helm): production-HA qualification profile (issue #350 slice 3)

### DIFF
--- a/.github/workflows/ha-qualification.yml
+++ b/.github/workflows/ha-qualification.yml
@@ -1,0 +1,99 @@
+name: HA Qualification
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'helm/omniscience/**'
+      - 'tests/test_helm*.py'
+      - 'tests/test_production_ha*.py'
+      - '.github/workflows/ha-qualification.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'helm/omniscience/**'
+      - 'tests/test_helm*.py'
+      - 'tests/test_production_ha*.py'
+      - '.github/workflows/ha-qualification.yml'
+
+permissions:
+  contents: read
+
+# Shared --set overrides for a fully evidenced, guard-satisfying production-HA
+# profile (see docs/runbooks/production-ha.md "Supplying production evidence").
+env:
+  PROD_SET: >-
+    --set secrets.postgresPassword=ci-test
+    --set serviceAccount.create=false
+    --set postgres.enabled=false
+    --set retention.enabled=true
+    --set production.enabled=true
+    --set postgresql.enabled=false
+    --set neo4j.enabled=false
+    --set qdrant.enabled=false
+    --set nats.enabled=false
+    --set replicaCount=3
+    --set production.evidence.account=111111111111
+    --set production.evidence.cluster=ci-eks
+    --set production.evidence.region=us-east-1
+    --set production.evidence.zones[0]=us-east-1a
+    --set production.evidence.zones[1]=us-east-1b
+    --set production.evidence.zones[2]=us-east-1c
+    --set production.evidence.rds.endpoint=ci-rds.example.internal
+    --set production.evidence.rds.multiAz=true
+    --set production.evidence.jetstream.externalUrl=nats://ci-jetstream.example.internal:4222
+    --set production.evidence.jetstream.replicas=3
+    --set production.evidence.neo4j.topology=causal-cluster
+    --set production.evidence.neo4j.entitlementRef=secret/neo4j-license#key
+    --set production.evidence.qdrant.topology=distributed
+    --set production.evidence.qdrant.nodes=3
+  EVAL_SET: >-
+    --set secrets.postgresPassword=ci-test
+    --set serviceAccount.create=false
+    --set postgres.enabled=false
+    --set retention.enabled=true
+
+jobs:
+  helm:
+    name: Helm lint + template + qualification tests (#350)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.15.4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install python deps
+        run: pip install pyyaml pytest
+
+      - name: helm lint (default evaluation profile)
+        run: helm lint helm/omniscience $EVAL_SET
+
+      - name: helm lint (production-HA profile, fully evidenced)
+        run: helm lint helm/omniscience $PROD_SET
+
+      - name: helm template (evaluation profile)
+        run: |
+          helm template omniscience helm/omniscience $EVAL_SET > /tmp/rendered-eval.yaml
+          test -s /tmp/rendered-eval.yaml
+
+      - name: helm template (production-HA profile)
+        run: |
+          helm template omniscience helm/omniscience $PROD_SET > /tmp/rendered-prod.yaml
+          test -s /tmp/rendered-prod.yaml
+
+      - name: Production-HA qualification tests (#350)
+        run: pytest tests/test_production_ha_render.py tests/test_helm_posture.py -v -o addopts=""
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin kubeconform
+
+      - name: kubeconform -strict (production-HA profile, #350)
+        run: |
+          helm template omniscience helm/omniscience $PROD_SET \
+          | kubeconform -strict -summary -schema-location default \
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

--- a/.github/workflows/ha-qualification.yml
+++ b/.github/workflows/ha-qualification.yml
@@ -67,10 +67,12 @@ jobs:
           python-version: '3.11'
       - uses: astral-sh/setup-uv@v3
       - name: Install python deps
-        # Full project dev deps (not bare pip): the shared tests/conftest.py
+        # Full project deps (not bare pip): the shared tests/conftest.py
         # imports pytest_asyncio, so a minimal `pip install pytest` fails
-        # collection with ModuleNotFoundError.
-        run: uv sync --frozen --extra dev
+        # collection with ModuleNotFoundError. The root project has no `dev`
+        # extra — plain `uv sync --frozen` already includes the test deps
+        # (matches the main `test` job).
+        run: uv sync --frozen
 
       - name: helm lint (default evaluation profile)
         run: helm lint helm/omniscience $EVAL_SET

--- a/.github/workflows/ha-qualification.yml
+++ b/.github/workflows/ha-qualification.yml
@@ -65,8 +65,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - uses: astral-sh/setup-uv@v3
       - name: Install python deps
-        run: pip install pyyaml pytest
+        # Full project dev deps (not bare pip): the shared tests/conftest.py
+        # imports pytest_asyncio, so a minimal `pip install pytest` fails
+        # collection with ModuleNotFoundError.
+        run: uv sync --frozen --extra dev
 
       - name: helm lint (default evaluation profile)
         run: helm lint helm/omniscience $EVAL_SET
@@ -85,7 +89,7 @@ jobs:
           test -s /tmp/rendered-prod.yaml
 
       - name: Production-HA qualification tests (#350)
-        run: pytest tests/test_production_ha_render.py tests/test_helm_posture.py -v -o addopts=""
+        run: uv run pytest tests/test_production_ha_render.py tests/test_helm_posture.py -v -o addopts=""
 
       - name: Install kubeconform
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,43 @@ For an even lower-ops path, combine the lite profile with **managed Postgres**
 (above): point `DATABASE_URL` at RDS/Cloud SQL/Neon and drop the `postgres`
 service, leaving only NATS + Neo4j + Qdrant to self-host.
 
+### Production-HA posture (Helm)
+
+The `helm/omniscience` chart's default install is an **evaluation** posture:
+`replicaCount: 1` and the four stateful-dependency toggles (`postgresql`,
+`neo4j`, `qdrant`, `nats`) all default `false` — no subchart dependency is
+declared in `Chart.yaml`, so the container talks to external/pre-existing
+stateful services via `postgres.*`/`nats.*` connection settings. That shape
+is intentionally never presented as production-ready — see
+[issue #350](https://github.com/100rd/Omniscience/issues/350) and the
+[production-HA runbook](runbooks/production-ha.md) for the qualified
+profile, its evidence requirements, and what remains a decision-return.
+
+Three postures exist, computed by the chart itself (`omniscience.posture`
+helper in `_helpers.tpl`) and rendered as the `omniscience.io/posture` label
+on every chart object — a caller cannot set this label directly. This is the
+REQ-OPS-6 mapping (`specs/SPEC-OPS-operational-evidence.md`: "Evaluation/
+lite, governed, and production-HA deployment postures have explicit claims
+and required evidence... **Fallback:** unknown posture is evaluation-only."):
+
+| Posture | Trigger | Meaning |
+|---|---|---|
+| `evaluation` | REQ-OPS-6 fallback — `production.enabled=false` and no `production.evidence.*` field populated | disposable, non-HA default |
+| `governed` | `production.enabled=false` but at least one `production.evidence.*` field populated by hand | hardened beyond the default, not HA-qualified |
+| `production-ha` | `production.enabled=true` **and** every AC-HA-1/2/3/5 + REQ-OPS-6 guard passes | dedicated-account target, ≥3-zone HA scheduling, external Multi-AZ/HA stateful dependencies, reconciliation + retention both enabled |
+
+`production-ha` is fail-closed: setting `production.enabled=true` without a
+complete evidence set (account/cluster/region/zones, external RDS Multi-AZ,
+external JetStream ×3, Neo4j HA topology + entitlement reference, Qdrant
+distributed ×3 nodes), without disabling the stateful-dependency toggles, or
+with retention/reconciliation disabled (REQ-OPS-6 — disabling either cannot
+be presented as production healthy) aborts the Helm render entirely
+(`fail()` in `templates/_production_guards.tpl`, naming the exact missing
+field) rather than silently downgrading to a lesser posture. Failure-domain
+qualification (live pod/node/AZ fault injection with measured SLOs) and the
+Neo4j/Qdrant entitlement decision itself are out of this chart's scope —
+see the runbook's "blocked on external" section.
+
 ## Agent layer (for AgenticConnector only)
 
 Most of Omniscience is deterministic. The exception is **AgenticConnector** — a connector variant whose `discover()` phase uses an LLM to decide what to index (see [ADR 0003](decisions/0003-agent-framework-langgraph-primary.md)).

--- a/docs/runbooks/production-ha.md
+++ b/docs/runbooks/production-ha.md
@@ -1,0 +1,215 @@
+# Omniscience Production-HA Qualification Runbook
+
+Runbook for the production-HA profile in `helm/omniscience` (issue #350,
+[docs/specs/gh-issue-350-production-ha.md](../specs/gh-issue-350-production-ha.md)).
+Covers how to supply evidence, what the posture model means, how to run the
+qualification checks, and what remains a decision-return outside this chart's
+scope.
+
+## Table of contents
+
+- [Posture model](#posture-model)
+- [Supplying production evidence](#supplying-production-evidence)
+- [Scheduling policy (AC-HA-2)](#scheduling-policy-ac-ha-2)
+- [Running the qualification checks](#running-the-qualification-checks)
+- [Known pre-existing chart defects](#known-pre-existing-chart-defects)
+- [Blocked on external — decision returns](#blocked-on-external--decision-returns)
+
+## Posture model
+
+The chart computes `omniscience.io/posture` (rendered on every object) —
+it is **not** a value you set directly. This is the REQ-OPS-6 posture
+mapping (`specs/SPEC-OPS-operational-evidence.md`):
+
+| Posture | How it's reached |
+|---|---|
+| `evaluation` | REQ-OPS-6 fallback: `production.enabled=false` and no `production.evidence.*` field populated (the chart's own default) |
+| `governed` | `production.enabled=false`, but at least one `production.evidence.*` field has been populated by hand (external stateful dependency wired ahead of a full production cutover) |
+| `production-ha` | `production.enabled=true` **and** every guard below passed, including the REQ-OPS-6 guard that retention and reconciliation both stay enabled |
+
+A caller cannot `--set omniscience.io/posture=production-ha` — the label is
+derived, and `production.enabled=true` only renders anything at all if the
+fail-closed guard in `helm/omniscience/templates/_production_guards.tpl`
+passes. See [docs/architecture.md](../architecture.md#production-ha-posture-helm)
+for the architectural summary.
+
+## Supplying production evidence
+
+Set `production.enabled=true` and populate every field under
+`production.evidence` (AC-HA-1, AC-HA-3). All fields are **required** when
+`production.enabled=true`; an empty/invalid one aborts the render and names
+the exact missing key:
+
+```yaml
+production:
+  enabled: true
+  evidence:
+    account: "111111111111"          # AWS account id — dedicated-account boundary
+    cluster: "omniscience-prod-eks"  # EKS cluster name/ARN
+    region: "us-east-1"
+    zones: ["us-east-1a", "us-east-1b", "us-east-1c"]   # exactly 3
+    rds:
+      endpoint: "omniscience-prod.xxxxx.us-east-1.rds.amazonaws.com"
+      multiAz: true                   # must be true
+    jetstream:
+      externalUrl: "nats://jetstream-prod.internal:4222"
+      replicas: 3                     # must be >= 3
+    neo4j:
+      topology: "causal-cluster"      # or "aura-managed"
+      entitlementRef: "secret/neo4j-license#key"   # REFERENCE ONLY, never a literal license
+    qdrant:
+      topology: "distributed"
+      nodes: 3                        # must be >= 3
+```
+
+`entitlementRef` fields are pointers (a Kubernetes Secret key, a
+managed-service plan id, a procurement ticket URL) — the chart never accepts
+or renders a literal license key or credential in values.
+
+You must also disable all four bundled subcharts when going to production
+(AC-HA-5 — bundled stateful charts are evaluation-only):
+
+```bash
+--set postgresql.enabled=false --set neo4j.enabled=false \
+--set qdrant.enabled=false --set nats.enabled=false
+```
+
+## Scheduling policy (AC-HA-2)
+
+Enforced and rendered only when `production.enabled=true`:
+
+- `replicaCount >= 3` (guard-enforced; also `production.autoscaling.minReplicas >= 3`)
+- `topologySpreadConstraints`: `maxSkew: 1`, `topologyKey: topology.kubernetes.io/zone`,
+  `whenUnsatisfiable: DoNotSchedule` (hard — pods that can't satisfy the spread
+  are left `Pending`, never bin-packed into one zone)
+- `PodDisruptionBudget`: `maxUnavailable: 1`
+- `HorizontalPodAutoscaler` (`autoscaling/v2`): `minReplicas: 3`, scaling on CPU utilization
+- `PriorityClass` (`<release>-critical-read`): assigned to the Deployment via `priorityClassName`
+
+All four are additive net-new templates (`templates/{pdb,hpa,priorityclass}.yaml`
+plus the Deployment's `topologySpreadConstraints`/`priorityClassName` blocks)
+and render exclusively under `production.enabled=true` — the default
+evaluation install is unaffected.
+
+**PriorityClass blast radius.** `<release>-critical-read` sets
+`value: 100000` with `globalDefault: false` (`values.yaml`
+`production.priorityClass.value`) — it will never silently become the
+cluster's default priority, and it only renders under the explicit
+`production.enabled=true` opt-in. But `PriorityClass` is a cluster-scoped
+object: 100000 sits well above the implicit `0` most workloads run at in a
+shared cluster, so any pod carrying this class can preempt lower-priority
+pods from *other* namespaces/teams on the same cluster, not just within this
+release. Before enabling `production.enabled=true` on a shared (non-dedicated)
+cluster, the operator should confirm 100000 doesn't collide with another
+team's priority-class numbering and is consistent with that cluster's overall
+priority/preemption policy.
+
+## Running the qualification checks
+
+```bash
+# 1. Structural lint
+helm lint helm/omniscience --set secrets.postgresPassword=x \
+  --set serviceAccount.create=false --set postgres.enabled=false --set retention.enabled=true \
+  --set production.enabled=true --set postgresql.enabled=false --set neo4j.enabled=false \
+  --set qdrant.enabled=false --set nats.enabled=false --set replicaCount=3 \
+  --set production.evidence.account=111111111111 --set production.evidence.cluster=c \
+  --set production.evidence.region=us-east-1 \
+  --set 'production.evidence.zones[0]=us-east-1a' \
+  --set 'production.evidence.zones[1]=us-east-1b' \
+  --set 'production.evidence.zones[2]=us-east-1c' \
+  --set production.evidence.rds.endpoint=x --set production.evidence.rds.multiAz=true \
+  --set production.evidence.jetstream.externalUrl=x --set production.evidence.jetstream.replicas=3 \
+  --set production.evidence.neo4j.topology=x --set production.evidence.neo4j.entitlementRef=x \
+  --set production.evidence.qdrant.topology=x --set production.evidence.qdrant.nodes=3
+
+# 2. Rendered-object + posture assertions
+uv run pytest tests/test_production_ha_render.py tests/test_helm_posture.py -v
+```
+
+`.github/workflows/ha-qualification.yml` runs both on every PR/push touching
+`helm/omniscience/**` or the test files.
+
+## Known pre-existing chart defects
+
+Discovered while building this profile. The dead-subchart-dependency defect
+below is **resolved**; the remaining app-wiring defect is **not fixed here**
+— out of this task's scope (`docs/specs/gh-issue-350-production-ha.md` scope
+excludes `apps/**`/`packages/**`, and it is a separate wiring defect, not
+part of the production-HA acceptance criteria):
+
+- **Resolved: dead subchart dependencies removed.** `Chart.yaml` previously
+  declared `postgresql`/`neo4j`/`qdrant`/`nats` subchart dependencies; two of
+  the four repository URLs (`neo4j`, `qdrant`) returned HTTP 404 from the
+  public internet, which blocked `helm template`/`helm install` entirely
+  (Helm requires every declared dependency archive under `charts/` before it
+  renders anything, regardless of `condition:`) unless `helm dependency
+  build` had succeeded. The `dependencies:` block has been removed from
+  `Chart.yaml` and the four stateful services are now modeled purely via
+  `values.yaml` toggles (`postgresql.enabled`, `neo4j.enabled`,
+  `qdrant.enabled`, `nats.enabled`, all default `false` — see AC-HA-5). `helm
+  template`/`helm install`/`helm lint` all render directly with no
+  dependency-build step, and the qualification test suite's rendered-object
+  assertions run unconditionally (they only skip if the `helm` binary itself
+  is missing from PATH).
+- **Resolved: nil-pointer crash on a bare render.** An earlier draft of this
+  runbook reported that bare `helm lint`/`helm template` (no `--set` at all)
+  crashed with `nil pointer evaluating interface {}.create` on
+  `templates/serviceaccount.yaml` (`.Values.serviceAccount` had no default)
+  and similarly for `.Values.postgres.enabled` (`templates/pvc.yaml`). That
+  was accurate against the tree at the time it was written but predates the
+  values-default fix: `values.yaml` now ships `serviceAccount: {create:
+  false, ...}` and `postgres: {enabled: false, storageSize: "10Gi", ...}` as
+  defaults. Verified empirically: `helm template helm/omniscience --set
+  secrets.postgresPassword=x` (the one remaining required value, gated by
+  `templates/secret.yaml`'s `required`) renders cleanly with no nil-pointer
+  and no other `--set` overrides needed. The `serviceAccount.create=false` /
+  `postgres.enabled=false` overrides still shown in the qualification
+  commands above are harmless no-ops against the current defaults, kept for
+  explicitness rather than because they route around a live crash.
+- **Remaining, out of scope: bundled-toggle app wiring is incomplete.**
+  `postgresql.enabled`/`neo4j.enabled`/`qdrant.enabled`/`nats.enabled` are
+  plain value toggles with no subchart behind them — enabling one does not
+  deploy an in-cluster instance of that service; the container only talks to
+  Postgres/NATS via the separate `postgres.*`/`nats.*` connection settings,
+  and Neo4j/Qdrant have no env-var wiring in `configmap.yaml`/`secret.yaml`
+  at all — a container claiming `neo4j.enabled`/`qdrant.enabled` still has no
+  way to actually reach a Neo4j/Qdrant instance through this chart. Same
+  pre-existing `postgres`/`postgresql` key-naming mismatch noted above (one
+  "l" vs two) also affects `retention`/`config.retention` (see
+  `values.yaml` comments). This is a separate app-wiring defect, not part of
+  the production-HA acceptance criteria for issue #350, and is not fixed
+  here.
+- **Resolved: the real `postgres.enabled` toggle is now guarded under
+  production.** `_production_guards.tpl` previously only rejected the dead
+  bitnami-style `postgresql.enabled` (double "l", unused since the subchart
+  `dependencies:` block was removed) and never checked the toggle actually
+  consumed by `templates/pvc.yaml` — `postgres.enabled` (single "l"). That
+  gap let `production.enabled=true` render successfully alongside a live,
+  non-Multi-AZ, PVC-backed local Postgres, contradicting AC-HA-1/AC-HA-5's
+  "RDS is the Multi-AZ authority" requirement. The guard now also fails
+  closed when `postgres.enabled=true` under `production.enabled=true`.
+
+## Blocked on external — decision returns
+
+Per the task-spec's execution order, the following cannot be completed from
+this repository checkout and are named here rather than defaulted or waived:
+
+- **AC-HA-4 (live fault-domain probe).** Surviving one pod/node/AZ fault with
+  a measured SLO and PostgreSQL ledger-hash/JetStream-ack evidence requires a
+  real, disposable-or-approved 3-AZ Kubernetes cluster with live traffic —
+  categorically unavailable from this control-plane checkout, and explicitly
+  out of scope ("destructive stateful failover against a production
+  environment"; no AWS account/EKS mutation authority here). The schema,
+  scheduling-policy, and evidence guards in this chart are the portable,
+  repo-local half of AC-HA-4's prerequisites; the fault injection and SLO
+  measurement itself must run against a real qualification environment.
+- **Neo4j license entitlement / Qdrant managed-plan selection.** Explicitly
+  out of scope ("selecting or purchasing Neo4j/Qdrant licenses or
+  managed-service plans"). The chart only models a reference slot
+  (`production.evidence.neo4j.entitlementRef`) that a human populates after
+  procuring — it does not and must not default to Community-vs-Enterprise
+  Neo4j or auto-select a Qdrant Cloud plan.
+- **Real account/cluster/RDS/JetStream endpoint identity.** The chart
+  requires these be supplied (fail-closed if empty) but cannot generate or
+  verify them against a real AWS account from this environment; populating
+  them with real values is itself out of scope here.

--- a/helm/omniscience/Chart.yaml
+++ b/helm/omniscience/Chart.yaml
@@ -4,20 +4,3 @@ description: A Helm chart for Omniscience — Semantic Knowledge Graph for SRE
 type: application
 version: 0.1.0
 appVersion: "0.2.0"
-dependencies:
-  - name: postgresql
-    version: 15.5.2
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled
-  - name: neo4j
-    version: 5.19.0
-    repository: https://helm.neo4j.com/
-    condition: neo4j.enabled
-  - name: qdrant
-    version: 0.1.0
-    repository: https://qdrant.github.io/helm-charts
-    condition: qdrant.enabled
-  - name: nats
-    version: 1.2.1
-    repository: https://nats-io.github.io/k8s/helm/charts/
-    condition: nats.enabled

--- a/helm/omniscience/templates/_helpers.tpl
+++ b/helm/omniscience/templates/_helpers.tpl
@@ -38,6 +38,43 @@ helm.sh/chart: {{ include "omniscience.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+omniscience.io/posture: {{ include "omniscience.posture" . }}
+{{- end }}
+
+{{/*
+Posture — evaluation | governed | production-ha (AC-HA-5, REQ-OPS-6).
+
+Derived, not user-settable. REQ-OPS-6 mapping:
+
+  - "production-ha" requires production.enabled=true, which in turn only
+    renders (see _production_guards.tpl, included from deployment.yaml) once
+    every AC-HA-1/2/3 evidence/policy guard passes AND retention +
+    reconciliation stay enabled — REQ-OPS-6 forbids presenting a build with
+    reconciliation/retention disabled as production healthy. A caller cannot
+    `--set` this label directly to claim production-ha without satisfying
+    those guards first — the guard `fail`s the render before this helper
+    would ever compute "production-ha" for an unqualified install.
+  - "governed" is the explicit intermediate signal: production.enabled is
+    still false, but at least one production.evidence.* field has been
+    populated by hand (an external stateful dependency wired in ahead of a
+    full production cutover) — hardened beyond the bare default, but not a
+    qualified production claim.
+  - "evaluation" is the REQ-OPS-6 fallback: no production.enabled and no
+    evidence signal at all resolves to evaluation-only. An unrecognized/
+    unpopulated configuration never silently resolves to something stronger.
+*/}}
+{{- define "omniscience.posture" -}}
+{{- if .Values.production.enabled -}}
+production-ha
+{{- else -}}
+{{- $ev := .Values.production.evidence -}}
+{{- $hasEvidenceSignal := or $ev.account $ev.cluster $ev.region (gt (len $ev.zones) 0) $ev.rds.endpoint $ev.rds.multiAz $ev.jetstream.externalUrl (gt (int $ev.jetstream.replicas) 0) $ev.neo4j.topology $ev.neo4j.entitlementRef $ev.qdrant.topology (gt (int $ev.qdrant.nodes) 0) -}}
+{{- if $hasEvidenceSignal -}}
+governed
+{{- else -}}
+evaluation
+{{- end -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/helm/omniscience/templates/_production_guards.tpl
+++ b/helm/omniscience/templates/_production_guards.tpl
@@ -1,0 +1,107 @@
+{{/*
+Production-HA fail-closed evidence + policy guard (issue #350).
+
+  AC-HA-1    dedicated-account EKS target + external HA stateful evidence
+  AC-HA-2    deterministic HA scheduling policy (replicas / autoscaling floor)
+  AC-HA-3    per-stateful-dependency topology + entitlement evidence
+  AC-HA-5    bundled stateful charts / single-replica installs cannot claim
+             production-ha posture
+  REQ-OPS-6  disabling reconciliation/retention cannot be presented as
+             production healthy
+
+No-op when production.enabled is false. When true, each check below either
+passes silently or calls `fail` naming the exact missing/invalid field —
+Helm aborts the render rather than emitting a partially-qualified profile.
+Included from deployment.yaml so it always evaluates during template/install.
+*/}}
+{{- define "omniscience.productionGuards" -}}
+{{- if .Values.production.enabled }}
+{{- $ev := .Values.production.evidence }}
+{{- $prod := .Values.production }}
+
+{{- /* AC-HA-1: dedicated-account / cluster / region / zone-placement evidence */}}
+{{- if not $ev.account }}
+{{- fail "production.evidence.account is required when production.enabled=true (dedicated-account EKS target evidence)" }}
+{{- end }}
+{{- if not $ev.cluster }}
+{{- fail "production.evidence.cluster is required when production.enabled=true (dedicated-account EKS target evidence)" }}
+{{- end }}
+{{- if not $ev.region }}
+{{- fail "production.evidence.region is required when production.enabled=true (dedicated-account EKS target evidence)" }}
+{{- end }}
+{{- if ne (len $ev.zones) 3 }}
+{{- fail (printf "production.evidence.zones must list exactly 3 availability zones when production.enabled=true (got %d)" (len $ev.zones)) }}
+{{- end }}
+{{- range $zone := $ev.zones }}
+{{- if not $zone }}
+{{- fail "production.evidence.zones must not contain an empty zone name when production.enabled=true" }}
+{{- end }}
+{{- end }}
+
+{{- /* AC-HA-2: deterministic HA scheduling policy floor */}}
+{{- if lt (int .Values.replicaCount) 3 }}
+{{- fail (printf "replicaCount must be >= 3 when production.enabled=true (got %d)" (int .Values.replicaCount)) }}
+{{- end }}
+{{- if lt (int $prod.autoscaling.minReplicas) 3 }}
+{{- fail (printf "production.autoscaling.minReplicas must be >= 3 when production.enabled=true (got %d)" (int $prod.autoscaling.minReplicas)) }}
+{{- end }}
+
+{{- /* AC-HA-5: bundled stateful subcharts are evaluation-only, never production */}}
+{{- if .Values.postgresql.enabled }}
+{{- fail "postgresql.enabled must be false when production.enabled=true (bundled stateful charts are evaluation-only — supply production.evidence.rds instead)" }}
+{{- end }}
+{{- if .Values.neo4j.enabled }}
+{{- fail "neo4j.enabled must be false when production.enabled=true (bundled stateful charts are evaluation-only — supply production.evidence.neo4j instead)" }}
+{{- end }}
+{{- if .Values.qdrant.enabled }}
+{{- fail "qdrant.enabled must be false when production.enabled=true (bundled stateful charts are evaluation-only — supply production.evidence.qdrant instead)" }}
+{{- end }}
+{{- if .Values.nats.enabled }}
+{{- fail "nats.enabled must be false when production.enabled=true (bundled stateful charts are evaluation-only — supply production.evidence.jetstream instead)" }}
+{{- end }}
+{{- if eq (toString .Values.postgres.enabled) "true" }}
+{{- fail "postgres.enabled must be false when production.enabled=true (bundled in-cluster Postgres (postgres.enabled) is evaluation-only; production requires external RDS Multi-AZ (production.evidence.rds) (AC-HA-1/5))" }}
+{{- end }}
+
+{{- /* AC-HA-3: RDS is the Multi-AZ authority */}}
+{{- if not $ev.rds.endpoint }}
+{{- fail "production.evidence.rds.endpoint is required when production.enabled=true (external RDS Multi-AZ authority evidence)" }}
+{{- end }}
+{{- if ne (toString $ev.rds.multiAz) "true" }}
+{{- fail "production.evidence.rds.multiAz must be true when production.enabled=true (RDS must be the Multi-AZ authority)" }}
+{{- end }}
+
+{{- /* AC-HA-3: JetStream — 3 replicas, external cluster */}}
+{{- if not $ev.jetstream.externalUrl }}
+{{- fail "production.evidence.jetstream.externalUrl is required when production.enabled=true (external JetStream cluster evidence)" }}
+{{- end }}
+{{- if lt (int $ev.jetstream.replicas) 3 }}
+{{- fail (printf "production.evidence.jetstream.replicas must be >= 3 when production.enabled=true (got %d)" (int $ev.jetstream.replicas)) }}
+{{- end }}
+
+{{- /* AC-HA-3: Neo4j — approved HA topology + entitlement reference (never a literal secret) */}}
+{{- if not $ev.neo4j.topology }}
+{{- fail "production.evidence.neo4j.topology is required when production.enabled=true (approved Neo4j HA topology evidence)" }}
+{{- end }}
+{{- if not $ev.neo4j.entitlementRef }}
+{{- fail "production.evidence.neo4j.entitlementRef is required when production.enabled=true (license/managed-service entitlement reference — never a literal secret value)" }}
+{{- end }}
+
+{{- /* AC-HA-3: Qdrant — distributed, >= 3 nodes */}}
+{{- if not $ev.qdrant.topology }}
+{{- fail "production.evidence.qdrant.topology is required when production.enabled=true (distributed Qdrant topology evidence)" }}
+{{- end }}
+{{- if lt (int $ev.qdrant.nodes) 3 }}
+{{- fail (printf "production.evidence.qdrant.nodes must be >= 3 when production.enabled=true (got %d)" (int $ev.qdrant.nodes)) }}
+{{- end }}
+
+{{- /* REQ-OPS-6: disabling reconciliation/retention cannot be presented as production healthy */}}
+{{- if ne (toString .Values.retention.enabled) "true" }}
+{{- fail "cannot claim production-ha with retention/reconciliation disabled (REQ-OPS-6): retention.enabled must be true when production.enabled=true" }}
+{{- end }}
+{{- if ne (toString .Values.config.reconcileEnabled) "true" }}
+{{- fail "cannot claim production-ha with retention/reconciliation disabled (REQ-OPS-6): config.reconcileEnabled must be true when production.enabled=true" }}
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/helm/omniscience/templates/configmap.yaml
+++ b/helm/omniscience/templates/configmap.yaml
@@ -41,3 +41,5 @@ data:
   RETENTION_ARCHIVE_S3_ENDPOINT_URL: {{ .Values.retention.archiveS3EndpointUrl | quote }}
   {{- end }}
   RETENTION_ARCHIVE_S3_REGION: {{ .Values.retention.archiveS3Region | quote }}
+  # Reconciliation worker (REQ-OPS-6) — see omniscience.posture.
+  RECONCILE_ENABLED: {{ .Values.config.reconcileEnabled | toString | quote }}

--- a/helm/omniscience/templates/deployment.yaml
+++ b/helm/omniscience/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "omniscience.productionGuards" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,6 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "omniscience.serviceAccountName" . }}
+      {{- if .Values.production.enabled }}
+      priorityClassName: {{ include "omniscience.fullname" . }}-critical-read
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -70,4 +74,13 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.production.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.production.topologySpreadConstraints.maxSkew }}
+          topologyKey: {{ .Values.production.topologySpreadConstraints.topologyKey }}
+          whenUnsatisfiable: {{ .Values.production.topologySpreadConstraints.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "omniscience.selectorLabels" . | nindent 14 }}
       {{- end }}

--- a/helm/omniscience/templates/hpa.yaml
+++ b/helm/omniscience/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.production.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "omniscience.fullname" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "omniscience.fullname" . }}
+  minReplicas: {{ .Values.production.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.production.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.production.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/omniscience/templates/pdb.yaml
+++ b/helm/omniscience/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.production.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "omniscience.fullname" . }}
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+spec:
+  maxUnavailable: {{ .Values.production.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "omniscience.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/omniscience/templates/priorityclass.yaml
+++ b/helm/omniscience/templates/priorityclass.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.production.enabled }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "omniscience.fullname" . }}-critical-read
+  labels:
+    {{- include "omniscience.labels" . | nindent 4 }}
+value: {{ .Values.production.priorityClass.value }}
+globalDefault: false
+description: "Critical-read priority for the Omniscience production-HA application pods (AC-HA-2)."
+{{- end }}

--- a/helm/omniscience/values.yaml
+++ b/helm/omniscience/values.yaml
@@ -6,6 +6,16 @@ image:
   pullPolicy: IfNotPresent
   tag: "latest"
 
+serviceAccount:
+  create: false
+  name: ""
+  annotations: {}
+
+# Secret values consumed by templates/secret.yaml. postgresPassword has no
+# default (templates/secret.yaml `required`-gates it) — supply it via --set
+# or a values override file.
+secrets: {}
+
 service:
   type: ClusterIP
   port: 8000
@@ -20,32 +30,72 @@ ingress:
         - path: /
           pathType: ImplementationSpecific
 
-# Built-in dependencies (sub-charts)
+# Bundled stateful sub-charts. Disabled by default (issue #350 AC-HA-5):
+# a plain `helm install` no longer bundles stateful services in-cluster —
+# see docs/runbooks/production-ha.md for the evaluation/governed/production-ha
+# posture model and the known postgres/postgresql key-naming mismatch.
 postgresql:
-  enabled: true
+  enabled: false
   auth:
     database: omniscience
     username: omniscience
     password: "change-me"
 
 neo4j:
-  enabled: true
+  enabled: false
   neo4j:
     password: "change-me"
 
 qdrant:
-  enabled: true
+  enabled: false
 
 nats:
-  enabled: true
+  enabled: false
   nats:
     jetstream:
       enabled: true
+
+# Custom (non-subchart) Postgres wiring referenced by templates/pvc.yaml and
+# _helpers.tpl. Pre-existing postgres/postgresql naming mismatch — see
+# docs/runbooks/production-ha.md "Known pre-existing chart defects" (not
+# fixed here; out of scope for issue #350's HA-render unblock).
+postgres:
+  enabled: false
+  storageSize: "10Gi"
+  storageClass: ""
+
+# Retention worker (ADR-0009, issue #135). templates/configmap.yaml reads
+# this top-level block, not config.retention below (same pre-existing
+# mismatch as postgres/postgresql — flagged, not fixed here).
+retention:
+  enabled: true
+  hotDays: 90
+  warmDays: 365
+  archiveYears: 7
+  tickSeconds: 21600
+  dryRun: false
+  batchSize: 500
+  sampleSize: 20
+  archiveBucket: ""
+  archiveKmsKeyArn: ""
+  archiveS3EndpointUrl: ""
+  archiveS3Region: "us-east-1"
 
 # Application Config
 config:
   logLevel: "INFO"
   environment: "production"
+  embeddingsProvider: "ollama"
+  embeddingModel: "nomic-embed-text"
+  mcpTransport: "streamable-http"
+  freshnessSloSeconds: 300
+  ollamaUrl: ""
+  openaiBaseUrl: ""
+  corsOrigins: ""
+  # Reconciliation worker toggle (REQ-OPS-6): disabling it, like retention,
+  # cannot be presented as a production-ha posture — see
+  # omniscience.posture / _production_guards.tpl.
+  reconcileEnabled: true
   storage:
     graph: "neo4j"
     vector: "qdrant"
@@ -55,3 +105,46 @@ config:
     warmDays: 365
   discovery:
     intervalSeconds: 3600
+
+# Production HA qualification profile (issue #350). Opt-in and additive: the
+# default install (production.enabled=false) is unaffected and stays an
+# evaluation/governed posture. When enabled, the chart fails closed (Helm
+# `fail`) unless every evidence field below is supplied and the scheduling
+# policy meets the HA floor — see docs/runbooks/production-ha.md.
+production:
+  enabled: false
+
+  # Scheduling policy floor (AC-HA-2). Only rendered/enforced when enabled.
+  topologySpreadConstraints:
+    maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+  podDisruptionBudget:
+    maxUnavailable: 1
+  autoscaling:
+    minReplicas: 3
+    maxReplicas: 9
+    targetCPUUtilizationPercentage: 70
+  priorityClass:
+    value: 100000
+
+  # Immutable environment + stateful-dependency evidence (AC-HA-1, AC-HA-3).
+  # entitlementRef fields are references (Secret key, plan id, ticket URL) —
+  # never a literal license key or credential.
+  evidence:
+    account: ""
+    cluster: ""
+    region: ""
+    zones: []
+    rds:
+      endpoint: ""
+      multiAz: false
+    jetstream:
+      externalUrl: ""
+      replicas: 0
+    neo4j:
+      topology: ""
+      entitlementRef: ""
+    qdrant:
+      topology: ""
+      nodes: 0

--- a/tests/test_helm_posture.py
+++ b/tests/test_helm_posture.py
@@ -1,0 +1,90 @@
+"""Posture-label separation assertions (AC-HA-5, REQ-OPS-6, issue #350).
+
+`omniscience.io/posture` (evaluation | governed | production-ha) is a derived
+label — see helm/omniscience/templates/_helpers.tpl `omniscience.posture` and
+the fail-closed guard in `_production_guards.tpl`. A caller cannot claim
+production-ha via `--set` without satisfying every AC-HA-1/2/3/REQ-OPS-6
+guard first, because the guard `fail()`s the render before the posture
+helper would ever compute "production-ha" for an unqualified install.
+
+Rendered-label assertions require `helm template`, which renders directly —
+`Chart.yaml` declares no subchart dependencies, so no `helm dependency build`
+step is needed. They self-skip via the shared `_needs_helm` marker only when
+the `helm` binary itself is unavailable on PATH.
+
+Runner: pytest tests/test_helm_posture.py
+"""
+
+from __future__ import annotations
+
+from tests.test_production_ha_render import (
+    BASELINE_SET,
+    VALID_PRODUCTION_SET,
+    _by_kind,
+    _needs_helm,
+    _render,
+)
+
+
+@_needs_helm
+class TestPostureLabel:
+    def test_default_bundled_install_is_evaluation_posture(self):
+        """REQ-OPS-6 fallback: no production.enabled and no evidence signal → evaluation."""
+        docs = _render(BASELINE_SET)
+        deployment = _by_kind(docs, "Deployment")[0]
+        assert deployment["metadata"]["labels"]["omniscience.io/posture"] == "evaluation"
+
+    def test_external_wiring_without_production_enabled_is_governed_posture(self):
+        """REQ-OPS-6 intermediate signal: one evidence field set, production still disabled."""
+        overrides = {
+            **BASELINE_SET,
+            "production.evidence.rds.endpoint": "external-rds.example.internal",
+        }
+        docs = _render(overrides)
+        deployment = _by_kind(docs, "Deployment")[0]
+        assert deployment["metadata"]["labels"]["omniscience.io/posture"] == "governed"
+
+    def test_fully_qualified_production_is_production_ha_posture(self):
+        docs = _render(VALID_PRODUCTION_SET)
+        deployment = _by_kind(docs, "Deployment")[0]
+        assert deployment["metadata"]["labels"]["omniscience.io/posture"] == "production-ha"
+        # AC-HA-5 groundTruth: production-ha posture must co-occur with the
+        # full HA scheduling policy, not just the label.
+        assert _by_kind(docs, "PodDisruptionBudget")
+        assert _by_kind(docs, "HorizontalPodAutoscaler")
+        assert _by_kind(docs, "PriorityClass")
+        pod_spec = deployment["spec"]["template"]["spec"]
+        assert pod_spec["topologySpreadConstraints"]
+
+    def test_service_object_also_carries_posture_label(self):
+        docs = _render(VALID_PRODUCTION_SET)
+        service = _by_kind(docs, "Service")[0]
+        assert service["metadata"]["labels"]["omniscience.io/posture"] == "production-ha"
+
+    def test_posture_boundary_progression_per_req_ops_6(self):
+        """REQ-OPS-6: no signal -> evaluation; one evidence field -> governed;
+        fully evidenced + production.enabled -> production-ha. Verifies the
+        three postures are reached by strictly increasing configuration
+        commitment, not by any single unrelated --set flag."""
+        eval_docs = _render(BASELINE_SET)
+        eval_posture = _by_kind(eval_docs, "Deployment")[0]["metadata"]["labels"][
+            "omniscience.io/posture"
+        ]
+
+        governed_overrides = {
+            **BASELINE_SET,
+            "production.evidence.neo4j.topology": "causal-cluster",
+        }
+        governed_docs = _render(governed_overrides)
+        governed_posture = _by_kind(governed_docs, "Deployment")[0]["metadata"]["labels"][
+            "omniscience.io/posture"
+        ]
+
+        prod_docs = _render(VALID_PRODUCTION_SET)
+        prod_posture = _by_kind(prod_docs, "Deployment")[0]["metadata"]["labels"][
+            "omniscience.io/posture"
+        ]
+
+        assert eval_posture == "evaluation"
+        assert governed_posture == "governed"
+        assert prod_posture == "production-ha"

--- a/tests/test_production_ha_render.py
+++ b/tests/test_production_ha_render.py
@@ -39,7 +39,7 @@ import yaml
 CHART_PATH = Path(__file__).resolve().parents[1] / "helm" / "omniscience"
 HELM = shutil.which("helm") or "helm"
 
-_FAIL_LOG_RE = re.compile(r'msg="funcMap fail" message="(?P<msg>.*)"\s*$')
+_FAIL_TEMPLATE_RE = re.compile(r"execution error at \([^)]*\):\s*(?P<msg>.+)")
 
 # Routes around pre-existing nil-pointer gaps in values.yaml that are
 # unrelated to production-HA (serviceAccount/postgres/retention keys the
@@ -105,7 +105,15 @@ def _set_string_args(overrides: dict[str, str]) -> list[str]:
 def _lint_fail_message(
     overrides: dict[str, str], *, string_keys: frozenset[str] = frozenset()
 ) -> str | None:
-    """Return the `fail()` guard message `helm lint` logged, if any fired.
+    """Return the `fail()` guard message helm surfaces, if any guard fired.
+
+    Uses `helm template` (deterministic: a `fail()` guard makes it exit
+    non-zero with the message on the `Error: execution error at (...): <msg>`
+    stderr line) rather than `helm lint`, whose `funcMap fail` log format
+    varies across helm versions and is silent on some — so lint-stderr
+    parsing returned `None` on the CI runner's default helm even though the
+    guard fired. Requires no `helm dependency build` (the four dead subchart
+    dependencies were removed).
 
     `string_keys` selects which override keys go through `--set-string`
     (literal-string, no auto-typing) instead of `--set` (Helm auto-types
@@ -118,16 +126,25 @@ def _lint_fail_message(
     plain = {k: v for k, v in overrides.items() if k not in string_keys}
     stringy = {k: v for k, v in overrides.items() if k in string_keys}
     proc = subprocess.run(
-        [HELM, "lint", str(CHART_PATH), *_set_args(plain), *_set_string_args(stringy)],
+        [
+            HELM,
+            "template",
+            "release-name",
+            str(CHART_PATH),
+            *_set_args(plain),
+            *_set_string_args(stringy),
+        ],
         text=True,
         capture_output=True,
         check=False,
     )
+    if proc.returncode == 0:
+        return None
     for line in proc.stderr.splitlines():
-        match = _FAIL_LOG_RE.search(line)
+        match = _FAIL_TEMPLATE_RE.search(line)
         if match:
-            return match.group("msg")
-    return None
+            return match.group("msg").strip()
+    return proc.stderr.strip() or None
 
 
 def _helm_available() -> bool:
@@ -151,9 +168,13 @@ _needs_helm = pytest.mark.skipif(
     reason="helm binary not found on PATH — install helm to run rendered-object assertions",
 )
 
+# Every assertion in this module shells out to `helm`; skip the whole file
+# cleanly where the binary is absent rather than erroring on a missing exe.
+pytestmark = _needs_helm
+
 
 # ── Fail-closed guard messages (AC-HA-1, AC-HA-2, AC-HA-3, AC-HA-5) ──────────
-# Deps-independent: uses `helm lint`, which tolerates a missing charts/ dir.
+# Uses `helm template` (deterministic non-zero exit + message); no charts/.
 
 
 def test_valid_production_config_triggers_no_guard():

--- a/tests/test_production_ha_render.py
+++ b/tests/test_production_ha_render.py
@@ -1,0 +1,355 @@
+"""Helm chart assertions for the production-HA qualification profile (issue #350).
+
+Covers AC-HA-1 (fail-closed environment evidence), AC-HA-2 (deterministic HA
+scheduling policy), AC-HA-3 (per-stateful-dependency topology + entitlement
+evidence), and REQ-OPS-6 (reconciliation/retention cannot be disabled while
+claiming production-ha). AC-HA-5 posture-label assertions live in
+test_helm_posture.py.
+
+Two independent verification layers, both always runnable — `Chart.yaml`
+declares no subchart dependencies (see docs/runbooks/production-ha.md), so
+`helm template`/`helm install` render directly without a
+`helm dependency build` step:
+
+  1. Guard-message tests (`test_guard_fires_*`, `test_valid_production_config_*`)
+     run `helm lint` and parse the `funcMap fail` log line it emits when a
+     template `fail()` call fires. `helm lint` does NOT propagate a fired
+     `fail()` into its own exit code.
+  2. Rendered-object tests (`TestRenderedObjects`) run `helm template` and
+     assert on the actual manifest field values. These only self-skip via
+     `pytest.mark.skipif` when the `helm` binary itself is unavailable on
+     PATH — AC-HA-4 (live fault-domain probe) is the only acceptance
+     criterion in this profile that genuinely requires a live cluster, and
+     it has no assertions in this file.
+
+Runner: pytest tests/test_production_ha_render.py
+Requires: pyyaml, helm (CI: azure/setup-helm@v4)
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+CHART_PATH = Path(__file__).resolve().parents[1] / "helm" / "omniscience"
+HELM = shutil.which("helm") or "helm"
+
+_FAIL_LOG_RE = re.compile(r'msg="funcMap fail" message="(?P<msg>.*)"\s*$')
+
+# Routes around pre-existing nil-pointer gaps in values.yaml that are
+# unrelated to production-HA (serviceAccount/postgres/retention keys the
+# templates reference but values.yaml never defaulted — see the runbook's
+# "Known pre-existing chart defects" section). Not a fix for those gaps,
+# just the minimum needed for *any* render to complete.
+BASELINE_SET = {
+    "secrets.postgresPassword": "test-password",
+    "serviceAccount.create": "false",
+    "postgres.enabled": "false",
+    "retention.enabled": "true",
+}
+
+# A fully evidenced, guard-satisfying production-HA configuration.
+VALID_PRODUCTION_SET = {
+    **BASELINE_SET,
+    "production.enabled": "true",
+    "postgresql.enabled": "false",
+    "neo4j.enabled": "false",
+    "qdrant.enabled": "false",
+    "nats.enabled": "false",
+    "replicaCount": "3",
+    "production.evidence.account": "111111111111",
+    "production.evidence.cluster": "omniscience-prod-eks",
+    "production.evidence.region": "us-east-1",
+    "production.evidence.zones[0]": "us-east-1a",
+    "production.evidence.zones[1]": "us-east-1b",
+    "production.evidence.zones[2]": "us-east-1c",
+    "production.evidence.rds.endpoint": "omniscience-prod.abcdef.us-east-1.rds.amazonaws.com",
+    "production.evidence.rds.multiAz": "true",
+    "production.evidence.jetstream.externalUrl": "nats://jetstream-prod.internal:4222",
+    "production.evidence.jetstream.replicas": "3",
+    "production.evidence.neo4j.topology": "causal-cluster",
+    "production.evidence.neo4j.entitlementRef": "secret/neo4j-license#key",
+    "production.evidence.qdrant.topology": "distributed",
+    "production.evidence.qdrant.nodes": "3",
+}
+
+
+def _set_args(overrides: dict[str, str]) -> list[str]:
+    args: list[str] = []
+    for key, value in overrides.items():
+        args += ["--set", f"{key}={value}"]
+    return args
+
+
+def _set_string_args(overrides: dict[str, str]) -> list[str]:
+    """Like `_set_args`, but forces every value through `--set-string`.
+
+    Unlike `--set`, `--set-string` never auto-types `true`/`false` into a Go
+    bool — the value always arrives at the template as the literal string.
+    This is what a type-unsafe `not $x` guard would treat as truthy even for
+    the string "false", and what GitOps tools (Terraform `helm_release` with
+    `type = "auto"` unset, Helmfile/ArgoCD string-serialized values) commonly
+    produce in practice.
+    """
+    args: list[str] = []
+    for key, value in overrides.items():
+        args += ["--set-string", f"{key}={value}"]
+    return args
+
+
+def _lint_fail_message(
+    overrides: dict[str, str], *, string_keys: frozenset[str] = frozenset()
+) -> str | None:
+    """Return the `fail()` guard message `helm lint` logged, if any fired.
+
+    `string_keys` selects which override keys go through `--set-string`
+    (literal-string, no auto-typing) instead of `--set` (Helm auto-types
+    bare `true`/`false`). Only the field(s) under test should go through
+    `--set-string` — sending the *whole* overrides dict that way would also
+    turn every other `"false"` value (e.g. the AC-HA-5 bundled-subchart
+    toggles, which must stay real bool `false`) into a truthy string and
+    trip an unrelated guard first, masking the one under test.
+    """
+    plain = {k: v for k, v in overrides.items() if k not in string_keys}
+    stringy = {k: v for k, v in overrides.items() if k in string_keys}
+    proc = subprocess.run(
+        [HELM, "lint", str(CHART_PATH), *_set_args(plain), *_set_string_args(stringy)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    for line in proc.stderr.splitlines():
+        match = _FAIL_LOG_RE.search(line)
+        if match:
+            return match.group("msg")
+    return None
+
+
+def _helm_available() -> bool:
+    return shutil.which("helm") is not None
+
+
+def _render(overrides: dict[str, str]) -> list[dict]:
+    out = subprocess.check_output(
+        [HELM, "template", "release-name", str(CHART_PATH), *_set_args(overrides)],
+        text=True,
+    )
+    return [doc for doc in yaml.safe_load_all(out) if doc]
+
+
+def _by_kind(docs: list[dict], kind: str) -> list[dict]:
+    return [doc for doc in docs if doc.get("kind") == kind]
+
+
+_needs_helm = pytest.mark.skipif(
+    not _helm_available(),
+    reason="helm binary not found on PATH — install helm to run rendered-object assertions",
+)
+
+
+# ── Fail-closed guard messages (AC-HA-1, AC-HA-2, AC-HA-3, AC-HA-5) ──────────
+# Deps-independent: uses `helm lint`, which tolerates a missing charts/ dir.
+
+
+def test_valid_production_config_triggers_no_guard():
+    assert _lint_fail_message(VALID_PRODUCTION_SET) is None
+
+
+@pytest.mark.parametrize(
+    ("override", "expected_substring"),
+    [
+        # AC-HA-1: dedicated-account / cluster / region / zone evidence
+        ({"production.evidence.account": ""}, "production.evidence.account is required"),
+        ({"production.evidence.cluster": ""}, "production.evidence.cluster is required"),
+        ({"production.evidence.region": ""}, "production.evidence.region is required"),
+        # AC-HA-2: scheduling policy floor
+        ({"replicaCount": "2"}, "replicaCount must be >= 3"),
+        (
+            {"production.autoscaling.minReplicas": "2"},
+            "production.autoscaling.minReplicas must be >= 3",
+        ),
+        # AC-HA-5: bundled stateful subcharts are evaluation-only
+        ({"postgresql.enabled": "true"}, "postgresql.enabled must be false"),
+        ({"neo4j.enabled": "true"}, "neo4j.enabled must be false"),
+        ({"qdrant.enabled": "true"}, "qdrant.enabled must be false"),
+        ({"nats.enabled": "true"}, "nats.enabled must be false"),
+        # AC-HA-1/5: the *real* local-Postgres toggle (single "l", consumed by
+        # templates/pvc.yaml) — distinct from the dead bitnami-style
+        # `postgresql.enabled` above.
+        ({"postgres.enabled": "true"}, "postgres.enabled must be false"),
+        # AC-HA-3: RDS Multi-AZ authority
+        ({"production.evidence.rds.endpoint": ""}, "production.evidence.rds.endpoint"),
+        ({"production.evidence.rds.multiAz": "false"}, "production.evidence.rds.multiAz"),
+        # AC-HA-3: JetStream — external, >= 3 replicas
+        (
+            {"production.evidence.jetstream.externalUrl": ""},
+            "production.evidence.jetstream.externalUrl",
+        ),
+        (
+            {"production.evidence.jetstream.replicas": "2"},
+            "production.evidence.jetstream.replicas must be >= 3",
+        ),
+        # AC-HA-3: Neo4j — approved topology + entitlement reference
+        ({"production.evidence.neo4j.topology": ""}, "production.evidence.neo4j.topology"),
+        (
+            {"production.evidence.neo4j.entitlementRef": ""},
+            "production.evidence.neo4j.entitlementRef",
+        ),
+        # AC-HA-3: Qdrant — distributed, >= 3 nodes
+        ({"production.evidence.qdrant.topology": ""}, "production.evidence.qdrant.topology"),
+        (
+            {"production.evidence.qdrant.nodes": "2"},
+            "production.evidence.qdrant.nodes must be >= 3",
+        ),
+        # REQ-OPS-6: reconciliation/retention cannot be disabled under production-ha
+        (
+            {"retention.enabled": "false"},
+            "cannot claim production-ha with retention/reconciliation disabled (REQ-OPS-6)",
+        ),
+        (
+            {"config.reconcileEnabled": "false"},
+            "cannot claim production-ha with retention/reconciliation disabled (REQ-OPS-6)",
+        ),
+    ],
+)
+def test_guard_fires_for_invalid_or_missing_evidence(override, expected_substring):
+    overrides = {**VALID_PRODUCTION_SET, **override}
+    message = _lint_fail_message(overrides)
+    assert message is not None, f"expected a fail() guard for override {override}"
+    assert expected_substring in message
+
+
+def test_guard_fires_when_zones_are_not_exactly_three():
+    overrides = {
+        k: v
+        for k, v in VALID_PRODUCTION_SET.items()
+        if not k.startswith("production.evidence.zones")
+    }
+    overrides["production.evidence.zones[0]"] = "us-east-1a"
+    overrides["production.evidence.zones[1]"] = "us-east-1b"
+    message = _lint_fail_message(overrides)
+    assert message is not None
+    assert "production.evidence.zones must list exactly 3" in message
+
+
+def test_guard_fires_when_zones_are_three_empty_strings():
+    """AC-HA-1: length-3 alone is not "evidence" — content must be non-empty."""
+    overrides = {
+        k: v
+        for k, v in VALID_PRODUCTION_SET.items()
+        if not k.startswith("production.evidence.zones")
+    }
+    overrides["production.evidence.zones[0]"] = ""
+    overrides["production.evidence.zones[1]"] = ""
+    overrides["production.evidence.zones[2]"] = ""
+    zone_keys = frozenset(
+        [
+            "production.evidence.zones[0]",
+            "production.evidence.zones[1]",
+            "production.evidence.zones[2]",
+        ]
+    )
+    message = _lint_fail_message(overrides, string_keys=zone_keys)
+    assert message is not None
+    assert "production.evidence.zones must not contain an empty zone name" in message
+
+
+# ── String-typed boolean bypass closure (REQ-OPS-6 / AC-HA-3) ───────────────
+# Go templates treat any non-empty string, including the literal "false", as
+# truthy. A bare `not $x`/`if $x` guard on a bool-shaped field therefore
+# no-ops when the value arrives as the *string* "false" instead of the YAML
+# boolean `false` — a realistic path via `--set-string`, Terraform
+# `helm_release` `set {}` blocks (string by default), or Helmfile/ArgoCD
+# values serialization. `--set` alone (used above) auto-types true/false and
+# cannot exercise this bypass.
+
+
+@pytest.mark.parametrize(
+    ("override", "expected_substring"),
+    [
+        (
+            {"production.evidence.rds.multiAz": "false"},
+            "production.evidence.rds.multiAz must be true",
+        ),
+        (
+            {"retention.enabled": "false"},
+            "cannot claim production-ha with retention/reconciliation disabled (REQ-OPS-6)",
+        ),
+        (
+            {"config.reconcileEnabled": "false"},
+            "cannot claim production-ha with retention/reconciliation disabled (REQ-OPS-6)",
+        ),
+    ],
+)
+def test_guard_closes_string_typed_false_bypass(override, expected_substring):
+    overrides = {**VALID_PRODUCTION_SET, **override}
+    message = _lint_fail_message(overrides, string_keys=frozenset(override))
+    assert message is not None, (
+        f"expected a fail() guard for --set-string override {override} "
+        "(string-typed boolean bypass)"
+    )
+    assert expected_substring in message
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["production.evidence.rds.multiAz", "retention.enabled", "config.reconcileEnabled"],
+)
+def test_real_boolean_false_still_fails_control(field):
+    """Control: a genuine boolean `false` via `--set` (Helm auto-types) must
+    still fail — the string-typed fix must not weaken this existing path."""
+    overrides = {**VALID_PRODUCTION_SET, field: "false"}
+    message = _lint_fail_message(overrides)
+    assert message is not None
+
+
+# ── Rendered objects (AC-HA-2, AC-HA-3): exact scheduling-policy values ─────
+
+
+@_needs_helm
+class TestRenderedObjects:
+    def test_valid_production_renders_ha_scheduling_objects_with_exact_values(self):
+        docs = _render(VALID_PRODUCTION_SET)
+        deployment = _by_kind(docs, "Deployment")[0]
+        pod_spec = deployment["spec"]["template"]["spec"]
+
+        tsc = pod_spec["topologySpreadConstraints"][0]
+        assert tsc["maxSkew"] == 1
+        assert tsc["topologyKey"] == "topology.kubernetes.io/zone"
+        assert tsc["whenUnsatisfiable"] == "DoNotSchedule"
+
+        pdb = _by_kind(docs, "PodDisruptionBudget")[0]
+        assert pdb["spec"]["maxUnavailable"] == 1
+
+        hpa = _by_kind(docs, "HorizontalPodAutoscaler")[0]
+        assert hpa["spec"]["minReplicas"] == 3
+        assert hpa["spec"]["scaleTargetRef"]["kind"] == "Deployment"
+
+        priority_class = _by_kind(docs, "PriorityClass")[0]
+        assert priority_class["metadata"]["name"].endswith("-critical-read")
+        assert pod_spec["priorityClassName"] == priority_class["metadata"]["name"]
+
+    def test_default_install_renders_no_ha_scheduling_objects(self):
+        docs = _render(BASELINE_SET)
+        deployment = _by_kind(docs, "Deployment")[0]
+        pod_spec = deployment["spec"]["template"]["spec"]
+        assert "topologySpreadConstraints" not in pod_spec
+        assert "priorityClassName" not in pod_spec
+        assert _by_kind(docs, "PodDisruptionBudget") == []
+        assert _by_kind(docs, "HorizontalPodAutoscaler") == []
+        assert _by_kind(docs, "PriorityClass") == []
+
+    def test_render_fails_when_replica_count_below_three(self):
+        overrides = {**VALID_PRODUCTION_SET, "replicaCount": "2"}
+        with pytest.raises(subprocess.CalledProcessError):
+            _render(overrides)
+
+    def test_render_fails_when_bundled_subchart_still_enabled(self):
+        overrides = {**VALID_PRODUCTION_SET, "postgresql.enabled": "true"}
+        with pytest.raises(subprocess.CalledProcessError):
+            _render(overrides)


### PR DESCRIPTION
Implements the ready task SPEC `docs/specs/gh-issue-350-production-ha.md` — slice 3 of issue #350. Branches from `main` (depends only on merged MCP v1 conformance). This is Helm/K8s chart authoring + render/policy tests — **no Terraform, no live apply**.

## What ships (AC-HA-1/2/3/5 — GREEN, in-repo)

A fail-closed production-HA qualification profile layered on `helm/omniscience`, additive (default install stays a usable evaluation profile).

- **AC-HA-1** — production render **fails closed** unless every evidence reference is supplied (account, cluster, three zones, external RDS Multi-AZ, JetStream ≥3, Neo4j HA topology + entitlement **reference**, distributed Qdrant ≥3). Entitlement is a reference, never a literal secret.
- **AC-HA-2** — ≥3 replicas, three-zone `topologySpread` with `DoNotSchedule` maxSkew 1, PDB `maxUnavailable: 1`, HPA `minReplicas: 3`, explicit critical-read PriorityClass. Exact values asserted against real `helm template` output.
- **AC-HA-3** — per-stateful-dependency topology + entitlement records; missing evidence is RED with a per-service message.
- **AC-HA-5** — derived, **non-user-settable** posture label (`evaluation | governed | production-ha`) aligned to SPEC-OPS **REQ-OPS-6** (`unknown → evaluation`; disabling retention/reconciliation cannot be production), with negative fixtures.

## Chart renderability (approved scope expansion)

The chart could not `helm template` at all (pre-existing): four subchart dependencies point at repositories returning **HTTP 404**, and Helm requires all declared deps present regardless of `condition`. Removed those four dead, unused, production-forbidden deps and added the missing values defaults so the chart renders without `helm dependency build`. Evaluation install goes from broken to rendering.

## Review hardening (security + best-practices, empirically reproduced)

- **Type-juggling bypass (BLOCKING):** a quoted string `"false"` satisfied bare boolean guards — reachable via `--set-string`, Terraform `helm_release`, Helmfile, ArgoCD. Guards now require `toString == "true"`; `--set-string rds.multiAz=false` now fails render.
- **Real bundled-Postgres toggle (BLOCKING):** guards checked only the dead bitnami-style key, not the real `postgres.enabled` that provisions a local PVC — production + `postgres.enabled=true` now fails closed.
- Empty zone entries rejected; stale runbook defect notes corrected; PriorityClass blast-radius documented.

## Not in this slice — decision-return / RED by design

- **AC-HA-4** (live pod/node/AZ fault-domain probe + measured SLO + ledger-hash/JetStream-ack): needs a disposable/approved 3-AZ cluster — unavailable here, documented as blocked-on-external.
- **Neo4j license / Qdrant plan entitlements**: procurement is out of scope; the chart models a reference slot and fails closed when empty.
- A residual app-wiring defect (Neo4j/Qdrant not wired to the container) is documented as a **separate** task.

## Verification

- `uv run pytest tests/test_production_ha_render.py tests/test_helm_posture.py` → **38 passed, 0 skipped**.
- `helm lint helm/omniscience` → clean; `helm template` renders eval (`posture: evaluation`) and production (`posture: production-ha`, all HA objects with exact values) without dependency build.
- All five guard bypasses reproduced and confirmed to fail render (exit 1, correct messages).
- `ruff check` + `ruff format --check` → clean.

## Test plan

- [ ] CI green (new `ha-qualification.yml` runs helm lint + template + pytest + kubeconform)
- [ ] Reviewer confirms AC-HA-4 + entitlements stay out-of-scope until a disposable cluster and procurement decision exist
