### PR TITLE
feat(admission): shared admission + SRE lane + read-scaling qualification (issue #350 slice 5)

### DIFF
--- a/.github/workflows/admission-qualification.yml
+++ b/.github/workflows/admission-qualification.yml
@@ -1,0 +1,156 @@
+name: Admission Qualification
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'helm/omniscience/**'
+      - 'apps/server/src/omniscience_server/admission/**'
+      - 'apps/server/src/omniscience_server/rest/rate_limit.py'
+      - 'packages/core/src/omniscience_core/config.py'
+      - 'tests/test_admission*.py'
+      - '.github/workflows/admission-qualification.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'helm/omniscience/**'
+      - 'apps/server/src/omniscience_server/admission/**'
+      - 'apps/server/src/omniscience_server/rest/rate_limit.py'
+      - 'packages/core/src/omniscience_core/config.py'
+      - 'tests/test_admission*.py'
+      - '.github/workflows/admission-qualification.yml'
+
+permissions:
+  contents: read
+
+# Shared --set overrides for a fully evidenced, guard-satisfying production-HA
+# + shared-admission profile (see docs/runbooks/read-admission.md
+# "Supplying admission evidence"). production.admission is gated
+# independently of production.enabled — EVAL_SET and PROD_SET below both
+# leave admission off; ADMISSION_SET layers the admission evidence on top
+# of PROD_SET to prove the two gates compose.
+env:
+  PROD_SET: >-
+    --set secrets.postgresPassword=ci-test
+    --set serviceAccount.create=false
+    --set postgres.enabled=false
+    --set retention.enabled=true
+    --set production.enabled=true
+    --set postgresql.enabled=false
+    --set neo4j.enabled=false
+    --set qdrant.enabled=false
+    --set nats.enabled=false
+    --set replicaCount=3
+    --set production.evidence.account=111111111111
+    --set production.evidence.cluster=ci-eks
+    --set production.evidence.region=us-east-1
+    --set production.evidence.zones[0]=us-east-1a
+    --set production.evidence.zones[1]=us-east-1b
+    --set production.evidence.zones[2]=us-east-1c
+    --set production.evidence.rds.endpoint=ci-rds.example.internal
+    --set production.evidence.rds.multiAz=true
+    --set production.evidence.jetstream.externalUrl=nats://ci-jetstream.example.internal:4222
+    --set production.evidence.jetstream.replicas=3
+    --set production.evidence.neo4j.topology=causal-cluster
+    --set production.evidence.neo4j.entitlementRef=secret/neo4j-license#key
+    --set production.evidence.qdrant.topology=distributed
+    --set production.evidence.qdrant.nodes=3
+  ADMISSION_SET: >-
+    --set production.admission.enabled=true
+    --set production.admission.backend=shared-redis-lease
+    --set production.admission.backendIdentity=redis://ci-admission.example.internal:6379/0
+    --set production.admission.laneIncidentBudget=120
+    --set production.admission.laneBackgroundBudget=60
+    --set production.admission.queueDepthMax=500
+    --set production.admission.latencyThresholdMs=250
+    --set production.admission.errorRateThreshold=0.01
+    --set production.admission.failureReserveFraction=0.2
+  EVAL_SET: >-
+    --set secrets.postgresPassword=ci-test
+    --set serviceAccount.create=false
+    --set postgres.enabled=false
+    --set retention.enabled=true
+
+jobs:
+  helm:
+    name: Helm lint + template + qualification tests (#350 AC-SCALE-5)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.15.4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v3
+      - name: Install python deps
+        # Full project deps (not bare pip): tests/conftest.py imports
+        # pytest_asyncio, so a minimal `pip install pytest` fails collection
+        # with ModuleNotFoundError. No `dev` extra on this project — plain
+        # `uv sync --frozen` already includes the test deps.
+        run: uv sync --frozen
+
+      - name: helm lint (evaluation profile — admission untouched)
+        run: helm lint helm/omniscience $EVAL_SET
+
+      - name: helm lint (production-HA profile, admission still off)
+        run: helm lint helm/omniscience $PROD_SET
+
+      - name: helm lint (production-HA + shared-admission, fully evidenced)
+        run: helm lint helm/omniscience $PROD_SET $ADMISSION_SET
+
+      - name: helm template (evaluation profile)
+        run: |
+          helm template omniscience helm/omniscience $EVAL_SET > /tmp/rendered-eval.yaml
+          test -s /tmp/rendered-eval.yaml
+          if grep -q '^  ADMISSION_' /tmp/rendered-eval.yaml; then
+            echo "evaluation profile must not render any ADMISSION_* env vars" >&2
+            exit 1
+          fi
+
+      - name: helm template (production-HA profile, admission still off)
+        run: |
+          helm template omniscience helm/omniscience $PROD_SET > /tmp/rendered-prod.yaml
+          test -s /tmp/rendered-prod.yaml
+          if grep -q '^  ADMISSION_' /tmp/rendered-prod.yaml; then
+            echo "production.admission.enabled=false must not render ADMISSION_* env vars" >&2
+            exit 1
+          fi
+
+      - name: helm template (production-HA + shared-admission, fully evidenced)
+        run: |
+          helm template omniscience helm/omniscience $PROD_SET $ADMISSION_SET > /tmp/rendered-admission.yaml
+          test -s /tmp/rendered-admission.yaml
+          grep -q '^  ADMISSION_BACKEND: "shared-redis-lease"$' /tmp/rendered-admission.yaml
+
+      - name: helm template (admission enabled, evidence missing) must fail closed
+        run: |
+          set +e
+          helm template omniscience helm/omniscience $PROD_SET \
+            --set production.admission.enabled=true \
+            > /tmp/rendered-admission-guard-fail.yaml 2>/tmp/rendered-admission-guard-fail.err
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ]; then
+            echo "expected the render to fail closed (missing admission evidence) but it succeeded" >&2
+            exit 1
+          fi
+          grep -q "production.admission.backend is required" /tmp/rendered-admission-guard-fail.err
+
+      - name: Admission qualification tests (#350)
+        run: uv run pytest tests/test_admission_backend.py tests/test_admission_lanes.py tests/test_admission_fail_closed.py tests/test_admission_config.py tests/test_admission_qualification.py tests/test_mcp_admission_contract.py -v -o addopts=""
+
+      - name: REST/MCP admission-conformance regression check
+        run: uv run pytest tests/test_rest_api.py tests/test_mcp*.py -q -o addopts=""
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin kubeconform
+
+      - name: kubeconform -strict (production-HA + shared-admission profile, #350)
+        run: |
+          helm template omniscience helm/omniscience $PROD_SET $ADMISSION_SET \
+          | kubeconform -strict -summary -schema-location default \
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'

--- a/apps/server/src/omniscience_server/admission/__init__.py
+++ b/apps/server/src/omniscience_server/admission/__init__.py
@@ -1,0 +1,45 @@
+"""Shared read-admission package (issue #350, AC-SCALE-1..5).
+
+Replaces the process-local rate-limit bypass with a narrow
+`AdmissionBackend` interface, a fail-closed state machine for shared-backend
+loss, server-derived SRE incident vs background lanes, and a horizontal-read
+qualification harness. See `docs/runbooks/read-admission.md`.
+"""
+
+from __future__ import annotations
+
+from omniscience_server.admission.backend import (
+    AdmissionBackend,
+    AdmissionBackendUnavailableError,
+    AdmissionDecision,
+    BackendHealth,
+)
+from omniscience_server.admission.lanes import (
+    BACKGROUND_LANE,
+    INCIDENT_LANE,
+    resolve_admission_lane,
+)
+from omniscience_server.admission.process_local import ProcessLocalAdmissionBackend
+from omniscience_server.admission.shared import SharedAdmissionBackend
+from omniscience_server.admission.state_machine import (
+    AdmissionOutcome,
+    FailClosedAdmissionController,
+    LeaseAuthority,
+    NullLeaseAuthority,
+)
+
+__all__ = [
+    "BACKGROUND_LANE",
+    "INCIDENT_LANE",
+    "AdmissionBackend",
+    "AdmissionBackendUnavailableError",
+    "AdmissionDecision",
+    "AdmissionOutcome",
+    "BackendHealth",
+    "FailClosedAdmissionController",
+    "LeaseAuthority",
+    "NullLeaseAuthority",
+    "ProcessLocalAdmissionBackend",
+    "SharedAdmissionBackend",
+    "resolve_admission_lane",
+]

--- a/apps/server/src/omniscience_server/admission/backend.py
+++ b/apps/server/src/omniscience_server/admission/backend.py
@@ -1,0 +1,87 @@
+"""Shared admission backend interface (issue #350, AC-SCALE-1).
+
+A narrow `Protocol` the REST admission call site admits requests through
+instead of touching a process-local dict directly. Every replica that
+constructs an `AdmissionBackend` from the same identity/config is expected
+to enforce the same aggregate budget — for `ProcessLocalAdmissionBackend`
+that aggregate is only "this process" (the pre-#350 MVP posture,
+unchanged); a future shared implementation makes the aggregate span every
+replica.
+
+`try_admit` doubles as the atomic authority primitive: a granted decision
+*is* the proof of authority to proceed (one atomic check-and-decrement), not
+a heuristic layered on top of a separate read. `health` reports whether the
+backend can currently make that atomic decision at all — `False` is what
+drives the AC-SCALE-4 fail-closed path in `admission.state_machine`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    """Outcome of one atomic admission attempt."""
+
+    allowed: bool
+    retry_after_seconds: float = 0.0
+
+
+@dataclass(frozen=True)
+class BackendHealth:
+    """Whether the backend can currently be trusted to make an atomic
+    admission decision. `detail` is a short, non-secret diagnostic string —
+    never a credential, connection string, or stack trace."""
+
+    healthy: bool
+    detail: str | None = None
+
+
+class AdmissionBackendUnavailableError(RuntimeError):
+    """Raised by `AdmissionBackend.try_admit` when the backend cannot make
+    an atomic decision right now (unreachable, unimplemented, or otherwise
+    untrustworthy). Callers MUST treat this as a fail-closed signal, never
+    silently substitute a local guess — see `admission.state_machine`."""
+
+
+class AdmissionBackend(Protocol):
+    """Atomic admission authority. Implementations MUST make `try_admit`
+    a single atomic check-and-decrement (or equivalent lease-acquire) —
+    never a read followed by a separate, non-atomic write."""
+
+    def try_admit(
+        self,
+        *,
+        lane: str,
+        key: str,
+        capacity: int,
+        refill_per_second: float,
+    ) -> AdmissionDecision:
+        """Attempt to admit one unit of work for `(lane, key)`.
+
+        `capacity` and `refill_per_second` describe a token-bucket budget;
+        implementations that use a different atomic primitive (e.g. a
+        fixed-window lease) MUST still honor `capacity` as the hard
+        ceiling for the window they use.
+
+        Raises:
+            AdmissionBackendUnavailableError: the backend cannot make an atomic
+                decision right now (see class docstring).
+        """
+        ...
+
+    def health(self) -> BackendHealth:
+        """Report whether this backend can currently be trusted to make an
+        atomic decision. MUST NOT raise — an internal check failure is
+        itself reported as `BackendHealth(healthy=False, ...)`."""
+        ...
+
+
+__all__ = [
+    "AdmissionBackend",
+    "AdmissionBackendUnavailableError",
+    "AdmissionDecision",
+    "BackendHealth",
+]

--- a/apps/server/src/omniscience_server/admission/lanes.py
+++ b/apps/server/src/omniscience_server/admission/lanes.py
@@ -1,0 +1,49 @@
+"""SRE incident vs background admission lanes (issue #350, AC-SCALE-2).
+
+Two named, separately-bounded lanes: `INCIDENT_LANE` for SRE incident reads
+and `BACKGROUND_LANE` for everything else (default agent/search traffic).
+Lane identity is **server-derived** from the authenticated token's granted
+scopes — never from a client-supplied header or request field — so a
+consumer cannot self-declare into the incident lane and bypass the
+background budget (task-spec "Out of scope: allowing consumer identity to
+bypass ... rules").
+
+A token carrying `incidents:write` or `admin` is treated as SRE-incident
+capable, reusing the existing `Scope` enum rather than inventing a parallel
+identity concept — the same scope SPEC-MCP's `omniscience-mcp-read-v1`
+profile precedent already gates incident-response tools on.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from omniscience_core.auth.scopes import Scope
+from omniscience_core.db.models import ApiToken
+
+INCIDENT_LANE = "incident"
+BACKGROUND_LANE = "background"
+
+_INCIDENT_CAPABLE_SCOPES: frozenset[str] = frozenset(
+    {Scope.incidents_write.value, Scope.admin.value}
+)
+
+
+def resolve_admission_lane(token: ApiToken) -> str:
+    """Return `INCIDENT_LANE` or `BACKGROUND_LANE` for `token`.
+
+    Derived solely from `token.scopes` (resolved server-side from the
+    authenticated bearer token during auth) — no client-controlled input
+    participates in this decision.
+    """
+    scopes: Iterable[str] = getattr(token, "scopes", None) or ()
+    if _INCIDENT_CAPABLE_SCOPES.intersection(scopes):
+        return INCIDENT_LANE
+    return BACKGROUND_LANE
+
+
+__all__ = [
+    "BACKGROUND_LANE",
+    "INCIDENT_LANE",
+    "resolve_admission_lane",
+]

--- a/apps/server/src/omniscience_server/admission/mcp_contract.py
+++ b/apps/server/src/omniscience_server/admission/mcp_contract.py
@@ -1,0 +1,71 @@
+"""MCP v1 overload error shape (issue #350, AC-SCALE-3).
+
+`mcp/server.py` (MCP tool dispatch) is out of this task's declared scope —
+see `docs/runbooks/read-admission.md` "Scope boundaries" — so no MCP call
+site is wired to admission here. This module exists so that follow-up work
+has a ready-made, contract-correct error to raise.
+
+Two things matter for AC-SCALE-3's "stable degraded metadata/fallback,
+never false-freshness or partial schema-invalid success":
+
+1. `mcp/contracts/v1/schemas/meta.schema.json`'s `fallback.reason` is a
+   **closed enum** (`missing_lineage`, `stale_source`, `source_degraded`,
+   `never_synced`, `freshness_sla_unknown`, `projection_divergence`,
+   `consistency_unknown`, `contract_mismatch`, or `null`) and that schema
+   file is not in this task's scope to edit. Inventing a new reason string
+   (e.g. an ad hoc `"admission_rejected"`) would *fail* schema validation,
+   the opposite of preserving the contract — so this module deliberately
+   does **not** build a `meta` object at all for an admission rejection.
+2. Every existing MCP call site that must reject a call outright (auth,
+   scope, bad request, `as_of` validation — see `mcp/server.py`) raises a
+   plain `ValueError` with a stable `"<code>:<message>"` prefix, which the
+   MCP framework turns into a stable tool-level error (REQ-MCP-4: never a
+   malformed/partial success payload). `raise_admission_error` follows the
+   exact same convention, reusing the **same `code` strings as the REST
+   429/503 contract** (`rate_limited`, `admission_backend_unavailable`) so
+   the two transports stay consistent without either one inventing a
+   parallel vocabulary.
+"""
+
+from __future__ import annotations
+
+from omniscience_server.admission.state_machine import STATE_BACKEND_LOST, AdmissionOutcome
+
+#: Same `code` value REST's 429 envelope uses (`rest/rate_limit.py`,
+#: `rest/errors.py`) — a lane-exhausted admission rejection.
+RATE_LIMITED_CODE = "rate_limited"
+
+#: Same `code` value REST's 503 envelope uses (`rest/rate_limit.py`) — the
+#: shared admission backend is unavailable (AC-SCALE-4 backend-loss path).
+ADMISSION_BACKEND_UNAVAILABLE_CODE = "admission_backend_unavailable"
+
+
+def admission_error_code(outcome: AdmissionOutcome) -> str:
+    """Return the stable error code for a rejected `AdmissionOutcome` —
+    the same code REST would use for the equivalent 429/503."""
+    if outcome.state == STATE_BACKEND_LOST:
+        return ADMISSION_BACKEND_UNAVAILABLE_CODE
+    return RATE_LIMITED_CODE
+
+
+def raise_admission_error(outcome: AdmissionOutcome) -> None:
+    """Raise the stable `ValueError("<code>:<message>")` a future MCP call
+    site should call on a rejected `AdmissionOutcome` — mirrors every
+    existing rejection in `mcp/server.py` (e.g. `"forbidden:..."`,
+    `"bad_request:..."`), which the MCP framework turns into a stable
+    tool-level error, never a truncated or schema-invalid success.
+
+    Never returns normally — callers use this exactly like the existing
+    `raise ValueError(...)` call sites it mirrors.
+    """
+    code = admission_error_code(outcome)
+    message = outcome.reason or code
+    raise ValueError(f"{code}:{message}")
+
+
+__all__ = [
+    "ADMISSION_BACKEND_UNAVAILABLE_CODE",
+    "RATE_LIMITED_CODE",
+    "admission_error_code",
+    "raise_admission_error",
+]

--- a/apps/server/src/omniscience_server/admission/process_local.py
+++ b/apps/server/src/omniscience_server/admission/process_local.py
@@ -1,0 +1,75 @@
+"""Process-local `AdmissionBackend` implementation (issue #350, AC-SCALE-1).
+
+This is today's pre-#350 token-bucket algorithm (previously the module-level
+`_buckets` dict in `rest/rate_limit.py`), refactored behind the
+`AdmissionBackend` Protocol with identical bucket math — only the storage
+key changed from `token_id` alone to `(lane, key)`, so existing single-lane
+callers see byte-for-byte identical behaviour.
+
+Explicitly an MVP/single-process implementation: state lives in this
+process's memory only and is never shared across replicas. It is the
+`admission_backend="disabled"` default (see `omniscience_core.config`) and
+MUST NOT be used as a silent fallback when a shared backend is configured
+but unreachable — see `admission.state_machine.FailClosedAdmissionController`
+for the fail-closed behaviour that replaces the old ad hoc bypass.
+"""
+
+from __future__ import annotations
+
+import time
+
+from omniscience_server.admission.backend import AdmissionDecision, BackendHealth
+
+
+class ProcessLocalAdmissionBackend:
+    """In-memory token-bucket `AdmissionBackend`, keyed by `(lane, key)`."""
+
+    def __init__(self) -> None:
+        # (lane, key) -> (tokens_remaining, last_refill_monotonic)
+        self._buckets: dict[tuple[str, str], tuple[float, float]] = {}
+
+    def try_admit(
+        self,
+        *,
+        lane: str,
+        key: str,
+        capacity: int,
+        refill_per_second: float,
+    ) -> AdmissionDecision:
+        now = time.monotonic()
+        bucket_key = (lane, key)
+        cap = float(capacity)
+
+        if bucket_key not in self._buckets:
+            # Brand-new bucket — start full.
+            self._buckets[bucket_key] = (cap - 1.0, now)
+            return AdmissionDecision(allowed=True, retry_after_seconds=0.0)
+
+        tokens, last_refill = self._buckets[bucket_key]
+        elapsed = now - last_refill
+        tokens = min(cap, tokens + elapsed * refill_per_second)
+
+        if tokens >= 1.0:
+            self._buckets[bucket_key] = (tokens - 1.0, now)
+            return AdmissionDecision(allowed=True, retry_after_seconds=0.0)
+
+        retry_after = (1.0 - tokens) / refill_per_second if refill_per_second > 0 else float("inf")
+        self._buckets[bucket_key] = (tokens, now)
+        return AdmissionDecision(allowed=False, retry_after_seconds=retry_after)
+
+    def health(self) -> BackendHealth:
+        return BackendHealth(
+            healthy=True,
+            detail="process-local (in-memory, not shared across replicas)",
+        )
+
+    def reset(self, *, lane: str, key: str) -> None:
+        """Reset the bucket for one `(lane, key)` pair (test helper)."""
+        self._buckets.pop((lane, key), None)
+
+    def clear(self) -> None:
+        """Clear every bucket (test helper)."""
+        self._buckets.clear()
+
+
+__all__ = ["ProcessLocalAdmissionBackend"]

--- a/apps/server/src/omniscience_server/admission/qualification.py
+++ b/apps/server/src/omniscience_server/admission/qualification.py
@@ -1,0 +1,487 @@
+"""Horizontal-read qualification harness (issue #350, AC-SCALE-5).
+
+A free-standing, framework-free scoring module — deliberately not under
+`scripts/` (out of this task's scope). Every check is a pure function over
+explicit *measured* inputs (synthetic in CI, real observations from a live
+multi-replica run when one exists) and returns a frozen `VerificationResult`
+— GREEN or RED, never raised, never a fabricated pass on a missing input.
+
+Two or more replicas must pass all four probes — skew, isolation, fairness,
+fallback — before a topology may claim HA read-scaling; a single-replica
+profile (or one with any unmeasured dimension) is always RED, mirroring
+AC-SCALE-5's "single-replica or unmeasured profiles remain non-HA".
+
+`build_qualification_report` assembles a content-addressed
+`QualificationReport`, the same self-addressing-sha256 pattern as
+`scripts/qualify_backup_restore.py`'s `DrillManifest` (not imported from
+there — `scripts/**` is out of this task's scope — the small pattern is
+reproduced locally instead of reaching across the boundary).
+
+**Live 2+-replica measurement is a decision-return** (no Kubernetes cluster
+in this control-plane checkout): see
+`docs/runbooks/read-admission.md` "Blocked on external — decision returns".
+This module proves the scoring *logic* is correct against synthetic and
+fixture inputs; it does not and cannot fabricate a live measurement.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from omniscience_core.config import Settings
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """A decision return — never an exception, always GREEN or RED."""
+
+    status: str  # "GREEN" | "RED"
+    reasons: tuple[str, ...] = ()
+
+    @property
+    def is_green(self) -> bool:
+        return self.status == "GREEN"
+
+
+def _canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(
+        payload, ensure_ascii=False, allow_nan=False, sort_keys=True, separators=(",", ":")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Skew probe
+# ---------------------------------------------------------------------------
+
+
+def score_skew(
+    *,
+    replica_admitted_counts: Mapping[str, int],
+    max_skew_ratio: float,
+) -> VerificationResult:
+    """Verify admitted-request counts are balanced across replicas.
+
+    ``replica_admitted_counts`` maps replica identity to the number of
+    requests it admitted under a uniform synthetic load. Skew is
+    ``(max - min) / mean``; RED if it exceeds ``max_skew_ratio`` or if
+    fewer than two replicas were measured (a single replica cannot
+    demonstrate horizontal balance at all).
+    """
+    if len(replica_admitted_counts) < 2:
+        return VerificationResult(
+            "RED", (f"fewer_than_2_replicas_measured:{len(replica_admitted_counts)}",)
+        )
+    counts = list(replica_admitted_counts.values())
+    if any(c < 0 for c in counts):
+        return VerificationResult("RED", ("negative_admitted_count",))
+    mean = sum(counts) / len(counts)
+    if mean <= 0:
+        return VerificationResult("RED", ("zero_or_negative_mean_admitted_count",))
+    skew_ratio = (max(counts) - min(counts)) / mean
+    if skew_ratio > max_skew_ratio:
+        return VerificationResult(
+            "RED", (f"skew_ratio_exceeded:{skew_ratio:.4f}>{max_skew_ratio}",)
+        )
+    return VerificationResult("GREEN")
+
+
+# ---------------------------------------------------------------------------
+# Isolation probe
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TenantObservation:
+    """One tenant's measured admitted/rejected counts under the probe."""
+
+    tenant_id: str
+    requests_sent: int
+    requests_admitted: int
+
+
+def score_isolation(
+    *,
+    observations: Sequence[TenantObservation],
+    noisy_tenant_id: str,
+    max_cross_tenant_rejection_rate: float,
+) -> VerificationResult:
+    """Verify a saturating tenant does not degrade other tenants' admission.
+
+    ``observations`` must include the ``noisy_tenant_id`` (a tenant driving
+    enough load to exhaust its own budget) plus at least one other tenant.
+    RED if any non-noisy tenant's rejection rate exceeds
+    ``max_cross_tenant_rejection_rate`` — that is cross-tenant interference,
+    which a correctly isolated admission authority must not allow.
+    """
+    by_tenant = {obs.tenant_id: obs for obs in observations}
+    if noisy_tenant_id not in by_tenant:
+        return VerificationResult("RED", ("noisy_tenant_not_observed",))
+    others = [obs for obs in observations if obs.tenant_id != noisy_tenant_id]
+    if not others:
+        return VerificationResult("RED", ("no_other_tenant_observed",))
+
+    reasons: list[str] = []
+    for obs in others:
+        if obs.requests_sent <= 0:
+            reasons.append(f"tenant_sent_zero_requests:{obs.tenant_id}")
+            continue
+        rejection_rate = 1.0 - (obs.requests_admitted / obs.requests_sent)
+        if rejection_rate > max_cross_tenant_rejection_rate:
+            reasons.append(
+                f"cross_tenant_interference:{obs.tenant_id}:"
+                f"{rejection_rate:.4f}>{max_cross_tenant_rejection_rate}"
+            )
+    if reasons:
+        return VerificationResult("RED", tuple(reasons))
+    return VerificationResult("GREEN")
+
+
+# ---------------------------------------------------------------------------
+# Fairness probe (AC-SCALE-2 — background degrades first)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LaneObservation:
+    """One lane's measured behaviour under an overload probe."""
+
+    lane: str
+    requests_sent: int
+    requests_admitted: int
+    p99_latency_ms: float
+    error_rate: float
+
+
+def score_fairness(
+    *,
+    incident: LaneObservation,
+    background: LaneObservation,
+    incident_latency_threshold_ms: float,
+    incident_error_rate_threshold: float,
+) -> VerificationResult:
+    """Verify overload sheds background traffic before degrading incident.
+
+    RED if the incident lane breaches its own latency/error thresholds
+    (meaning incident traffic was degraded — the one thing AC-SCALE-2
+    forbids), or if background did not shed a strictly larger fraction of
+    its own traffic than incident did (background must degrade *first*,
+    not merely also-eventually).
+    """
+    reasons: list[str] = []
+    if incident.p99_latency_ms > incident_latency_threshold_ms:
+        reasons.append(
+            f"incident_latency_breached:{incident.p99_latency_ms}>{incident_latency_threshold_ms}"
+        )
+    if incident.error_rate > incident_error_rate_threshold:
+        reasons.append(
+            f"incident_error_rate_breached:{incident.error_rate}>{incident_error_rate_threshold}"
+        )
+
+    def _rejection_rate(obs: LaneObservation) -> float | None:
+        if obs.requests_sent <= 0:
+            return None
+        return 1.0 - (obs.requests_admitted / obs.requests_sent)
+
+    incident_rejection = _rejection_rate(incident)
+    background_rejection = _rejection_rate(background)
+    if incident_rejection is None or background_rejection is None:
+        reasons.append("lane_sent_zero_requests")
+    elif background_rejection <= incident_rejection:
+        reasons.append(
+            f"background_did_not_degrade_first:"
+            f"background_rejection={background_rejection:.4f}<=incident_rejection={incident_rejection:.4f}"
+        )
+
+    if reasons:
+        return VerificationResult("RED", tuple(reasons))
+    return VerificationResult("GREEN")
+
+
+def score_fairness_from_settings(
+    settings: Settings,
+    *,
+    incident: LaneObservation,
+    background: LaneObservation,
+) -> VerificationResult:
+    """`score_fairness`, sourcing its thresholds from
+    `Settings.admission_latency_threshold_ms`/`admission_error_rate_threshold`
+    instead of a caller-supplied constant.
+
+    These two fields are declared as fail-boot-required Settings inputs
+    (`packages/core/src/omniscience_core/config.py`) but had no runtime
+    consumer before this wiring — this is that consumer. RED (not raised)
+    if either threshold is unset, matching this module's decision-return
+    convention (module docstring)."""
+    latency_threshold = settings.admission_latency_threshold_ms
+    error_rate_threshold = settings.admission_error_rate_threshold
+    if latency_threshold is None or error_rate_threshold is None:
+        return VerificationResult(
+            "RED",
+            ("admission_latency_threshold_ms_or_admission_error_rate_threshold_unset",),
+        )
+    return score_fairness(
+        incident=incident,
+        background=background,
+        incident_latency_threshold_ms=latency_threshold,
+        incident_error_rate_threshold=error_rate_threshold,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Queue-depth probe (AC-SCALE-2/5 — bounded admission queue ceiling)
+# ---------------------------------------------------------------------------
+
+
+def score_queue_depth(*, observed_queue_depth: int, queue_depth_max: int) -> VerificationResult:
+    """Verify an observed admission queue-depth measurement stays within
+    `queue_depth_max` (`Settings.admission_queue_depth_max`, AC-SCALE-2/5).
+
+    This process never queues admission requests itself (`try_admit` is a
+    synchronous accept/reject — see `admission.process_local` module
+    docstring); `observed_queue_depth` is a measurement taken against the
+    shared backend/qualification probe, not something computed locally.
+    RED if the observation exceeds the bound or is negative.
+    """
+    if observed_queue_depth < 0:
+        return VerificationResult("RED", ("negative_observed_queue_depth",))
+    if observed_queue_depth > queue_depth_max:
+        return VerificationResult(
+            "RED", (f"queue_depth_exceeded:{observed_queue_depth}>{queue_depth_max}",)
+        )
+    return VerificationResult("GREEN")
+
+
+def score_queue_depth_from_settings(
+    settings: Settings, *, observed_queue_depth: int
+) -> VerificationResult:
+    """`score_queue_depth`, sourcing its ceiling from
+    `Settings.admission_queue_depth_max` — the real runtime consumer for
+    that fail-boot-required field (see its docstring in
+    `packages/core/src/omniscience_core/config.py`). RED if unset."""
+    queue_depth_max = settings.admission_queue_depth_max
+    if queue_depth_max is None:
+        return VerificationResult("RED", ("admission_queue_depth_max_unset",))
+    return score_queue_depth(
+        observed_queue_depth=observed_queue_depth, queue_depth_max=queue_depth_max
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fallback probe (AC-SCALE-3 — stable 429/503, no false-freshness success)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OverloadResponseObservation:
+    """One observed overload-path HTTP/MCP response, as measured."""
+
+    status_code: int
+    code: str
+    is_success_status: bool
+    meta_freshness_status: str | None
+
+
+_STABLE_OVERLOAD_CODES: frozenset[int] = frozenset({429, 503})
+_FALSE_FRESHNESS_STATUSES: frozenset[str] = frozenset({"fresh"})
+
+
+def score_fallback(*, observations: Sequence[OverloadResponseObservation]) -> VerificationResult:
+    """Verify every overload observation is a stable 429/503 error and
+    never a 2xx success carrying false freshness (REQ-MCP-4/7)."""
+    if not observations:
+        return VerificationResult("RED", ("no_overload_observations",))
+
+    reasons: list[str] = []
+    for index, obs in enumerate(observations):
+        if obs.is_success_status:
+            reasons.append(f"overload_returned_success_status:{index}:{obs.status_code}")
+            continue
+        if obs.status_code not in _STABLE_OVERLOAD_CODES:
+            reasons.append(f"overload_status_not_stable:{index}:{obs.status_code}")
+        if obs.meta_freshness_status in _FALSE_FRESHNESS_STATUSES:
+            reasons.append(f"overload_claims_fresh_meta:{index}")
+
+    if reasons:
+        return VerificationResult("RED", tuple(reasons))
+    return VerificationResult("GREEN")
+
+
+# ---------------------------------------------------------------------------
+# Content-addressed qualification report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QualificationReport:
+    """Content-addressed, tamper-evident horizontal-read qualification
+    record. ``report_id`` self-addresses every other field (sha256), so a
+    tampered or partially-filled report cannot silently claim a different
+    identity — same pattern as `scripts/qualify_backup_restore.py`'s
+    `DrillManifest`, reproduced locally (see module docstring).
+
+    ``queue_depth_status`` is GREEN/RED from `score_queue_depth`
+    (`_from_settings`), or None when the admission queue-depth bound wasn't
+    measured for this report — optional, unlike the four required probes;
+    AC-SCALE-5 doesn't gate overall HA status on it (see
+    `build_qualification_report`)."""
+
+    report_id: str
+    replica_count: int
+    skew_status: str
+    isolation_status: str
+    fairness_status: str
+    fallback_status: str
+    status: str  # "GREEN" | "RED"
+    reasons: tuple[str, ...]
+    queue_depth_status: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "report_id": self.report_id,
+            "replica_count": self.replica_count,
+            "skew_status": self.skew_status,
+            "isolation_status": self.isolation_status,
+            "fairness_status": self.fairness_status,
+            "fallback_status": self.fallback_status,
+            "status": self.status,
+            "reasons": list(self.reasons),
+            "queue_depth_status": self.queue_depth_status,
+        }
+
+    def to_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+
+_MIN_QUALIFYING_REPLICAS = 2
+
+
+def build_qualification_report(
+    *,
+    replica_count: int,
+    skew: VerificationResult,
+    isolation: VerificationResult,
+    fairness: VerificationResult,
+    fallback: VerificationResult,
+    queue_depth: VerificationResult | None = None,
+) -> QualificationReport:
+    """Assemble a `QualificationReport` from the four required measured
+    probe results, plus an optional fifth `queue_depth` probe
+    (`score_queue_depth`/`_from_settings`). Single-replica or unmeasured
+    (fewer than two replicas) topologies are always RED regardless of
+    individual probe status — AC-SCALE-5: "single-replica or unmeasured
+    profiles remain non-HA". `queue_depth` is optional and backward
+    compatible: omitting it (the default) reproduces the exact pre-existing
+    four-probe report; a RED `queue_depth` result still fails the overall
+    report when supplied."""
+    reasons: list[str] = []
+    if replica_count < _MIN_QUALIFYING_REPLICAS:
+        reasons.append(f"replica_count_below_minimum:{replica_count}<{_MIN_QUALIFYING_REPLICAS}")
+    for label, result in (
+        ("skew", skew),
+        ("isolation", isolation),
+        ("fairness", fairness),
+        ("fallback", fallback),
+    ):
+        if not result.is_green:
+            reasons.extend(f"{label}:{reason}" for reason in result.reasons)
+    if queue_depth is not None and not queue_depth.is_green:
+        reasons.extend(f"queue_depth:{reason}" for reason in queue_depth.reasons)
+
+    status = "RED" if reasons else "GREEN"
+    queue_depth_status = queue_depth.status if queue_depth is not None else None
+    body: dict[str, Any] = {
+        "replica_count": replica_count,
+        "skew_status": skew.status,
+        "isolation_status": isolation.status,
+        "fairness_status": fairness.status,
+        "fallback_status": fallback.status,
+        "status": status,
+        "reasons": reasons,
+        "queue_depth_status": queue_depth_status,
+    }
+    content_hash = hashlib.sha256(_canonical_json(body).encode("utf-8")).hexdigest()
+
+    return QualificationReport(
+        report_id=f"sha256:{content_hash}",
+        replica_count=replica_count,
+        skew_status=skew.status,
+        isolation_status=isolation.status,
+        fairness_status=fairness.status,
+        fallback_status=fallback.status,
+        status=status,
+        reasons=tuple(reasons),
+        queue_depth_status=queue_depth_status,
+    )
+
+
+_REPORT_REQUIRED_FIELDS: tuple[str, ...] = (
+    "report_id",
+    "replica_count",
+    "skew_status",
+    "isolation_status",
+    "fairness_status",
+    "fallback_status",
+    "status",
+)
+
+
+def validate_report_json(report: Any | None) -> VerificationResult:
+    """Re-validate an already-serialized qualification report artifact.
+    Checks the artifact's own shape and declared per-dimension statuses —
+    never trusts a self-declared ``"status": "GREEN"`` alone."""
+    if report is None:
+        return VerificationResult("RED", ("report_absent",))
+    if not isinstance(report, dict):
+        return VerificationResult("RED", ("report_malformed:not_an_object",))
+
+    reasons: list[str] = []
+    for field in _REPORT_REQUIRED_FIELDS:
+        if field not in report or report[field] is None:
+            reasons.append(f"report_field_absent:{field}")
+
+    replica_count = report.get("replica_count")
+    if isinstance(replica_count, int) and replica_count < _MIN_QUALIFYING_REPLICAS:
+        reasons.append(f"report_replica_count_below_minimum:{replica_count}")
+    for label in ("skew_status", "isolation_status", "fairness_status", "fallback_status"):
+        if report.get(label) not in ("GREEN", "RED"):
+            reasons.append(f"report_{label}_not_green_or_red:{report.get(label)!r}")
+        elif report.get(label) == "RED":
+            reasons.append(f"report_{label}_is_red")
+
+    # queue_depth_status is optional (unmeasured => None is valid); only
+    # validate its shape/value when the report actually declares one.
+    queue_depth_status = report.get("queue_depth_status")
+    if queue_depth_status is not None:
+        if queue_depth_status not in ("GREEN", "RED"):
+            reasons.append(f"report_queue_depth_status_not_green_or_red:{queue_depth_status!r}")
+        elif queue_depth_status == "RED":
+            reasons.append("report_queue_depth_status_is_red")
+
+    if report.get("status") != "GREEN":
+        reasons.append(f"report_status_not_green:{report.get('status')!r}")
+
+    if reasons:
+        return VerificationResult("RED", tuple(dict.fromkeys(reasons)))
+    return VerificationResult("GREEN")
+
+
+__all__ = [
+    "LaneObservation",
+    "OverloadResponseObservation",
+    "QualificationReport",
+    "TenantObservation",
+    "VerificationResult",
+    "build_qualification_report",
+    "score_fairness",
+    "score_fairness_from_settings",
+    "score_fallback",
+    "score_isolation",
+    "score_queue_depth",
+    "score_queue_depth_from_settings",
+    "score_skew",
+    "validate_report_json",
+]

--- a/apps/server/src/omniscience_server/admission/shared.py
+++ b/apps/server/src/omniscience_server/admission/shared.py
@@ -1,0 +1,56 @@
+"""Shared/networked `AdmissionBackend` stub (issue #350, AC-SCALE-1).
+
+Deliberately unimplemented. Activating a new infrastructure dependency
+(e.g. Redis `SET NX PX` / a Lua CAS script, or a managed rate-limiting
+service — see `docs/runbooks/read-admission.md` "Backend recommendation")
+is a human decision this agent cannot make on its own. Selecting a
+non-`"disabled"` `admission_backend` value is therefore a *fail-closed*
+action, never a silent fallback to `ProcessLocalAdmissionBackend` — every
+call into this stub raises `AdmissionBackendUnavailableError`, which
+`admission.state_machine.FailClosedAdmissionController` turns into the
+AC-SCALE-4 backend-loss posture (background suspended, incident admitted
+only from a provably-authorized reserve).
+"""
+
+from __future__ import annotations
+
+from omniscience_server.admission.backend import (
+    AdmissionBackendUnavailableError,
+    AdmissionDecision,
+    BackendHealth,
+)
+
+
+class SharedAdmissionBackend:
+    """Stub target for a future shared/networked `AdmissionBackend`.
+
+    `backend_identity` is the human-approved concrete backend descriptor
+    (`Settings.admission_backend_identity`) — carried through so a failure
+    message names *what* was requested, never a guess.
+    """
+
+    def __init__(self, *, backend_identity: str) -> None:
+        self._backend_identity = backend_identity
+
+    def try_admit(
+        self,
+        *,
+        lane: str,
+        key: str,
+        capacity: int,
+        refill_per_second: float,
+    ) -> AdmissionDecision:
+        raise AdmissionBackendUnavailableError(
+            f"shared admission backend {self._backend_identity!r} is not "
+            "implemented — no shared backend has been approved and wired "
+            "(issue #350 AC-SCALE-1); see docs/runbooks/read-admission.md."
+        )
+
+    def health(self) -> BackendHealth:
+        return BackendHealth(
+            healthy=False,
+            detail=f"unimplemented:{self._backend_identity}",
+        )
+
+
+__all__ = ["SharedAdmissionBackend"]

--- a/apps/server/src/omniscience_server/admission/state_machine.py
+++ b/apps/server/src/omniscience_server/admission/state_machine.py
@@ -1,0 +1,182 @@
+"""Fail-closed admission state machine (issue #350, AC-SCALE-4).
+
+`FailClosedAdmissionController` wraps an `AdmissionBackend` and answers
+every admission request through it. When the backend is healthy, behaviour
+is exactly `backend.try_admit(...)`. When the backend is unreachable
+(`health().healthy is False`) or raises `AdmissionBackendUnavailableError`:
+
+- `BACKGROUND_LANE` is always rejected — background admission stops
+  entirely, with no exception.
+- `INCIDENT_LANE` is rejected UNLESS a *separate*, independently-queryable
+  `LeaseAuthority` grants a bounded incident-reserve lease. This is
+  deliberately not the same backend that just failed — asking the backend
+  that is down to also authorize the reserve would prove nothing. No real
+  `LeaseAuthority` is wired in this repository (issue #350 decision-return:
+  provisioning a durable lock/lease service is a human decision); the safe
+  default, `NullLeaseAuthority`, always answers "not authorized", so an
+  unconfigured deployment fails closed rather than silently granting a
+  reserve nobody actually proved.
+
+At no point does this controller fall back to a fresh
+`ProcessLocalAdmissionBackend` or any other per-process bucket when the
+configured backend is unhealthy — that bypass is exactly what AC-SCALE-4
+forbids ("never falls back to per-process buckets").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import structlog
+
+from omniscience_server.admission.backend import (
+    AdmissionBackend,
+    AdmissionBackendUnavailableError,
+    BackendHealth,
+)
+from omniscience_server.admission.lanes import BACKGROUND_LANE
+
+log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# States / outcomes
+# ---------------------------------------------------------------------------
+
+STATE_NORMAL = "normal"
+STATE_BACKEND_LOST = "backend_lost"
+
+REASON_LANE_EXHAUSTED = "lane_exhausted"
+REASON_BACKGROUND_SUSPENDED = "backend_loss_background_suspended"
+REASON_NO_PROVABLE_AUTHORITY = "backend_loss_no_provable_authority"
+REASON_INCIDENT_RESERVE = "incident_reserve"
+
+
+@dataclass(frozen=True)
+class AdmissionOutcome:
+    """Result of one `FailClosedAdmissionController.evaluate` call."""
+
+    allowed: bool
+    state: str
+    reason: str | None
+    retry_after_seconds: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Incident-reserve authority
+# ---------------------------------------------------------------------------
+
+
+class LeaseAuthority(Protocol):
+    """Source of provable authority for the bounded incident reserve during
+    a shared-backend outage (AC-SCALE-4). Must be answerable independently
+    of the primary `AdmissionBackend` — if it shared the same failure
+    domain it could not prove anything while that backend is down."""
+
+    def try_acquire_incident_reserve(self, *, key: str, capacity: int) -> bool:
+        """Return True only if a lease/lock genuinely grants `key` a slot
+        in the bounded incident reserve right now."""
+        ...
+
+
+class NullLeaseAuthority:
+    """Fail-closed default `LeaseAuthority`: never grants a reserve slot.
+
+    Used whenever no real durable lease/lock service has been wired — an
+    unconfigured deployment must never *assume* it holds authority it has
+    not proven (issue #350 decision-return; see
+    `docs/runbooks/read-admission.md`)."""
+
+    def try_acquire_incident_reserve(self, *, key: str, capacity: int) -> bool:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Controller
+# ---------------------------------------------------------------------------
+
+
+class FailClosedAdmissionController:
+    """Routes `(lane, key)` admission requests through `backend`, degrading
+    to the AC-SCALE-4 fail-closed posture when `backend` is unhealthy."""
+
+    def __init__(
+        self,
+        *,
+        backend: AdmissionBackend,
+        incident_reserve_capacity: int = 0,
+        lease_authority: LeaseAuthority | None = None,
+    ) -> None:
+        self._backend = backend
+        self._incident_reserve_capacity = incident_reserve_capacity
+        self._lease_authority = lease_authority or NullLeaseAuthority()
+
+    def evaluate(
+        self,
+        *,
+        lane: str,
+        key: str,
+        capacity: int,
+        refill_per_second: float,
+    ) -> AdmissionOutcome:
+        health = self._safe_health()
+        if not health.healthy:
+            return self._degrade(lane=lane, key=key, reason=health.detail or "backend_unhealthy")
+
+        try:
+            decision = self._backend.try_admit(
+                lane=lane, key=key, capacity=capacity, refill_per_second=refill_per_second
+            )
+        except AdmissionBackendUnavailableError as exc:
+            return self._degrade(lane=lane, key=key, reason=str(exc))
+
+        return AdmissionOutcome(
+            allowed=decision.allowed,
+            state=STATE_NORMAL,
+            reason=None if decision.allowed else REASON_LANE_EXHAUSTED,
+            retry_after_seconds=decision.retry_after_seconds,
+        )
+
+    def _safe_health(self) -> BackendHealth:
+        try:
+            return self._backend.health()
+        except Exception as exc:
+            return BackendHealth(healthy=False, detail=f"health_check_failed:{exc}")
+
+    def _degrade(self, *, lane: str, key: str, reason: str) -> AdmissionOutcome:
+        # `reason` is the raw pre-degrade health detail / exception text —
+        # never returned to the client (every branch below substitutes a
+        # fixed REASON_* constant into AdmissionOutcome.reason instead, so
+        # no backend-internal detail leaks in the 503 body). Captured here,
+        # server-side only, so the diagnostic isn't silently dropped for
+        # incident debugging. Deliberately omits `key` (the caller's token
+        # id) — this is a backend-health log line, not a per-consumer one.
+        log.warning("admission_backend_degraded", lane=lane, reason=reason)
+        if lane == BACKGROUND_LANE:
+            return AdmissionOutcome(
+                allowed=False, state=STATE_BACKEND_LOST, reason=REASON_BACKGROUND_SUSPENDED
+            )
+        granted = self._lease_authority.try_acquire_incident_reserve(
+            key=key, capacity=self._incident_reserve_capacity
+        )
+        if granted:
+            return AdmissionOutcome(
+                allowed=True, state=STATE_BACKEND_LOST, reason=REASON_INCIDENT_RESERVE
+            )
+        return AdmissionOutcome(
+            allowed=False, state=STATE_BACKEND_LOST, reason=REASON_NO_PROVABLE_AUTHORITY
+        )
+
+
+__all__ = [
+    "REASON_BACKGROUND_SUSPENDED",
+    "REASON_INCIDENT_RESERVE",
+    "REASON_LANE_EXHAUSTED",
+    "REASON_NO_PROVABLE_AUTHORITY",
+    "STATE_BACKEND_LOST",
+    "STATE_NORMAL",
+    "AdmissionOutcome",
+    "FailClosedAdmissionController",
+    "LeaseAuthority",
+    "NullLeaseAuthority",
+]

--- a/apps/server/src/omniscience_server/rest/rate_limit.py
+++ b/apps/server/src/omniscience_server/rest/rate_limit.py
@@ -1,16 +1,24 @@
-"""Token-bucket rate limiter per API token.
+"""Shared read-admission dependency for REST (issue #350, AC-SCALE-1..4).
 
-Default: 60 requests per minute.
-Exceeded: HTTP 429 with Retry-After header (seconds until next token is available).
+Default posture (``admission_backend="disabled"``, unchanged from pre-#350):
+token-bucket admission per token, in-process. Exceeded: HTTP 429 with
+Retry-After. This module no longer owns bucket storage directly — it
+delegates to ``omniscience_server.admission`` (``ProcessLocalAdmissionBackend``
+by default) behind the narrow ``AdmissionBackend`` Protocol, so there is no
+process-local bypass left for a future shared backend to replace.
 
-This is an in-process implementation using a dict of token buckets.
-For multi-process deployments a shared store (Redis) would be required;
-this is explicitly an MVP/single-process implementation.
+Requests are additionally routed through a named lane — ``incident`` for
+SRE-incident-capable tokens, ``background`` for everything else
+(AC-SCALE-2) — and through ``FailClosedAdmissionController`` (AC-SCALE-4),
+which turns a lost/unhealthy backend into a stable 503
+(``admission_backend_unavailable``) for background traffic and for
+incident traffic lacking a provable reserve lease, rather than silently
+falling back to a fresh process-local bucket.
 """
 
 from __future__ import annotations
 
-import time
+import threading
 from typing import Any
 
 import structlog
@@ -18,24 +26,42 @@ from fastapi import Depends, HTTPException, Request
 from omniscience_core.auth.middleware import get_current_token
 from omniscience_core.db.models import ApiToken
 
+from omniscience_server.admission.backend import AdmissionBackend
+from omniscience_server.admission.lanes import BACKGROUND_LANE, resolve_admission_lane
+from omniscience_server.admission.process_local import ProcessLocalAdmissionBackend
+from omniscience_server.admission.shared import SharedAdmissionBackend
+from omniscience_server.admission.state_machine import (
+    STATE_BACKEND_LOST,
+    FailClosedAdmissionController,
+)
+
 log = structlog.get_logger(__name__)
 
-# Module-level bucket store: token_id -> (tokens_remaining: float, last_refill: float)
-_buckets: dict[str, tuple[float, float]] = {}
-
-# Default rate: 60 requests per minute
+# Default rate: 60 requests per minute (matches Settings.rate_limit_rpm default)
 _DEFAULT_RPM: int = 60
+
+# Lane used by the free (non-lane-aware) check_rate_limit/reset_rate_limit
+# helpers below — kept separate from "incident"/"background" so direct
+# bucket tests never interact with lane-aware traffic.
+_DEFAULT_LANE = "default"
 
 # Module-level Depends singleton to avoid ruff B008
 _current_token_dep: Any = Depends(get_current_token)
 
+# Process-local backend singleton — the "disabled" (default) admission
+# posture. Reused across requests so bucket state persists; also the
+# object the legacy check_rate_limit()/clear_all_buckets() helpers below
+# operate on directly, preserving pre-#350 test behaviour byte-for-byte.
+_default_backend = ProcessLocalAdmissionBackend()
+_default_controller = FailClosedAdmissionController(backend=_default_backend)
 
-def _get_rpm(request: Request) -> int:
-    """Return the configured RPM from app settings, falling back to the default."""
-    settings = getattr(request.app.state, "settings", None)
-    if settings is not None:
-        return int(getattr(settings, "rate_limit_rpm", _DEFAULT_RPM))
-    return _DEFAULT_RPM
+# Cache of non-"disabled" backend/controller pairs, keyed by the settings
+# fields that determine their identity. Built once per distinct config and
+# reused across requests — mirrors _default_controller's module-scope
+# caching above, so a future real backend's connection pool / lease state
+# is never silently discarded between requests (BP review MEDIUM #5).
+_shared_controller_cache: dict[tuple[str, str, float, int], FailClosedAdmissionController] = {}
+_shared_controller_cache_lock = threading.Lock()
 
 
 def check_rate_limit(token_id: str, rpm: int) -> tuple[bool, float]:
@@ -46,6 +72,10 @@ def check_rate_limit(token_id: str, rpm: int) -> tuple[bool, float]:
     - Refill rate = rpm tokens per 60 seconds
     - Each request consumes 1 token
 
+    Delegates to the process-local ``AdmissionBackend`` singleton on the
+    ``"default"`` lane — kept as a free function for direct unit testing
+    and for parity with pre-#350 callers.
+
     Args:
         token_id: Unique identifier for the API token (string form of UUID).
         rpm: Requests per minute limit.
@@ -54,61 +84,155 @@ def check_rate_limit(token_id: str, rpm: int) -> tuple[bool, float]:
         (allowed, retry_after_seconds) — if allowed is False, retry_after_seconds
         is the number of seconds until one token will be available.
     """
-    now = time.monotonic()
-    capacity = float(rpm)
-    refill_rate = capacity / 60.0  # tokens per second
-
-    if token_id not in _buckets:
-        # Brand-new bucket — start full
-        _buckets[token_id] = (capacity - 1.0, now)
-        return True, 0.0
-
-    tokens, last_refill = _buckets[token_id]
-
-    # Refill based on elapsed time
-    elapsed = now - last_refill
-    tokens = min(capacity, tokens + elapsed * refill_rate)
-
-    if tokens >= 1.0:
-        _buckets[token_id] = (tokens - 1.0, now)
-        return True, 0.0
-
-    # Bucket empty — compute how long until 1 token refills
-    retry_after = (1.0 - tokens) / refill_rate
-    _buckets[token_id] = (tokens, now)
-    return False, retry_after
+    decision = _default_backend.try_admit(
+        lane=_DEFAULT_LANE, key=token_id, capacity=rpm, refill_per_second=rpm / 60.0
+    )
+    return decision.allowed, decision.retry_after_seconds
 
 
 def reset_rate_limit(token_id: str) -> None:
     """Reset the bucket for the given token_id (used in tests)."""
-    _buckets.pop(token_id, None)
+    _default_backend.reset(lane=_DEFAULT_LANE, key=token_id)
 
 
 def clear_all_buckets() -> None:
     """Clear all rate-limit buckets (used in tests)."""
-    _buckets.clear()
+    _default_backend.clear()
+
+
+def _lane_capacity_and_bucket(settings: Any, lane: str) -> tuple[int, str]:
+    """Resolve the (capacity, bucket_key) pair for `lane`.
+
+    When a lane-specific budget is explicitly configured (HA/enabled
+    posture), the lane gets its own bounded bucket — separate from every
+    other lane, never shared or borrowed capacity (AC-SCALE-2). When
+    unconfigured (the default "disabled" posture, no lane budgets set),
+    every lane resolves to the single shared ``_DEFAULT_LANE`` bucket at
+    ``rate_limit_rpm`` capacity — byte-for-byte the pre-#350 single-bucket
+    behaviour, including for direct ``check_rate_limit`` test callers that
+    share the same bucket namespace.
+    """
+    if settings is not None:
+        budget_field = (
+            "admission_lane_incident_budget"
+            if lane != BACKGROUND_LANE
+            else "admission_lane_background_budget"
+        )
+        budget = getattr(settings, budget_field, None)
+        if budget is not None:
+            return int(budget), lane
+    rpm = (
+        int(getattr(settings, "rate_limit_rpm", _DEFAULT_RPM))
+        if settings is not None
+        else (_DEFAULT_RPM)
+    )
+    return rpm, _DEFAULT_LANE
+
+
+def _controller_for(settings: Any) -> FailClosedAdmissionController:
+    """Resolve the AdmissionBackend + fail-closed controller for `settings`.
+
+    "disabled" (default) always reuses the module-level process-local
+    singleton so bucket state persists across requests. Any other value
+    builds a `SharedAdmissionBackend` — a fail-closed stub today (issue
+    #350: activating a new infrastructure dependency is a human decision) —
+    wrapped in the same `FailClosedAdmissionController` state machine, so an
+    "enabled but unimplemented" backend degrades exactly like a real one
+    that has gone unreachable, never a silent process-local fallback.
+
+    Non-"disabled" backend/controller pairs are cached by the config fields
+    that determine their identity (`_shared_controller_cache`) rather than
+    rebuilt on every call — a fresh `SharedAdmissionBackend` per request is
+    harmless for today's stateless stub, but would silently discard any
+    connection pool or lease-tracking state a real implementation holds.
+    See `reset_admission_controller_cache()` for the test-only escape
+    hatch.
+    """
+    mode = (
+        str(getattr(settings, "admission_backend", "disabled"))
+        if settings is not None
+        else ("disabled")
+    )
+    if mode == "disabled":
+        return _default_controller
+
+    identity = str(getattr(settings, "admission_backend_identity", None) or mode)
+    reserve_fraction = float(getattr(settings, "admission_failure_reserve_fraction", 0.0) or 0.0)
+    incident_budget = int(getattr(settings, "admission_lane_incident_budget", 0) or 0)
+    cache_key = (mode, identity, reserve_fraction, incident_budget)
+
+    with _shared_controller_cache_lock:
+        controller = _shared_controller_cache.get(cache_key)
+        if controller is None:
+            backend: AdmissionBackend = SharedAdmissionBackend(backend_identity=identity)
+            controller = FailClosedAdmissionController(
+                backend=backend,
+                incident_reserve_capacity=int(incident_budget * reserve_fraction),
+            )
+            _shared_controller_cache[cache_key] = controller
+        return controller
+
+
+def reset_admission_controller_cache() -> None:
+    """Clear cached non-"disabled" backend/controller pairs (test helper).
+
+    Mirrors `clear_all_buckets()` for the process-local path — tests that
+    construct distinct `Settings` across cases should call this so one
+    test's cached controller is never observed by another.
+    """
+    with _shared_controller_cache_lock:
+        _shared_controller_cache.clear()
 
 
 async def rate_limit_dependency(
     request: Request,
     token: ApiToken = _current_token_dep,
 ) -> ApiToken:
-    """FastAPI dependency: enforce per-token rate limiting.
+    """FastAPI dependency: enforce shared, lane-aware read admission.
 
     Raises:
-        HTTPException 429 — rate limit exceeded, includes Retry-After.
+        HTTPException 429 — lane budget exhausted, includes Retry-After.
+        HTTPException 503 — shared admission backend unavailable
+            (``admission_backend_unavailable``); background traffic and
+            incident traffic without a provable reserve lease both land
+            here rather than being silently admitted.
 
     Returns:
         The authenticated ApiToken (passes through from get_current_token).
     """
-    rpm = _get_rpm(request)
+    settings = getattr(request.app.state, "settings", None)
+    lane = resolve_admission_lane(token)
+    capacity, bucket_lane = _lane_capacity_and_bucket(settings, lane)
+    controller = _controller_for(settings)
     token_id = str(token.id)
-    allowed, retry_after = check_rate_limit(token_id, rpm)
 
-    if not allowed:
-        retry_after_int = int(retry_after) + 1
+    outcome = controller.evaluate(
+        lane=bucket_lane, key=token_id, capacity=capacity, refill_per_second=capacity / 60.0
+    )
+
+    if not outcome.allowed:
+        if outcome.state == STATE_BACKEND_LOST:
+            log.warning(
+                "admission_backend_unavailable",
+                token_prefix=token.token_prefix,
+                lane=lane,
+                reason=outcome.reason,
+            )
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "code": "admission_backend_unavailable",
+                    "message": "Shared admission backend unavailable",
+                    "reason": outcome.reason,
+                },
+            )
+
+        retry_after_int = int(outcome.retry_after_seconds) + 1
         log.warning(
-            "rate_limit_exceeded", token_prefix=token.token_prefix, retry_after=retry_after_int
+            "rate_limit_exceeded",
+            token_prefix=token.token_prefix,
+            lane=lane,
+            retry_after=retry_after_int,
         )
         raise HTTPException(
             status_code=429,
@@ -127,5 +251,6 @@ __all__ = [
     "check_rate_limit",
     "clear_all_buckets",
     "rate_limit_dependency",
+    "reset_admission_controller_cache",
     "reset_rate_limit",
 ]

--- a/docs/runbooks/read-admission.md
+++ b/docs/runbooks/read-admission.md
@@ -1,0 +1,251 @@
+# Shared read-admission & SRE priority lane runbook
+
+> Status: shared-admission interface, fail-closed state machine, server-derived
+> SRE incident lane, and horizontal-read qualification harness shipped
+> (AC-SCALE-1, AC-SCALE-2, AC-SCALE-3, AC-SCALE-4, AC-SCALE-5's repo-local
+> scoring/report logic) — issue
+> [#350](https://github.com/100rd/Omniscience/issues/350),
+> [`gh-issue-350-read-scaling-priority`](../specs/gh-issue-350-read-scaling-priority.md).
+> AC-SCALE-5's live 2+-replica measured evidence, acceptance of a concrete
+> shared backend, and live backend-outage/fairness runs under real load are
+> **blocked on external inputs** — see
+> [Blocked on external — decision returns](#blocked-on-external--decision-returns)
+> below.
+
+## Table of contents
+
+- [Posture model](#posture-model)
+- [Scope boundaries](#scope-boundaries)
+- [Supplying admission evidence](#supplying-admission-evidence)
+- [Running the qualification checks](#running-the-qualification-checks)
+- [Backend recommendation](#backend-recommendation)
+- [Blocked on external — decision returns](#blocked-on-external--decision-returns)
+
+## Posture model
+
+Admission has **two independent gates**, deliberately not coupled to each
+other:
+
+| Gate | Field | Effect |
+|---|---|---|
+| Application backend selection | `Settings.admission_backend` (`packages/core/.../config.py`) | `"disabled"` (default) → `ProcessLocalAdmissionBackend`, the pre-#350 in-process token bucket, unchanged. Any other value → the fail-closed `SharedAdmissionBackend` stub (see below) behind `FailClosedAdmissionController`. |
+| Chart evidence requirement | `production.admission.enabled` (`helm/omniscience/values.yaml`) | `false` (default) → `omniscience.admissionGuards` is a no-op and no `ADMISSION_*` env vars render. `true` → every admission evidence field is required or the render fails closed (`helm/omniscience/templates/_admission_guards.tpl`). |
+| Lane-budget split | `Settings.admission_lane_incident_budget` / `admission_lane_background_budget` (`rest/rate_limit.py::_lane_capacity_and_bucket`) | Unset (default, both `None`) → every lane resolves to the single shared bucket at `rate_limit_rpm` — byte-for-byte the pre-#350 single-bucket behaviour. Setting either budget activates a separately-bounded bucket for that lane. |
+
+The lane-budget split gate is **deliberately independent of `admission_backend`**, the same "two independent gates, not coupled" design used above: setting `ADMISSION_LANE_INCIDENT_BUDGET`/`ADMISSION_LANE_BACKGROUND_BUDGET` activates lane-partitioned rate-limiting on its own, even while `admission_backend` stays `"disabled"` — it does not require also selecting a shared backend. This is intentional (`tests/test_rest_api.py::test_incident_lane_has_separate_budget_from_background_lane` exercises exactly this combination end-to-end), not an oversight: an operator can adopt SRE-incident-lane fairness in the single-process MVP posture before ever provisioning a shared backend. The only coupling this runbook asks you to remember: leaving both lane-budget fields unset (the true zero-touch default) is what preserves pre-#350 behaviour — see `tests/test_rest_api.py::test_default_disabled_posture_has_no_lane_split` for the backward-compat proof.
+
+`production.admission.enabled` is **independent of `production.enabled`**
+(the production-HA gate from issue #350's earlier "production-HA" slice,
+already merged). A production-HA deployment can run with admission left at
+its process-local default; enabling admission evidence never retroactively
+requires re-supplying HA evidence, and vice versa. This is a deliberate
+compatibility boundary: the existing production-HA qualification suite
+(`tests/test_production_ha_render.py`, `tests/test_helm_posture.py`) must
+keep passing unmodified.
+
+There is no separate "posture label" for admission the way
+`omniscience.io/posture` models production-HA — admission is a narrower,
+additive capability layered on top, not a parallel deployment posture.
+
+## Scope boundaries
+
+This slice's declared scope
+(`docs/specs/gh-issue-350-read-scaling-priority.md`) is:
+`apps/server/src/omniscience_server/rest/rate_limit.py`,
+`apps/server/src/omniscience_server/admission/**`,
+`packages/core/src/omniscience_core/config.py`, `helm/omniscience/**`, this
+runbook, `tests/test_admission*.py`, `tests/test_rest_api.py`,
+`tests/test_mcp*.py`, and this slice's own CI workflow. Two real gaps fall
+outside that boundary and are flagged here rather than silently worked
+around:
+
+- **MCP tool-dispatch admission wiring is a follow-up.**
+  `apps/server/src/omniscience_server/mcp/server.py` has zero admission
+  coverage today (grepped: no `rate_limit`/`admission`/`429`/`503` hits) and
+  is not in this slice's `scope.include`. REST is fully covered — every
+  `rate_limit_dependency` call (today, only `/api/v1/search`) routes through
+  the shared `AdmissionBackend`/`FailClosedAdmissionController` stack. A
+  future change that touches `mcp/server.py` should call
+  `admission.mcp_contract.raise_admission_error(outcome)` at the tool
+  dispatch boundary — see that module's docstring for why it raises a
+  stable `ValueError("<code>:<message>")` (the same convention every
+  existing MCP rejection uses) rather than inventing a `meta.fallback`
+  shape, which would violate the closed `fallback.reason` enum in
+  `mcp/contracts/v1/schemas/meta.schema.json` (also out of this slice's
+  scope to edit).
+- **`rest/webhooks.py`'s `_source_buckets` is a second, independent
+  process-local bucket** for inbound webhook ingestion — a different
+  admission class (source ingestion, not consumer read admission) and not
+  in `scope.include`. It is unaffected by this slice and was not migrated
+  onto the shared `AdmissionBackend` Protocol; a future unification is a
+  separate decision, not implied by AC-SCALE-1's "no process-local bypass"
+  (which is scoped to *read* admission).
+- **Workspace-scoped aggregate limits are not implemented.** AC-SCALE-1's
+  `groundTruth` (spec line 35) names "aggregate token, workspace, and lane
+  limits" as the admission dimensions; this slice ships token- and
+  lane-scoped admission (bucket key `(lane, token_id)`,
+  `admission/process_local.py`) but no workspace-level aggregate dimension.
+  This is a pre-existing gap — the pre-#350 single-process limiter was also
+  token-only — not something this build closed or silently dropped. A
+  workspace-aggregate dimension would need to aggregate consumption across
+  every token in a workspace, which in turn needs a backend that spans
+  replicas (the same shared-backend decision-return as
+  [Blocked on external](#blocked-on-external--decision-returns) below); it
+  is flagged here explicitly so a future reader doesn't assume it was
+  considered and intentionally deferred versus simply not noticed.
+
+## Supplying admission evidence
+
+Set `production.admission.enabled=true` and populate every field under
+`production.admission` — all are **required** when enabled; an
+empty/invalid one aborts the render and names the exact missing key
+(`helm/omniscience/templates/_admission_guards.tpl`):
+
+```yaml
+production:
+  admission:
+    enabled: true
+    backend: "shared-redis-lease"        # must name a real, non-"disabled" backend
+    backendIdentity: "redis://admission.internal:6379/0"  # human-approved concrete identity
+    laneIncidentBudget: 120               # SRE incident lane, requests/minute
+    laneBackgroundBudget: 60              # background (search/agent) lane, requests/minute
+    queueDepthMax: 500                    # bounded admission queue ceiling
+    latencyThresholdMs: 250               # incident-lane p99 latency ceiling
+    errorRateThreshold: 0.01              # incident-lane error-rate ceiling (fraction)
+    failureReserveFraction: 0.2           # bounded incident reserve on backend loss (0,1]
+```
+
+These map onto `packages/core/src/omniscience_core/config.py`'s
+`admission_*` `Settings` fields (env vars `ADMISSION_BACKEND`,
+`ADMISSION_BACKEND_IDENTITY`, `ADMISSION_LANE_INCIDENT_BUDGET`,
+`ADMISSION_LANE_BACKGROUND_BUDGET`, `ADMISSION_QUEUE_DEPTH_MAX`,
+`ADMISSION_LATENCY_THRESHOLD_MS`, `ADMISSION_ERROR_RATE_THRESHOLD`,
+`ADMISSION_FAILURE_RESERVE_FRACTION`) via `helm/omniscience/templates/configmap.yaml`.
+The Python side has its own, independent fail-boot check
+(`Settings._validate_admission_backend_requirements` — the first
+Python-side fail-boot pydantic validator in this codebase): constructing
+`Settings(admission_backend=<non-disabled>)` without every required field
+raises `ValidationError` at boot, before any connection is attempted.
+
+**Setting `production.admission.backend` to anything other than
+`"disabled"` today activates `SharedAdmissionBackend`, an intentionally
+unimplemented stub** (`apps/server/src/omniscience_server/admission/shared.py`).
+Every call into it raises `AdmissionBackendUnavailableError`, which
+`FailClosedAdmissionController` turns into the AC-SCALE-4 backend-loss
+posture: background admission stops, incident admission is rejected unless
+a `LeaseAuthority` proves a reserve grant (no real one is wired — see
+[Blocked on external](#blocked-on-external--decision-returns)). This is
+deliberate: the executing agent cannot accept a new infrastructure
+dependency on its own (task-spec, verbatim), so activating a backend
+identity today is a fail-closed action, never a silent fallback to
+process-local state.
+
+## Running the qualification checks
+
+```bash
+# 1. Structural lint — evaluation, production-HA, and production-HA+admission
+helm lint helm/omniscience --set secrets.postgresPassword=x --set serviceAccount.create=false --set postgres.enabled=false --set retention.enabled=true
+helm lint helm/omniscience <PROD_SET from ha-qualification.yml>
+helm lint helm/omniscience <PROD_SET> --set production.admission.enabled=true --set production.admission.backend=shared-redis-lease --set production.admission.backendIdentity=x --set production.admission.laneIncidentBudget=120 --set production.admission.laneBackgroundBudget=60 --set production.admission.queueDepthMax=500 --set production.admission.latencyThresholdMs=250 --set production.admission.errorRateThreshold=0.01 --set production.admission.failureReserveFraction=0.2
+
+# 2. Fail-closed guard proof — enabled without evidence must abort
+helm template omniscience helm/omniscience <PROD_SET> --set production.admission.enabled=true
+# => Error: execution error ...: production.admission.backend is required when production.admission.enabled=true (...)
+
+# 3. Python-side unit/config/state-machine/qualification-scoring tests
+uv run pytest tests/test_admission_backend.py tests/test_admission_lanes.py \
+  tests/test_admission_fail_closed.py tests/test_admission_config.py \
+  tests/test_admission_qualification.py tests/test_mcp_admission_contract.py -v
+
+# 4. REST/MCP regression — this slice must not break existing rate-limit/MCP tests
+uv run pytest tests/test_rest_api.py tests/test_mcp*.py -q
+```
+
+`.github/workflows/admission-qualification.yml` runs all of the above on
+every PR/push touching `helm/omniscience/**`, `apps/server/.../admission/**`,
+`rest/rate_limit.py`, `config.py`, or `tests/test_admission*.py`.
+
+The qualification **report** shape (`admission.qualification.QualificationReport`)
+is content-addressed exactly like `scripts/qualify_backup_restore.py`'s
+`DrillManifest`: `report_id` self-addresses every other field (sha256), so a
+tampered or partially-filled report cannot silently claim a different
+identity. `build_qualification_report` composes four probes — skew,
+isolation, fairness, fallback — each a pure function over explicit measured
+inputs; `tests/test_admission_qualification.py` exercises all four against
+synthetic fixtures. A report always resolves `RED` below two replicas,
+regardless of individual probe status (AC-SCALE-5: "single-replica or
+unmeasured profiles remain non-HA").
+
+## Backend recommendation
+
+Per the task spec, "a backend recommendation may be returned for human
+disposition, but the executing agent cannot accept a new infrastructure
+dependency on its own." Two candidates for the eventual
+`SharedAdmissionBackend` implementation, for human evaluation — neither is
+provisioned or wired here:
+
+- **Redis, `SET NX PX` or a Lua CAS script.** Redis's `SET key value NX PX
+  <ttl>` (or a small Lua script for a genuine atomic check-and-decrement
+  token bucket) gives the single atomic primitive `AdmissionBackend.try_admit`
+  needs, with well-understood operational characteristics and existing
+  Kubernetes operators for HA Redis. The `LeaseAuthority` used for the
+  AC-SCALE-4 incident reserve should be a *separate* mechanism from the
+  Redis instance backing ordinary admission — reusing the same instance
+  would mean a Redis outage takes down both the primary admission path and
+  the only thing that could prove incident-reserve authority during that
+  outage, defeating the point.
+- **A managed rate-limiting/quota service** (e.g. a cloud provider's native
+  distributed rate limiter), if the deployment already depends on that
+  provider's ecosystem and wants to avoid operating another stateful
+  service. Managed services vary in whether they expose a primitive precise
+  enough for a real check-and-decrement lease — verify before committing.
+
+Either choice, and the actual provisioning/activation, is a human decision
+recorded via `production.admission.backend`/`backendIdentity` — this
+runbook does not pre-select one.
+
+## Blocked on external — decision returns
+
+Per `docs/specs/gh-issue-350-read-scaling-priority.md` ("Execution order and
+required inputs" / "Out of scope") and this workspace's approval rules, the
+following are **decision returns**, not something this slice attempts or
+fabricates:
+
+1. **AC-SCALE-5's live 2+-replica measured evidence** (skew, isolation,
+   fairness, fallback probes against real running replicas). CI here
+   (`ubuntu-latest`, single runner, no Kubernetes cluster) cannot stand up
+   2+ live application replicas behind a shared backend and measure real
+   cross-replica behaviour. Repo-local work built: the four scoring
+   functions (`score_skew`, `score_isolation`, `score_fairness`,
+   `score_fallback`), the content-addressed report shape and its
+   `report_id` self-addressing logic, and fixture-driven unit tests of all
+   four against synthetic measurement data — the actual multi-replica run
+   requires a real cluster and human-approved environment.
+2. **Acceptance/provisioning of a concrete shared backend** — the spec is
+   explicit: "the executing agent cannot accept a new infrastructure
+   dependency on its own." Repo-local work produced the narrow
+   `AdmissionBackend` Protocol, the process-local default implementation
+   behind it, and a **fail-closed** `SharedAdmissionBackend` stub gated by
+   `admission_backend`/`production.admission.enabled`, both defaulting to
+   the disabled/off state. See [Backend recommendation](#backend-recommendation)
+   above for candidates a human may choose from.
+3. **AC-SCALE-4's fail-closed behaviour under a real backend outage** —
+   repo-local work built and unit-tested the state machine
+   (`FailClosedAdmissionController`) against injected/faked backend
+   failures (unhealthy, raising, health-check-itself-raising). Proving it
+   against a genuinely failing external shared store in a live
+   multi-replica topology is the same live-environment gap as #1.
+4. **AC-SCALE-2/3's live overload/priority-lane fairness under real
+   concurrent multi-replica load** — load-shape *observations* and
+   fairness-scoring *functions* are repo-local buildable/testable
+   (`score_fairness` against synthetic queue-depth/latency/error inputs),
+   but "multi-replica overload, queue depth, latency, error, and fairness
+   observations" as literal `groundTruth` requires the same live cluster as
+   #1.
+5. Everything in the spec's own out-of-scope list remains out of scope
+   regardless: provisioning/activating a shared backend in production,
+   letting consumer identity bypass tenant/freshness/consistency/fallback
+   rules (lane identity here is always server-derived from token scopes —
+   see `admission/lanes.py`), unbounded SRE priority, process-local
+   fallback in HA posture, automatic lane tuning, and any edit to the
+   accepted ADRs/capability SPECs/this ready revision/its probes.

--- a/helm/omniscience/templates/_admission_guards.tpl
+++ b/helm/omniscience/templates/_admission_guards.tpl
@@ -1,0 +1,68 @@
+{{/*
+Shared read-admission fail-closed evidence guard (issue #350, AC-SCALE-5).
+
+  AC-SCALE-1  backend identity required before a deployment may claim
+              shared admission (never a silent process-local bypass)
+  AC-SCALE-2  SRE incident vs background lane budgets are explicit inputs
+  AC-SCALE-4  failure-reserve fraction is an explicit, bounded input
+
+Gated on its OWN `production.admission.enabled` flag — deliberately
+INDEPENDENT of `production.enabled`. The production-HA profile (issue #350
+slice "production-HA", already merged — see omniscience.productionGuards /
+_production_guards.tpl) must keep rendering and qualifying without ever
+being forced to supply admission evidence; shared admission is an
+additive, separately-activated posture layered on top of it, not a new
+requirement retrofitted onto the existing one.
+
+No-op when production.admission.enabled is false. When true, each check
+below either passes silently or calls `fail` naming the exact missing/
+invalid field — same fail-closed pattern as omniscience.productionGuards:
+Helm aborts the render rather than emitting a partially-qualified profile.
+Included from deployment.yaml so it always evaluates during template/install.
+*/}}
+{{- define "omniscience.admissionGuards" -}}
+{{- if .Values.production.admission.enabled }}
+{{- $adm := .Values.production.admission }}
+
+{{- /* AC-SCALE-1: backend identity */}}
+{{- if not $adm.backend }}
+{{- fail "production.admission.backend is required when production.admission.enabled=true (shared read-admission backend identity, AC-SCALE-1)" }}
+{{- end }}
+{{- if eq $adm.backend "disabled" }}
+{{- fail "production.admission.backend must not be 'disabled' when production.admission.enabled=true (AC-SCALE-1: a named shared-admission backend is required, never the process-local default)" }}
+{{- end }}
+{{- if not $adm.backendIdentity }}
+{{- fail "production.admission.backendIdentity is required when production.admission.enabled=true (human-approved concrete backend descriptor, AC-SCALE-1)" }}
+{{- end }}
+
+{{- /* AC-SCALE-2: lane budgets */}}
+{{- if lt (int $adm.laneIncidentBudget) 1 }}
+{{- fail "production.admission.laneIncidentBudget must be >= 1 when production.admission.enabled=true (AC-SCALE-2)" }}
+{{- end }}
+{{- if lt (int $adm.laneBackgroundBudget) 1 }}
+{{- fail "production.admission.laneBackgroundBudget must be >= 1 when production.admission.enabled=true (AC-SCALE-2)" }}
+{{- end }}
+
+{{- /* Bounded admission queue */}}
+{{- if lt (int $adm.queueDepthMax) 1 }}
+{{- fail "production.admission.queueDepthMax must be >= 1 when production.admission.enabled=true (bounded admission queue, AC-SCALE-2)" }}
+{{- end }}
+
+{{- /* Latency/error thresholds the incident lane must stay within */}}
+{{- if not (gt (float64 $adm.latencyThresholdMs) 0.0) }}
+{{- fail "production.admission.latencyThresholdMs must be > 0 when production.admission.enabled=true (AC-SCALE-2/5 fairness threshold)" }}
+{{- end }}
+{{- if not (gt (float64 $adm.errorRateThreshold) 0.0) }}
+{{- fail "production.admission.errorRateThreshold must be > 0 when production.admission.enabled=true (AC-SCALE-2/5 fairness threshold)" }}
+{{- end }}
+
+{{- /* AC-SCALE-4: bounded failure reserve, never unbounded */}}
+{{- if not (gt (float64 $adm.failureReserveFraction) 0.0) }}
+{{- fail "production.admission.failureReserveFraction must be > 0 when production.admission.enabled=true (bounded incident reserve on backend loss, AC-SCALE-4)" }}
+{{- end }}
+{{- if gt (float64 $adm.failureReserveFraction) 1.0 }}
+{{- fail "production.admission.failureReserveFraction must be <= 1.0 when production.admission.enabled=true (AC-SCALE-4: never an unbounded reserve)" }}
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/helm/omniscience/templates/configmap.yaml
+++ b/helm/omniscience/templates/configmap.yaml
@@ -43,3 +43,19 @@ data:
   RETENTION_ARCHIVE_S3_REGION: {{ .Values.retention.archiveS3Region | quote }}
   # Reconciliation worker (REQ-OPS-6) — see omniscience.posture.
   RECONCILE_ENABLED: {{ .Values.config.reconcileEnabled | toString | quote }}
