### PR TITLE
feat(dr): backup/restore qualification harness (issue #350 slice 4)

### DIFF
--- a/.github/workflows/restore-qualification.yml
+++ b/.github/workflows/restore-qualification.yml
@@ -1,0 +1,309 @@
+name: Restore Qualification
+
+# AC-DR-6: deterministic, reproducible-without-production-credentials CI
+# fixtures for the backup/restore qualification harness (issue #350,
+# docs/specs/gh-issue-350-backup-restore.md).
+#
+# Two independent jobs:
+#   unit-checks   — refusal/approval/manifest/policy logic, pure fixtures,
+#                   no service containers, no cloud credentials.
+#   convergence   — seeds a fixture dataset, exercises the pre-wipe safety
+#                   guard + rebuild + idempotent verify-only (mirrors
+#                   dr-drill.yml's service/dependency shape), then asserts
+#                   the documented breach (exit 2) and mismatch (exit 3)
+#                   exit codes on deliberately broken fixtures.
+#
+# This workflow never touches a real cloud account and never performs a
+# live destructive restore — see docs/runbooks/backup-restore.md
+# "Blocked on external — decision returns".
+
+on:
+  workflow_dispatch:
+    inputs:
+      rto_seconds:
+        description: "RTO budget in seconds for the convergence job (default: 120 for fixture dataset)"
+        required: false
+        default: "120"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/qualify_backup_restore.py"
+      - "scripts/rebuild_all_projections.py"
+      - "scripts/dr_verify.py"
+      - "scripts/seed_dr_drill.py"
+      - "tests/test_backup_restore*.py"
+      - "tests/test_dr_rebuild.py"
+      - ".github/workflows/restore-qualification.yml"
+  pull_request:
+    paths:
+      - "scripts/qualify_backup_restore.py"
+      - "scripts/rebuild_all_projections.py"
+      - "scripts/dr_verify.py"
+      - "scripts/seed_dr_drill.py"
+      - "tests/test_backup_restore*.py"
+      - "tests/test_dr_rebuild.py"
+      - ".github/workflows/restore-qualification.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  unit-checks:
+    name: Refusal / approval / manifest / policy unit checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.6.2"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra local
+
+      - name: Run backup/restore unit tests (no services, no credentials)
+        run: uv run pytest tests/test_backup_restore*.py -v --no-header
+
+  convergence:
+    name: Pre-wipe guard + rebuild convergence + breach/mismatch handling
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: omniscience_restore_qual
+          POSTGRES_USER: omniscience
+          POSTGRES_PASSWORD: restore_qual_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      neo4j:
+        image: neo4j:5.19-community
+        env:
+          NEO4J_AUTH: neo4j/restore_qual_password
+          NEO4J_server_memory_heap_initial__size: 512m
+          NEO4J_server_memory_heap_max__size: 1G
+          NEO4J_server_memory_pagecache_size: 256m
+        ports:
+          - 7687:7687
+          - 7474:7474
+        options: >-
+          --health-cmd "wget -q -O - http://localhost:7474 > /dev/null"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 10
+          --health-start-period 45s
+
+      qdrant:
+        image: qdrant/qdrant:v1.12.4
+        ports:
+          - 6333:6333
+          - 6334:6334
+        options: >-
+          --health-cmd "bash -c '</dev/tcp/localhost/6333'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 20s
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.6.2"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra local
+
+      - name: Run database migrations
+        working-directory: packages/core
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+        run: uv run alembic upgrade head
+
+      - name: Seed fixture dataset
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: restore_qual_password
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+          OMNISCIENCE_DR_DRILL: "1"
+        run: uv run python scripts/seed_dr_drill.py
+
+      - name: Determine RTO budget
+        id: rto
+        env:
+          RTO_SECONDS_INPUT: ${{ github.event.inputs.rto_seconds }}
+        run: |
+          RTO="$RTO_SECONDS_INPUT"
+          if [ -z "$RTO" ]; then
+            RTO=120
+          fi
+          echo "rto_seconds=$RTO" >> "$GITHUB_OUTPUT"
+
+      - name: Run rebuild with pre-wipe guard + RTO enforcement
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: restore_qual_password
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+          EMBEDDING_PROVIDER: local
+          OMNISCIENCE_DR_DRILL: "1"
+          RTO_SECONDS: ${{ steps.rto.outputs.rto_seconds }}
+        # Exit codes: 0 pass, 2 RTO exceeded, 3 verification mismatch,
+        # 4 pre-wipe safety refusal (see docs/runbooks/backup-restore.md).
+        run: |
+          uv run python scripts/rebuild_all_projections.py \
+            --yes \
+            --recompute-embeddings \
+            --rto-seconds "$RTO_SECONDS"
+
+      - name: Verify-only pass (idempotency check)
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: restore_qual_password
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+          EMBEDDING_PROVIDER: local
+          RTO_SECONDS: ${{ steps.rto.outputs.rto_seconds }}
+        run: |
+          uv run python scripts/rebuild_all_projections.py \
+            --verify-only \
+            --rto-seconds "$RTO_SECONDS"
+
+      - name: Run DR + backup-restore integration tests
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: restore_qual_password
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+          EMBEDDING_PROVIDER: local
+          OMNISCIENCE_DR_DRILL: "1"
+        # Includes TestDrIntegration::test_pre_wipe_refusal_aborts_on_non_empty_without_drill_context
+        # (AC-DR-3 / P-SOT-6 live behaviour) and leaves the fixture dataset
+        # in a passing, populated state for the breach/mismatch steps below.
+        run: |
+          uv run pytest tests/test_dr_rebuild.py -v --no-header
+
+      - name: Breach handling — deliberately tiny RTO budget exits 2
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: restore_qual_password
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+          EMBEDDING_PROVIDER: local
+          OMNISCIENCE_DR_DRILL: "1"
+        run: |
+          set +e
+          uv run python scripts/rebuild_all_projections.py \
+            --yes \
+            --recompute-embeddings \
+            --rto-seconds 0
+          code=$?
+          set -e
+          if [ "$code" -ne 2 ]; then
+            echo "expected exit code 2 (RTO exceeded), got $code"
+            exit 1
+          fi
+          echo "breach handling OK: exit code 2 as documented"
+
+      - name: Restore a passing dataset before the mismatch step
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: restore_qual_password
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+          EMBEDDING_PROVIDER: local
+          OMNISCIENCE_DR_DRILL: "1"
+          RTO_SECONDS: ${{ steps.rto.outputs.rto_seconds }}
+        run: |
+          uv run python scripts/rebuild_all_projections.py \
+            --yes \
+            --recompute-embeddings \
+            --rto-seconds "$RTO_SECONDS"
+
+      - name: Corrupt-fixture handling — Postgres/Qdrant divergence exits 3
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+        run: |
+          uv run python -c "
+          import asyncio
+          from omniscience_core.config import Settings
+          from omniscience_core.db import create_async_engine, create_session_factory
+          from sqlalchemy import text
+
+
+          async def corrupt() -> None:
+              settings = Settings()
+              engine = create_async_engine(settings)
+              session_factory = create_session_factory(engine)
+              async with session_factory() as session, session.begin():
+                  await session.execute(
+                      text(
+                          'DELETE FROM chunks WHERE id = ('
+                          'SELECT id FROM chunks ORDER BY document_id, ord LIMIT 1)'
+                      )
+                  )
+              await engine.dispose()
+
+
+          asyncio.run(corrupt())
+          "
+
+      - name: Assert corrupted fixture fails verify-only with exit 3
+        env:
+          DATABASE_URL: postgresql+asyncpg://omniscience:restore_qual_test@localhost:5432/omniscience_restore_qual
+          NEO4J_URI: bolt://localhost:7687
+          NEO4J_USERNAME: neo4j
+          NEO4J_PASSWORD: restore_qual_password
+          QDRANT_HOST: localhost
+          QDRANT_HTTP_PORT: "6333"
+          QDRANT_GRPC_PORT: "6334"
+          EMBEDDING_PROVIDER: local
+          RTO_SECONDS: ${{ steps.rto.outputs.rto_seconds }}
+        run: |
+          set +e
+          uv run python scripts/rebuild_all_projections.py \
+            --verify-only \
+            --rto-seconds "$RTO_SECONDS"
+          code=$?
+          set -e
+          if [ "$code" -ne 3 ]; then
+            echo "expected exit code 3 (verification mismatch), got $code"
+            exit 1
+          fi
+          echo "mismatch handling OK: exit code 3 as documented"

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,279 @@
+# Backup/restore qualification runbook
+
+> Status: qualification harness + safety interlocks shipped (AC-DR-1, AC-DR-2,
+> AC-DR-3, AC-DR-5, AC-DR-6, and the AC-DR-3/P-SOT-6 pre-wipe refusal gap in
+> `rebuild_all_projections.py`) — issue
+> [#350](https://github.com/100rd/Omniscience/issues/350),
+> [`gh-issue-350-backup-restore`](../specs/gh-issue-350-backup-restore.md).
+> AC-DR-1's live destructive restore, AC-DR-2's live cloud-identity binding,
+> AC-DR-3's live target-checks, and AC-DR-5's full measured drill are
+> **blocked on external inputs** — see
+> [Blocked on external — decision returns](#blocked-on-external--decision-returns)
+> below.
+
+This runbook documents `scripts/qualify_backup_restore.py`: a repo-local
+qualification harness for PostgreSQL-authoritative backup/restore. It never
+performs a destructive operation, never opens a cloud SDK connection, and
+never stores or requires cloud credentials — every check is a pure function
+over explicit evidence (JSON files, injected fakes) that returns a frozen
+`GREEN`/`RED` decision-return and never fabricates a passing result.
+
+## What this kit proves, and what it doesn't
+
+- **Proves (repo-local, GREEN today):**
+  - AC-DR-1's evidence shape: a backup-policy document names every
+    SPEC-SOT authority table plus immutable-copy ownership, retention,
+    encryption, cross-account/region copies, and a measured recovery point
+    — missing fields are RED (`check_backup_policy_evidence`).
+  - AC-DR-2's approval logic: absent, expired, mismatched, or replayed
+    one-shot approval envelopes abort before mutation, each with a
+    field-specific reason (`verify_approval_envelope`).
+  - AC-DR-3's refusal logic: production-like target names, an absent
+    disposable-identity tag, non-empty projections outside a sanctioned
+    drill context, active writer leases, and ambiguous credentials each
+    independently abort (`check_destructive_safety`).
+  - AC-DR-3 / P-SOT-6's rebuild gap: `scripts/rebuild_all_projections.py`
+    now measures Neo4j/Qdrant occupancy immediately before wiping them and
+    refuses to proceed if either is non-empty, unless
+    `OMNISCIENCE_DR_DRILL=1` is set (exit code `4`). Previously `--yes`
+    wiped unconditionally with no precondition check at all.
+  - AC-DR-5's manifest shape: a drill manifest is content-addressed
+    (`manifest_id` is a self-addressing sha256 of every other field) and
+    any absent or breached target — RPO, RTO, verification, hash
+    equivalence, query probes — produces `status="RED"`, never a
+    placeholder (`build_manifest`, `validate_manifest_json`).
+  - AC-DR-6's reproducibility: every check above runs from committed,
+    deterministic fixtures with no cloud credentials — see
+    `tests/test_backup_restore_fixtures.py` for the content-addressed
+    fixture matrix and `.github/workflows/restore-qualification.yml` for
+    the CI wiring.
+- **Does not prove:** that a real destructive restore into an isolated
+  recovery environment succeeds, that a live cloud identity check agrees
+  with an envelope's claim, that a live target's tags/writer-leases/
+  credentials were actually inspected, or that a full measured RPO/RTO
+  drill converges. Those require external inputs this agent must not
+  self-authorize — see below.
+
+## Running the qualification CLI
+
+Each check runs independently; supply the flags for the checks you want.
+The process exits `0` and prints `GREEN` only if every requested check
+passes; otherwise it exits `1`, prints `RED (decision-return)` to stderr,
+and lists one reason per line — never a traceback.
+
+### AC-DR-1: backup-policy evidence
+
+```bash
+uv run python scripts/qualify_backup_restore.py --policy backup-policy.json
+```
+
+`backup-policy.json` shape:
+
+```json
+{
+  "authority_tables": ["workspaces", "sources", "documents", "ingestion_runs", "chunks", "entities", "edges", "entity_emitter", "outbox_events", "audit_log"],
+  "immutable_copy": {"owner": "backup-team", "retention_days": 35, "encryption": "aws:kms:alias/omniscience-backup"},
+  "cross_account_copy": {"account": "<recovery account id>"},
+  "cross_region_copy": {"region": "<recovery region>"},
+  "measured_recovery_point_seconds": 300
+}
+```
+
+The `authority_tables` list is checked against `AUTHORITY_TABLES` in
+`scripts/qualify_backup_restore.py`. This is not simply "every
+`__tablename__` in `db/models.py`" — it is the subset that
+[REQ-SOT-1] ("source/document/chunk content and lineage, versions,
+entity/outbox records, workspaces, and governance metadata required to
+rebuild projections") and [REQ-SOT-8] ("every field needed for projection
+rebuild and tenant/audit history") actually name, spelled out per table in
+the constant's own comment: `workspaces`/`sources`/`documents`/`chunks`
+(content), `ingestion_runs` (lineage), `entities`/`edges`/`outbox_events`
+(entity/outbox records), `entity_emitter` (governance — the
+authority-emitter state machine a projection consumer uses to accept/drop
+an entity write), and `audit_log`
+(`packages/core/src/omniscience_core/audit/models.py` — REQ-SOT-8's
+"tenant and audit history" verbatim). `api_tokens` is deliberately
+excluded: it is authentication/authorization credential material, not
+ledger content, lineage, an entity/outbox record, or rebuild-relevant
+governance metadata.
+
+### AC-DR-2: destructive-command approval envelope
+
+```bash
+uv run python scripts/qualify_backup_restore.py \
+  --envelope approval-envelope.json \
+  --command "<exact destructive command string, including all args>" \
+  --source-backup-id <backup id> \
+  --target-account <cloud account id> \
+  --target-region <cloud region> \
+  --environment-identity <independently observed target identity> \
+  --now <RFC3339 timestamp> \
+  --nonce-ledger-path nonce-ledger.json
+```
+
+`--environment-identity` must come from a source independent of the
+envelope (a live identity check in a real drill; a known value in a test)
+— the envelope's own `environment_identity` claim is never trusted as its
+own proof. `--nonce-ledger-path` points at a JSON array file of already-
+consumed nonces; a second submission of the same nonce is `RED
+nonce_replayed`. A rejected submission (bad digest, expired, mismatched)
+never consumes the nonce, so a legitimate resubmission with a corrected
+envelope still works.
+
+Approval-envelope shape:
+
+```json
+{
+  "command_digest": "<sha256 hex of the exact destructive command>",
+  "source_backup_id": "<opaque backup id the approval authorizes restoring from>",
+  "target_account": "<cloud account id>",
+  "target_region": "<cloud region>",
+  "environment_identity": "<independently observed target identity>",
+  "issued_at": "<RFC3339>",
+  "expires_at": "<RFC3339, short TTL>",
+  "nonce": "<random, single-use token>",
+  "approved_by": "<human identity>"
+}
+```
+
+### AC-DR-3: destructive-safety refusal
+
+```bash
+uv run python scripts/qualify_backup_restore.py \
+  --target-name <target identifier> \
+  --target-tags-json '{"disposable": "true"}' \
+  --qdrant-chunk-count <measured count> \
+  --neo4j-entity-count <measured count> \
+  [--drill-context] [--active-writers] [--ambiguous-credentials]
+```
+
+`--drill-context` authorizes wiping projections that are already non-empty
+(the ordinary DR-rebuild case). It does not bypass the production-name,
+disposable-tag, writer-lease, or credential-ambiguity checks.
+
+### AC-DR-5: drill manifest validation
+
+```bash
+uv run python scripts/qualify_backup_restore.py --manifest drill-manifest.json
+```
+
+Re-validates an already-produced manifest artifact's shape and declared
+status — it does not trust a self-declared `"status": "GREEN"` on its own:
+`rto_exceeded: true`, `verification_passed: false`, or
+`query_probes_passed: false` (or absent) all fail validation even if
+`status` claims GREEN (tamper-evidence, not just shape checking). Build
+a manifest programmatically with `build_manifest(...)` from measured drill
+inputs (`drill_started_at`, `drill_completed_at`, `measured_rpo_seconds`, a
+`dr_verify.RtoResult`, `source_backup_id`, `restored_environment_identity`,
+a `dr_verify.DRVerificationResult`, hash-equivalence mismatches, and
+`query_probes_passed`) — any absent input produces `status="RED"` with a
+named reason, never an invented value.
+
+## Pre-wipe refusal in `rebuild_all_projections.py`
+
+`scripts/rebuild_all_projections.py --yes` now measures total Qdrant point
+count and total Neo4j node count immediately before wiping either store.
+If either is non-empty, the script refuses to wipe (exit code `4`) unless
+`OMNISCIENCE_DR_DRILL=1` is set — the same sanctioned-drill marker
+`scripts/seed_dr_drill.py` already requires. This closes a real gap:
+previously `--yes` alone wiped whatever it found with no precondition check
+(REQ-SOT-6: "unmet precondition aborts before destructive action").
+
+`.github/workflows/dr-drill.yml` is unaffected: its Neo4j/Qdrant service
+containers start empty on every run, so the check passes trivially even
+without the env var. The env var only matters for a rebuild against
+already-populated projections (a repeat run, or a real incident where
+Neo4j/Qdrant hold stale data that needs replacing from the Postgres source
+of truth).
+
+The production-like-name, disposable-tag, writer-lease, and credential-
+ambiguity checks in `check_destructive_safety` are **not** wired into
+`rebuild_all_projections.py` today — there is no target-identity config
+surface in `omniscience_core.config.Settings` to source a target name/tag
+set/writer-lease query from. A future live-drill runner that has access to
+a real cloud target's identity and tags should call
+`check_destructive_safety` with those fields populated; until then this is
+a flagged architectural gap, not a silent omission.
+
+Exit codes for `rebuild_all_projections.py`:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Rebuild and verification passed, RTO met |
+| 1 | Missing `--yes` (and not `--verify-only`), or bad `--rto-seconds` |
+| 2 | RTO budget exceeded |
+| 3 | Post-rebuild verification mismatch |
+| 4 | Pre-wipe destructive-safety refusal (non-empty projections outside a drill context) |
+
+## RPO/RTO budget
+
+ADR-0018 sets the default projection-rebuild budget at **900 seconds (15
+minutes)**: Neo4j+Qdrant wipe ≤30s, rebuild 50k chunks ≤600s, verification
+≤30s, safety margin 240s. `scripts/qualify_backup_restore.py` imports
+`DEFAULT_RTO_SECONDS`-carrying types from `scripts/dr_verify.py` rather
+than redefining the budget — any caller claiming production-representative
+timing must use 900s unless an explicit, human-approved environment
+profile supplies a stricter number.
+
+`.github/workflows/dr-drill.yml` and `.github/workflows/restore-
+qualification.yml` both use a **120-second CI-fixture budget**
+(`--rto-seconds 120`) because their seeded dataset is a handful of
+documents/chunks, not 50k. This is a small-fixture budget for a small
+fixture dataset — it is not, and must never be read as, evidence that a
+production-scale rebuild meets the real 900s target. Only a live drill
+against a production-representative dataset measures that.
+
+## Blocked on external — decision returns
+
+Per `docs/specs/gh-issue-350-backup-restore.md` ("Execution order and
+required inputs" / "Out of scope") and this workspace's approval rules,
+the following are **decision returns**, not something this harness
+attempts or fabricates:
+
+1. **AC-DR-1's live destructive restore** — requires real cloud provider
+   backup metadata and a genuinely separate recovery account/environment.
+   Unavailable from a control-plane checkout; no cloud mutation authority
+   here.
+2. **AC-DR-2's live "independently observed cloud identity"** — the
+   envelope-verification logic is fully built and tested with fixtures;
+   binding `observed_environment_identity` to a real cloud identity
+   provider (STS, IAM, etc.) requires credentials this agent must not
+   hold, and requires a fresh one-shot human approval this agent cannot
+   self-grant.
+3. **AC-DR-3's live target-tag/writer-lease/credential-ambiguity checks
+   against a real cloud account** — the refusal logic is built and tested
+   with fakes; running it against a real disposable-or-approved recovery
+   environment is a live-drill action requiring the same separate
+   approval as #1. The concrete writer-lease source (a consumer heartbeat
+   row? a NATS consumer status query?) also needs an architectural
+   decision — no such mechanism exists in `apps/**` today.
+4. **AC-DR-5's full destructive drill and its measured real-world
+   RPO/RTO** — the manifest schema and validation logic is built; a
+   genuine measured RPO/RTO against a live restore requires the isolated
+   recovery environment from #1, plus a fresh one-shot approval per drill.
+   Readiness approval, a previous drill approval, a target name, or
+   possession of credentials is explicitly **not** a substitute
+   (task-spec, verbatim).
+5. **Any actual deletion, restore, or infra apply in a production
+   account** — explicit out-of-scope line in the task spec.
+
+Two additional precision questions are flagged for the Lead/architect,
+not resolved here:
+
+- **Vector tolerance for non-deterministic embeddings.** `dr_verify.
+  verify_hash_equivalence` does an exact sha256 digest comparison, which
+  is correct only because the DR-drill fixture forces a deterministic
+  local embedding model (`EMBEDDING_PROVIDER=local`). A live drill against
+  a non-deterministic remote embedding provider would need a tolerance-
+  band comparison (e.g. cosine similarity ≥ threshold) instead — not
+  implemented here, since no such live drill exists yet to size the
+  threshold against.
+- **Writer-lease source.** `check_destructive_safety`'s
+  `writer_lease_source` parameter is a `Protocol` with a fake
+  implementation for tests; there is no concrete, real writer-lease query
+  wired to any live consumer/heartbeat mechanism in this repo today.
+
+Each live destructive restore and each destructive cleanup/rollback needs
+a separate, fresh, one-shot human approval envelope bound to the exact
+command digest and independently observed target identity — this agent
+does not perform destructive actions and does not self-authorize them.

--- a/scripts/qualify_backup_restore.py
+++ b/scripts/qualify_backup_restore.py
@@ -1,0 +1,913 @@
+#!/usr/bin/env python3
+"""Backup/restore qualification harness (AC-DR-1, AC-DR-2, AC-DR-3, AC-DR-5).
+
+This module is a free-standing, framework-free qualification harness for
+PostgreSQL-authoritative backup/restore. It NEVER performs a destructive
+operation, NEVER opens a cloud SDK connection, and NEVER stores or requires
+cloud credentials. Every public check is a pure function that takes explicit
+inputs (JSON evidence files, injected fixtures/fakes) and returns a frozen
+``VerificationResult`` — it never raises an uncaught exception and never
+fabricates a GREEN. An absent input is a typed RED result, not a placeholder
+(docs/specs/gh-issue-350-backup-restore.md, "Execution order and required
+inputs").
+
+Public surface
+--------------
+VerificationResult            — frozen GREEN/RED decision-return, never raised
+check_backup_policy_evidence  — AC-DR-1: backup policy names every SPEC-SOT
+                                 authority table + immutable-copy metadata
+verify_approval_envelope      — AC-DR-2: one-shot destructive-approval envelope
+check_destructive_safety      — AC-DR-3: production-name/disposable/non-empty/
+                                 writer-lease/credential-ambiguity refusal
+DrillManifest                 — AC-DR-5: frozen, content-addressed drill record
+build_manifest                — construct a DrillManifest from measured inputs
+validate_manifest_json        — re-validate a serialized manifest artifact
+NonceLedger / WriterLeaseSource / CredentialResolver — injectable Protocols
+AmbiguousIdentityError         — raised by a CredentialResolver, never escapes
+                                  check_destructive_safety uncaught
+NonceLedgerCorruptError         — raised by a NonceLedger on corrupted durable
+                                  state; verify_approval_envelope catches it
+                                  and returns RED, never an empty consumed-set
+
+What this module deliberately does NOT do
+------------------------------------------
+It does not perform a live destructive restore, does not bind to a real
+cloud identity provider, and does not execute a full measured RPO/RTO drill.
+Those require an isolated recovery environment and a separate, fresh,
+one-shot human approval this agent cannot self-grant — see
+docs/runbooks/backup-restore.md "Blocked on external — decision returns".
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dr_verify import DRVerificationResult, RtoResult  # noqa: E402
+
+# A qualification evidence file (policy, envelope, or manifest) is a small
+# JSON object. 1,000,000 bytes is generous headroom over any real evidence
+# file while still bounding a truncated/corrupted or adversarial read —
+# mirrors scripts/check_consumer_severance.py's own budget.
+_MAX_EVIDENCE_BYTES = 1_000_000
+
+#: Authority tables required by specs/SPEC-SOT-ledger-and-projections.md
+#: [REQ-SOT-1] ("Postgres owns source/document/chunk content and lineage,
+#: versions, entity/outbox records, workspaces, and governance metadata
+#: required to rebuild projections") and [REQ-SOT-8] ("Backup/restore
+#: preserves every field needed for projection rebuild and tenant/audit
+#: history"). This is NOT "every __tablename__ in db/models.py" and NOT
+#: "whatever rebuild_all_projections.py happens to import" — both of those
+#: would silently under- or over-claim what REQ-SOT-1/8 actually names.
+#: The ORM defines eleven tables total (ten in db/models.py, one in
+#: audit/models.py); this constant includes ten of them, each mapped to a
+#: REQ-SOT-1/8 clause:
+#:   - workspaces, sources, documents, chunks: "source/document/chunk
+#:     content", "workspaces"
+#:   - ingestion_runs: "lineage" (per-source ingestion history that chunks
+#:     reference via ingestion_run_id)
+#:   - entities, edges: "entity/outbox records" (the entity/edge half)
+#:   - outbox_events: "entity/outbox records" (the outbox half)
+#:   - entity_emitter: "governance metadata required to rebuild
+#:     projections" (the authority_emitter state machine a projection
+#:     consumer uses to accept/drop an incoming entity write)
+#:   - audit_log (packages/core/src/omniscience_core/audit/models.py):
+#:     "tenant and audit history" verbatim — an append-only,
+#:     workspace_id-scoped record of every audited tool invocation
+#: Excluded: api_tokens. It is authentication/authorization credential
+#: material (hashed tokens, scopes) — not ledger content, lineage, an
+#: entity/outbox record, or governance metadata that a projection rebuild
+#: or an audit-history claim depends on. If the schema grows a new
+#: authority table, this constant (and only this constant) must move.
+AUTHORITY_TABLES: frozenset[str] = frozenset(
+    {
+        "workspaces",
+        "sources",
+        "documents",
+        "ingestion_runs",
+        "chunks",
+        "entities",
+        "edges",
+        "entity_emitter",
+        "outbox_events",
+        "audit_log",
+    }
+)
+
+# Case-insensitive substring match on "prod" or "live" — deliberately not
+# \b-word-bounded. A \b boundary treats digits as word characters, so
+# \bprod\b misses prod1/prod01/production2/prodenv/liveenv, all ordinary
+# cloud-resource naming patterns (numeric suffixes, concatenated env+role
+# names). AC-DR-3 requires unconditional refusal on a production-like name;
+# a substring match over-flags a name like "olive-branch" but that is the
+# correct bias here — a false-positive refusal costs a renamed disposable
+# target, a false-negative lets a wipe hit production.
+_PRODUCTION_LIKE_PATTERN = re.compile(r"(?i)(prod|live)")
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """A decision return — never an exception, always GREEN or RED."""
+
+    status: str  # "GREEN" | "RED"
+    reasons: tuple[str, ...] = ()
+
+    @property
+    def is_green(self) -> bool:
+        return self.status == "GREEN"
+
+    @property
+    def abort(self) -> bool:
+        """True when the destructive path must abort (RED)."""
+        return not self.is_green
+
+
+def _load_json_evidence(path: Path | None) -> tuple[Any | None, str | None]:
+    """Load and parse a JSON evidence file with the same guards as
+    scripts/check_consumer_severance.py::_load_receipt (byte cap, strict
+    UTF-8, strict JSON). Returns (parsed, None) or (None, reason)."""
+    if path is None:
+        return None, "absent"
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        return None, f"unreadable:{exc}"
+    if size > _MAX_EVIDENCE_BYTES:
+        return None, f"too_large:{size}>{_MAX_EVIDENCE_BYTES}"
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError as exc:
+        return None, f"unreadable:{exc}"
+    try:
+        raw = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        return None, f"not_utf8:{exc}"
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"malformed:{exc}"
+    return parsed, None
+
+
+# ---------------------------------------------------------------------------
+# AC-DR-1: backup-policy evidence
+# ---------------------------------------------------------------------------
+
+
+def check_backup_policy_evidence(policy: Any | None) -> VerificationResult:
+    """Verify a backup-policy/manifest evidence object names every SPEC-SOT
+    authority table and carries immutable-copy ownership, retention,
+    encryption, cross-account/region copies, and a measured recovery point.
+
+    ``policy`` is the already-parsed JSON object (or None if absent/unreadable
+    — callers should use ``_load_json_evidence`` first). Missing/empty/
+    wrong-typed fields are RED with a specific reason each; nothing is
+    silently assumed complete.
+    """
+    if policy is None:
+        return VerificationResult("RED", ("policy_absent",))
+    if not isinstance(policy, dict):
+        return VerificationResult("RED", ("policy_malformed:not_an_object",))
+
+    reasons: list[str] = []
+
+    raw_tables = policy.get("authority_tables")
+    if not isinstance(raw_tables, list) or not all(isinstance(t, str) for t in raw_tables):
+        reasons.append("authority_tables_absent_or_malformed")
+        named_tables: frozenset[str] = frozenset()
+    else:
+        named_tables = frozenset(raw_tables)
+    missing_tables = AUTHORITY_TABLES - named_tables
+    for table in sorted(missing_tables):
+        reasons.append(f"authority_table_missing:{table}")
+
+    immutable_copy = policy.get("immutable_copy")
+    if not isinstance(immutable_copy, dict):
+        reasons.append("immutable_copy_absent_or_malformed")
+        immutable_copy = {}
+    owner = immutable_copy.get("owner")
+    if not isinstance(owner, str) or not owner.strip():
+        reasons.append("immutable_copy_owner_absent")
+    retention_days = immutable_copy.get("retention_days")
+    if (
+        not isinstance(retention_days, int)
+        or isinstance(retention_days, bool)
+        or retention_days <= 0
+    ):
+        reasons.append("immutable_copy_retention_days_absent_or_invalid")
+    encryption = immutable_copy.get("encryption")
+    if not isinstance(encryption, str) or not encryption.strip():
+        reasons.append("immutable_copy_encryption_absent")
+
+    cross_account = policy.get("cross_account_copy")
+    account = cross_account.get("account") if isinstance(cross_account, dict) else None
+    if not isinstance(account, str) or not account.strip():
+        reasons.append("cross_account_copy_absent")
+
+    cross_region = policy.get("cross_region_copy")
+    region = cross_region.get("region") if isinstance(cross_region, dict) else None
+    if not isinstance(region, str) or not region.strip():
+        reasons.append("cross_region_copy_absent")
+
+    recovery_point = policy.get("measured_recovery_point_seconds")
+    if (
+        not isinstance(recovery_point, (int, float))
+        or isinstance(recovery_point, bool)
+        or recovery_point < 0
+    ):
+        reasons.append("measured_recovery_point_absent_or_invalid")
+
+    if reasons:
+        return VerificationResult("RED", tuple(reasons))
+    return VerificationResult("GREEN")
+
+
+# ---------------------------------------------------------------------------
+# AC-DR-2: destructive-command approval envelope
+# ---------------------------------------------------------------------------
+
+_ENVELOPE_REQUIRED_FIELDS: tuple[str, ...] = (
+    "command_digest",
+    "source_backup_id",
+    "target_account",
+    "target_region",
+    "environment_identity",
+    "issued_at",
+    "expires_at",
+    "nonce",
+    "approved_by",
+)
+
+
+class NonceLedger(Protocol):
+    """Append-only redemption ledger — a nonce may be consumed exactly once."""
+
+    def is_consumed(self, nonce: str) -> bool: ...
+
+    def consume(self, nonce: str) -> None: ...
+
+
+class InMemoryNonceLedger:
+    """Process-local NonceLedger. Real drills need a durable ledger; this is
+    sufficient for a single-process CLI invocation or a unit test fake."""
+
+    def __init__(self) -> None:
+        self._consumed: set[str] = set()
+
+    def is_consumed(self, nonce: str) -> bool:
+        return nonce in self._consumed
+
+    def consume(self, nonce: str) -> None:
+        self._consumed.add(nonce)
+
+
+class NonceLedgerCorruptError(RuntimeError):
+    """Raised by a NonceLedger when its durable state cannot be trusted
+    (unreadable, oversized, non-UTF-8, malformed JSON, or wrong-shaped).
+
+    A NonceLedger MUST fail closed on corruption, never fall back to an
+    empty consumed-set: an empty set means "nothing has ever been
+    consumed," which would let a previously-redeemed nonce (and the
+    destructive approval it was attached to) pass as fresh again.
+    """
+
+
+class FileNonceLedger:
+    """Durable NonceLedger backed by a JSON array file of consumed nonces.
+
+    Suitable for the CLI where successive one-shot invocations must share
+    redemption state without a database. Not suitable for concurrent writers
+    (no locking) — a real drill runner should back this with the same
+    durable store as the rest of its redemption audit trail.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def _read(self) -> set[str]:
+        """Read the consumed-nonce set. A missing file is a legitimate,
+        never-yet-used ledger (empty set). Any other unreadable/oversized/
+        malformed state raises NonceLedgerCorruptError — it is never
+        silently treated as "nothing consumed."
+        """
+        if not self._path.is_file():
+            return set()
+        try:
+            size = self._path.stat().st_size
+        except OSError as exc:
+            raise NonceLedgerCorruptError(f"unreadable:{exc}") from exc
+        if size > _MAX_EVIDENCE_BYTES:
+            raise NonceLedgerCorruptError(f"too_large:{size}>{_MAX_EVIDENCE_BYTES}")
+        try:
+            raw_bytes = self._path.read_bytes()
+        except OSError as exc:
+            raise NonceLedgerCorruptError(f"unreadable:{exc}") from exc
+        try:
+            raw = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise NonceLedgerCorruptError(f"not_utf8:{exc}") from exc
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise NonceLedgerCorruptError(f"malformed:{exc}") from exc
+        if not isinstance(data, list) or not all(isinstance(n, str) for n in data):
+            raise NonceLedgerCorruptError("not_a_list_of_strings")
+        return set(data)
+
+    def is_consumed(self, nonce: str) -> bool:
+        return nonce in self._read()
+
+    def consume(self, nonce: str) -> None:
+        consumed = self._read()
+        consumed.add(nonce)
+        # Atomic write: a crash/SIGKILL/disk-full between these two steps
+        # must never leave self._path truncated or partially written — the
+        # rename is the only step that can touch the real path, and it is
+        # atomic on the same filesystem.
+        tmp_path = self._path.parent / f"{self._path.name}.tmp"
+        tmp_path.write_text(json.dumps(sorted(consumed)), encoding="utf-8")
+        os.replace(tmp_path, self._path)
+
+
+def compute_command_digest(command: str) -> str:
+    """Return the sha256 hex digest of the exact destructive command string."""
+    return hashlib.sha256(command.encode("utf-8")).hexdigest()
+
+
+def _parse_rfc3339(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def verify_approval_envelope(
+    *,
+    envelope: Any | None,
+    now: datetime,
+    expected_command: str,
+    expected_source_backup_id: str,
+    expected_target_account: str,
+    expected_target_region: str,
+    observed_environment_identity: str,
+    nonce_ledger: NonceLedger,
+) -> VerificationResult:
+    """Verify a one-shot destructive-command approval envelope.
+
+    ``now`` is injected (never ``datetime.now()`` internally) so the check is
+    deterministic and testable. ``observed_environment_identity`` must come
+    from a source independent of the envelope itself (a live identity check
+    in a real drill; a fixture value in a test) — the envelope's own claim is
+    never trusted as its own proof.
+
+    Absent, expired, mismatched, or replayed approval returns RED with a
+    field-specific reason and never mutates the nonce ledger. Only a fully
+    valid envelope consumes its nonce (on the same call that returns GREEN),
+    so a rejected submission never burns a legitimate nonce.
+    """
+    if envelope is None:
+        return VerificationResult("RED", ("envelope_absent",))
+    if not isinstance(envelope, dict):
+        return VerificationResult("RED", ("envelope_malformed:not_an_object",))
+
+    missing = [
+        f
+        for f in _ENVELOPE_REQUIRED_FIELDS
+        if not isinstance(envelope.get(f), str) or not envelope.get(f)
+    ]
+    if missing:
+        return VerificationResult("RED", tuple(f"envelope_field_missing:{f}" for f in missing))
+
+    expires_at = _parse_rfc3339(envelope["expires_at"])
+    if expires_at is None:
+        return VerificationResult("RED", ("envelope_expires_at_unparseable",))
+    if now > expires_at:
+        return VerificationResult(
+            "RED", (f"envelope_expired:expires_at={envelope['expires_at']}",)
+        )
+
+    expected_digest = compute_command_digest(expected_command)
+    if envelope["command_digest"] != expected_digest:
+        return VerificationResult("RED", ("command_digest_mismatch",))
+    if envelope["source_backup_id"] != expected_source_backup_id:
+        return VerificationResult("RED", ("source_backup_id_mismatch",))
+    if envelope["target_account"] != expected_target_account:
+        return VerificationResult("RED", ("target_account_mismatch",))
+    if envelope["target_region"] != expected_target_region:
+        return VerificationResult("RED", ("target_region_mismatch",))
+    if envelope["environment_identity"] != observed_environment_identity:
+        return VerificationResult("RED", ("environment_identity_mismatch",))
+
+    nonce = envelope["nonce"]
+    try:
+        already_consumed = nonce_ledger.is_consumed(nonce)
+    except NonceLedgerCorruptError as exc:
+        return VerificationResult("RED", (f"nonce_ledger_corrupt:{exc}",))
+    if already_consumed:
+        return VerificationResult("RED", ("nonce_replayed",))
+
+    try:
+        nonce_ledger.consume(nonce)
+    except NonceLedgerCorruptError as exc:
+        return VerificationResult("RED", (f"nonce_ledger_corrupt:{exc}",))
+    return VerificationResult("GREEN")
+
+
+# ---------------------------------------------------------------------------
+# AC-DR-3: destructive-safety refusal
+# ---------------------------------------------------------------------------
+
+
+class AmbiguousIdentityError(Exception):
+    """Raised by a CredentialResolver when more than one candidate cloud
+    identity resolves for the operation, or the identity cannot be uniquely
+    resolved."""
+
+
+class WriterLeaseSource(Protocol):
+    """Reports whether a live writer/consumer lease is currently held."""
+
+    def has_active_writers(self) -> bool: ...
+
+
+class CredentialResolver(Protocol):
+    """Resolves the single cloud identity the destructive command would run
+    as. Must raise AmbiguousIdentityError when more than one candidate
+    resolves."""
+
+    def resolve_identity(self) -> str: ...
+
+
+def check_destructive_safety(
+    *,
+    target_name: str | None = None,
+    target_tags: dict[str, str] | None = None,
+    qdrant_chunk_count: int,
+    neo4j_entity_count: int,
+    drill_context: bool = False,
+    writer_lease_source: WriterLeaseSource | None = None,
+    credential_resolver: CredentialResolver | None = None,
+) -> VerificationResult:
+    """Refuse a destructive wipe/restore unless every available safety
+    check passes. Each check is evaluated only when its input is supplied
+    (``None`` means "not applicable in this caller's context", not "assume
+    safe") — see module docstring for why rebuild_all_projections.py only
+    exercises a subset of these checks today.
+
+    ``drill_context=True`` authorizes wiping projections that are already
+    non-empty (the ordinary DR-rebuild case: Neo4j/Qdrant hold stale data
+    that is about to be replaced from the Postgres source of truth). It does
+    NOT bypass the production-name, disposable-tag, writer-lease, or
+    credential-ambiguity checks.
+    """
+    reasons: list[str] = []
+
+    if target_name is not None and _PRODUCTION_LIKE_PATTERN.search(target_name):
+        reasons.append(f"production_like_name:{target_name!r}")
+
+    if target_tags is not None and target_tags.get("disposable") != "true":
+        reasons.append("absent_disposable_identity")
+
+    if not drill_context and (qdrant_chunk_count != 0 or neo4j_entity_count != 0):
+        reasons.append(
+            f"non_empty_projections:qdrant={qdrant_chunk_count}:neo4j={neo4j_entity_count}"
+        )
+
+    if writer_lease_source is not None:
+        try:
+            if writer_lease_source.has_active_writers():
+                reasons.append("active_writers_detected")
+        except Exception as exc:
+            reasons.append(f"writer_lease_check_failed:{exc}")
+
+    if credential_resolver is not None:
+        try:
+            credential_resolver.resolve_identity()
+        except AmbiguousIdentityError as exc:
+            reasons.append(f"ambiguous_credentials:{exc}")
+        except Exception as exc:
+            reasons.append(f"credential_resolution_failed:{exc}")
+
+    if reasons:
+        return VerificationResult("RED", tuple(reasons))
+    return VerificationResult("GREEN")
+
+
+# ---------------------------------------------------------------------------
+# AC-DR-5: drill manifest
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(
+        payload, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+@dataclass(frozen=True)
+class DrillManifest:
+    """Content-addressed, tamper-evident record of a backup/restore drill.
+
+    ``manifest_id`` is a self-addressing sha256 of every other field, so a
+    tampered or partially-filled manifest cannot silently claim a different
+    identity. Any field that could not be measured is ``None`` (an honest
+    absence marker), never a fabricated placeholder — see ``build_manifest``.
+    """
+
+    manifest_id: str
+    drill_started_at: str | None
+    drill_completed_at: str | None
+    measured_rpo_seconds: float | None
+    measured_rto_seconds: float | None
+    rto_budget_seconds: int | None
+    rto_exceeded: bool | None
+    source_backup_id: str | None
+    restored_environment_identity: str | None
+    verification_passed: bool | None
+    verification_mismatches: tuple[str, ...]
+    hash_equivalence_mismatches: tuple[str, ...]
+    query_probes_passed: bool | None
+    status: str  # "GREEN" | "RED"
+    reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest_id": self.manifest_id,
+            "drill_started_at": self.drill_started_at,
+            "drill_completed_at": self.drill_completed_at,
+            "measured_rpo_seconds": self.measured_rpo_seconds,
+            "measured_rto_seconds": self.measured_rto_seconds,
+            "rto_budget_seconds": self.rto_budget_seconds,
+            "rto_exceeded": self.rto_exceeded,
+            "source_backup_id": self.source_backup_id,
+            "restored_environment_identity": self.restored_environment_identity,
+            "verification_passed": self.verification_passed,
+            "verification_mismatches": list(self.verification_mismatches),
+            "hash_equivalence_mismatches": list(self.hash_equivalence_mismatches),
+            "query_probes_passed": self.query_probes_passed,
+            "status": self.status,
+            "reasons": list(self.reasons),
+        }
+
+    def to_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+
+def build_manifest(
+    *,
+    drill_started_at: str | None,
+    drill_completed_at: str | None,
+    measured_rpo_seconds: float | None,
+    rto_result: RtoResult | None,
+    source_backup_id: str | None,
+    restored_environment_identity: str | None,
+    verification_result: DRVerificationResult | None,
+    hash_equivalence_mismatches: list[str] | None,
+    query_probes_passed: bool | None,
+) -> DrillManifest:
+    """Build a DrillManifest from measured drill inputs.
+
+    Every parameter is the caller's own measured/observed value — this
+    function never invents one. A ``None``/absent input, an RTO breach, a
+    failed verification, a non-empty hash-equivalence mismatch list, or
+    ``query_probes_passed=False`` all produce ``status="RED"`` with a
+    specific reason; nothing here silently defaults to a passing state.
+    """
+    reasons: list[str] = []
+
+    if not drill_started_at:
+        reasons.append("drill_started_at_absent")
+    if not drill_completed_at:
+        reasons.append("drill_completed_at_absent")
+    if measured_rpo_seconds is None or measured_rpo_seconds < 0:
+        reasons.append("measured_rpo_seconds_absent_or_invalid")
+
+    if rto_result is None:
+        reasons.append("rto_result_absent")
+    elif rto_result.exceeded:
+        reasons.append(
+            f"rto_exceeded:elapsed={rto_result.elapsed_seconds:.1f}:"
+            f"budget={rto_result.budget_seconds}"
+        )
+
+    if not source_backup_id:
+        reasons.append("source_backup_id_absent")
+    if not restored_environment_identity:
+        reasons.append("restored_environment_identity_absent")
+
+    if verification_result is None:
+        reasons.append("verification_result_absent")
+    elif not verification_result.passed:
+        reasons.append("verification_failed")
+
+    if hash_equivalence_mismatches is None:
+        reasons.append("hash_equivalence_result_absent")
+    elif hash_equivalence_mismatches:
+        reasons.append("hash_equivalence_mismatch")
+
+    if query_probes_passed is None:
+        reasons.append("query_probes_absent")
+    elif not query_probes_passed:
+        reasons.append("query_probes_failed")
+
+    status = "RED" if reasons else "GREEN"
+
+    body: dict[str, Any] = {
+        "drill_started_at": drill_started_at,
+        "drill_completed_at": drill_completed_at,
+        "measured_rpo_seconds": measured_rpo_seconds,
+        "measured_rto_seconds": rto_result.elapsed_seconds if rto_result is not None else None,
+        "rto_budget_seconds": rto_result.budget_seconds if rto_result is not None else None,
+        "rto_exceeded": rto_result.exceeded if rto_result is not None else None,
+        "source_backup_id": source_backup_id,
+        "restored_environment_identity": restored_environment_identity,
+        "verification_passed": (
+            verification_result.passed if verification_result is not None else None
+        ),
+        "verification_mismatches": (
+            list(verification_result.mismatches) if verification_result else []
+        ),
+        "hash_equivalence_mismatches": list(hash_equivalence_mismatches or []),
+        "query_probes_passed": query_probes_passed,
+        "status": status,
+        "reasons": reasons,
+    }
+    content_hash = hashlib.sha256(_canonical_json(body).encode("utf-8")).hexdigest()
+
+    return DrillManifest(
+        manifest_id=f"sha256:{content_hash}",
+        drill_started_at=body["drill_started_at"],
+        drill_completed_at=body["drill_completed_at"],
+        measured_rpo_seconds=body["measured_rpo_seconds"],
+        measured_rto_seconds=body["measured_rto_seconds"],
+        rto_budget_seconds=body["rto_budget_seconds"],
+        rto_exceeded=body["rto_exceeded"],
+        source_backup_id=body["source_backup_id"],
+        restored_environment_identity=body["restored_environment_identity"],
+        verification_passed=body["verification_passed"],
+        verification_mismatches=tuple(body["verification_mismatches"]),
+        hash_equivalence_mismatches=tuple(body["hash_equivalence_mismatches"]),
+        query_probes_passed=body["query_probes_passed"],
+        status=status,
+        reasons=tuple(reasons),
+    )
+
+
+_MANIFEST_REQUIRED_FIELDS: tuple[str, ...] = (
+    "manifest_id",
+    "drill_started_at",
+    "drill_completed_at",
+    "measured_rpo_seconds",
+    "measured_rto_seconds",
+    "rto_budget_seconds",
+    "rto_exceeded",
+    "source_backup_id",
+    "restored_environment_identity",
+    "verification_passed",
+    "query_probes_passed",
+    "status",
+)
+
+
+def validate_manifest_json(manifest: Any | None) -> VerificationResult:
+    """Re-validate an already-serialized drill manifest artifact (e.g. one
+    produced by a prior drill run and committed as CI evidence). Distinct
+    from ``build_manifest``: this only checks the artifact's own shape and
+    declared status, never reconstructs one.
+    """
+    if manifest is None:
+        return VerificationResult("RED", ("manifest_absent",))
+    if not isinstance(manifest, dict):
+        return VerificationResult("RED", ("manifest_malformed:not_an_object",))
+
+    reasons: list[str] = []
+    for f in _MANIFEST_REQUIRED_FIELDS:
+        if f not in manifest or manifest[f] is None:
+            reasons.append(f"manifest_field_absent:{f}")
+
+    if manifest.get("rto_exceeded") is True:
+        reasons.append("manifest_rto_exceeded")
+    if manifest.get("verification_passed") is False:
+        reasons.append("manifest_verification_failed")
+    if manifest.get("query_probes_passed") is False:
+        reasons.append("manifest_query_probes_failed")
+    declared_status = manifest.get("status")
+    if declared_status != "GREEN":
+        reasons.append(f"manifest_status_not_green:{declared_status!r}")
+
+    if reasons:
+        return VerificationResult("RED", tuple(dict.fromkeys(reasons)))
+    return VerificationResult("GREEN")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class _CliWriterLeaseSource:
+    def __init__(self, active: bool) -> None:
+        self._active = active
+
+    def has_active_writers(self) -> bool:
+        return self._active
+
+
+class _CliCredentialResolver:
+    def __init__(self, *, ambiguous: bool, identity: str) -> None:
+        self._ambiguous = ambiguous
+        self._identity = identity
+
+    def resolve_identity(self) -> str:
+        if self._ambiguous:
+            raise AmbiguousIdentityError("multiple candidate identities resolved")
+        return self._identity
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--policy", type=Path, default=None, help="AC-DR-1 backup-policy evidence JSON."
+    )
+    parser.add_argument(
+        "--envelope", type=Path, default=None, help="AC-DR-2 approval envelope JSON."
+    )
+    parser.add_argument(
+        "--command", default=None, help="Exact destructive command the envelope must pin."
+    )
+    parser.add_argument("--source-backup-id", default=None)
+    parser.add_argument("--target-account", default=None)
+    parser.add_argument("--target-region", default=None)
+    parser.add_argument(
+        "--environment-identity", default=None, help="Independently observed target identity."
+    )
+    parser.add_argument(
+        "--now", default=None, help="RFC3339 timestamp used as 'now' for expiry checks."
+    )
+    parser.add_argument("--nonce-ledger-path", type=Path, default=None)
+    parser.add_argument(
+        "--target-name", default=None, help="AC-DR-3 refusal check: target identifier."
+    )
+    parser.add_argument(
+        "--target-tags-json", default=None, help="AC-DR-3 refusal check: JSON object of tags."
+    )
+    parser.add_argument("--qdrant-chunk-count", type=int, default=None)
+    parser.add_argument("--neo4j-entity-count", type=int, default=None)
+    parser.add_argument("--drill-context", action="store_true")
+    parser.add_argument("--active-writers", action="store_true")
+    parser.add_argument("--ambiguous-credentials", action="store_true")
+    parser.add_argument("--credential-identity", default="unknown")
+    parser.add_argument(
+        "--manifest", type=Path, default=None, help="AC-DR-5 manifest JSON to validate."
+    )
+    return parser
+
+
+def _is_blank_required_arg(value: object) -> bool:
+    """True for None or an empty/whitespace-only str/Path — a required
+    binding field (command, target account/region, ...) must be genuinely
+    present, not an empty string that would bind against a vacuous
+    expected value (e.g. compute_command_digest(""))."""
+    if value is None:
+        return True
+    if isinstance(value, (str, Path)):
+        return not str(value).strip()
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
+    ran_any = False
+    all_reasons: list[str] = []
+    overall_green = True
+
+    def _record(label: str, result: VerificationResult) -> None:
+        nonlocal overall_green
+        if not result.is_green:
+            overall_green = False
+            for reason in result.reasons:
+                all_reasons.append(f"{label}:{reason}")
+
+    if args.policy is not None:
+        ran_any = True
+        policy, load_error = _load_json_evidence(args.policy)
+        if load_error is not None:
+            _record("policy", VerificationResult("RED", (f"policy_{load_error}",)))
+        else:
+            _record("policy", check_backup_policy_evidence(policy))
+
+    if args.envelope is not None:
+        ran_any = True
+        required = (
+            args.command,
+            args.source_backup_id,
+            args.target_account,
+            args.target_region,
+            args.environment_identity,
+            args.now,
+            args.nonce_ledger_path,
+        )
+        if any(_is_blank_required_arg(v) for v in required):
+            _record(
+                "envelope",
+                VerificationResult("RED", ("cli_missing_required_envelope_arguments",)),
+            )
+        else:
+            envelope, load_error = _load_json_evidence(args.envelope)
+            if load_error is not None:
+                _record("envelope", VerificationResult("RED", (f"envelope_{load_error}",)))
+            else:
+                now = _parse_rfc3339(args.now)
+                if now is None:
+                    _record("envelope", VerificationResult("RED", ("cli_now_unparseable",)))
+                else:
+                    ledger = FileNonceLedger(args.nonce_ledger_path)
+                    _record(
+                        "envelope",
+                        verify_approval_envelope(
+                            envelope=envelope,
+                            now=now,
+                            expected_command=args.command,
+                            expected_source_backup_id=args.source_backup_id,
+                            expected_target_account=args.target_account,
+                            expected_target_region=args.target_region,
+                            observed_environment_identity=args.environment_identity,
+                            nonce_ledger=ledger,
+                        ),
+                    )
+
+    if (
+        args.target_name is not None
+        or args.qdrant_chunk_count is not None
+        or args.neo4j_entity_count is not None
+    ):
+        ran_any = True
+        if args.qdrant_chunk_count is None or args.neo4j_entity_count is None:
+            _record("refusal", VerificationResult("RED", ("refusal_counts_required",)))
+        else:
+            target_tags: dict[str, str] | None = None
+            if args.target_tags_json is not None:
+                try:
+                    parsed_tags = json.loads(args.target_tags_json)
+                except json.JSONDecodeError:
+                    _record("refusal", VerificationResult("RED", ("target_tags_malformed",)))
+                    parsed_tags = None
+                if isinstance(parsed_tags, dict):
+                    target_tags = {str(k): str(v) for k, v in parsed_tags.items()}
+            _record(
+                "refusal",
+                check_destructive_safety(
+                    target_name=args.target_name,
+                    target_tags=target_tags,
+                    qdrant_chunk_count=args.qdrant_chunk_count,
+                    neo4j_entity_count=args.neo4j_entity_count,
+                    drill_context=args.drill_context,
+                    writer_lease_source=_CliWriterLeaseSource(args.active_writers),
+                    credential_resolver=_CliCredentialResolver(
+                        ambiguous=args.ambiguous_credentials, identity=args.credential_identity
+                    ),
+                ),
+            )
+
+    if args.manifest is not None:
+        ran_any = True
+        manifest, load_error = _load_json_evidence(args.manifest)
+        if load_error is not None:
+            _record("manifest", VerificationResult("RED", (f"manifest_{load_error}",)))
+        else:
+            _record("manifest", validate_manifest_json(manifest))
+
+    if not ran_any:
+        print(
+            "qualify-backup-restore: RED (decision-return) — no check requested", file=sys.stderr
+        )
+        print("- no_check_requested", file=sys.stderr)
+        return 1
+
+    if overall_green:
+        print("qualify-backup-restore verification: GREEN")
+        return 0
+
+    print("qualify-backup-restore verification: RED (decision-return)", file=sys.stderr)
+    for reason in all_reasons:
+        print(f"- {reason}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rebuild_all_projections.py
+++ b/scripts/rebuild_all_projections.py
@@ -27,6 +27,23 @@ Default budget: 900 seconds (15 minutes).  Override with --rto-seconds N.
 The script exits with code 2 if elapsed time exceeds the budget.
 See docs/decisions/0018-rebuild-direct-write-exception.md §RTO for guidance.
 
+Pre-wipe destructive-safety refusal (AC-DR-3 / P-SOT-6)
+=========================================================
+Before wiping Neo4j/Qdrant, the script measures each store's current point/
+node count and refuses to proceed if either is non-empty, UNLESS the
+OMNISCIENCE_DR_DRILL=1 environment variable is set (the same sanctioned-drill
+marker scripts/seed_dr_drill.py already requires).  This closes the gap where
+`--yes` alone wiped whatever it found with no precondition check at all
+(REQ-SOT-6: "unmet precondition aborts before destructive action").  A
+routine drill run (dr-drill.yml) is unaffected: its Neo4j/Qdrant containers
+start empty, so the check passes trivially even without the env var; the env
+var only matters for a repeat rebuild against already-populated projections.
+Exit code 4 on refusal.  See scripts/qualify_backup_restore.py for the shared
+check_destructive_safety() implementation and docs/runbooks/backup-restore.md
+for the full safety-interlock picture (production-name/disposable-tag/
+writer-lease/credential-ambiguity checks are available there but are not
+wired into this script — no target-identity config surface exists yet).
+
 --recompute-embeddings (AP5)
 =============================
 When set, the rebuild IGNORES stored ``chunk.embedding`` values and
@@ -48,6 +65,7 @@ this flag.
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import time
 import uuid
@@ -69,6 +87,7 @@ from omniscience_index.stores.qdrant_config import QdrantConfig
 from omniscience_index.stores.qdrant_constants import COLLECTION_NAME_PREFIX
 from omniscience_index.stores.qdrant_store import QdrantVectorStore
 from qdrant_client import AsyncQdrantClient
+from qualify_backup_restore import VerificationResult, check_destructive_safety
 from sqlalchemy import func, select, text
 
 #: AP5 flag: exported so tests can assert the flag exists and is parseable.
@@ -121,6 +140,30 @@ async def _reset_qdrant_collections(
     # connect() bootstraps only after close() clears the store's lifecycle state.
     await vector_store.close()
     await vector_store.connect()
+
+
+async def _pre_wipe_counts(
+    qdrant_client: AsyncQdrantClient,
+    graph_store: Neo4jGraphStore,
+) -> tuple[int, int]:
+    """Return (total_qdrant_points, total_neo4j_nodes) across managed stores.
+
+    Measured immediately before a wipe so check_destructive_safety() can
+    refuse to proceed against a non-empty target outside a sanctioned drill
+    context (AC-DR-3 / P-SOT-6).
+    """
+    qdrant_total = 0
+    for collection in (await qdrant_client.get_collections()).collections:
+        if collection.name.startswith(COLLECTION_NAME_PREFIX):
+            count_result = await qdrant_client.count(collection_name=collection.name, exact=True)
+            qdrant_total += count_result.count
+
+    async with graph_store._driver.session(database=graph_store._config.database) as session:
+        result = await session.run("MATCH (n) RETURN count(n) AS c")
+        record = await result.single()
+        neo4j_total = int(record["c"]) if record is not None else 0
+
+    return qdrant_total, neo4j_total
 
 
 class EntityWrapper:
@@ -409,6 +452,31 @@ async def main() -> None:
     # ------------------------------------------------------------------
     # Full rebuild path
     # ------------------------------------------------------------------
+
+    # Pre-wipe destructive-safety refusal (AC-DR-3 / P-SOT-6). Measure
+    # current store occupancy and refuse to wipe a non-empty target unless
+    # a sanctioned drill context authorizes it (see module docstring).
+    drill_context = os.environ.get("OMNISCIENCE_DR_DRILL") == "1"
+    pre_qdrant_count, pre_neo4j_count = await _pre_wipe_counts(qdrant_client, graph_store)
+    safety: VerificationResult = check_destructive_safety(
+        qdrant_chunk_count=pre_qdrant_count,
+        neo4j_entity_count=pre_neo4j_count,
+        drill_context=drill_context,
+    )
+    if not safety.is_green:
+        print("Refusing to wipe: destructive-safety precondition failed (AC-DR-3 / P-SOT-6).")
+        for reason in safety.reasons:
+            print(f"  - {reason}")
+        print(
+            "Set OMNISCIENCE_DR_DRILL=1 to authorize wiping already-populated projections "
+            "in a sanctioned drill/DR context."
+        )
+        await vector_store.close()
+        await graph_store.close()
+        await qdrant_client.close()
+        await engine.dispose()
+        sys.exit(4)
+
     print("Wiping Neo4j and Qdrant...")
 
     # 1. Wipe Neo4j

--- a/tests/test_backup_restore_approval.py
+++ b/tests/test_backup_restore_approval.py
@@ -1,0 +1,407 @@
+"""AC-DR-2 tests: destructive-command approval envelope verification.
+
+Absent, expired, mismatched, or replayed approval must abort before
+mutation, each with a field-specific RED reason — see fixture ids
+approval-* in test_backup_restore_fixtures.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import qualify_backup_restore
+from qualify_backup_restore import (
+    _ENVELOPE_REQUIRED_FIELDS,
+    FileNonceLedger,
+    InMemoryNonceLedger,
+    NonceLedgerCorruptError,
+    compute_command_digest,
+    verify_approval_envelope,
+)
+from qualify_backup_restore import main as cli_main
+
+NOW = datetime(2026, 7, 20, 12, 0, 0, tzinfo=UTC)
+EXPECTED_COMMAND = "python scripts/rebuild_all_projections.py --yes --restore-from backup-123"
+EXPECTED_DIGEST = compute_command_digest(EXPECTED_COMMAND)
+EXPECTED_SOURCE_BACKUP_ID = "backup-123"
+EXPECTED_TARGET_ACCOUNT = "111122223333"
+EXPECTED_TARGET_REGION = "us-east-1"
+OBSERVED_ENVIRONMENT_IDENTITY = "recovery-env-alpha"
+
+
+def _valid_envelope(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "command_digest": EXPECTED_DIGEST,
+        "source_backup_id": EXPECTED_SOURCE_BACKUP_ID,
+        "target_account": EXPECTED_TARGET_ACCOUNT,
+        "target_region": EXPECTED_TARGET_REGION,
+        "environment_identity": OBSERVED_ENVIRONMENT_IDENTITY,
+        "issued_at": "2026-07-20T11:45:00Z",
+        "expires_at": "2026-07-20T12:15:00Z",
+        "nonce": "nonce-abc-123",
+        "approved_by": "alice@example.com",
+    }
+    base.update(overrides)
+    return base
+
+
+def _verify(envelope: object, *, now: datetime = NOW, ledger=None):
+    return verify_approval_envelope(
+        envelope=envelope,
+        now=now,
+        expected_command=EXPECTED_COMMAND,
+        expected_source_backup_id=EXPECTED_SOURCE_BACKUP_ID,
+        expected_target_account=EXPECTED_TARGET_ACCOUNT,
+        expected_target_region=EXPECTED_TARGET_REGION,
+        observed_environment_identity=OBSERVED_ENVIRONMENT_IDENTITY,
+        nonce_ledger=ledger if ledger is not None else InMemoryNonceLedger(),
+    )
+
+
+def test_absent_envelope_is_red() -> None:
+    result = _verify(None)
+    assert result.status == "RED"
+    assert result.reasons == ("envelope_absent",)
+
+
+def test_non_object_envelope_is_red() -> None:
+    result = _verify(["not", "an", "object"])
+    assert result.status == "RED"
+    assert result.reasons == ("envelope_malformed:not_an_object",)
+
+
+@pytest.mark.parametrize("field", _ENVELOPE_REQUIRED_FIELDS)
+def test_missing_required_field_is_red(field: str) -> None:
+    envelope = _valid_envelope()
+    del envelope[field]
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == (f"envelope_field_missing:{field}",)
+
+
+def test_empty_string_field_is_red_same_as_missing() -> None:
+    envelope = _valid_envelope(approved_by="")
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == ("envelope_field_missing:approved_by",)
+
+
+def test_unparseable_expires_at_is_red() -> None:
+    envelope = _valid_envelope(expires_at="not-a-timestamp")
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == ("envelope_expires_at_unparseable",)
+
+
+def test_expired_envelope_is_red() -> None:
+    envelope = _valid_envelope(expires_at="2026-07-20T11:00:00Z")  # before NOW
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons[0].startswith("envelope_expired")
+
+
+def test_exactly_at_expiry_is_not_expired() -> None:
+    envelope = _valid_envelope(expires_at=NOW.isoformat().replace("+00:00", "Z"))
+    result = _verify(envelope)
+    assert result.status == "GREEN"
+
+
+def test_command_digest_mismatch_is_red() -> None:
+    envelope = _valid_envelope(command_digest="0" * 64)
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == ("command_digest_mismatch",)
+
+
+def test_source_backup_id_mismatch_is_red() -> None:
+    envelope = _valid_envelope(source_backup_id="backup-999")
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == ("source_backup_id_mismatch",)
+
+
+def test_target_account_mismatch_is_red() -> None:
+    envelope = _valid_envelope(target_account="999999999999")
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == ("target_account_mismatch",)
+
+
+def test_target_region_mismatch_is_red() -> None:
+    envelope = _valid_envelope(target_region="eu-west-1")
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == ("target_region_mismatch",)
+
+
+def test_environment_identity_mismatch_is_red() -> None:
+    envelope = _valid_envelope(environment_identity="wrong-env")
+    result = _verify(envelope)
+    assert result.status == "RED"
+    assert result.reasons == ("environment_identity_mismatch",)
+
+
+def test_replayed_nonce_is_red() -> None:
+    ledger = InMemoryNonceLedger()
+    envelope = _valid_envelope()
+
+    first = _verify(envelope, ledger=ledger)
+    assert first.status == "GREEN"
+
+    second = _verify(envelope, ledger=ledger)
+    assert second.status == "RED"
+    assert second.reasons == ("nonce_replayed",)
+
+
+def test_rejected_envelope_does_not_consume_nonce() -> None:
+    """A mismatched submission must not burn the nonce for a later, valid one."""
+    ledger = InMemoryNonceLedger()
+    bad_envelope = _valid_envelope(command_digest="0" * 64)
+    rejected = _verify(bad_envelope, ledger=ledger)
+    assert rejected.status == "RED"
+
+    good_envelope = _valid_envelope()  # same nonce
+    accepted = _verify(good_envelope, ledger=ledger)
+    assert accepted.status == "GREEN"
+
+
+def test_valid_envelope_is_green() -> None:
+    result = _verify(_valid_envelope())
+    assert result.status == "GREEN"
+    assert result.reasons == ()
+
+
+def test_now_injected_never_wall_clock() -> None:
+    """now is an explicit parameter — the same envelope is expired or not
+    purely as a function of the injected value, proving no hidden
+    datetime.now() call is involved."""
+    envelope = _valid_envelope()
+    before_expiry = _verify(envelope, now=NOW)
+    after_expiry = _verify(envelope, now=NOW + timedelta(hours=1))
+    assert before_expiry.status == "GREEN"
+    assert after_expiry.status == "RED"
+
+
+# ---------------------------------------------------------------------------
+# FileNonceLedger: fail-closed on corruption, atomic writes
+# ---------------------------------------------------------------------------
+
+
+class TestFileNonceLedger:
+    def test_missing_file_is_legitimately_empty(self, tmp_path: Path) -> None:
+        """No prior ledger file is a genuinely never-used ledger, not
+        corruption — the first use of a nonce must be GREEN."""
+        ledger = FileNonceLedger(tmp_path / "nonce-ledger.json")
+        assert ledger.is_consumed("n1") is False
+
+    def test_truncated_json_raises_corrupt(self, tmp_path: Path) -> None:
+        path = tmp_path / "nonce-ledger.json"
+        path.write_bytes(b'["n1", "n2"')
+        ledger = FileNonceLedger(path)
+        with pytest.raises(NonceLedgerCorruptError):
+            ledger.is_consumed("n1")
+
+    def test_zero_byte_file_raises_corrupt(self, tmp_path: Path) -> None:
+        path = tmp_path / "nonce-ledger.json"
+        path.write_bytes(b"")
+        ledger = FileNonceLedger(path)
+        with pytest.raises(NonceLedgerCorruptError):
+            ledger.is_consumed("n1")
+
+    def test_non_utf8_bytes_raises_corrupt(self, tmp_path: Path) -> None:
+        path = tmp_path / "nonce-ledger.json"
+        path.write_bytes(b"\xff\xfe\x00\x01")
+        ledger = FileNonceLedger(path)
+        with pytest.raises(NonceLedgerCorruptError):
+            ledger.is_consumed("n1")
+
+    def test_oversized_file_raises_corrupt(self, tmp_path: Path) -> None:
+        path = tmp_path / "nonce-ledger.json"
+        oversized_payload = json.dumps([f"nonce-{i}" for i in range(200_000)])
+        assert len(oversized_payload.encode("utf-8")) > 1_000_000
+        path.write_text(oversized_payload, encoding="utf-8")
+        ledger = FileNonceLedger(path)
+        with pytest.raises(NonceLedgerCorruptError):
+            ledger.is_consumed("n1")
+
+    def test_non_list_json_raises_corrupt(self, tmp_path: Path) -> None:
+        path = tmp_path / "nonce-ledger.json"
+        path.write_text(json.dumps({"not": "a list"}), encoding="utf-8")
+        ledger = FileNonceLedger(path)
+        with pytest.raises(NonceLedgerCorruptError):
+            ledger.is_consumed("n1")
+
+    def test_consume_writes_atomically_no_tmp_residue(self, tmp_path: Path) -> None:
+        path = tmp_path / "nonce-ledger.json"
+        ledger = FileNonceLedger(path)
+        ledger.consume("n1")
+        assert ledger.is_consumed("n1") is True
+        assert not (tmp_path / "nonce-ledger.json.tmp").exists()
+
+    def test_crash_during_replace_leaves_prior_valid_state_not_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash between the temp-file write and the atomic rename must
+        never silently reset the ledger to empty — the un-replaced original
+        file (still holding the previously consumed nonce) is untouched."""
+        path = tmp_path / "nonce-ledger.json"
+        ledger = FileNonceLedger(path)
+        ledger.consume("n1")
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("simulated crash during os.replace")
+
+        monkeypatch.setattr(qualify_backup_restore.os, "replace", _boom)
+        with pytest.raises(OSError):
+            ledger.consume("n2")
+
+        monkeypatch.undo()
+        assert ledger.is_consumed("n1") is True
+        assert ledger.is_consumed("n2") is False
+
+
+def test_corrupt_nonce_ledger_causes_envelope_red_not_replay_bypass(tmp_path: Path) -> None:
+    """The exploit scenario the fail-open bug enabled: consume a nonce,
+    corrupt the durable ledger (crash/truncation), then resubmit the same
+    already-used envelope. It must be RED nonce_ledger_corrupt, never a
+    GREEN produced by a silently-reset-to-empty consumed set."""
+    ledger_path = tmp_path / "nonce-ledger.json"
+    ledger = FileNonceLedger(ledger_path)
+    envelope = _valid_envelope()
+
+    first = _verify(envelope, ledger=ledger)
+    assert first.status == "GREEN"
+
+    ledger_path.write_bytes(b"{not valid json")
+
+    second = _verify(envelope, ledger=ledger)
+    assert second.status == "RED"
+    assert len(second.reasons) == 1
+    assert second.reasons[0].startswith("nonce_ledger_corrupt:")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_json(tmp_path: Path, payload: object, name: str) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _cli_args(
+    tmp_path: Path, envelope_path: Path, *, now: str = "2026-07-20T12:00:00Z"
+) -> list[str]:
+    return [
+        "--envelope",
+        str(envelope_path),
+        "--command",
+        EXPECTED_COMMAND,
+        "--source-backup-id",
+        EXPECTED_SOURCE_BACKUP_ID,
+        "--target-account",
+        EXPECTED_TARGET_ACCOUNT,
+        "--target-region",
+        EXPECTED_TARGET_REGION,
+        "--environment-identity",
+        OBSERVED_ENVIRONMENT_IDENTITY,
+        "--now",
+        now,
+        "--nonce-ledger-path",
+        str(tmp_path / "nonce-ledger.json"),
+    ]
+
+
+def test_cli_green_on_valid_envelope(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    envelope_path = _write_json(tmp_path, _valid_envelope(), "envelope.json")
+    exit_code = cli_main(_cli_args(tmp_path, envelope_path))
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "GREEN" in captured.out
+
+
+def test_cli_red_on_expired_envelope(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    envelope_path = _write_json(
+        tmp_path, _valid_envelope(expires_at="2020-01-01T00:00:00Z"), "envelope.json"
+    )
+    exit_code = cli_main(_cli_args(tmp_path, envelope_path))
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "envelope_expired" in captured.err
+
+
+def test_cli_replayed_nonce_across_two_invocations_is_red(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    envelope_path = _write_json(tmp_path, _valid_envelope(), "envelope.json")
+    args = _cli_args(tmp_path, envelope_path)
+
+    first_exit = cli_main(args)
+    capsys.readouterr()
+    assert first_exit == 0
+
+    second_exit = cli_main(args)
+    captured = capsys.readouterr()
+    assert second_exit == 1
+    assert "nonce_replayed" in captured.err
+
+
+def test_cli_missing_required_arguments_is_red(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    envelope_path = _write_json(tmp_path, _valid_envelope(), "envelope.json")
+    exit_code = cli_main(["--envelope", str(envelope_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "cli_missing_required_envelope_arguments" in captured.err
+
+
+def test_cli_empty_string_required_argument_is_red(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An empty string is not None — `is None` alone would let a blank
+    required binding field (e.g. --command "") through to bind against a
+    vacuous expected value."""
+    envelope_path = _write_json(tmp_path, _valid_envelope(), "envelope.json")
+    args = _cli_args(tmp_path, envelope_path)
+    args[args.index("--command") + 1] = ""
+    exit_code = cli_main(args)
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "cli_missing_required_envelope_arguments" in captured.err
+
+
+def test_cli_whitespace_only_required_argument_is_red(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    envelope_path = _write_json(tmp_path, _valid_envelope(), "envelope.json")
+    args = _cli_args(tmp_path, envelope_path)
+    args[args.index("--target-account") + 1] = "   "
+    exit_code = cli_main(args)
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "cli_missing_required_envelope_arguments" in captured.err
+
+
+def test_cli_corrupt_nonce_ledger_is_red_not_traceback(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    envelope_path = _write_json(tmp_path, _valid_envelope(), "envelope.json")
+    args = _cli_args(tmp_path, envelope_path)
+    ledger_path = tmp_path / "nonce-ledger.json"
+    ledger_path.write_bytes(b"not json at all")
+    exit_code = cli_main(args)
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "nonce_ledger_corrupt" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_backup_restore_fixtures.py
+++ b/tests/test_backup_restore_fixtures.py
@@ -1,0 +1,152 @@
+"""Content-addressed fixture matrix for the backup/restore harness (AC-DR-6).
+
+Single source of truth for the deterministic scenario ids exercised across
+test_backup_restore_policy.py, test_backup_restore_approval.py,
+test_backup_restore_refusal.py, and test_backup_restore_manifest.py. Mirrors
+tests/conformance/consumer_severance/fixtures.py's content-addressed style so
+CI can assert the exact fixture set exercised (AC-DR-6 "deterministic
+fixtures exercise identity refusal, restore verification, projection
+convergence, breach handling, and manifest validation"), not just "some
+tests ran".
+
+This module lists fixture *ids and expected decisions* only — the concrete
+input construction lives in each scenario's own test file, next to the
+assertions that exercise it, so the two stay in sync without a layer of
+indirection between them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScenarioFixture:
+    id: str
+    category: str  # "policy" | "approval" | "refusal" | "manifest"
+    description: str
+    expected_status: str  # "GREEN" | "RED"
+
+
+FIXTURES: tuple[ScenarioFixture, ...] = (
+    # AC-DR-1 backup-policy evidence
+    ScenarioFixture("policy-absent", "policy", "no policy evidence supplied", "RED"),
+    ScenarioFixture(
+        "policy-missing-authority-table", "policy", "one SPEC-SOT table not named", "RED"
+    ),
+    ScenarioFixture(
+        "policy-missing-immutable-copy", "policy", "owner/retention/encryption absent", "RED"
+    ),
+    ScenarioFixture("policy-missing-cross-account", "policy", "no cross-account copy", "RED"),
+    ScenarioFixture("policy-missing-cross-region", "policy", "no cross-region copy", "RED"),
+    ScenarioFixture(
+        "policy-missing-recovery-point", "policy", "no measured recovery point", "RED"
+    ),
+    ScenarioFixture("policy-complete", "policy", "every required field present", "GREEN"),
+    # AC-DR-2 destructive-command approval envelope
+    ScenarioFixture("approval-absent", "approval", "no envelope supplied", "RED"),
+    ScenarioFixture("approval-expired", "approval", "now is past expires_at", "RED"),
+    ScenarioFixture(
+        "approval-mismatched-command-digest", "approval", "digest != sha256(command)", "RED"
+    ),
+    ScenarioFixture(
+        "approval-mismatched-environment-identity",
+        "approval",
+        "envelope identity != observed identity",
+        "RED",
+    ),
+    ScenarioFixture("approval-replayed-nonce", "approval", "nonce already consumed", "RED"),
+    ScenarioFixture("approval-valid", "approval", "every field matches, nonce fresh", "GREEN"),
+    # AC-DR-3 destructive-safety refusal
+    ScenarioFixture(
+        "refusal-production-like-name", "refusal", "target name contains 'prod'", "RED"
+    ),
+    ScenarioFixture(
+        "refusal-missing-disposable-tag", "refusal", "target tags lack disposable=true", "RED"
+    ),
+    ScenarioFixture(
+        "refusal-non-empty-projections",
+        "refusal",
+        "qdrant/neo4j counts non-zero outside drill context",
+        "RED",
+    ),
+    ScenarioFixture(
+        "refusal-active-writer", "refusal", "writer lease source reports an active writer", "RED"
+    ),
+    ScenarioFixture(
+        "refusal-ambiguous-credentials",
+        "refusal",
+        "credential resolver raises AmbiguousIdentityError",
+        "RED",
+    ),
+    ScenarioFixture(
+        "refusal-all-clear",
+        "refusal",
+        "disposable target, empty projections, no writers, unique identity",
+        "GREEN",
+    ),
+    # AC-DR-5 drill manifest
+    ScenarioFixture("manifest-all-absent", "manifest", "no measured inputs supplied", "RED"),
+    ScenarioFixture("manifest-rto-exceeded", "manifest", "measured RTO over budget", "RED"),
+    ScenarioFixture(
+        "manifest-verification-failed", "manifest", "projection verification failed", "RED"
+    ),
+    ScenarioFixture(
+        "manifest-hash-equivalence-mismatch", "manifest", "AP5 hash mismatch present", "RED"
+    ),
+    ScenarioFixture("manifest-query-probes-failed", "manifest", "query probes failed", "RED"),
+    ScenarioFixture(
+        "manifest-complete", "manifest", "every measured input present and passing", "GREEN"
+    ),
+)
+
+
+def all_ids() -> frozenset[str]:
+    return frozenset(f.id for f in FIXTURES)
+
+
+def fixture_matrix_canonical_json() -> str:
+    """Deterministic, content-addressable serialization of the fixture matrix."""
+    payload = sorted(
+        (
+            {"id": f.id, "category": f.category, "expected_status": f.expected_status}
+            for f in FIXTURES
+        ),
+        key=lambda row: row["id"],
+    )
+    return (
+        json.dumps(
+            payload, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":")
+        )
+        + "\n"
+    )
+
+
+def fixture_matrix_sha256() -> str:
+    return hashlib.sha256(fixture_matrix_canonical_json().encode("utf-8")).hexdigest()
+
+
+def test_fixture_ids_are_unique() -> None:
+    ids = [f.id for f in FIXTURES]
+    assert len(ids) == len(set(ids))
+
+
+def test_every_category_has_exactly_one_green_fixture() -> None:
+    categories = {f.category for f in FIXTURES}
+    for category in categories:
+        greens = [f for f in FIXTURES if f.category == category and f.expected_status == "GREEN"]
+        assert len(greens) == 1, f"category {category!r} must have exactly one GREEN fixture"
+
+
+def test_fixture_matrix_sha256_is_stable_and_well_formed() -> None:
+    digest_a = fixture_matrix_sha256()
+    digest_b = fixture_matrix_sha256()
+    assert digest_a == digest_b
+    assert len(digest_a) == 64
+    int(digest_a, 16)  # raises ValueError if not hex
+
+
+def test_fixture_matrix_covers_expected_total_count() -> None:
+    assert len(FIXTURES) == 25

--- a/tests/test_backup_restore_manifest.py
+++ b/tests/test_backup_restore_manifest.py
@@ -1,0 +1,263 @@
+"""AC-DR-5 tests: drill manifest construction and validation.
+
+Absent or breached targets remain RED, never a placeholder — see fixture
+ids manifest-* in test_backup_restore_fixtures.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from dr_verify import DRVerificationResult, RtoResult
+from qualify_backup_restore import (
+    build_manifest,
+    validate_manifest_json,
+)
+from qualify_backup_restore import main as cli_main
+
+_WS = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+
+
+def _passing_rto() -> RtoResult:
+    return RtoResult(elapsed_seconds=300.0, budget_seconds=900, exceeded=False)
+
+
+def _breached_rto() -> RtoResult:
+    return RtoResult(elapsed_seconds=1200.0, budget_seconds=900, exceeded=True)
+
+
+def _passing_verification() -> DRVerificationResult:
+    return DRVerificationResult(workspace_id=_WS, mismatches=[])
+
+
+def _failing_verification() -> DRVerificationResult:
+    return DRVerificationResult(
+        workspace_id=_WS,
+        mismatches=["Qdrant chunk count mismatch for source X"],
+    )
+
+
+def _consistent_manifest_kwargs() -> dict[str, object]:
+    return {
+        "drill_started_at": "2026-07-20T00:00:00Z",
+        "drill_completed_at": "2026-07-20T00:05:00Z",
+        "measured_rpo_seconds": 30.0,
+        "rto_result": _passing_rto(),
+        "source_backup_id": "backup-123",
+        "restored_environment_identity": "recovery-env-alpha",
+        "verification_result": _passing_verification(),
+        "hash_equivalence_mismatches": [],
+        "query_probes_passed": True,
+    }
+
+
+class TestBuildManifest:
+    def test_all_absent_inputs_is_red_with_reasons(self) -> None:
+        manifest = build_manifest(
+            drill_started_at=None,
+            drill_completed_at=None,
+            measured_rpo_seconds=None,
+            rto_result=None,
+            source_backup_id=None,
+            restored_environment_identity=None,
+            verification_result=None,
+            hash_equivalence_mismatches=None,
+            query_probes_passed=None,
+        )
+        assert manifest.status == "RED"
+        assert "drill_started_at_absent" in manifest.reasons
+        assert "rto_result_absent" in manifest.reasons
+        assert "verification_result_absent" in manifest.reasons
+        assert "hash_equivalence_result_absent" in manifest.reasons
+        assert "query_probes_absent" in manifest.reasons
+        # honest absence, never a fabricated placeholder value
+        assert manifest.source_backup_id is None
+        assert manifest.restored_environment_identity is None
+
+    def test_rto_exceeded_is_red(self) -> None:
+        kwargs = _consistent_manifest_kwargs()
+        kwargs["rto_result"] = _breached_rto()
+        manifest = build_manifest(**kwargs)
+        assert manifest.status == "RED"
+        assert manifest.rto_exceeded is True
+        assert any(r.startswith("rto_exceeded:") for r in manifest.reasons)
+
+    def test_verification_failed_is_red(self) -> None:
+        kwargs = _consistent_manifest_kwargs()
+        kwargs["verification_result"] = _failing_verification()
+        manifest = build_manifest(**kwargs)
+        assert manifest.status == "RED"
+        assert manifest.verification_passed is False
+        assert "verification_failed" in manifest.reasons
+        assert manifest.verification_mismatches == ("Qdrant chunk count mismatch for source X",)
+
+    def test_hash_equivalence_mismatch_is_red(self) -> None:
+        kwargs = _consistent_manifest_kwargs()
+        kwargs["hash_equivalence_mismatches"] = ["chunk abc: vector_digest mismatch"]
+        manifest = build_manifest(**kwargs)
+        assert manifest.status == "RED"
+        assert "hash_equivalence_mismatch" in manifest.reasons
+
+    def test_query_probes_failed_is_red(self) -> None:
+        kwargs = _consistent_manifest_kwargs()
+        kwargs["query_probes_passed"] = False
+        manifest = build_manifest(**kwargs)
+        assert manifest.status == "RED"
+        assert "query_probes_failed" in manifest.reasons
+
+    def test_negative_rpo_is_red(self) -> None:
+        kwargs = _consistent_manifest_kwargs()
+        kwargs["measured_rpo_seconds"] = -5.0
+        manifest = build_manifest(**kwargs)
+        assert manifest.status == "RED"
+        assert "measured_rpo_seconds_absent_or_invalid" in manifest.reasons
+
+    def test_full_consistent_manifest_is_green(self) -> None:
+        manifest = build_manifest(**_consistent_manifest_kwargs())
+        assert manifest.status == "GREEN"
+        assert manifest.reasons == ()
+        assert manifest.rto_exceeded is False
+        assert manifest.verification_passed is True
+
+    def test_manifest_id_is_content_addressed(self) -> None:
+        manifest_a = build_manifest(**_consistent_manifest_kwargs())
+        manifest_b = build_manifest(**_consistent_manifest_kwargs())
+        assert manifest_a.manifest_id == manifest_b.manifest_id
+        assert manifest_a.manifest_id.startswith("sha256:")
+
+        kwargs_c = _consistent_manifest_kwargs()
+        kwargs_c["source_backup_id"] = "backup-999"
+        manifest_c = build_manifest(**kwargs_c)
+        assert manifest_c.manifest_id != manifest_a.manifest_id
+
+    def test_to_json_round_trips_through_json_loads(self) -> None:
+        manifest = build_manifest(**_consistent_manifest_kwargs())
+        parsed = json.loads(manifest.to_json())
+        assert parsed["status"] == "GREEN"
+        assert parsed["manifest_id"] == manifest.manifest_id
+
+
+class TestValidateManifestJson:
+    def _green_manifest_dict(self) -> dict[str, object]:
+        return build_manifest(**_consistent_manifest_kwargs()).to_dict()
+
+    def test_absent_manifest_is_red(self) -> None:
+        result = validate_manifest_json(None)
+        assert result.status == "RED"
+        assert result.reasons == ("manifest_absent",)
+
+    def test_not_an_object_is_red(self) -> None:
+        result = validate_manifest_json([1, 2, 3])
+        assert result.status == "RED"
+        assert result.reasons == ("manifest_malformed:not_an_object",)
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "manifest_id",
+            "drill_started_at",
+            "drill_completed_at",
+            "measured_rpo_seconds",
+            "measured_rto_seconds",
+            "rto_budget_seconds",
+            "rto_exceeded",
+            "source_backup_id",
+            "restored_environment_identity",
+            "verification_passed",
+            "query_probes_passed",
+            "status",
+        ],
+    )
+    def test_missing_required_field_is_red(self, field: str) -> None:
+        manifest = self._green_manifest_dict()
+        del manifest[field]
+        result = validate_manifest_json(manifest)
+        assert result.status == "RED"
+        assert f"manifest_field_absent:{field}" in result.reasons
+
+    def test_declared_red_status_is_red(self) -> None:
+        manifest = self._green_manifest_dict()
+        manifest["status"] = "RED"
+        result = validate_manifest_json(manifest)
+        assert result.status == "RED"
+        assert "manifest_status_not_green:'RED'" in result.reasons
+
+    def test_forged_green_status_with_rto_exceeded_is_still_red(self) -> None:
+        """A manifest that self-declares GREEN but carries rto_exceeded=True
+        must not be trusted on its word — tamper-evidence, not just shape."""
+        manifest = self._green_manifest_dict()
+        manifest["rto_exceeded"] = True
+        result = validate_manifest_json(manifest)
+        assert result.status == "RED"
+        assert "manifest_rto_exceeded" in result.reasons
+
+    def test_forged_green_status_with_verification_failed_is_still_red(self) -> None:
+        manifest = self._green_manifest_dict()
+        manifest["verification_passed"] = False
+        result = validate_manifest_json(manifest)
+        assert result.status == "RED"
+        assert "manifest_verification_failed" in result.reasons
+
+    def test_forged_green_status_with_query_probes_failed_is_still_red(self) -> None:
+        """AC-DR-5 lists query probes as one of the four evidence types
+        (manifest, timestamps, hashes, query probes) — a manifest that
+        self-declares GREEN but carries query_probes_passed=False must not
+        be trusted on its word, same as rto_exceeded/verification_passed."""
+        manifest = self._green_manifest_dict()
+        manifest["query_probes_passed"] = False
+        result = validate_manifest_json(manifest)
+        assert result.status == "RED"
+        assert "manifest_query_probes_failed" in result.reasons
+
+    def test_forged_green_status_with_query_probes_absent_is_still_red(self) -> None:
+        """An absent query_probes_passed field (never ran the probes) must
+        not silently validate as GREEN either."""
+        manifest = self._green_manifest_dict()
+        del manifest["query_probes_passed"]
+        result = validate_manifest_json(manifest)
+        assert result.status == "RED"
+        assert "manifest_field_absent:query_probes_passed" in result.reasons
+
+    def test_valid_green_manifest_passes(self) -> None:
+        result = validate_manifest_json(self._green_manifest_dict())
+        assert result.status == "GREEN"
+        assert result.reasons == ()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_json(tmp_path: Path, payload: object, name: str = "manifest.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_cli_green_on_valid_manifest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    manifest_dict = build_manifest(**_consistent_manifest_kwargs()).to_dict()
+    manifest_path = _write_json(tmp_path, manifest_dict)
+    exit_code = cli_main(["--manifest", str(manifest_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "GREEN" in captured.out
+
+
+def test_cli_red_on_breached_manifest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    kwargs = _consistent_manifest_kwargs()
+    kwargs["rto_result"] = _breached_rto()
+    manifest_dict = build_manifest(**kwargs).to_dict()
+    manifest_path = _write_json(tmp_path, manifest_dict)
+    exit_code = cli_main(["--manifest", str(manifest_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "manifest_status_not_green" in captured.err or "manifest_rto_exceeded" in captured.err

--- a/tests/test_backup_restore_policy.py
+++ b/tests/test_backup_restore_policy.py
@@ -1,0 +1,202 @@
+"""AC-DR-1 tests: backup-policy evidence must name every SPEC-SOT authority
+table and carry immutable-copy ownership, retention, encryption, cross-
+account/region copies, and a measured recovery point. Missing fields are RED
+— see fixture ids policy-* in test_backup_restore_fixtures.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from qualify_backup_restore import (
+    AUTHORITY_TABLES,
+    check_backup_policy_evidence,
+)
+from qualify_backup_restore import main as cli_main
+
+
+def _valid_policy() -> dict[str, object]:
+    return {
+        "authority_tables": sorted(AUTHORITY_TABLES),
+        "immutable_copy": {
+            "owner": "backup-team",
+            "retention_days": 35,
+            "encryption": "aws:kms:alias/omniscience-backup",
+        },
+        "cross_account_copy": {"account": "222233334444"},
+        "cross_region_copy": {"region": "us-west-2"},
+        "measured_recovery_point_seconds": 300,
+    }
+
+
+def test_policy_absent_is_red() -> None:
+    result = check_backup_policy_evidence(None)
+    assert result.status == "RED"
+    assert result.reasons == ("policy_absent",)
+
+
+def test_policy_not_an_object_is_red() -> None:
+    result = check_backup_policy_evidence(["not", "an", "object"])
+    assert result.status == "RED"
+    assert result.reasons == ("policy_malformed:not_an_object",)
+
+
+def test_policy_missing_one_authority_table_is_red() -> None:
+    policy = _valid_policy()
+    policy["authority_tables"] = sorted(AUTHORITY_TABLES - {"outbox_events"})
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    assert "authority_table_missing:outbox_events" in result.reasons
+
+
+def test_policy_authority_tables_absent_lists_every_missing_table() -> None:
+    policy = _valid_policy()
+    del policy["authority_tables"]
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    assert "authority_tables_absent_or_malformed" in result.reasons
+    for table in AUTHORITY_TABLES:
+        assert f"authority_table_missing:{table}" in result.reasons
+
+
+@pytest.mark.parametrize(
+    "mutate,expected_reason",
+    [
+        (lambda p: p["immutable_copy"].pop("owner"), "immutable_copy_owner_absent"),
+        (
+            lambda p: p["immutable_copy"].__setitem__("retention_days", 0),
+            "immutable_copy_retention_days_absent_or_invalid",
+        ),
+        (
+            lambda p: p["immutable_copy"].__setitem__("retention_days", "35"),
+            "immutable_copy_retention_days_absent_or_invalid",
+        ),
+        (lambda p: p["immutable_copy"].pop("encryption"), "immutable_copy_encryption_absent"),
+        (lambda p: p.pop("immutable_copy"), "immutable_copy_absent_or_malformed"),
+    ],
+    ids=[
+        "owner-absent",
+        "retention-zero",
+        "retention-wrong-type",
+        "encryption-absent",
+        "immutable-copy-absent",
+    ],
+)
+def test_policy_immutable_copy_field_missing_is_red(mutate, expected_reason) -> None:
+    policy = _valid_policy()
+    mutate(policy)
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    assert expected_reason in result.reasons
+
+
+def test_policy_missing_cross_account_copy_is_red() -> None:
+    policy = _valid_policy()
+    del policy["cross_account_copy"]
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    assert "cross_account_copy_absent" in result.reasons
+
+
+def test_policy_missing_cross_region_copy_is_red() -> None:
+    policy = _valid_policy()
+    del policy["cross_region_copy"]
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    assert "cross_region_copy_absent" in result.reasons
+
+
+def test_policy_missing_recovery_point_is_red() -> None:
+    policy = _valid_policy()
+    del policy["measured_recovery_point_seconds"]
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    assert "measured_recovery_point_absent_or_invalid" in result.reasons
+
+
+def test_policy_negative_recovery_point_is_red() -> None:
+    policy = _valid_policy()
+    policy["measured_recovery_point_seconds"] = -1
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    assert "measured_recovery_point_absent_or_invalid" in result.reasons
+
+
+def test_authority_tables_includes_governance_and_audit_history_tables() -> None:
+    """REQ-SOT-1 'governance metadata required to rebuild projections' and
+    REQ-SOT-8 'tenant and audit history' must be named explicitly in
+    AUTHORITY_TABLES. This asserts against a hardcoded expectation, not
+    against AUTHORITY_TABLES itself — unlike _valid_policy() (which derives
+    its fixture from the same constant under test and so cannot catch an
+    omission), this test fails if audit_log or entity_emitter is removed.
+    """
+    required_governance_and_audit_tables = {"audit_log", "entity_emitter"}
+    missing = required_governance_and_audit_tables - AUTHORITY_TABLES
+    assert not missing, (
+        f"AUTHORITY_TABLES must include {missing} per REQ-SOT-1 (governance "
+        "metadata) / REQ-SOT-8 (tenant and audit history)"
+    )
+
+
+def test_authority_tables_excludes_authentication_credential_table() -> None:
+    """api_tokens is authentication/authorization credential material, not
+    ledger content/lineage/entity-outbox-records/governance metadata that
+    REQ-SOT-1/8 names — it is deliberately excluded from AUTHORITY_TABLES.
+    """
+    assert "api_tokens" not in AUTHORITY_TABLES
+
+
+def test_policy_complete_evidence_is_green() -> None:
+    result = check_backup_policy_evidence(_valid_policy())
+    assert result.status == "GREEN"
+    assert result.reasons == ()
+
+
+def test_policy_multiple_missing_fields_all_collected() -> None:
+    """All mismatches are collected, not short-circuited on the first one."""
+    policy = {"authority_tables": []}
+    result = check_backup_policy_evidence(policy)
+    assert result.status == "RED"
+    # every table + immutable_copy + cross-account + cross-region + recovery point
+    assert len(result.reasons) >= len(AUTHORITY_TABLES) + 3
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_json(tmp_path: Path, payload: object, name: str = "policy.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_cli_green_on_complete_policy(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    policy_path = _write_json(tmp_path, _valid_policy())
+    exit_code = cli_main(["--policy", str(policy_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "GREEN" in captured.out
+
+
+def test_cli_red_on_absent_policy_file(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli_main(["--policy", str(tmp_path / "does-not-exist.json")])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "RED" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_no_checks_requested_is_red(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli_main([])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "no_check_requested" in captured.err

--- a/tests/test_backup_restore_refusal.py
+++ b/tests/test_backup_restore_refusal.py
@@ -1,0 +1,225 @@
+"""AC-DR-3 tests: destructive-safety refusal.
+
+Production-like names, absent disposable identity, non-empty projections,
+active writers, or ambiguous credentials must abort before deletion or
+restore — see fixture ids refusal-* in test_backup_restore_fixtures.py.
+One test per negative fixture asserting abort=True + a specific reason,
+plus one all-clear positive fixture asserting abort=False, mirroring
+TestVerifyProjections in tests/test_dr_rebuild.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from qualify_backup_restore import (
+    AmbiguousIdentityError,
+    check_destructive_safety,
+)
+from qualify_backup_restore import main as cli_main
+
+
+class _FakeWriterLeaseSource:
+    def __init__(self, *, active: bool) -> None:
+        self._active = active
+
+    def has_active_writers(self) -> bool:
+        return self._active
+
+
+class _FailingWriterLeaseSource:
+    def has_active_writers(self) -> bool:
+        raise RuntimeError("lease query unreachable")
+
+
+class _FakeCredentialResolver:
+    def __init__(self, *, ambiguous: bool, identity: str = "unique-recovery-role") -> None:
+        self._ambiguous = ambiguous
+        self._identity = identity
+
+    def resolve_identity(self) -> str:
+        if self._ambiguous:
+            raise AmbiguousIdentityError("multiple candidate roles active")
+        return self._identity
+
+
+def _all_clear_kwargs() -> dict[str, object]:
+    return {
+        "target_name": "restore-qual-recovery",
+        "target_tags": {"disposable": "true"},
+        "qdrant_chunk_count": 0,
+        "neo4j_entity_count": 0,
+        "drill_context": False,
+        "writer_lease_source": _FakeWriterLeaseSource(active=False),
+        "credential_resolver": _FakeCredentialResolver(ambiguous=False),
+    }
+
+
+class TestDestructiveSafetyRefusal:
+    def test_production_like_name_aborts(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["target_name"] = "prod-recovery-env"
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+        assert any(r.startswith("production_like_name:") for r in result.reasons)
+
+    def test_production_like_name_case_insensitive_and_word_boundary(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["target_name"] = "PRODUCTION-recovery"
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "prod1-cluster",
+            "prod01",
+            "production2",
+            "PRODUCTION1",
+            "myproduction2",
+            "prodenv-restore",
+            "live2-cluster",
+            "liveenv",
+        ],
+    )
+    def test_production_like_name_digit_suffix_and_concatenation_not_bypassed(
+        self, name: str
+    ) -> None:
+        """A \\b-word-boundary regex treats digits as word characters, so it
+        misses prod1/prod01/production2/prodenv/liveenv — all ordinary
+        cloud-resource naming patterns. The refusal must be a substring
+        match, not word-boundary-anchored."""
+        kwargs = _all_clear_kwargs()
+        kwargs["target_name"] = name
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+        assert any(r.startswith("production_like_name:") for r in result.reasons)
+
+    def test_missing_disposable_tag_aborts(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["target_tags"] = {"env": "recovery"}  # no disposable=true
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+        assert "absent_disposable_identity" in result.reasons
+
+    def test_non_empty_projections_aborts(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["qdrant_chunk_count"] = 42
+        kwargs["neo4j_entity_count"] = 0
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+        assert any(r.startswith("non_empty_projections:") for r in result.reasons)
+
+    def test_non_empty_projections_allowed_in_drill_context(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["qdrant_chunk_count"] = 42
+        kwargs["neo4j_entity_count"] = 6
+        kwargs["drill_context"] = True
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is False
+
+    def test_active_writers_aborts(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["writer_lease_source"] = _FakeWriterLeaseSource(active=True)
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+        assert "active_writers_detected" in result.reasons
+
+    def test_writer_lease_check_failure_is_red_not_a_crash(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["writer_lease_source"] = _FailingWriterLeaseSource()
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+        assert any(r.startswith("writer_lease_check_failed:") for r in result.reasons)
+
+    def test_ambiguous_credentials_aborts(self) -> None:
+        kwargs = _all_clear_kwargs()
+        kwargs["credential_resolver"] = _FakeCredentialResolver(ambiguous=True)
+        result = check_destructive_safety(**kwargs)
+        assert result.abort is True
+        assert any(r.startswith("ambiguous_credentials:") for r in result.reasons)
+
+    def test_all_clear_passes(self) -> None:
+        result = check_destructive_safety(**_all_clear_kwargs())
+        assert result.abort is False
+        assert result.status == "GREEN"
+        assert result.reasons == ()
+
+    def test_multiple_failures_all_collected(self) -> None:
+        result = check_destructive_safety(
+            target_name="prod-live-env",
+            target_tags={},
+            qdrant_chunk_count=5,
+            neo4j_entity_count=3,
+            drill_context=False,
+            writer_lease_source=_FakeWriterLeaseSource(active=True),
+            credential_resolver=_FakeCredentialResolver(ambiguous=True),
+        )
+        assert result.abort is True
+        assert len(result.reasons) >= 5
+
+    def test_optional_checks_skipped_when_not_supplied(self) -> None:
+        """target_name/tags/writer_lease/credential_resolver=None means 'not
+        evaluated in this caller's context', not an automatic RED — this is
+        the subset rebuild_all_projections.py exercises today."""
+        result = check_destructive_safety(
+            qdrant_chunk_count=0,
+            neo4j_entity_count=0,
+        )
+        assert result.status == "GREEN"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_refusal_red_on_production_name(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli_main(
+        [
+            "--target-name",
+            "prod-cluster",
+            "--target-tags-json",
+            json.dumps({"disposable": "true"}),
+            "--qdrant-chunk-count",
+            "0",
+            "--neo4j-entity-count",
+            "0",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "production_like_name" in captured.err
+
+
+def test_cli_refusal_green_on_all_clear(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = cli_main(
+        [
+            "--target-name",
+            "restore-qual-recovery",
+            "--target-tags-json",
+            json.dumps({"disposable": "true"}),
+            "--qdrant-chunk-count",
+            "0",
+            "--neo4j-entity-count",
+            "0",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "GREEN" in captured.out
+
+
+def test_cli_refusal_counts_required_when_target_name_given(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = cli_main(["--target-name", "restore-qual-recovery"])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "refusal_counts_required" in captured.err

--- a/tests/test_dr_rebuild.py
+++ b/tests/test_dr_rebuild.py
@@ -173,6 +173,24 @@ def test_dr_rebuild_advances_graph_checkpoint_for_empty_projection() -> None:
     assert "if wrapped_entities" not in rebuild_source
 
 
+def test_rebuild_pre_wipe_safety_guard_runs_before_wipe() -> None:
+    """AC-DR-3 / P-SOT-6: the destructive-safety guard must run — and be
+    able to abort — before any wipe command executes. CI-portable source
+    check; the live behaviour is exercised by
+    TestDrIntegration::test_pre_wipe_refusal_aborts_on_non_empty_without_drill_context.
+    """
+    rebuild_source = (
+        Path(__file__).resolve().parents[1] / "scripts" / "rebuild_all_projections.py"
+    ).read_text(encoding="utf-8")
+
+    guard_idx = rebuild_source.index("check_destructive_safety(")
+    wipe_idx = rebuild_source.index('print("Wiping Neo4j and Qdrant...")')
+
+    assert guard_idx < wipe_idx, "destructive-safety guard must run before the wipe begins"
+    assert "sys.exit(4)" in rebuild_source
+    assert "OMNISCIENCE_DR_DRILL" in rebuild_source
+
+
 def _perfect_fakes(
     *,
     chunk_count: int = 9,
@@ -480,4 +498,47 @@ class TestDrIntegration:
 
         assert versions[0] == versions[1], (
             f"Non-deterministic rebuild: run 1={versions[0]}, run 2={versions[1]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pre_wipe_refusal_aborts_on_non_empty_without_drill_context(self) -> None:
+        """AC-DR-3 / P-SOT-6: a rebuild against already-populated projections
+        must abort BEFORE wipe when OMNISCIENCE_DR_DRILL is not set. The
+        ordinary sanctioned-drill path (env var present, exercised by every
+        other test in this class) is unaffected.
+        """
+        import subprocess
+
+        rebuild_cmd = [
+            sys.executable,
+            "scripts/rebuild_all_projections.py",
+            "--yes",
+            "--rto-seconds",
+            "120",
+        ]
+
+        # Ensure Neo4j/Qdrant are populated by a normal, drill-sanctioned rebuild.
+        populate = subprocess.run(rebuild_cmd, capture_output=True, text=True)
+        assert populate.returncode == 0, (
+            f"setup rebuild failed (exit {populate.returncode}):\n"
+            f"{populate.stdout}\n{populate.stderr}"
+        )
+
+        # Strip only the drill marker; keep DATABASE_URL/NEO4J_*/QDRANT_* so
+        # the process can still reach the (now non-empty) stores.
+        env = os.environ.copy()
+        env.pop("OMNISCIENCE_DR_DRILL", None)
+        refused = subprocess.run(rebuild_cmd, capture_output=True, text=True, env=env)
+        assert refused.returncode == 4, (
+            f"expected pre-wipe refusal exit code 4, got {refused.returncode}:\n"
+            f"{refused.stdout}\n{refused.stderr}"
+        )
+        assert "non_empty_projections" in refused.stdout
+
+        # Restore a known-good state (drill-sanctioned) for any test that
+        # runs after this one in the same session.
+        cleanup = subprocess.run(rebuild_cmd, capture_output=True, text=True)
+        assert cleanup.returncode == 0, (
+            f"cleanup rebuild failed (exit {cleanup.returncode}):\n"
+            f"{cleanup.stdout}\n{cleanup.stderr}"
         )


### PR DESCRIPTION
Implements the ready task SPEC `docs/specs/gh-issue-350-backup-restore.md` — slice 4 of issue #350. Branches from `main`. This is a producer-side Python qualification harness + safety interlocks + deterministic CI fixtures — **no destructive or cloud command is ever executed**; everything is built and tested with local fixtures/fakes.

## What ships (AC-DR-1/2/3/5/6 — GREEN, in-repo)

- **AC-DR-1** — `check_backup_policy_evidence` enumerates the SPEC-SOT authority tables per REQ-SOT-1/8 (`workspaces, sources, documents, chunks, entities, edges, outbox_events, ingestion_runs, entity_emitter, audit_log`; `api_tokens` explicitly excluded as credential material) plus immutable-copy owner, retention, encryption, and recovery point — missing fields are RED.
- **AC-DR-2** — `verify_approval_envelope` binds command digest, source backup, target account/region, environment identity, expiry, and nonce; absent/expired/mismatched/replayed aborts before mutation. The nonce ledger **fails closed** on a corrupt store (a truncated/non-UTF8 ledger is `nonce_ledger_corrupt` → RED, never a silent replay window) and writes atomically (temp + `os.replace`).
- **AC-DR-3** — `check_destructive_safety` refuses production-like names, absent disposable identity, non-empty projections, active writers, and ambiguous credentials. `rebuild_all_projections.py` now runs a **pre-wipe emptiness guard** that aborts (exit 4) before any wipe unless a sanctioned drill (`OMNISCIENCE_DR_DRILL=1`) — closing a real prior gap where `--yes` wiped unconditionally.
- **AC-DR-5** — tamper-evident drill manifest (measured RPO/RTO vs the ADR-0018 **900s** budget, imported not redefined; query probes). A forged `GREEN` with a breached or absent target — including `query_probes_passed=false` — is RED.
- **AC-DR-6** — content-addressed fixture matrix (25 ids) + `restore-qualification.yml` exercising identity refusal, restore verification, projection convergence, breach handling (exit 2), and manifest validation, reproducible without production credentials.

## Review hardening (security + best-practices, empirically reproduced)

5 BLOCKING + 2 MEDIUM fixed and re-verified:
- **nonce ledger fail-open → fail-closed** (replay-protection): corrupt/oversized/non-UTF8 store now RED, atomic write.
- **production-name regex** `\bprod\b` → `(?i)(prod|live)` (missed `prod01`, `PRODUCTION1`, `liveenv`).
- **authority tables** missing `audit_log` (REQ-SOT-8 tenant/audit history) — reconciled against the spec, with an independent coverage test.
- **manifest tamper** did not cover `query_probes_passed` — now required + checked.
- workflow `rto_seconds` shell-injection → passed via `env`; blank CLI required-args rejected.

## Not in this slice — decision-return / RED by design

Every live destructive restore/cleanup, the independently observed cloud identity binding, live target checks, and the full measured RPO/RTO drill remain RED: each needs an **isolated recovery environment** and a **fresh one-shot human approval** this agent cannot self-grant (task SPEC + AGENTS.md). Documented as "Blocked on external" in the runbook. Two follow-ups noted: wiring the full refusal set into a real target-identity config surface (needs `Settings`/`apps` surface, out of scope), and a cosine tolerance for non-deterministic embeddings.

## Verification

- `uv run pytest tests/test_backup_restore*.py tests/test_dr_rebuild.py` → **142 passed, 4 skipped** (skips = live-service integration, run in CI).
- CLI decision-return contract confirmed: corrupt ledger, `prod01`/`PRODUCTION1`, missing `audit_log`, forged manifest → RED with specific reasons, no traceback.
- `ruff check` + `ruff format --check` → clean; both workflow YAMLs parse.

## Test plan

- [ ] CI green (new `restore-qualification.yml`: unit refusal/approval/manifest + service-container convergence/breach/corrupt tiers)
- [ ] Reviewer confirms the live destructive drill + full refusal wiring stay out-of-scope until an isolated recovery env + approval envelope exist