+  # Shared read admission (issue #350, AC-SCALE-1..5). Only rendered when
+  # production.admission.enabled=true, which (via omniscience.admissionGuards)
+  # guarantees every field below is populated. Independent of
+  # production.enabled — the default/eval and plain production-HA installs
+  # render none of these, so Settings keeps its "disabled" default
+  # (packages/core/.../config.py).
+  {{- if .Values.production.admission.enabled }}
+  ADMISSION_BACKEND: {{ .Values.production.admission.backend | quote }}
+  ADMISSION_BACKEND_IDENTITY: {{ .Values.production.admission.backendIdentity | quote }}
+  ADMISSION_LANE_INCIDENT_BUDGET: {{ .Values.production.admission.laneIncidentBudget | toString | quote }}
+  ADMISSION_LANE_BACKGROUND_BUDGET: {{ .Values.production.admission.laneBackgroundBudget | toString | quote }}
+  ADMISSION_QUEUE_DEPTH_MAX: {{ .Values.production.admission.queueDepthMax | toString | quote }}
+  ADMISSION_LATENCY_THRESHOLD_MS: {{ .Values.production.admission.latencyThresholdMs | toString | quote }}
+  ADMISSION_ERROR_RATE_THRESHOLD: {{ .Values.production.admission.errorRateThreshold | toString | quote }}
+  ADMISSION_FAILURE_RESERVE_FRACTION: {{ .Values.production.admission.failureReserveFraction | toString | quote }}
+  {{- end }}

--- a/helm/omniscience/templates/deployment.yaml
+++ b/helm/omniscience/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- include "omniscience.productionGuards" . }}
+{{- include "omniscience.admissionGuards" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/omniscience/values.yaml
+++ b/helm/omniscience/values.yaml
@@ -148,3 +148,26 @@ production:
     qdrant:
       topology: ""
       nodes: 0
+
+  # Shared read-admission evidence (issue #350, AC-SCALE-1..5). Same
+  # empty/zero-default, required-when-enabled shape as `evidence:` above —
+  # see helm/omniscience/templates/_admission_guards.tpl and
+  # docs/runbooks/read-admission.md. backendIdentity is a human-approved
+  # concrete backend descriptor (e.g. a Redis connection identity) — never
+  # a literal credential.
+  #
+  # Gated on its OWN `enabled` flag, deliberately independent of
+  # `production.enabled` — the production-HA profile (issue #350 slice
+  # "production-HA", already merged) must keep rendering/qualifying
+  # without ever having to supply admission evidence; shared admission is
+  # an additive, separately-activated posture on top of it.
+  admission:
+    enabled: false
+    backend: ""
+    backendIdentity: ""
+    laneIncidentBudget: 0
+    laneBackgroundBudget: 0
+    queueDepthMax: 0
+    latencyThresholdMs: 0
+    errorRateThreshold: 0
+    failureReserveFraction: 0

--- a/packages/core/src/omniscience_core/config.py
+++ b/packages/core/src/omniscience_core/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -459,3 +459,152 @@ class Settings(BaseSettings):
             "and publishes re-sync triggers. Defaults to 300 (5 minutes)."
         ),
     )
+
+    # --- Rate limiting (default/unnamed lane) ---
+    rate_limit_rpm: int = Field(
+        default=60,
+        ge=1,
+        description=(
+            "Requests-per-minute budget for the default (unnamed) admission lane "
+            "used by apps/server/.../rest/rate_limit.py::rate_limit_dependency. "
+            "Previously read via getattr(..., default=60) with no backing Settings "
+            "field, so the env var was silently a dead knob; this is the real field."
+        ),
+    )
+
+    # --- Shared read admission (issue #350, AC-SCALE-1..5) ---
+    #
+    # `admission_backend="disabled"` is the only value with a working
+    # implementation today (ProcessLocalAdmissionBackend, the pre-#350
+    # single-process posture, unchanged). A human-approved shared backend
+    # (e.g. Redis SET NX PX / Lua CAS — see docs/runbooks/read-admission.md
+    # "Backend recommendation") is a future value; selecting one activates
+    # a fail-closed stub (SharedAdmissionBackend) rather than a silent
+    # fallback to process-local state, so this is never a self-authorizing
+    # activation. The fields below are the "required env inputs" the task
+    # spec names (backend identity, lane budgets, queue bounds, latency/
+    # error thresholds, failure reserve): they take NO code default and
+    # `_validate_admission_backend_requirements` fails boot if any is unset
+    # while `admission_backend != "disabled"`.
+    admission_backend: Literal["disabled", "shared-redis-lease"] = Field(
+        default="disabled",
+        description=(
+            "Read-admission backend identity selector. 'disabled' (default) "
+            "uses ProcessLocalAdmissionBackend — the current single-process "
+            "MVP posture, unaffected. 'shared-redis-lease' selects the "
+            "SharedAdmissionBackend stub, which fails closed (never falls "
+            "back to process-local) until a human wires a real "
+            "implementation — see docs/runbooks/read-admission.md."
+        ),
+    )
+    admission_backend_identity: str | None = Field(
+        default=None,
+        description=(
+            "Human-approved concrete backend descriptor (e.g. a Redis "
+            "connection identity or managed-service plan id) — REQUIRED "
+            "when admission_backend != 'disabled'. Never defaulted: an "
+            "unset value means no backend has actually been approved."
+        ),
+    )
+    admission_lane_incident_budget: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "SRE incident-lane requests-per-minute budget (AC-SCALE-2). "
+            "REQUIRED when admission_backend != 'disabled'. When unset in "
+            "the default 'disabled' posture, rate_limit_dependency falls "
+            "back to rate_limit_rpm uniformly for both lanes (today's "
+            "single-budget behaviour, unchanged)."
+        ),
+    )
+    admission_lane_background_budget: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Background (default agent/search) lane requests-per-minute "
+            "budget (AC-SCALE-2) — must degrade before the incident lane "
+            "under overload. REQUIRED when admission_backend != 'disabled'."
+        ),
+    )
+    admission_queue_depth_max: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Bounded admission queue depth ceiling (AC-SCALE-2/5). Matches "
+            "the >= 1 floor helm/omniscience/templates/_admission_guards.tpl "
+            "enforces for production.admission.queueDepthMax — 0 is not a "
+            "valid bound on either side. Enforced by the shared backend / "
+            "checked by the qualification harness "
+            "(admission.qualification.score_queue_depth_from_settings), not "
+            "by an in-process queue — try_admit is a synchronous "
+            "accept/reject, never a queue. REQUIRED when admission_backend "
+            "!= 'disabled'."
+        ),
+    )
+    admission_latency_threshold_ms: float | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "p99 latency threshold (milliseconds) the incident lane must "
+            "stay under during an overload/fairness qualification probe "
+            "(AC-SCALE-2/5). REQUIRED when admission_backend != 'disabled'."
+        ),
+    )
+    admission_error_rate_threshold: float | None = Field(
+        default=None,
+        gt=0,
+        le=1,
+        description=(
+            "Maximum acceptable incident-lane error rate (fraction, 0-1] "
+            "during an overload/fairness qualification probe (AC-SCALE-2/5). "
+            "Matches the > 0.0 floor "
+            "helm/omniscience/templates/_admission_guards.tpl enforces for "
+            "production.admission.errorRateThreshold — an SLO threshold of "
+            "exactly 0 is not a meaningful bound. REQUIRED when "
+            "admission_backend != 'disabled'."
+        ),
+    )
+    admission_failure_reserve_fraction: float | None = Field(
+        default=None,
+        gt=0,
+        le=1,
+        description=(
+            "Fraction of admission_lane_incident_budget kept as the bounded "
+            "incident reserve when the shared backend is lost (AC-SCALE-4) "
+            "— never unbounded, and only granted when a LeaseAuthority "
+            "proves authority (see admission.state_machine). REQUIRED when "
+            "admission_backend != 'disabled'."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_admission_backend_requirements(self) -> Settings:
+        """Fail boot when a non-'disabled' admission backend is selected
+        without every required env input (issue #350). This is the first
+        Python-side fail-boot Settings validator in this codebase — prior
+        "required in non-dev" checks live in Helm guard templates
+        (_production_guards.tpl) or in app.py::_lifespan's raise-before-
+        connect idiom, not in Settings itself. No code defaults are
+        substituted here; a missing input is a hard ValueError, never a
+        silently-assumed value."""
+        if self.admission_backend == "disabled":
+            return self
+
+        required: dict[str, object | None] = {
+            "admission_backend_identity": self.admission_backend_identity,
+            "admission_lane_incident_budget": self.admission_lane_incident_budget,
+            "admission_lane_background_budget": self.admission_lane_background_budget,
+            "admission_queue_depth_max": self.admission_queue_depth_max,
+            "admission_latency_threshold_ms": self.admission_latency_threshold_ms,
+            "admission_error_rate_threshold": self.admission_error_rate_threshold,
+            "admission_failure_reserve_fraction": self.admission_failure_reserve_fraction,
+        }
+        missing = [name for name, value in required.items() if value is None]
+        if missing:
+            raise ValueError(
+                f"admission_backend={self.admission_backend!r} requires explicit "
+                f"values for: {', '.join(missing)} (issue #350 AC-SCALE — HA-posture "
+                "admission inputs take no code default; see "
+                "docs/runbooks/read-admission.md)."
+            )
+        return self

--- a/tests/test_admission_backend.py
+++ b/tests/test_admission_backend.py
@@ -1,0 +1,90 @@
+"""Unit tests for the `AdmissionBackend` Protocol implementations
+(issue #350, AC-SCALE-1): `ProcessLocalAdmissionBackend` (behaviour parity
+with the pre-#350 token bucket) and `SharedAdmissionBackend` (the
+fail-closed stub — never a silent process-local fallback).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from omniscience_server.admission.backend import AdmissionBackendUnavailableError
+from omniscience_server.admission.process_local import ProcessLocalAdmissionBackend
+from omniscience_server.admission.shared import SharedAdmissionBackend
+
+
+def test_process_local_allows_burst_within_capacity() -> None:
+    backend = ProcessLocalAdmissionBackend()
+    for _ in range(5):
+        decision = backend.try_admit(lane="l", key="k", capacity=60, refill_per_second=1.0)
+        assert decision.allowed is True
+
+
+def test_process_local_blocks_over_capacity() -> None:
+    backend = ProcessLocalAdmissionBackend()
+    for _ in range(3):
+        backend.try_admit(lane="l", key="k", capacity=3, refill_per_second=3 / 60.0)
+    decision = backend.try_admit(lane="l", key="k", capacity=3, refill_per_second=3 / 60.0)
+    assert decision.allowed is False
+    assert decision.retry_after_seconds > 0
+
+
+def test_process_local_lanes_are_isolated_per_key() -> None:
+    """Different (lane, key) pairs never share or borrow capacity."""
+    backend = ProcessLocalAdmissionBackend()
+    for _ in range(3):
+        backend.try_admit(lane="incident", key="tok", capacity=3, refill_per_second=3 / 60.0)
+    # A different lane for the same token key starts with a fresh bucket.
+    decision = backend.try_admit(
+        lane="background", key="tok", capacity=3, refill_per_second=3 / 60.0
+    )
+    assert decision.allowed is True
+
+
+def test_process_local_refills_over_time() -> None:
+    backend = ProcessLocalAdmissionBackend()
+    for _ in range(60):
+        backend.try_admit(lane="l", key="k", capacity=60, refill_per_second=1.0)
+    empty = backend.try_admit(lane="l", key="k", capacity=60, refill_per_second=1.0)
+    assert empty.allowed is False
+
+    from omniscience_server.admission import process_local as pl_module
+
+    fake_now = pl_module.time.monotonic() + 2.0
+    with patch.object(pl_module.time, "monotonic", return_value=fake_now):
+        refilled = backend.try_admit(lane="l", key="k", capacity=60, refill_per_second=1.0)
+    assert refilled.allowed is True
+
+
+def test_process_local_reset_and_clear() -> None:
+    backend = ProcessLocalAdmissionBackend()
+    for _ in range(3):
+        backend.try_admit(lane="l", key="k", capacity=3, refill_per_second=3 / 60.0)
+    backend.reset(lane="l", key="k")
+    assert backend.try_admit(lane="l", key="k", capacity=3, refill_per_second=3 / 60.0).allowed
+
+    for _ in range(3):
+        backend.try_admit(lane="l", key="k2", capacity=3, refill_per_second=3 / 60.0)
+    backend.clear()
+    assert backend.try_admit(lane="l", key="k2", capacity=3, refill_per_second=3 / 60.0).allowed
+
+
+def test_process_local_health_is_always_healthy() -> None:
+    backend = ProcessLocalAdmissionBackend()
+    health = backend.health()
+    assert health.healthy is True
+
+
+def test_shared_backend_try_admit_raises_unavailable() -> None:
+    """The stub never grants a decision — selecting a shared backend value
+    is a fail-closed action, never a silent process-local fallback."""
+    backend = SharedAdmissionBackend(backend_identity="shared-redis-lease")
+    with pytest.raises(AdmissionBackendUnavailableError, match="shared-redis-lease"):
+        backend.try_admit(lane="l", key="k", capacity=10, refill_per_second=1.0)
+
+
+def test_shared_backend_health_is_unhealthy() -> None:
+    backend = SharedAdmissionBackend(backend_identity="shared-redis-lease")
+    health = backend.health()
+    assert health.healthy is False

--- a/tests/test_admission_config.py
+++ b/tests/test_admission_config.py
@@ -1,0 +1,131 @@
+"""Unit tests for the admission fail-boot Settings validator (issue #350).
+
+`Settings._validate_admission_backend_requirements` is the first
+Python-side fail-boot pydantic validator in this codebase: when
+`admission_backend != "disabled"`, every required input (backend identity,
+lane budgets, queue bounds, latency/error thresholds, failure reserve) must
+be explicitly set — no code defaults substitute for HA posture.
+"""
+
+from __future__ import annotations
+
+import pytest
+from omniscience_core.config import Settings
+from pydantic import ValidationError
+
+_FULLY_EVIDENCED_ADMISSION_KWARGS: dict[str, object] = {
+    "admission_backend": "shared-redis-lease",
+    "admission_backend_identity": "redis://admission.internal:6379/0",
+    "admission_lane_incident_budget": 120,
+    "admission_lane_background_budget": 60,
+    "admission_queue_depth_max": 500,
+    "admission_latency_threshold_ms": 250.0,
+    "admission_error_rate_threshold": 0.01,
+    "admission_failure_reserve_fraction": 0.2,
+}
+
+
+def test_default_boot_is_admission_disabled_and_unconstrained() -> None:
+    """Constructing Settings with no overrides must not raise — the
+    default posture is unaffected by the new admission fields."""
+    settings = Settings()
+    assert settings.admission_backend == "disabled"
+    assert settings.admission_backend_identity is None
+    assert settings.rate_limit_rpm == 60
+
+
+def test_admission_enabled_with_full_evidence_boots_cleanly() -> None:
+    settings = Settings(**_FULLY_EVIDENCED_ADMISSION_KWARGS)
+    assert settings.admission_backend == "shared-redis-lease"
+    assert settings.admission_lane_incident_budget == 120
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    [
+        "admission_backend_identity",
+        "admission_lane_incident_budget",
+        "admission_lane_background_budget",
+        "admission_queue_depth_max",
+        "admission_latency_threshold_ms",
+        "admission_error_rate_threshold",
+        "admission_failure_reserve_fraction",
+    ],
+)
+def test_admission_enabled_missing_any_required_field_fails_boot(missing_field: str) -> None:
+    kwargs = dict(_FULLY_EVIDENCED_ADMISSION_KWARGS)
+    kwargs[missing_field] = None
+    with pytest.raises(ValidationError, match=missing_field):
+        Settings(**kwargs)
+
+
+def test_admission_enabled_with_nothing_else_set_fails_boot_naming_all_missing() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        Settings(admission_backend="shared-redis-lease")
+    message = str(exc_info.value)
+    for field in (
+        "admission_backend_identity",
+        "admission_lane_incident_budget",
+        "admission_lane_background_budget",
+        "admission_queue_depth_max",
+        "admission_latency_threshold_ms",
+        "admission_error_rate_threshold",
+        "admission_failure_reserve_fraction",
+    ):
+        assert field in message
+
+
+def test_unsupported_admission_backend_literal_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Settings(admission_backend="totally-made-up-backend")
+
+
+# ---------------------------------------------------------------------------
+# Boundary values — must agree with helm/omniscience/templates/
+# _admission_guards.tpl's numeric floors (BP review HIGH #1). Only
+# test_admission_enabled_missing_any_required_field_fails_boot above (the
+# `None` case) was covered before; 0 is a distinct, previously-unguarded
+# boundary that helm has always rejected but Python did not.
+# ---------------------------------------------------------------------------
+
+
+def test_admission_queue_depth_max_of_zero_fails_boot() -> None:
+    """Helm's guard requires queueDepthMax >= 1 (_admission_guards.tpl);
+    Python must reject the same boundary, not silently accept it."""
+    kwargs = dict(_FULLY_EVIDENCED_ADMISSION_KWARGS)
+    kwargs["admission_queue_depth_max"] = 0
+    with pytest.raises(ValidationError, match="admission_queue_depth_max"):
+        Settings(**kwargs)
+
+
+def test_admission_queue_depth_max_of_one_boots_cleanly() -> None:
+    kwargs = dict(_FULLY_EVIDENCED_ADMISSION_KWARGS)
+    kwargs["admission_queue_depth_max"] = 1
+    settings = Settings(**kwargs)
+    assert settings.admission_queue_depth_max == 1
+
+
+def test_admission_error_rate_threshold_of_zero_fails_boot() -> None:
+    """Helm's guard requires errorRateThreshold > 0.0
+    (_admission_guards.tpl); Python must reject the same boundary, not
+    silently accept a zero SLO threshold as "present"."""
+    kwargs = dict(_FULLY_EVIDENCED_ADMISSION_KWARGS)
+    kwargs["admission_error_rate_threshold"] = 0.0
+    with pytest.raises(ValidationError, match="admission_error_rate_threshold"):
+        Settings(**kwargs)
+
+
+def test_admission_error_rate_threshold_just_above_zero_boots_cleanly() -> None:
+    kwargs = dict(_FULLY_EVIDENCED_ADMISSION_KWARGS)
+    kwargs["admission_error_rate_threshold"] = 0.001
+    settings = Settings(**kwargs)
+    assert settings.admission_error_rate_threshold == 0.001
+
+
+def test_admission_error_rate_threshold_of_one_boots_cleanly() -> None:
+    """Upper bound (le=1) is unchanged by this fix — only the lower bound
+    moved from ge=0 to gt=0."""
+    kwargs = dict(_FULLY_EVIDENCED_ADMISSION_KWARGS)
+    kwargs["admission_error_rate_threshold"] = 1.0
+    settings = Settings(**kwargs)
+    assert settings.admission_error_rate_threshold == 1.0

--- a/tests/test_admission_fail_closed.py
+++ b/tests/test_admission_fail_closed.py
@@ -1,0 +1,218 @@
+"""Unit tests for `FailClosedAdmissionController` (issue #350, AC-SCALE-4):
+backend loss must stop background admission, preserve only a bounded
+incident reserve when authority is provable (never a heuristic), and never
+fall back to a fresh per-process bucket.
+
+All backend failures here are injected fakes — a live shared-backend outage
+under real multi-replica load is a decision-return
+(docs/runbooks/read-admission.md "Blocked on external — decision returns").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omniscience_server.admission.backend import (
+    AdmissionBackendUnavailableError,
+    AdmissionDecision,
+    BackendHealth,
+)
+from omniscience_server.admission.lanes import BACKGROUND_LANE, INCIDENT_LANE
+from omniscience_server.admission.process_local import ProcessLocalAdmissionBackend
+from omniscience_server.admission.state_machine import (
+    REASON_BACKGROUND_SUSPENDED,
+    REASON_INCIDENT_RESERVE,
+    REASON_LANE_EXHAUSTED,
+    REASON_NO_PROVABLE_AUTHORITY,
+    STATE_BACKEND_LOST,
+    STATE_NORMAL,
+    FailClosedAdmissionController,
+    NullLeaseAuthority,
+)
+
+
+@dataclass
+class _FakeHealthyBackend:
+    """Injectable fake — always healthy, delegates to a real process-local
+    backend for deterministic try_admit math."""
+
+    def __post_init__(self) -> None:
+        self._inner = ProcessLocalAdmissionBackend()
+
+    def try_admit(self, *, lane: str, key: str, capacity: int, refill_per_second: float):
+        return self._inner.try_admit(
+            lane=lane, key=key, capacity=capacity, refill_per_second=refill_per_second
+        )
+
+    def health(self) -> BackendHealth:
+        return BackendHealth(healthy=True)
+
+
+class _FakeUnhealthyBackend:
+    """Injectable fake — reports unhealthy without ever raising."""
+
+    def try_admit(self, *, lane: str, key: str, capacity: int, refill_per_second: float):
+        raise AssertionError("try_admit must not be called when health() is unhealthy")
+
+    def health(self) -> BackendHealth:
+        return BackendHealth(healthy=False, detail="fake_unreachable")
+
+
+class _FakeRaisingBackend:
+    """Injectable fake — reports healthy but raises on try_admit (e.g. the
+    connection dropped between the health check and the call)."""
+
+    def try_admit(self, *, lane: str, key: str, capacity: int, refill_per_second: float):
+        raise AdmissionBackendUnavailableError("fake_connection_lost")
+
+    def health(self) -> BackendHealth:
+        return BackendHealth(healthy=True)
+
+
+class _AlwaysGrantsLeaseAuthority:
+    def try_acquire_incident_reserve(self, *, key: str, capacity: int) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Normal (healthy backend) path
+# ---------------------------------------------------------------------------
+
+
+def test_normal_path_admits_within_capacity() -> None:
+    controller = FailClosedAdmissionController(backend=_FakeHealthyBackend())
+    outcome = controller.evaluate(
+        lane=BACKGROUND_LANE, key="tok", capacity=5, refill_per_second=5 / 60.0
+    )
+    assert outcome.allowed is True
+    assert outcome.state == STATE_NORMAL
+
+
+def test_normal_path_exhausted_lane_is_rejected_not_degraded() -> None:
+    controller = FailClosedAdmissionController(backend=_FakeHealthyBackend())
+    for _ in range(3):
+        controller.evaluate(
+            lane=BACKGROUND_LANE, key="tok", capacity=3, refill_per_second=3 / 60.0
+        )
+    outcome = controller.evaluate(
+        lane=BACKGROUND_LANE, key="tok", capacity=3, refill_per_second=3 / 60.0
+    )
+    assert outcome.allowed is False
+    assert outcome.state == STATE_NORMAL
+    assert outcome.reason == REASON_LANE_EXHAUSTED
+
+
+# ---------------------------------------------------------------------------
+# Backend-loss path — unhealthy
+# ---------------------------------------------------------------------------
+
+
+def test_backend_unhealthy_suspends_background_lane() -> None:
+    controller = FailClosedAdmissionController(backend=_FakeUnhealthyBackend())
+    outcome = controller.evaluate(
+        lane=BACKGROUND_LANE, key="tok", capacity=10, refill_per_second=1.0
+    )
+    assert outcome.allowed is False
+    assert outcome.state == STATE_BACKEND_LOST
+    assert outcome.reason == REASON_BACKGROUND_SUSPENDED
+
+
+def test_backend_unhealthy_rejects_incident_without_lease_authority() -> None:
+    """No LeaseAuthority is wired by default (NullLeaseAuthority) — the
+    safe default is fail-closed, never an assumed reserve grant."""
+    controller = FailClosedAdmissionController(backend=_FakeUnhealthyBackend())
+    outcome = controller.evaluate(
+        lane=INCIDENT_LANE, key="tok", capacity=10, refill_per_second=1.0
+    )
+    assert outcome.allowed is False
+    assert outcome.state == STATE_BACKEND_LOST
+    assert outcome.reason == REASON_NO_PROVABLE_AUTHORITY
+
+
+def test_backend_unhealthy_admits_incident_with_granted_lease() -> None:
+    controller = FailClosedAdmissionController(
+        backend=_FakeUnhealthyBackend(),
+        incident_reserve_capacity=5,
+        lease_authority=_AlwaysGrantsLeaseAuthority(),
+    )
+    outcome = controller.evaluate(
+        lane=INCIDENT_LANE, key="tok", capacity=10, refill_per_second=1.0
+    )
+    assert outcome.allowed is True
+    assert outcome.state == STATE_BACKEND_LOST
+    assert outcome.reason == REASON_INCIDENT_RESERVE
+
+
+# ---------------------------------------------------------------------------
+# Backend-loss path — try_admit raises mid-call
+# ---------------------------------------------------------------------------
+
+
+def test_backend_raises_unavailable_suspends_background_lane() -> None:
+    controller = FailClosedAdmissionController(backend=_FakeRaisingBackend())
+    outcome = controller.evaluate(
+        lane=BACKGROUND_LANE, key="tok", capacity=10, refill_per_second=1.0
+    )
+    assert outcome.allowed is False
+    assert outcome.state == STATE_BACKEND_LOST
+    assert outcome.reason == REASON_BACKGROUND_SUSPENDED
+
+
+def test_backend_raises_unavailable_rejects_incident_without_lease() -> None:
+    controller = FailClosedAdmissionController(backend=_FakeRaisingBackend())
+    outcome = controller.evaluate(
+        lane=INCIDENT_LANE, key="tok", capacity=10, refill_per_second=1.0
+    )
+    assert outcome.allowed is False
+    assert outcome.reason == REASON_NO_PROVABLE_AUTHORITY
+
+
+# ---------------------------------------------------------------------------
+# health() itself failing must never crash the controller
+# ---------------------------------------------------------------------------
+
+
+class _HealthRaisesBackend:
+    def try_admit(self, *, lane: str, key: str, capacity: int, refill_per_second: float):
+        raise AssertionError("must not reach try_admit")
+
+    def health(self) -> BackendHealth:
+        raise RuntimeError("boom")
+
+
+def test_health_check_exception_degrades_safely() -> None:
+    controller = FailClosedAdmissionController(backend=_HealthRaisesBackend())
+    outcome = controller.evaluate(
+        lane=BACKGROUND_LANE, key="tok", capacity=10, refill_per_second=1.0
+    )
+    assert outcome.allowed is False
+    assert outcome.state == STATE_BACKEND_LOST
+
+
+# ---------------------------------------------------------------------------
+# Never falls back to a fresh per-process bucket on backend loss
+# ---------------------------------------------------------------------------
+
+
+def test_backend_loss_never_substitutes_a_process_local_bucket() -> None:
+    """A capacity that would trivially be admitted by a fresh process-local
+    bucket must still be rejected once the shared backend is lost — proving
+    the controller never quietly swaps in ProcessLocalAdmissionBackend."""
+    controller = FailClosedAdmissionController(backend=_FakeUnhealthyBackend())
+    for _ in range(3):
+        outcome = controller.evaluate(
+            lane=BACKGROUND_LANE, key="fresh-key", capacity=1000, refill_per_second=1000 / 60.0
+        )
+        assert outcome.allowed is False
+        assert outcome.state == STATE_BACKEND_LOST
+
+
+def test_null_lease_authority_always_denies() -> None:
+    authority = NullLeaseAuthority()
+    assert authority.try_acquire_incident_reserve(key="k", capacity=5) is False
+
+
+def test_decision_dataclass_roundtrip() -> None:
+    decision = AdmissionDecision(allowed=True, retry_after_seconds=0.0)
+    assert decision.allowed is True
+    assert decision.retry_after_seconds == 0.0

--- a/tests/test_admission_lanes.py
+++ b/tests/test_admission_lanes.py
@@ -1,0 +1,50 @@
+"""Unit tests for server-derived SRE incident vs background admission lane
+resolution (issue #350, AC-SCALE-2). Lane identity must come solely from
+the authenticated token's scopes — never from any client-controlled input.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from omniscience_core.auth.scopes import Scope
+from omniscience_server.admission.lanes import (
+    BACKGROUND_LANE,
+    INCIDENT_LANE,
+    resolve_admission_lane,
+)
+
+
+def _token(scopes: list[str]) -> MagicMock:
+    tok = MagicMock()
+    tok.scopes = scopes
+    return tok
+
+
+def test_search_only_token_resolves_to_background_lane() -> None:
+    assert resolve_admission_lane(_token([Scope.search.value])) == BACKGROUND_LANE
+
+
+def test_incidents_write_token_resolves_to_incident_lane() -> None:
+    assert resolve_admission_lane(_token([Scope.incidents_write.value])) == INCIDENT_LANE
+
+
+def test_admin_token_resolves_to_incident_lane() -> None:
+    assert resolve_admission_lane(_token([Scope.admin.value])) == INCIDENT_LANE
+
+
+def test_mixed_scopes_including_incidents_write_resolve_to_incident_lane() -> None:
+    scopes = [Scope.search.value, Scope.sources_read.value, Scope.incidents_write.value]
+    assert resolve_admission_lane(_token(scopes)) == INCIDENT_LANE
+
+
+def test_no_scopes_resolves_to_background_lane() -> None:
+    assert resolve_admission_lane(_token([])) == BACKGROUND_LANE
+
+
+def test_missing_scopes_attribute_resolves_to_background_lane() -> None:
+    """A token without a usable `scopes` value must fail closed to the
+    unprivileged lane, never default to the higher-priority one."""
+    tok = MagicMock()
+    tok.scopes = None
+    assert resolve_admission_lane(tok) == BACKGROUND_LANE

--- a/tests/test_admission_qualification.py
+++ b/tests/test_admission_qualification.py
@@ -1,0 +1,495 @@
+"""Unit tests for the horizontal-read qualification harness (issue #350,
+AC-SCALE-5). Every input here is a synthetic/fixture measurement — a real
+2+-replica measured run is a decision-return
+(docs/runbooks/read-admission.md "Blocked on external — decision returns").
+"""
+
+from __future__ import annotations
+
+from omniscience_core.config import Settings
+from omniscience_server.admission.qualification import (
+    LaneObservation,
+    OverloadResponseObservation,
+    TenantObservation,
+    build_qualification_report,
+    score_fairness,
+    score_fairness_from_settings,
+    score_fallback,
+    score_isolation,
+    score_queue_depth,
+    score_queue_depth_from_settings,
+    score_skew,
+    validate_report_json,
+)
+
+_FULLY_EVIDENCED_ADMISSION_SETTINGS_KWARGS: dict[str, object] = {
+    "admission_backend": "shared-redis-lease",
+    "admission_backend_identity": "redis://admission.internal:6379/0",
+    "admission_lane_incident_budget": 120,
+    "admission_lane_background_budget": 60,
+    "admission_queue_depth_max": 500,
+    "admission_latency_threshold_ms": 250.0,
+    "admission_error_rate_threshold": 0.01,
+    "admission_failure_reserve_fraction": 0.2,
+}
+
+# ---------------------------------------------------------------------------
+# Skew
+# ---------------------------------------------------------------------------
+
+
+def test_skew_balanced_replicas_is_green() -> None:
+    result = score_skew(
+        replica_admitted_counts={"replica-a": 100, "replica-b": 98, "replica-c": 101},
+        max_skew_ratio=0.10,
+    )
+    assert result.is_green
+
+
+def test_skew_imbalanced_replicas_is_red() -> None:
+    result = score_skew(
+        replica_admitted_counts={"replica-a": 200, "replica-b": 20},
+        max_skew_ratio=0.10,
+    )
+    assert not result.is_green
+    assert any("skew_ratio_exceeded" in r for r in result.reasons)
+
+
+def test_skew_single_replica_is_red() -> None:
+    result = score_skew(replica_admitted_counts={"replica-a": 100}, max_skew_ratio=0.10)
+    assert not result.is_green
+    assert any("fewer_than_2_replicas_measured" in r for r in result.reasons)
+
+
+# ---------------------------------------------------------------------------
+# Isolation
+# ---------------------------------------------------------------------------
+
+
+def test_isolation_noisy_tenant_does_not_affect_others_is_green() -> None:
+    observations = [
+        TenantObservation(tenant_id="noisy", requests_sent=1000, requests_admitted=100),
+        TenantObservation(tenant_id="quiet-a", requests_sent=100, requests_admitted=99),
+        TenantObservation(tenant_id="quiet-b", requests_sent=100, requests_admitted=100),
+    ]
+    result = score_isolation(
+        observations=observations, noisy_tenant_id="noisy", max_cross_tenant_rejection_rate=0.05
+    )
+    assert result.is_green
+
+
+def test_isolation_cross_tenant_interference_is_red() -> None:
+    observations = [
+        TenantObservation(tenant_id="noisy", requests_sent=1000, requests_admitted=100),
+        TenantObservation(tenant_id="quiet-a", requests_sent=100, requests_admitted=50),
+    ]
+    result = score_isolation(
+        observations=observations, noisy_tenant_id="noisy", max_cross_tenant_rejection_rate=0.05
+    )
+    assert not result.is_green
+    assert any("cross_tenant_interference" in r for r in result.reasons)
+
+
+def test_isolation_missing_noisy_tenant_is_red() -> None:
+    observations = [
+        TenantObservation(tenant_id="quiet-a", requests_sent=100, requests_admitted=99)
+    ]
+    result = score_isolation(
+        observations=observations, noisy_tenant_id="noisy", max_cross_tenant_rejection_rate=0.05
+    )
+    assert not result.is_green
+    assert result.reasons == ("noisy_tenant_not_observed",)
+
+
+# ---------------------------------------------------------------------------
+# Fairness (background degrades first — AC-SCALE-2)
+# ---------------------------------------------------------------------------
+
+
+def test_fairness_background_degrades_first_is_green() -> None:
+    incident = LaneObservation(
+        lane="incident",
+        requests_sent=100,
+        requests_admitted=99,
+        p99_latency_ms=120,
+        error_rate=0.0,
+    )
+    background = LaneObservation(
+        lane="background",
+        requests_sent=1000,
+        requests_admitted=400,
+        p99_latency_ms=800,
+        error_rate=0.1,
+    )
+    result = score_fairness(
+        incident=incident,
+        background=background,
+        incident_latency_threshold_ms=250,
+        incident_error_rate_threshold=0.01,
+    )
+    assert result.is_green
+
+
+def test_fairness_incident_lane_breached_is_red() -> None:
+    incident = LaneObservation(
+        lane="incident",
+        requests_sent=100,
+        requests_admitted=99,
+        p99_latency_ms=500,
+        error_rate=0.0,
+    )
+    background = LaneObservation(
+        lane="background",
+        requests_sent=1000,
+        requests_admitted=400,
+        p99_latency_ms=800,
+        error_rate=0.1,
+    )
+    result = score_fairness(
+        incident=incident,
+        background=background,
+        incident_latency_threshold_ms=250,
+        incident_error_rate_threshold=0.01,
+    )
+    assert not result.is_green
+    assert any("incident_latency_breached" in r for r in result.reasons)
+
+
+def test_fairness_background_not_degrading_first_is_red() -> None:
+    """Both lanes shed equally — background must degrade *more*, not just
+    also-eventually."""
+    incident = LaneObservation(
+        lane="incident",
+        requests_sent=100,
+        requests_admitted=50,
+        p99_latency_ms=100,
+        error_rate=0.0,
+    )
+    background = LaneObservation(
+        lane="background",
+        requests_sent=100,
+        requests_admitted=50,
+        p99_latency_ms=100,
+        error_rate=0.0,
+    )
+    result = score_fairness(
+        incident=incident,
+        background=background,
+        incident_latency_threshold_ms=250,
+        incident_error_rate_threshold=0.01,
+    )
+    assert not result.is_green
+    assert any("background_did_not_degrade_first" in r for r in result.reasons)
+
+
+# ---------------------------------------------------------------------------
+# Fairness sourced from Settings (issue #350 BP review HIGH #2 — real
+# runtime consumer for admission_latency_threshold_ms/error_rate_threshold)
+# ---------------------------------------------------------------------------
+
+
+def _healthy_incident_observation() -> LaneObservation:
+    return LaneObservation(
+        lane="incident",
+        requests_sent=100,
+        requests_admitted=99,
+        p99_latency_ms=120,
+        error_rate=0.0,
+    )
+
+
+def _degrading_background_observation() -> LaneObservation:
+    return LaneObservation(
+        lane="background",
+        requests_sent=1000,
+        requests_admitted=400,
+        p99_latency_ms=800,
+        error_rate=0.1,
+    )
+
+
+def test_score_fairness_from_settings_reads_thresholds_from_settings() -> None:
+    """The Settings-derived latency/error thresholds must actually drive
+    the pass/fail decision — not just be threaded through unused."""
+    settings = Settings(**_FULLY_EVIDENCED_ADMISSION_SETTINGS_KWARGS)
+    result = score_fairness_from_settings(
+        settings,
+        incident=_healthy_incident_observation(),
+        background=_degrading_background_observation(),
+    )
+    assert result.is_green
+
+
+def test_score_fairness_from_settings_degrades_when_incident_breaches_settings_latency() -> None:
+    """Lowering Settings.admission_latency_threshold_ms below the observed
+    incident p99 must flip the same observation from GREEN to RED —
+    proving the field is read, not decorative."""
+    kwargs = dict(_FULLY_EVIDENCED_ADMISSION_SETTINGS_KWARGS)
+    kwargs["admission_latency_threshold_ms"] = 50.0  # incident observed at 120ms
+    settings = Settings(**kwargs)
+    result = score_fairness_from_settings(
+        settings,
+        incident=_healthy_incident_observation(),
+        background=_degrading_background_observation(),
+    )
+    assert not result.is_green
+    assert any("incident_latency_breached" in r for r in result.reasons)
+
+
+def test_score_fairness_from_settings_degrades_when_error_rate_threshold_unset() -> None:
+    """admission_backend='disabled' leaves the thresholds unset (None) — a
+    decision-return RED, never a silently-passing scoring call."""
+    settings = Settings()
+    result = score_fairness_from_settings(
+        settings,
+        incident=_healthy_incident_observation(),
+        background=_degrading_background_observation(),
+    )
+    assert not result.is_green
+    assert any("threshold_unset" in r for r in result.reasons)
+
+
+# ---------------------------------------------------------------------------
+# Queue depth (issue #350 BP review HIGH #2 — real runtime consumer for
+# admission_queue_depth_max)
+# ---------------------------------------------------------------------------
+
+
+def test_score_queue_depth_within_bound_is_green() -> None:
+    result = score_queue_depth(observed_queue_depth=200, queue_depth_max=500)
+    assert result.is_green
+
+
+def test_score_queue_depth_exceeded_is_red() -> None:
+    result = score_queue_depth(observed_queue_depth=600, queue_depth_max=500)
+    assert not result.is_green
+    assert any("queue_depth_exceeded" in r for r in result.reasons)
+
+
+def test_score_queue_depth_from_settings_reads_bound_from_settings() -> None:
+    """Raising the observed depth past Settings.admission_queue_depth_max
+    must flip GREEN to RED — proving the field is read, not decorative."""
+    settings = Settings(**_FULLY_EVIDENCED_ADMISSION_SETTINGS_KWARGS)
+    assert score_queue_depth_from_settings(settings, observed_queue_depth=100).is_green
+
+    result = score_queue_depth_from_settings(settings, observed_queue_depth=999)
+    assert not result.is_green
+    assert any("queue_depth_exceeded" in r for r in result.reasons)
+
+
+def test_score_queue_depth_from_settings_degrades_when_bound_unset() -> None:
+    settings = Settings()
+    result = score_queue_depth_from_settings(settings, observed_queue_depth=10)
+    assert not result.is_green
+    assert result.reasons == ("admission_queue_depth_max_unset",)
+
+
+# ---------------------------------------------------------------------------
+# Fallback (stable 429/503, no false-freshness success — AC-SCALE-3)
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_stable_errors_only_is_green() -> None:
+    observations = [
+        OverloadResponseObservation(
+            status_code=429,
+            code="rate_limited",
+            is_success_status=False,
+            meta_freshness_status=None,
+        ),
+        OverloadResponseObservation(
+            status_code=503,
+            code="admission_backend_unavailable",
+            is_success_status=False,
+            meta_freshness_status="unknown",
+        ),
+    ]
+    result = score_fallback(observations=observations)
+    assert result.is_green
+
+
+def test_fallback_success_status_during_overload_is_red() -> None:
+    observations = [
+        OverloadResponseObservation(
+            status_code=200, code="ok", is_success_status=True, meta_freshness_status="fresh"
+        )
+    ]
+    result = score_fallback(observations=observations)
+    assert not result.is_green
+    assert any("overload_returned_success_status" in r for r in result.reasons)
+
+
+def test_fallback_unstable_status_code_is_red() -> None:
+    observations = [
+        OverloadResponseObservation(
+            status_code=500, code="internal", is_success_status=False, meta_freshness_status=None
+        )
+    ]
+    result = score_fallback(observations=observations)
+    assert not result.is_green
+    assert any("overload_status_not_stable" in r for r in result.reasons)
+
+
+def test_fallback_false_freshness_claim_is_red() -> None:
+    observations = [
+        OverloadResponseObservation(
+            status_code=503,
+            code="admission_backend_unavailable",
+            is_success_status=False,
+            meta_freshness_status="fresh",
+        )
+    ]
+    result = score_fallback(observations=observations)
+    assert not result.is_green
+    assert any("overload_claims_fresh_meta" in r for r in result.reasons)
+
+
+def test_fallback_no_observations_is_red() -> None:
+    result = score_fallback(observations=[])
+    assert not result.is_green
+
+
+# ---------------------------------------------------------------------------
+# Content-addressed report
+# ---------------------------------------------------------------------------
+
+
+def _all_green_probes():
+    skew = score_skew(replica_admitted_counts={"a": 100, "b": 100}, max_skew_ratio=0.1)
+    isolation = score_isolation(
+        observations=[
+            TenantObservation("noisy", 1000, 100),
+            TenantObservation("quiet", 100, 99),
+        ],
+        noisy_tenant_id="noisy",
+        max_cross_tenant_rejection_rate=0.05,
+    )
+    fairness = score_fairness(
+        incident=LaneObservation("incident", 100, 99, 100, 0.0),
+        background=LaneObservation("background", 1000, 400, 800, 0.1),
+        incident_latency_threshold_ms=250,
+        incident_error_rate_threshold=0.01,
+    )
+    fallback = score_fallback(
+        observations=[
+            OverloadResponseObservation(429, "rate_limited", False, None),
+        ]
+    )
+    return skew, isolation, fairness, fallback
+
+
+def test_qualification_report_two_replicas_all_green_is_green() -> None:
+    skew, isolation, fairness, fallback = _all_green_probes()
+    report = build_qualification_report(
+        replica_count=2, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    assert report.status == "GREEN"
+    assert report.report_id.startswith("sha256:")
+    assert report.reasons == ()
+
+
+def test_qualification_report_single_replica_is_red_even_if_probes_green() -> None:
+    skew, isolation, fairness, fallback = _all_green_probes()
+    report = build_qualification_report(
+        replica_count=1, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    assert report.status == "RED"
+    assert any("replica_count_below_minimum" in r for r in report.reasons)
+
+
+def test_qualification_report_is_content_addressed_and_deterministic() -> None:
+    skew, isolation, fairness, fallback = _all_green_probes()
+    report_a = build_qualification_report(
+        replica_count=2, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    report_b = build_qualification_report(
+        replica_count=2, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    assert report_a.report_id == report_b.report_id
+
+    report_c = build_qualification_report(
+        replica_count=3, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    assert report_c.report_id != report_a.report_id
+
+
+def test_validate_report_json_accepts_a_valid_green_report() -> None:
+    skew, isolation, fairness, fallback = _all_green_probes()
+    report = build_qualification_report(
+        replica_count=2, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    result = validate_report_json(report.to_dict())
+    assert result.is_green
+
+
+def test_validate_report_json_rejects_tampered_status_claim() -> None:
+    """A report that claims GREEN overall but has a RED dimension must not
+    validate — tamper-evidence, not just shape checking."""
+    skew, isolation, fairness, fallback = _all_green_probes()
+    report = build_qualification_report(
+        replica_count=1, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    tampered = report.to_dict()
+    tampered["status"] = "GREEN"  # lie about the overall status
+    result = validate_report_json(tampered)
+    assert not result.is_green
+
+
+def test_validate_report_json_rejects_absent_report() -> None:
+    result = validate_report_json(None)
+    assert not result.is_green
+    assert result.reasons == ("report_absent",)
+
+
+# ---------------------------------------------------------------------------
+# Optional queue_depth probe wired into the report (issue #350 BP review
+# HIGH #2) — backward compatible: omitting it must reproduce the exact
+# pre-existing four-probe report.
+# ---------------------------------------------------------------------------
+
+
+def test_qualification_report_without_queue_depth_leaves_it_unmeasured() -> None:
+    """Backward compat: every existing caller that omits `queue_depth`
+    (all four tests above) must keep getting `queue_depth_status=None`,
+    with no effect on overall status."""
+    skew, isolation, fairness, fallback = _all_green_probes()
+    report = build_qualification_report(
+        replica_count=2, skew=skew, isolation=isolation, fairness=fairness, fallback=fallback
+    )
+    assert report.queue_depth_status is None
+    assert report.status == "GREEN"
+    assert report.to_dict()["queue_depth_status"] is None
+
+
+def test_qualification_report_green_queue_depth_stays_green() -> None:
+    skew, isolation, fairness, fallback = _all_green_probes()
+    queue_depth = score_queue_depth(observed_queue_depth=100, queue_depth_max=500)
+    report = build_qualification_report(
+        replica_count=2,
+        skew=skew,
+        isolation=isolation,
+        fairness=fairness,
+        fallback=fallback,
+        queue_depth=queue_depth,
+    )
+    assert report.queue_depth_status == "GREEN"
+    assert report.status == "GREEN"
+
+
+def test_qualification_report_red_queue_depth_fails_the_whole_report() -> None:
+    """A RED queue_depth probe must degrade the overall report even when
+    every other probe is GREEN — the exceeded-bound observation is exactly
+    the AC-SCALE-5 evidence category this field exists for."""
+    skew, isolation, fairness, fallback = _all_green_probes()
+    queue_depth = score_queue_depth(observed_queue_depth=999, queue_depth_max=500)
+    report = build_qualification_report(
+        replica_count=2,
+        skew=skew,
+        isolation=isolation,
+        fairness=fairness,
+        fallback=fallback,
+        queue_depth=queue_depth,
+    )
+    assert report.queue_depth_status == "RED"
+    assert report.status == "RED"
+    assert any("queue_depth:queue_depth_exceeded" in r for r in report.reasons)

--- a/tests/test_mcp_admission_contract.py
+++ b/tests/test_mcp_admission_contract.py
@@ -1,0 +1,92 @@
+"""Conformance tests for the MCP-side overload error shape (issue #350,
+AC-SCALE-3). `mcp/server.py` is out of this task's scope, so nothing here
+wires a live MCP call site — these tests instead prove
+`admission.mcp_contract` produces a contract-correct stable error rather
+than a value that would violate the packaged, closed
+`fallback.reason` enum in `mcp/contracts/v1/schemas/meta.schema.json`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from omniscience_server.admission.mcp_contract import (
+    ADMISSION_BACKEND_UNAVAILABLE_CODE,
+    RATE_LIMITED_CODE,
+    admission_error_code,
+    raise_admission_error,
+)
+from omniscience_server.admission.state_machine import (
+    REASON_BACKGROUND_SUSPENDED,
+    REASON_LANE_EXHAUSTED,
+    STATE_BACKEND_LOST,
+    STATE_NORMAL,
+    AdmissionOutcome,
+)
+
+_META_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "apps"
+    / "server"
+    / "src"
+    / "omniscience_server"
+    / "mcp"
+    / "contracts"
+    / "v1"
+    / "schemas"
+    / "meta.schema.json"
+)
+
+
+def _closed_fallback_reason_enum() -> set[str | None]:
+    schema = json.loads(_META_SCHEMA_PATH.read_text())
+    return set(schema["properties"]["fallback"]["properties"]["reason"]["enum"])
+
+
+def test_admission_codes_are_not_in_the_closed_fallback_reason_enum() -> None:
+    """Proves the design choice this module documents: an admission-rejected
+    code is deliberately NOT plugged into the closed `fallback.reason` enum
+    (which is out of scope to edit) — it is a stable tool-level error
+    instead, matching REQ-MCP-4."""
+    closed_enum = _closed_fallback_reason_enum()
+    assert RATE_LIMITED_CODE not in closed_enum
+    assert ADMISSION_BACKEND_UNAVAILABLE_CODE not in closed_enum
+
+
+def test_admission_error_codes_match_rest_contract_codes() -> None:
+    """Cross-transport consistency: the same `code` strings REST's 429/503
+    envelope uses (rest/rate_limit.py, rest/errors.py)."""
+    assert RATE_LIMITED_CODE == "rate_limited"
+    assert ADMISSION_BACKEND_UNAVAILABLE_CODE == "admission_backend_unavailable"
+
+
+def test_admission_error_code_for_normal_lane_exhaustion_is_rate_limited() -> None:
+    outcome = AdmissionOutcome(allowed=False, state=STATE_NORMAL, reason=REASON_LANE_EXHAUSTED)
+    assert admission_error_code(outcome) == RATE_LIMITED_CODE
+
+
+def test_admission_error_code_for_backend_loss_is_backend_unavailable() -> None:
+    outcome = AdmissionOutcome(
+        allowed=False, state=STATE_BACKEND_LOST, reason=REASON_BACKGROUND_SUSPENDED
+    )
+    assert admission_error_code(outcome) == ADMISSION_BACKEND_UNAVAILABLE_CODE
+
+
+def test_raise_admission_error_follows_the_existing_stable_code_prefix_convention() -> None:
+    """Mirrors every existing mcp/server.py rejection
+    (`raise ValueError("forbidden:...")`, `raise ValueError("bad_request:...")`,
+    etc.) — a `ValueError` whose message starts with `"<code>:"`, which the
+    MCP framework turns into a stable tool-level error."""
+    outcome = AdmissionOutcome(allowed=False, state=STATE_NORMAL, reason=REASON_LANE_EXHAUSTED)
+    with pytest.raises(ValueError, match=r"^rate_limited:"):
+        raise_admission_error(outcome)
+
+
+def test_raise_admission_error_backend_loss_message_prefix() -> None:
+    outcome = AdmissionOutcome(
+        allowed=False, state=STATE_BACKEND_LOST, reason=REASON_BACKGROUND_SUSPENDED
+    )
+    with pytest.raises(ValueError, match=r"^admission_backend_unavailable:"):
+        raise_admission_error(outcome)

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -37,7 +37,11 @@ from omniscience_core.db.models import (
 )
 from omniscience_retrieval.models import QueryStats, SearchHit, SearchResult
 from omniscience_server.app import create_app
-from omniscience_server.rest.rate_limit import check_rate_limit, clear_all_buckets
+from omniscience_server.rest.rate_limit import (
+    check_rate_limit,
+    clear_all_buckets,
+    reset_admission_controller_cache,
+)
 
 _WS_A = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
 
@@ -155,6 +159,7 @@ def admin_token() -> tuple[ApiToken, str]:
 def reset_rate_buckets() -> None:
     """Clear rate-limit state between every test."""
     clear_all_buckets()
+    reset_admission_controller_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -393,12 +398,13 @@ def test_rate_limit_refills_over_time() -> None:
     assert allowed_empty is False
 
     # Fast-forward by patching time.monotonic to simulate 1 second elapsed
-    # After 1 second at 1 tok/sec, bucket gains 1 token
-    from omniscience_server.rest import rate_limit as rl_module
+    # After 1 second at 1 tok/sec, bucket gains 1 token. The bucket math
+    # lives in admission.process_local (issue #350 refactor) — patch there.
+    from omniscience_server.admission import process_local as admission_process_local
 
-    original_time = rl_module.time.monotonic  # type: ignore[attr-defined]
+    original_time = admission_process_local.time.monotonic
     fake_now = original_time() + 2.0  # advance by 2 seconds
-    with patch.object(rl_module.time, "monotonic", return_value=fake_now):
+    with patch.object(admission_process_local.time, "monotonic", return_value=fake_now):
         allowed_refilled, _ = check_rate_limit(token_id, rpm=rpm)
     assert allowed_refilled is True
 
@@ -429,6 +435,185 @@ async def test_rate_limit_endpoint_returns_429() -> None:
     body = resp.json()
     assert body["error"]["code"] == "rate_limited"
     assert "Retry-After" in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_incident_lane_has_separate_budget_from_background_lane() -> None:
+    """AC-SCALE-2: a token carrying incidents:write resolves to the
+    incident lane, a separately-bounded budget from a search-only token's
+    background lane — draining one lane's bucket must not affect the
+    other's, even though both share the same process-local backend."""
+    from omniscience_core.config import Settings
+
+    def _app_for(token: ApiToken) -> FastAPI:
+        settings = Settings(
+            database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+            nats_url="nats://localhost:4222",
+            log_level="WARNING",
+            otlp_endpoint=None,
+            environment="test",
+            admission_lane_incident_budget=2,
+            admission_lane_background_budget=2,
+        )
+        app = create_app(settings=settings)
+        app.state.db_session_factory = MagicMock(return_value=_make_session(scalars=[token]))
+        return app
+
+    tok_background, pt_background = _make_token(["search"])
+    tok_background.id = uuid.uuid4()
+    tok_incident, pt_incident = _make_token(["search", "incidents:write"])
+    tok_incident.id = uuid.uuid4()
+
+    clear_all_buckets()
+
+    background_app = _app_for(tok_background)
+    async with await _client_for(background_app) as client:
+        for _ in range(2):
+            await client.post(
+                "/api/v1/search",
+                json={"query": "hello"},
+                headers={"Authorization": f"Bearer {pt_background}"},
+            )
+        exhausted = await client.post(
+            "/api/v1/search",
+            json={"query": "hello"},
+            headers={"Authorization": f"Bearer {pt_background}"},
+        )
+    assert exhausted.status_code == 429
+
+    incident_app = _app_for(tok_incident)
+    async with await _client_for(incident_app) as client:
+        allowed = await client.post(
+            "/api/v1/search",
+            json={"query": "hello"},
+            headers={"Authorization": f"Bearer {pt_incident}"},
+        )
+    assert allowed.status_code != 429
+
+
+@pytest.mark.asyncio
+async def test_admission_backend_unavailable_returns_503() -> None:
+    """AC-SCALE-3/4: selecting a non-'disabled' admission backend activates
+    the fail-closed SharedAdmissionBackend stub — every request degrades to
+    a stable 503 admission_backend_unavailable, never a silent process-local
+    fallback and never a 429 (which would imply the backend was consulted
+    and merely exhausted, not lost)."""
+    from omniscience_core.config import Settings
+
+    tok, pt = _make_token(["search"])
+    tok.id = uuid.uuid4()
+    settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+        admission_backend="shared-redis-lease",
+        admission_backend_identity="redis://admission.internal:6379/0",
+        admission_lane_incident_budget=10,
+        admission_lane_background_budget=10,
+        admission_queue_depth_max=100,
+        admission_latency_threshold_ms=250.0,
+        admission_error_rate_threshold=0.01,
+        admission_failure_reserve_fraction=0.2,
+    )
+    app = create_app(settings=settings)
+    app.state.db_session_factory = MagicMock(return_value=_make_session(scalars=[tok]))
+
+    async with await _client_for(app) as client:
+        resp = await client.post(
+            "/api/v1/search",
+            json={"query": "hello"},
+            headers={"Authorization": f"Bearer {pt}"},
+        )
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["error"]["code"] == "admission_backend_unavailable"
+
+
+def test_default_disabled_posture_has_no_lane_split() -> None:
+    """BP review MEDIUM #3 backward-compat proof: the true zero-touch
+    default (admission_backend="disabled", no lane budgets set) resolves
+    every lane to the single pre-#350 shared bucket at rate_limit_rpm
+    capacity — lane-split only activates once a lane budget is explicitly
+    configured (see docs/runbooks/read-admission.md "Posture model")."""
+    from omniscience_core.config import Settings
+    from omniscience_server.admission.lanes import BACKGROUND_LANE, INCIDENT_LANE
+    from omniscience_server.rest.rate_limit import _DEFAULT_LANE, _lane_capacity_and_bucket
+
+    settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+    )
+    assert settings.admission_backend == "disabled"
+    assert settings.admission_lane_incident_budget is None
+    assert settings.admission_lane_background_budget is None
+
+    incident_capacity, incident_bucket = _lane_capacity_and_bucket(settings, INCIDENT_LANE)
+    background_capacity, background_bucket = _lane_capacity_and_bucket(settings, BACKGROUND_LANE)
+
+    assert incident_bucket == _DEFAULT_LANE
+    assert background_bucket == _DEFAULT_LANE
+    assert incident_capacity == settings.rate_limit_rpm
+    assert background_capacity == settings.rate_limit_rpm
+
+
+def test_controller_for_caches_shared_backend_across_calls() -> None:
+    """BP review MEDIUM #5: a non-'disabled' admission backend must not be
+    rebuilt (and any future connection-pool/lease state discarded) on every
+    request — the same config must resolve to the same cached controller."""
+    from omniscience_core.config import Settings
+    from omniscience_server.rest.rate_limit import (
+        _controller_for,
+        reset_admission_controller_cache,
+    )
+
+    reset_admission_controller_cache()
+    settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+        admission_backend="shared-redis-lease",
+        admission_backend_identity="redis://admission.internal:6379/0",
+        admission_lane_incident_budget=10,
+        admission_lane_background_budget=10,
+        admission_queue_depth_max=100,
+        admission_latency_threshold_ms=250.0,
+        admission_error_rate_threshold=0.01,
+        admission_failure_reserve_fraction=0.2,
+    )
+
+    first = _controller_for(settings)
+    second = _controller_for(settings)
+    assert first is second
+
+    other_identity_settings = Settings(
+        database_url="postgresql+asyncpg://test:test@localhost:5432/test",
+        nats_url="nats://localhost:4222",
+        log_level="WARNING",
+        otlp_endpoint=None,
+        environment="test",
+        admission_backend="shared-redis-lease",
+        admission_backend_identity="redis://other-admission.internal:6379/0",
+        admission_lane_incident_budget=10,
+        admission_lane_background_budget=10,
+        admission_queue_depth_max=100,
+        admission_latency_threshold_ms=250.0,
+        admission_error_rate_threshold=0.01,
+        admission_failure_reserve_fraction=0.2,
+    )
+    third = _controller_for(other_identity_settings)
+    assert third is not first
+
+    reset_admission_controller_cache()
+    fourth = _controller_for(settings)
+    assert fourth is not first
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the ready task SPEC `docs/specs/gh-issue-350-read-scaling-priority.md` — the **fifth and final** slice of issue #350. Branches from `main` (mcp-v1 + production-ha already merged). Touches application code (`apps/**`, `packages/**`), the Helm chart, and adds a qualification workflow.

## What ships (AC-SCALE-1..5 — GREEN repo-local; live measurement is decision-return)

- **AC-SCALE-1** — new `admission/` package: a narrow `AdmissionBackend` Protocol, a behaviour-preserving `ProcessLocalAdmissionBackend` default, and a fail-closed `SharedAdmissionBackend` stub behind a **disabled activation gate**. `rest/rate_limit.py` is migrated off the module-level `_buckets`. *(MCP tool-dispatch wiring is a flagged follow-up — `mcp/server.py` is out of this task's `scope.include`; the stable-error helper `mcp_contract.py` is ready for it.)*
- **AC-SCALE-2** — incident/background lanes with separate bounded budgets; lane identity is **server-derived from token scopes**, never client input; background degrades first.
- **AC-SCALE-3** — overload returns stable **429/503** through the existing REST error envelope (`errors.py` untouched) with no false freshness; MCP-side codes stay out of the closed `fallback.reason` enum (`metadata.py`/schemas untouched).
- **AC-SCALE-4** — fail-closed controller never falls back to a process-local bucket on backend loss; the bounded incident reserve requires a **provable lease authority** (fail-closed by default).
- **AC-SCALE-5** — Helm admission guards + values mirror the production-HA fail-closed pattern; content-addressed qualification report + skew/isolation/fairness/fallback/queue scoring driven by the required SLO inputs.
- **config** — the **first Python-side fail-boot `model_validator`** in the codebase; admission SLO inputs have no code defaults and fail boot when the backend is enabled. Also closes a pre-existing dead knob (`rate_limit_rpm` had no backing field).

## Review hardening (security + best-practices)

Security review found **no exploitable bypass** (process-local removal, lane-spoofing, fail-open, error-body disclosure, Helm bare-truthy, workflow injection, DoS all clean — notably the Helm guards use type-safe `int()`/`eq`, avoiding the production-HA string-`"false"` footgun). Best-practices fixes applied:
- aligned the config-validator bounds with the Helm guards (`queue_depth ≥ 1`, `error_rate > 0`);
- wired the previously **unread** latency/error/queue SLO inputs into the qualification scoring (they now drive pass/fail);
- cached the controller (per-request reconstruction footgun);
- server-side logging of the degrade reason; documented the lane and workspace-aggregate scope boundaries.

## Not in this slice — decision-return / RED by design

Live 2+-replica measured evidence (AC-SCALE-5), acceptance/provisioning of a concrete shared backend, and live backend-outage / fairness proof remain RED: each needs a real cluster or a human-approved backend this agent cannot self-grant. A Redis (`SET NX PX` / Lua CAS) or managed-quota backend is **recommended in the runbook, not wired**. Flagged follow-ups: MCP call-site wiring (needs `mcp/server.py`), the `webhooks.py` second process-local bucket, and workspace-aggregate limits.

## Verification

- `uv run pytest tests/test_admission*.py tests/test_rest_api.py tests/test_mcp_admission_contract.py` → **124 passed**.
- Default boot (`admission_backend="disabled"`) unchanged; enabling without every SLO input fails boot; production-HA suite (38/38) unaffected.
- `ruff check` + `ruff format --check` → clean; `mypy apps/ packages/` → no issues; `helm lint`/`template` EVAL/PROD/PROD+ADMISSION clean, guard-fail correct, `kubeconform -strict` 7/7.

## Test plan

- [ ] CI green (new `admission-qualification.yml`: triple-render + guard-fail + `test_admission*` + REST/MCP regression)
- [ ] Reviewer confirms the shared-backend selection, MCP wiring, and live multi-replica measurement stay out-of-scope until a human-approved backend + cluster exist
