### PR TITLE
docs(platform): publish synchronized platform handoff

### DIFF
--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -1,0 +1,84 @@
+# Synchronized platform — Omniscience
+
+Omniscience is the shared, read-only knowledge plane and MCP producer for the synchronized platform. The
+canonical cross-repository ADR/SPEC plan is:
+
+<https://github.com/100rd/genai-enablement/blob/main/docs/synchronized-platform/README.md>
+
+In a sibling workspace it is normally available at
+`../genai-enablement/docs/synchronized-platform/README.md`.
+
+The full plan explains why and when components connect. Omniscience implementation authority remains
+local:
+
+```text
+accepted genai-enablement ADR
+        -> accepted Omniscience adoption ADR
+        -> specs/SPEC-INDEX.md capability contract
+        -> docs/specs/ one human-ready immutable task
+        -> docs/specs/execution-index.json terminal evidence
+```
+
+## Start one independent Omniscience task
+
+1. Read this file and the canonical plan to identify the cross-repository work package.
+2. Read the [local ADR index](docs/decisions/README.md) and
+   [capability-SPEC index](specs/SPEC-INDEX.md).
+3. Claim exactly one [task SPEC](docs/specs/README.md); its include/exclude paths and acceptance probes
+   are the writable execution boundary.
+4. Keep ready task revisions immutable. Write terminal evidence beside them in
+   `docs/specs/execution-index.json`.
+5. Do not edit `genai-enablement` or `omnius` from an Omniscience task. Publish producer artifacts or
+   read-only conformance fixtures; consumers return their own receipts from their repositories.
+
+## Local synchronized-platform contracts
+
+| Cross-repository package | Omniscience contract | Current boundary |
+|---|---|---|
+| `SP-10` MCP v1 producer | `SPEC-MCP` + `gh-issue-350-mcp-v1` | repo-local contract implementation merged; consumer pin, live canary/severance and human verification remain |
+| `SP-12` consumer severance | `gh-issue-350-consumer-severance` | producer fixtures/verifier merged; Omnius/SRE receipts and live drill remain external |
+| `SP-61` knowledge-plane PII boundary | `SPEC-PII` + `task-sp-61-pii-wall-pw0` | ready for fail-closed non-live development; no profile or data path is active |
+| `SP-81` management-context producer | `SPEC-MCTX` + `task-sp-81-management-context-v1` | ready for bounded non-live producer development; no consumer/live authority |
+| issue-350 HA | `gh-issue-350-production-ha` | portable profile merged; live fault-domain proof and stateful topology entitlements remain unverified |
+| issue-350 recovery | `gh-issue-350-backup-restore` | safety harness merged; every destructive drill still needs separate exact human approval |
+| issue-350 scaling | `gh-issue-350-read-scaling-priority` | controller/qualification logic merged; shared-backend selection, dispatch wiring and multi-replica proof remain |
+
+The complete ready capability set is `SPEC-IN`, `SPEC-SOT`, `SPEC-ACL`, `SPEC-EV`, `SPEC-OPS`,
+`SPEC-KP`, `SPEC-MCP`, `SPEC-PII`, and `SPEC-MCTX`. Their exact dependencies are authoritative in
+[`specs/SPEC-INDEX.md`](specs/SPEC-INDEX.md). PII and management-context readiness authorize only their
+exact non-live tasks.
+
+## Knowledge-plane boundary
+
+Omniscience returns cited, lineage-aware evidence. It is never the sole correctness, authorization,
+merge, apply, incident-action, or terminal-workflow oracle. Consumers must honor freshness,
+consistency, fallback, tenant, and contract pins and must degrade to direct authoritative sources or
+park safely.
+
+Portfolio state and accepted cross-repository decisions cannot promote an Omniscience task to
+`implemented` or `verified`; only component-owned execution evidence can do that.
+
+## PII Wall boundary
+
+Omniscience owns the earliest platform data gate: classification and admission must occur before
+ordinary raw-document persistence, parsing, chunking, embedding, graph/vector projection, archive, or
+external provider egress. It also owns retrieval revalidation and exact deletion/retention coverage
+across its stores.
+
+The accepted local contract is [`SPEC-PII`](specs/SPEC-PII-pii-wall-ingestion-lifecycle.md). It can be
+implemented independently inside this repository under ADR-0020 and the exact ready
+`task-sp-61-pii-wall-pw0`,
+then publish non-identifying `SanitizationReceipt`, `PrivacyCoverage`, and `DeletionReceipt` artifacts.
+Neither Omnius nor Platform Portal is permitted to classify or clean Omniscience data on its behalf.
+
+## Local UI boundary
+
+Omniscience remains MCP/API-first and may expose a small standalone operational UI for sources,
+ingestion/indexing, storage, freshness, PII quarantine/coverage for its own stores, MCP health, and
+component-local maintenance. It is not the platform-wide dashboard or shared control shell.
+
+Cross-component maps, correlated component detail, synchronized work packages, and delegated controls
+belong to [Platform Portal](https://github.com/100rd/platform-portal/blob/main/VISION.md). Omniscience
+publishes typed read/action projections with workspace, revision, freshness, coverage, and source-health
+provenance. Portal loss cannot block local operation; Omniscience loss becomes an explicit unavailable
+portal projection rather than a fabricated healthy or empty state.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Omniscience
 
+For synchronized-platform work, start at [`PLATFORM.md`](PLATFORM.md). It links the canonical
+cross-repository ADR/SPEC plan and then routes agents back to this repository's authoritative capability
+and task contracts.
+
 **A self-hosted Living Semantic Core for platform & SRE teams.** Omniscience turns fragmented operational data — cloud infrastructure, IaC code, Kubernetes runtime, CI/CD, alerts, incident chat, docs — into a single **causal + temporal + semantic graph**, exposed through an **MCP-first API** to any MCP-compatible AI client (Claude Code, Cursor, Gemini, custom agents, or AI pipelines).
 
 Retrieval-only by design: Omniscience returns **linked evidence with citations and confidence** — graph entities, related artifacts, and source chunks — and the calling LLM synthesizes the answer. No embedded LLM, no opinionated chat, no vendor lock-in. (Write actions against infrastructure are an explicit non-goal of this product; see Action Mode in [docs/vision.md](docs/vision.md#4-product-modes).)

--- a/docs/decisions/0020-adopt-distributed-pii-wall.md
+++ b/docs/decisions/0020-adopt-distributed-pii-wall.md
@@ -1,0 +1,35 @@
+# ADR-0020: Adopt the distributed PII Wall at the Omniscience propagation boundary
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** platform owner and Omniscience owner
+- **Governing decision:** `genai-enablement` ADR-0018
+
+## Context
+
+Omniscience can decode, parse, persist, chunk, embed and project source material before a downstream
+consumer sees it. A prompt/output filter cannot undo personal-data propagation into the authoritative
+ledger, graph/vector projections, caches, logs, archives or providers.
+
+## Decision
+
+Omniscience adopts the shared PII taxonomy, PW0/PW1/PW2 profiles and receipt semantics. It verifies an
+exact content-addressed policy bundle and enforces it before ordinary persistence, parsing propagation,
+chunking, embedding, projection and retrieval. Unknown, stale, unsigned or incompatible policy blocks
+new protected processing.
+
+The component implements a sealed `QuarantineStore` interface isolated from ordinary knowledge stores.
+Development uses deterministic disposable fixtures. A live backend, access path, encryption/retention
+profile and operator authority are required environment inputs and have no permissive default.
+
+Embedding and enrichment providers are explicit sinks. No provider is enabled for protected data unless
+the policy bundle names its exact posture and fields; missing posture is denial, not local fallback.
+
+Omniscience publishes only non-identifying coverage and lifecycle receipts. It does not declare legal
+compliance, mint a platform-wide permit, or make Platform Portal an enforcement dependency.
+
+## Development authority
+
+This decision authorizes `SPEC-PII` contract, fixture, validator and fail-closed repository work. It does
+not activate a profile, process live personal data, provision a quarantine backend or key, call a live
+provider, delete durable data, deploy, or claim privacy coverage.

--- a/docs/decisions/0020-adopt-distributed-pii-wall.md
+++ b/docs/decisions/0020-adopt-distributed-pii-wall.md
@@ -1,6 +1,6 @@
 # ADR-0020: Adopt the distributed PII Wall at the Omniscience propagation boundary
 
-- **Status:** Accepted
+Status: accepted
 - **Date:** 2026-07-21
 - **Deciders:** platform owner and Omniscience owner
 - **Governing decision:** `genai-enablement` ADR-0018

--- a/docs/decisions/0021-management-context-producer.md
+++ b/docs/decisions/0021-management-context-producer.md
@@ -1,6 +1,6 @@
 # ADR-0021: Publish severable management context without creating management authority
 
-- **Status:** Accepted
+Status: accepted
 - **Date:** 2026-07-21
 - **Deciders:** platform owner and Omniscience owner
 - **Governing decisions:** `genai-enablement` ADR-0017 and ADR-0020

--- a/docs/decisions/0021-management-context-producer.md
+++ b/docs/decisions/0021-management-context-producer.md
@@ -1,0 +1,32 @@
+# ADR-0021: Publish severable management context without creating management authority
+
+- **Status:** Accepted
+- **Date:** 2026-07-21
+- **Deciders:** platform owner and Omniscience owner
+- **Governing decisions:** `genai-enablement` ADR-0017 and ADR-0020
+
+## Context
+
+Barbarossa agents and domain evaluators need cited knowledge, change history and knowledge-quality
+conditions. If Omniscience output became an observation, verdict, approval or sole runtime dependency,
+the optional knowledge plane would become management authority.
+
+## Decision
+
+Omniscience owns a versioned `ManagementContextBundle` and `KnowledgeQualitySnapshot` producer. Every
+response binds tenant/workspace, subject and purpose, request and contract revisions, source citations,
+coverage, freshness, conflicts, projection state, policy/PII receipt and integrity.
+
+The producer returns evidence fitness and source health, never a domain outcome, priority, incident,
+risk acceptance, action recommendation, approval or verification. Consumers must operate through a
+typed severed/unavailable path using their direct authoritative sources.
+
+Authorization is least-privilege, read-only and purpose scoped. The bundle contains only fields admitted
+for the requested management purpose; no generic graph query, raw PII, active content or owner credential
+is exposed.
+
+## Development authority
+
+This decision authorizes contract/schema, fixtures, read-only producer code and severance conformance.
+It does not authorize live customer data, a provider/model call, a Barbarossa decision, a deployment or
+production readiness.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -27,6 +27,8 @@ Statuses: `Proposed`, `Accepted`, `Implemented`, `Superseded`, `Deprecated`.
 | ADR-0017 | Per-source epoch pin | Accepted |
 | ADR-0018 | Rebuild direct-write DR exception | Accepted |
 | [ADR-0019](0019-dark-factory-sdd-and-knowledge-plane-boundary.md) | Dark Factory SDD and knowledge-plane boundary | Accepted |
+| [ADR-0020](0020-adopt-distributed-pii-wall.md) | Adopt the distributed PII Wall at every knowledge propagation boundary | Accepted |
+| [ADR-0021](0021-management-context-producer.md) | Publish severable management context without management authority | Accepted |
 
 `ADR-0018` was originally committed with the duplicate id `ADR-0015`. The rename is a
 registry repair, not a change to its accepted decision.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 **Current release:** `v0.5.0`
 **Current engineering slice:** MCP contract `1.0.0`
-**Portfolio status:** `issue-350-ready-queue`
+**Portfolio status:** `issue-350-implemented-unverified`
 
 This roadmap is the compact component view. Mutable issue scheduling lives in
 [GitHub milestones](https://github.com/100rd/Omniscience/milestones); cross-repository status,
@@ -14,15 +14,16 @@ Capability/task contracts and execution evidence remain canonical in this reposi
 
 | Slice | State | Exit boundary |
 |---|---|---|
-| mcp-v1 | `ready/in-progress` | Stable manifest/schemas, 15-tool registry, `contract_info`, freshness/fallback metadata, exact token profile, consumer pin and severance evidence |
-| production-ha | `ready/queued` | Fail-closed HA profile plus redundant application, PostgreSQL, JetStream, and projection-topology qualification |
-| backup-restore | `ready/queued` | PostgreSQL PITR safety harness and a measured isolated restore/convergence drill |
-| read-scaling-priority | `ready/queued` | Shared admission, horizontal-read qualification, overload tests, and bounded SRE priority lane |
-| consumer-severance | `ready/queued` | Producer fixtures, pinned Omnius/SRE receipts, and a safe live direct-source fallback drill |
+| mcp-v1 | `implemented/unverified` | Repo-local v1 contract merged; exact consumer pin, live canary/severance drill and human verification remain |
+| production-ha | `implemented/unverified` | Portable fail-closed profile merged; live failure-domain/SLO evidence and topology entitlements remain |
+| backup-restore | `implemented/unverified` | Safety/qualification harness merged; approved isolated destructive restore and measured RPO/RTO remain |
+| read-scaling-priority | `implemented/unverified` | Admission/controller/qualification logic merged; shared backend, dispatch wiring and multi-replica proof remain |
+| consumer-severance | `implemented/unverified` | Producer fixtures/verifier merged; immutable Omnius/SRE receipts and live fallback drill remain |
 
-The queue is dependency ordered: `mcp-v1` precedes `consumer-severance` and `production-ha`;
-`production-ha` precedes `backup-restore` and `read-scaling-priority`. Ready HA/DR/scaling specs
-authorize repository-local implementation and disposable qualification, not production mutation.
+The task contracts remain dependency ordered and immutable `ready`: `mcp-v1` precedes
+`consumer-severance` and `production-ha`; `production-ha` precedes `backup-restore` and
+`read-scaling-priority`. Their adjacent execution records are `implemented`, not `verified`.
+HA/DR/scaling readiness and merged portable code still do not authorize production mutation.
 
 ## Backlog governance
 
@@ -30,16 +31,18 @@ authorize repository-local implementation and disposable qualification, not prod
   the epic open with only PM task [#242](https://github.com/100rd/Omniscience/issues/242) remaining.
 - [#244](https://github.com/100rd/Omniscience/issues/244): remains `pre-plan` pending a separate
   competing-hypothesis discovery.
-- [#350](https://github.com/100rd/Omniscience/issues/350): parent for the five bounded task SPECs above.
+- [#350](https://github.com/100rd/Omniscience/issues/350): parent for the five bounded task SPECs above;
+  all five have merged implementation evidence and outstanding decision returns in
+  [`docs/specs/execution-index.json`](specs/execution-index.json).
 - [#355](https://github.com/100rd/Omniscience/issues/355): implementation is terminally evidenced in
   [`docs/specs/execution-index.json`](specs/execution-index.json); the ready task SPEC is immutable.
 
 ## Release and contract policy
 
 - Product release `v0.5.0` is the current immutable release evidence.
-- MCP v0 remains the implemented public surface until the ready `1.0.0` task is materialized and
-  verified. After that cutover, v1 supersedes v0; compatible additions follow semver and breaking wire
-  changes require a new major contract.
+- MCP v1 is the implemented stable public repository contract and v0 is historical/superseded.
+  Consumer activation still requires exact pins, a live canary/severance drill and human verification;
+  compatible additions follow semver and breaking wire changes require a new major contract.
 - MCP v1 contract conformance must compare runtime, manifest, schemas, SDK dependency/lock, docs, SPEC
   indexes, roadmap, execution evidence, and `.mcp` catalogs through one offline drift checker.
 - MCP v1 requires a fail-closed portable canary verifier for an exact materialized bundle and canonical

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,5 +1,9 @@
 # Task SPEC and execution index
 
+Start synchronized-platform work at the root [`PLATFORM.md`](../../PLATFORM.md), then claim exactly one
+Omniscience-owned task here. The cross-repository plan orders producer/consumer work but does not grant
+sibling writes or replace this execution index.
+
 GitHub issues and reviews are mutable intake. Only a human-ready immutable task SPEC authorizes bounded
 execution under SPEC-IN. Terminal state comes from the separate
 [`execution-index.json`](execution-index.json), not an issue checkbox or edits to a ready task file.
@@ -11,7 +15,11 @@ slices. The five task revisions are human-ready, but their execution boundaries 
 consumer conformance may implement repository-local behavior, while HA, restore, and scaling first
 produce fail-closed qualification evidence and cannot mutate production without separate authority.
 
-| Task | Status | Purpose |
+All five now have adjacent `implemented` records in `execution-index.json`. The task files remain
+immutable `ready` contracts by design; none is `verified`, because each retains a live or
+owner-controlled decision return that merged repository-local code cannot satisfy.
+
+| Task | Contract status | Purpose |
 |---|---|---|
 | [gh-issue-350-mcp-v1](gh-issue-350-mcp-contract-v1.md) | `ready` | Stable contract `1.0.0`, freshness/fallback metadata, token profile, skew gates |
 | [gh-issue-350-production-ha](gh-issue-350-production-ha.md) | `ready` | Portable HA profile, policy validation, and disposable failure qualification |
@@ -36,17 +44,30 @@ One agent should claim one immutable task revision at a time. A task may return 
 `decision-required` when external evidence is absent; it cannot widen itself, edit another repository,
 or reinterpret readiness as production/cloud/destructive authority.
 
+## Synchronized-platform development tasks
+
+| Task | Contract status | Purpose |
+|---|---|---|
+| [task-sp-61-pii-wall-pw0](task-sp-61-pii-wall-pw0.md) | `ready` | fail-closed repository-local PW0 propagation boundary and fixtures |
+| [task-sp-81-management-context-v1](task-sp-81-management-context-v1.md) | `ready` | cited management context and knowledge-quality producer v1 |
+
+Both tasks are human-ready for their exact non-live repository scopes. They authorize no production
+policy/profile, live personal data, credential, provider, consumer pin, deployment or external effect.
+
 ## Terminal execution evidence
 
 | Task | State | Evidence |
 |---|---|---|
 | gh-issue-355 | `implemented` | [execution-index.json](execution-index.json): PR #359, implementation and merge commits, reported GitHub rollup 13 SUCCESS / 2 SKIPPED / 0 other |
+| gh-issue-350-mcp-v1 | `implemented`, not verified | PR #361; repo-local AC-MCP-1..4 merged; live consumer pin/canary/severance and human verification remain |
+| gh-issue-350-consumer-severance | `implemented`, not verified | PR #362; producer matrix/verifier merged; immutable Omnius/SRE receipts and live severance drill remain |
+| gh-issue-350-production-ha | `implemented`, not verified | PR #363; fail-closed portable HA profile merged; live fault-domain evidence and topology entitlements remain |
+| gh-issue-350-backup-restore | `implemented`, not verified | PR #364; safety/qualification harness merged; approved isolated destructive drill and measured RPO/RTO remain |
+| gh-issue-350-read-scaling-priority | `implemented`, not verified | PR #365; admission/controller/qualification logic merged; concrete shared backend and multi-replica evidence remain |
 
-The ready [issue #355 task SPEC](gh-issue-355-set-sources-tenant-id-from-the-token-workspace-on-create.md)
-is immutable and remains unchanged. Evidence is adjacent rather than written into its execution
-contract. The structured record also retains reported RED (2 failed / 15 passed), GREEN (17 passed),
-broader (102 passed), and protected CI (3535 passed / 6 skipped / 88% coverage) evidence without
-misrepresenting the rollup as one local pytest command.
+Every ready task SPEC above is immutable and remains unchanged. Evidence is adjacent rather than written
+into its execution contract. The structured index retains exact PR/commit, check-rollup, test and
+outstanding-boundary detail without misrepresenting merged implementation as independent verification.
 
 ## Historical implemented prose
 
@@ -64,7 +85,8 @@ active backlog or executable ready contracts.
 draft -> ready -> implemented -> verified -> superseded
 ```
 
-Only a component CODEOWNER may set `ready`. Implementation does not imply independent verification.
+Only a component CODEOWNER may set `ready`. The platform/Omniscience owner approved the two SP-61/SP-81
+development tasks on 2026-07-21. Implementation does not imply independent verification.
 Agents cannot modify a ready revision's governing ADRs/SPECs, scope, probes, fixtures, policy, or waiver
 state while executing it.
 

--- a/docs/specs/gh-issue-350-backup-restore.md
+++ b/docs/specs/gh-issue-350-backup-restore.md
@@ -10,6 +10,7 @@ governingAdrs: [genai-enablement/ADR-0017, Omniscience/ADR-0018, Omniscience/ADR
 capabilitySpecs: [SPEC-SOT, SPEC-OPS]
 sddMode: full
 repo: 100rd/Omniscience
+evidenceDestination: component-execution-index://docs/specs/execution-index.json#gh-issue-350-backup-restore
 scope:
   include:
     - scripts/qualify_backup_restore.py

--- a/docs/specs/gh-issue-350-consumer-severance.md
+++ b/docs/specs/gh-issue-350-consumer-severance.md
@@ -10,6 +10,7 @@ governingAdrs: [genai-enablement/ADR-0017, Omniscience/ADR-0019]
 capabilitySpecs: [SPEC-MCP, SPEC-KP, SPEC-EV]
 sddMode: full
 repo: 100rd/Omniscience
+evidenceDestination: component-execution-index://docs/specs/execution-index.json#gh-issue-350-consumer-severance
 scope:
   include:
     - scripts/check_consumer_severance.py

--- a/docs/specs/gh-issue-350-mcp-contract-v1.md
+++ b/docs/specs/gh-issue-350-mcp-contract-v1.md
@@ -20,6 +20,7 @@ capabilitySpecs:
   - SPEC-OPS
 sddMode: full
 repo: 100rd/Omniscience
+evidenceDestination: component-execution-index://docs/specs/execution-index.json#gh-issue-350-mcp-v1
 scope:
   include:
     - apps/server/src/omniscience_server/mcp/**

--- a/docs/specs/gh-issue-350-production-ha.md
+++ b/docs/specs/gh-issue-350-production-ha.md
@@ -10,6 +10,7 @@ governingAdrs: [genai-enablement/ADR-0017, Omniscience/ADR-0019]
 capabilitySpecs: [SPEC-OPS, SPEC-SOT]
 sddMode: full
 repo: 100rd/Omniscience
+evidenceDestination: component-execution-index://docs/specs/execution-index.json#gh-issue-350-production-ha
 scope:
   include:
     - helm/omniscience/**

--- a/docs/specs/gh-issue-350-read-scaling-priority.md
+++ b/docs/specs/gh-issue-350-read-scaling-priority.md
@@ -10,6 +10,7 @@ governingAdrs: [genai-enablement/ADR-0017, Omniscience/ADR-0019]
 capabilitySpecs: [SPEC-MCP, SPEC-EV, SPEC-OPS]
 sddMode: full
 repo: 100rd/Omniscience
+evidenceDestination: component-execution-index://docs/specs/execution-index.json#gh-issue-350-read-scaling-priority
 scope:
   include:
     - apps/server/src/omniscience_server/rest/rate_limit.py

--- a/docs/specs/gh-issue-355-set-sources-tenant-id-from-the-token-workspace-on-create.md
+++ b/docs/specs/gh-issue-355-set-sources-tenant-id-from-the-token-workspace-on-create.md
@@ -13,6 +13,7 @@ capabilitySpecs:
   - SPEC-ACL
 sddMode: full
 repo: 100rd/Omniscience
+evidenceDestination: component-execution-index://docs/specs/execution-index.json#gh-issue-355
 scope:
   include:
     - apps/server/src/omniscience_server/rest/sources.py

--- a/docs/specs/task-sp-61-pii-wall-pw0.md
+++ b/docs/specs/task-sp-61-pii-wall-pw0.md
@@ -1,0 +1,45 @@
+---
+id: task-sp-61-pii-wall-pw0
+title: Implement the fail-closed PW0 knowledge propagation boundary
+status: ready
+readiness:
+  approvedBy: "@100rd"
+  approvedAt: 2026-07-21
+source: { kind: human, ref: "SP-61" }
+governingAdrs: [genai-enablement/ADR-0018, Omniscience/ADR-0020]
+capabilitySpecs: [SPEC-PII]
+sddMode: full
+repo: 100rd/Omniscience
+evidenceDestination: ci-artifact://synchronized-platform/task-sp-61-pii-wall-pw0/
+scope:
+  include:
+    - apps/server/src/omniscience_server/privacy/**
+    - packages/core/src/omniscience_core/privacy/**
+    - contracts/pii/**
+    - tests/test_pii*.py
+    - tests/privacy/**
+    - docs/runbooks/pii-wall.md
+  exclude: [docs/decisions/**, docs/specs/**, specs/**, graphify-out/**, terraform/**]
+acceptanceCriteria:
+  - id: AC-SP61-1
+    requirement: PW0 blocks or sanitizes before every ordinary store, parse/chunk/embed/projection sink
+    probe: P-PII-1+P-PII-2+P-PII-3
+    expected: seeded personal, sensitive, prohibited and unknown fixtures never reach protected sinks
+    groundTruth: human-approved task revision and SPEC-PII probe contract, immutable to the execution identity
+  - id: AC-SP61-2
+    requirement: Policy skew, detector failure and quarantine failure are closed and visible
+    probe: P-PII-7+P-PII-8
+    expected: affected ingestion parks with a non-identifying receipt and no unsafe fallback
+    groundTruth: accepted policy-skew and dependency-failure matrix in SPEC-PII, independently replayed
+  - id: AC-SP61-3
+    requirement: Lifecycle receipts remain per-store and partial
+    probe: P-PII-5+P-PII-6
+    expected: deletion/restore cannot claim complete while any required store is pending or unavailable
+    groundTruth: per-store owner lifecycle receipts and SPEC-PII completion rules, not aggregate producer status
+rollback: { kind: revert-pr, probe: disable-unreleased-pw0-code-and-retain-ingestion-refusal }
+---
+
+## Authority boundary
+
+Repository-local implementation and disposable fixtures only. No live personal data, provider call,
+profile activation, production quarantine store, destructive deletion, deployment or privacy claim.

--- a/docs/specs/task-sp-81-management-context-v1.md
+++ b/docs/specs/task-sp-81-management-context-v1.md
@@ -1,0 +1,45 @@
+---
+id: task-sp-81-management-context-v1
+title: Implement management context and knowledge-quality producer v1
+status: ready
+readiness:
+  approvedBy: "@100rd"
+  approvedAt: 2026-07-21
+source: { kind: human, ref: "SP-81" }
+governingAdrs: [genai-enablement/ADR-0017, genai-enablement/ADR-0020, Omniscience/ADR-0021]
+capabilitySpecs: [SPEC-MCTX, SPEC-EV, SPEC-KP, SPEC-MCP, SPEC-ACL, SPEC-OPS]
+sddMode: full
+repo: 100rd/Omniscience
+evidenceDestination: ci-artifact://synchronized-platform/task-sp-81-management-context-v1/
+scope:
+  include:
+    - apps/server/src/omniscience_server/management/**
+    - packages/core/src/omniscience_core/management/**
+    - contracts/management/**
+    - tests/test_management_context*.py
+    - tests/management/**
+    - docs/api/management-context.md
+  exclude: [docs/decisions/**, docs/specs/**, specs/**, graphify-out/**, terraform/**]
+acceptanceCriteria:
+  - id: AC-SP81-1
+    requirement: Producer emits schema-valid cited context and orthogonal quality axes
+    probe: P-MCTX-1+P-MCTX-2+P-MCTX-4+P-MCTX-7
+    expected: pinned fixtures reproduce exact envelopes, citations and quality conditions
+    groundTruth: human-approved task revision and SPEC-MCTX requirement/probe contract, immutable to the execution identity
+  - id: AC-SP81-2
+    requirement: Producer cannot emit management truth or unsafe content
+    probe: P-MCTX-3+P-MCTX-5
+    expected: authority fields, active content, credentials and seeded PII fail before response
+    groundTruth: accepted SPEC-MCTX forbidden-field and PII corpus replayed by the independent conformance runner
+  - id: AC-SP81-3
+    requirement: Contract skew and severance are safe
+    probe: P-MCTX-6
+    expected: exact fallback-required states replace best-effort parsing or stale success
+    groundTruth: pinned producer manifest plus independently induced skew and severance observations
+rollback: { kind: revert-pr, probe: remove-unreleased-management-endpoint-and-retain-direct-source-path }
+---
+
+## Authority boundary
+
+Build schemas, fixtures, read-only producer code and conformance only. No live consumer pin, production
+token, provider/model call, management decision, deployment or readiness claim.

--- a/scripts/check_mcp_contract_drift.py
+++ b/scripts/check_mcp_contract_drift.py
@@ -531,10 +531,10 @@ def _validate_docs(root: Path, errors: list[str]) -> None:
     for fact in (
         "**Current release:** `v0.5.0`",
         "**Current engineering slice:** MCP contract `1.0.0`",
-        "production-ha | `ready/queued`",
-        "backup-restore | `ready/queued`",
-        "read-scaling-priority | `ready/queued`",
-        "consumer-severance | `ready/queued`",
+        "production-ha | `implemented/unverified`",
+        "backup-restore | `implemented/unverified`",
+        "read-scaling-priority | `implemented/unverified`",
+        "consumer-severance | `implemented/unverified`",
         "fail-closed portable canary verifier",
     ):
         _require_text(roadmap, fact, ROADMAP_DOC, errors)

--- a/specs/SPEC-INDEX.md
+++ b/specs/SPEC-INDEX.md
@@ -1,10 +1,16 @@
 # Omniscience Capability SPEC Index
 
+Cross-repository dependencies and independently claimable work packages are discoverable from the root
+[`PLATFORM.md`](../PLATFORM.md). This file remains the authoritative complete Omniscience capability
+inventory.
+
 Capability SPECs translate accepted human ADR decisions into reusable agent-executable contracts.
 They do not authorize one task; bounded work lives in `docs/specs/` and cites these contracts.
 
 All initial SDD specs are `ready` under accepted ADR-0019 and explicit owner approval recorded in
-each contract. Implementation and verification remain separate states backed by their probes.
+each contract. `SPEC-PII` and `SPEC-MCTX` are separately ready under accepted ADR-0020/0021 and the
+2026-07-21 owner development decision.
+Implementation and verification remain separate states backed by their probes.
 
 | ID | Capability | Primary boundary |
 |---|---|---|
@@ -15,6 +21,8 @@ each contract. Implementation and verification remain separate states backed by 
 | [SPEC-ACL](SPEC-ACL-workspace-isolation.md) | Workspace isolation | server-derived tenant scope and non-disclosure |
 | [SPEC-OPS](SPEC-OPS-operational-evidence.md) | Operational evidence | CI, conformance, benchmark, DR, documentation consistency |
 | [SPEC-MCP](SPEC-MCP-stable-contract-v1.md) | Stable MCP v1 | content-addressed wire contract, freshness, token profile, severance |
+| [SPEC-PII](SPEC-PII-pii-wall-ingestion-lifecycle.md) | PII Wall | pre-store/pre-embedding admission and cross-store lifecycle coverage |
+| [SPEC-MCTX](SPEC-MCTX-management-context-producer.md) | Management context producer | cited context and orthogonal knowledge-quality conditions; never management authority |
 
 ## Dependency order
 
@@ -26,6 +34,8 @@ ADR-0019
    +--> SPEC-ACL --------^       |
    +--> SPEC-OPS <---------------+
    +--> SPEC-EV + SPEC-KP + SPEC-ACL + SPEC-OPS --> SPEC-MCP
+   +--> SPEC-ACL + SPEC-SOT + SPEC-EV + SPEC-OPS --> SPEC-PII
+   +--> SPEC-ACL + SPEC-EV + SPEC-KP + SPEC-MCP + SPEC-OPS --> SPEC-MCTX
 ```
 
 ## Capability SPEC states

--- a/specs/SPEC-MCTX-management-context-producer.md
+++ b/specs/SPEC-MCTX-management-context-producer.md
@@ -1,0 +1,93 @@
+# SPEC-MCTX: Management context and knowledge-quality producer
+
+Status: ready · Depends on: SPEC-ACL, SPEC-EV, SPEC-KP, SPEC-MCP, SPEC-OPS · signal-only: SPEC-PII
+
+## Governing ADRs
+
+- genai-enablement ADR-0017 and ADR-0020
+- Omniscience ADR-0019 and ADR-0021
+
+## Goal
+
+Publish cited, scoped and severable context for Barbarossa and other management consumers without
+turning knowledge retrieval, synthesis or quality scoring into management truth or authority.
+
+## Scope
+
+**In:** request authorization; exact management purpose; evidence fitness; citations; provenance,
+freshness, coverage, conflicts and projection health; knowledge-quality snapshots; PII-safe field
+selection; version negotiation; content-addressed fixtures and severance behavior.
+
+**Out:** domain observations or snapshots; SLO/risk/budget policy; incident/action decisions; arbitrary
+graph access; agent/model recommendations presented as facts; consumer implementation; live activation.
+
+## Requirements
+
+[REQ-MCTX-1] A request binds tenant/workspace, subject, management domain and purpose, requested field
+classes, source/evidence cut, maximum age, contract/schema revisions, caller identity and correlation id.
+**Fallback:** missing, foreign, widened, future or unsupported scope is denied without retrieval.
+
+[REQ-MCTX-2] A `ManagementContextBundle` binds the request digest, producer/source revisions, produced
+and observed times, freshness deadline, coverage and source-health axes, citations, conflict set,
+projection state, PII receipt and integrity. **Fallback:** an incomplete bundle is unavailable, never a
+partial favorable result.
+
+[REQ-MCTX-3] Every factual statement is joined to one or more stable source citations and exact evidence
+fitness. Generated summaries are explicitly typed `synthesis` and cannot create an uncited fact.
+**Fallback:** unsupported content is omitted and recorded as a coverage gap.
+
+[REQ-MCTX-4] `KnowledgeQualitySnapshot` reports provenance, freshness, conformance, coverage, conflict
+and projection conditions independently. It publishes no global quality score and no management verdict.
+**Fallback:** missing required evidence yields `unknown`, `partial` or `severed` on the affected axis.
+
+[REQ-MCTX-5] The producer never emits availability, error-budget, incident, cost opportunity, risk,
+compliance, action, approval, effect or verification truth. **Fallback:** forbidden authority fields fail
+schema and conformance checks.
+
+[REQ-MCTX-6] PII policy is applied before retrieval projection and response assembly. The output carries
+only admitted fields and non-identifying receipts; active content, credentials and raw personal data are
+forbidden. **Fallback:** use a narrower safe projection or return privacy-blocked.
+
+[REQ-MCTX-7] Consumers pin an exact contract major, schema and producer manifest. Unknown major, digest
+skew or incompatible capability returns typed fallback-required. **Fallback:** no best-effort parsing.
+
+[REQ-MCTX-8] Severance is first-class. Producer loss, token revocation, source outage and stale evidence
+return distinguishable states; already materialized consumer work continues from direct sources or
+parks under consumer policy. **Fallback:** no cached context is represented as current beyond expiry.
+
+[REQ-MCTX-9] Access is read-only, least-privilege and purpose scoped. The API exposes closed query
+profiles, not arbitrary Cypher/vector queries or browsing of another workspace. **Fallback:** unsupported
+query shapes are denied and audited without echoing protected values.
+
+[REQ-MCTX-10] Context artifacts are content-addressed and replayable against fixtures. Same inputs and
+evidence cut produce the same envelope metadata and citation set; optional synthesis cannot affect the
+deterministic quality snapshot. **Fallback:** nondeterministic synthesis is excluded from authority and
+replay comparisons.
+
+## Interfaces
+
+```text
+ManagementContextRequest
+ManagementContextBundle
+ManagementCitation
+KnowledgeQualitySnapshot
+ManagementContextCapabilityManifest
+```
+
+## Verification
+
+- **P-MCTX-1 scope:** cross-tenant/workspace/purpose/field widening is denied before retrieval.
+- **P-MCTX-2 citations:** every fact has a valid citation and missing citations become coverage gaps.
+- **P-MCTX-3 no-authority:** forbidden management verdict/action fields fail static and schema checks.
+- **P-MCTX-4 quality axes:** missing/conflicting evidence cannot collapse to a favorable scalar.
+- **P-MCTX-5 PII/content:** seeded PII, credentials and active content never reach bundle or logs.
+- **P-MCTX-6 skew/severance:** version mismatch, token revocation and producer/source loss select exact
+  fallback-required states without false freshness.
+- **P-MCTX-7 replay:** deterministic envelope/citation/quality outputs reproduce from pinned fixtures.
+
+## Open questions / deferred
+
+- [must-resolve-before-live] Production identity issuer, token TTL, endpoint and rate/admission profile.
+- [must-resolve-before-live] First released consumer revision and live severance receipt.
+- [defer] Optional model-generated narrative after separate provider/PII admission; deterministic fields
+  remain complete without it.

--- a/specs/SPEC-MCTX-management-context-producer.md
+++ b/specs/SPEC-MCTX-management-context-producer.md
@@ -1,6 +1,7 @@
 # SPEC-MCTX: Management context and knowledge-quality producer
 
 Status: ready · Depends on: SPEC-ACL, SPEC-EV, SPEC-KP, SPEC-MCP, SPEC-OPS · signal-only: SPEC-PII
+Readiness: human-approved by @100rd on 2026-07-22 under accepted ADR-0019
 
 ## Governing ADRs
 
@@ -77,13 +78,22 @@ ManagementContextCapabilityManifest
 ## Verification
 
 - **P-MCTX-1 scope:** cross-tenant/workspace/purpose/field widening is denied before retrieval.
-- **P-MCTX-2 citations:** every fact has a valid citation and missing citations become coverage gaps.
-- **P-MCTX-3 no-authority:** forbidden management verdict/action fields fail static and schema checks.
+- **P-MCTX-2 envelope:** missing source revisions, time bounds, coverage, citations, PII receipt or
+  integrity makes the complete bundle unavailable rather than partially favorable.
+- **P-MCTX-3 citations:** every fact has a valid citation and missing citations become coverage gaps;
+  synthesis cannot introduce an uncited fact.
 - **P-MCTX-4 quality axes:** missing/conflicting evidence cannot collapse to a favorable scalar.
-- **P-MCTX-5 PII/content:** seeded PII, credentials and active content never reach bundle or logs.
-- **P-MCTX-6 skew/severance:** version mismatch, token revocation and producer/source loss select exact
-  fallback-required states without false freshness.
-- **P-MCTX-7 replay:** deterministic envelope/citation/quality outputs reproduce from pinned fixtures.
+- **P-MCTX-5 no-authority:** forbidden management verdict, incident, action, approval and effect fields
+  fail static and schema checks.
+- **P-MCTX-6 PII/content:** seeded PII, credentials and active content never reach bundle or logs.
+- **P-MCTX-7 version pin:** unknown contract major, schema or producer-manifest skew selects the typed
+  fallback-required path without best-effort parsing.
+- **P-MCTX-8 severance:** token revocation and producer/source loss select distinct unavailable states;
+  expired cached context is never represented as current.
+- **P-MCTX-9 closed access:** arbitrary graph/vector queries, foreign workspaces and unsupported query
+  profiles are denied and audited without protected-value echo.
+- **P-MCTX-10 replay:** deterministic envelope, citation and quality outputs reproduce from pinned
+  content-addressed fixtures while optional synthesis is excluded from the comparison.
 
 ## Open questions / deferred
 

--- a/specs/SPEC-PII-pii-wall-ingestion-lifecycle.md
+++ b/specs/SPEC-PII-pii-wall-ingestion-lifecycle.md
@@ -1,0 +1,144 @@
+# SPEC-PII: PII Wall — ingestion, knowledge stores, and lifecycle
+
+Status: ready · Depends on: SPEC-ACL, SPEC-SOT, SPEC-EV, SPEC-OPS · signal-only: SPEC-KP, SPEC-MCP
+
+## Governing ADRs
+
+- genai-enablement ADR-0018 (accepted) - distributed, purpose-bound PII Wall
+- ADR-0020 (accepted) - Omniscience PII Wall adoption and development boundary
+- ADR-0019 (accepted) - governed evidence boundary and capability readiness
+
+## Goal
+
+Prevent unadmitted personal data from propagating through Omniscience. Classification and policy
+admission happen before durable raw-document storage, parsing, chunking, embedding, graph/vector
+projection, archive, retrieval, or external egress; lifecycle operations return exact coverage
+receipts across every knowledge-store class.
+
+## Scope
+
+**In:** server-derived tenant/workspace and source policy; pre-ingest classification; quarantine;
+redaction/tokenization adapters; PW0/PW1/PW2 admission; storage and projection labels; embedding-provider
+admission; retrieval revalidation; correction/export/deletion/retention coverage; non-identifying
+privacy evidence.
+
+**Out:** legal classification and consent; policy authorship; Omnius prompt/model/tool enforcement;
+portal rendering; a general token-reidentification service; changing current ingestion runtime through
+this draft.
+
+## Requirements
+
+[REQ-PII-1] **Scope and policy are server-derived before content handling.** The authenticated principal,
+Source mapping, and signed policy revision determine tenant, workspace, source class, and allowed
+profile. Connector payloads, document content, metadata, and caller labels cannot widen them.
+**Fallback:** missing, foreign, ambiguous, expired, or signature-invalid scope/policy rejects before
+decode and emits only a scoped failure receipt.
+
+[REQ-PII-2] **Classification precedes the first durable or external sink.** Structured schema rules and
+deterministic detectors run before a raw document, parsed structure, chunk, embedding request, vector,
+graph node, cache, outbox payload, archive, backup seed, or provider request is created. Statistical/LLM
+classification may widen but never downgrade. **Fallback:** detector error, incomplete coverage, or
+unknown classification quarantines or blocks; the ordinary ingestion pipeline receives no content.
+
+[REQ-PII-3] **PW0 is the default admission profile.** Only `public`, `internal_non_personal`, or
+deterministically redacted content may enter normal stores, projections, embeddings, or retrieval under
+PW0. Raw `personal`, `sensitive_personal`, `prohibited`, and `unknown` data is rejected or held in an
+owner-controlled sealed quarantine outside normal indexes. **Fallback:** if the quarantine boundary is
+not independently qualified, reject without retaining the body.
+
+[REQ-PII-4] **Every transformation is deterministic, field-aware, and receipted.** Redaction or
+pseudonymization records input digest, optional safe-output digest, policy/detector revisions,
+field-level transformation set, coverage, and disposition in a `SanitizationReceipt`. Receipts contain
+no raw PII. **Fallback:** partial transformation or unrecognized structure remains quarantined and
+cannot be treated as sanitized.
+
+[REQ-PII-5] **PW1 pseudonyms are non-global and non-reidentifying here.** Tokens are tenant-scoped and,
+when correlation is needed, purpose/source scoped. Omniscience does not hold a general reveal key or
+expose a reveal tool. Raw and tokenized values cannot be searched together to recreate identity.
+**Fallback:** unavailable or over-broad tokenization falls back to irreversible redaction or PW0 reject.
+
+[REQ-PII-6] **PW2 requires an exact external permit.** Raw processing requires a valid `PIIPermit`
+binding source, selected fields, processing purpose, Omniscience sink/store/provider set, workload,
+tenant/workspace, retention deadline, policy revision, and expiry. Field, sink, provider, purpose, or
+time widening denies. **Fallback:** absent/expired/unverifiable permit blocks before the selected sink;
+there is no administrator or model best-effort override in the ingestion path.
+
+[REQ-PII-7] **Classification and lineage propagate to every derivative.** Document, parsed object, chunk,
+embedding/vector, graph entity/edge, cache, outbox, archive, and backup manifest retain the envelope id,
+class, transformation state, policy revision, source lineage, purpose/permit reference where applicable,
+and retention deadline. **Fallback:** a store adapter that cannot persist and enforce the minimum
+metadata is not admitted for PW1/PW2 and receives PW0-safe data only when independently proven.
+
+[REQ-PII-8] **Retrieval and egress re-evaluate the consumer sink.** Search, MCP/API response, export,
+connector callback, synthesis, and embedding-provider calls validate workspace, profile, purpose,
+allowed fields, policy freshness, and requested sink. Retrieval never silently rehydrates redacted
+data or returns a pseudonym outside its correlation scope. **Fallback:** mismatch produces a
+non-disclosing deny or a PW0-safe projection with an explicit degraded/coverage state.
+
+[REQ-PII-9] **Lifecycle operations cover ledger, projections, caches, archives, and backups.** Correction,
+export, retention expiry, and deletion enumerate Postgres, Neo4j, Qdrant, object/archive storage,
+caches, outboxes, checkpoints, quarantine, and backup generations. A `DeletionReceipt` names completed,
+excluded, pending, unavailable, and immutable-retention classes. **Fallback:** partial work parks and
+alerts; no API, task, or UI may report complete.
+
+[REQ-PII-10] **Privacy observability is useful without becoming a leak.** Metrics expose counts, latency,
+coverage, policy/detector revisions, store classes, and stable pseudonymous references. Logs, traces,
+errors, receipts, evidence bundles, and operational UI contain no raw values or reversible fingerprints.
+**Fallback:** an unsafe diagnostic field is dropped and the event records `redacted_diagnostic`; loss of
+the privacy evidence channel blocks readiness claims but not fail-closed enforcement.
+
+## Interfaces
+
+**Exposes:**
+
+```text
+IngestPIIGate.evaluate(source, principal, body_ref, policy_pin) -> admitted envelope | quarantine | deny
+KnowledgePIIProjection.read(scope, purpose, requested_fields) -> safe DataEnvelope[]
+PrivacyCoverage.read(workspace_id, policy_revision) -> PrivacyCoverage
+LifecyclePII.execute(request) -> DeletionReceipt | partial | denied
+```
+
+**Consumes:** signed `PIIPolicyBundle` and `PIIPermit` contracts; SPEC-ACL workspace resolution;
+SPEC-SOT store/outbox semantics; SPEC-EV lineage; SPEC-OPS evidence discipline. SPEC-KP and SPEC-MCP
+consume only released safe projections and coverage metadata.
+
+## Verification
+
+- **P-PII-1 pre-propagation:** seed each class and prove disallowed bytes never reach raw documents,
+  chunks, embedding requests, Postgres, Neo4j, Qdrant, cache, outbox, archive, or logs.
+- **P-PII-2 fail-closed matrix:** missing/expired/skewed policy, detector exception, forged workspace,
+  unknown class, permit expiry, field/sink/provider widening, and quarantine outage all reject before
+  ordinary ingestion.
+- **P-PII-3 transformation:** structured and free-text fixtures produce expected field manifests and
+  receipts; partial parsing never claims sanitized.
+- **P-PII-4 pseudonym isolation:** equal inputs in two tenants/purposes do not produce a joinable global
+  identity, and no reveal surface is reachable.
+- **P-PII-5 retrieval:** PW0/PW1/PW2 consumers receive only their admitted fields; MCP/search/export
+  cannot rehydrate or bypass purpose.
+- **P-PII-6 lifecycle:** delete one seeded subject/workspace across every store, restore an older backup,
+  reapply deletion, and prove the receipt remains partial until all declared coverage closes.
+- **P-PII-7 telemetry:** scan response/log/trace/metric/evidence/UI corpora for every seeded raw value and
+  reversible token; results are zero.
+- **P-PII-8 severance:** policy or evidence-plane loss blocks new propagation while already sanitized,
+  permitted reads follow explicit freshness/expiry rules.
+
+## Invariants honored
+
+ADR-0018 PII-1 through PII-8 and PII-10; SPEC-ACL server-derived workspace and non-disclosure; SPEC-SOT
+ledger/projection convergence; SPEC-EV lineage; SPEC-KP/MCP severability.
+
+## Open questions / deferred
+
+- [resolved-for-development] Consume the exact content-addressed `SPEC-PII-POLICY` bundle and a
+  deployment-supplied signer trust profile. Development uses a fixture signer; no live trust root or
+  active policy is defaulted.
+- [resolved-for-development] Implement the ADR-0020 `QuarantineStore` interface with disposable
+  fixtures. A live backend, access path, encryption, maximum retention and purge/forensic authority are
+  required before live activation.
+- [resolved-for-development] Treat every embedding/enrichment provider as an explicit policy sink and
+  deny when its exact field, retention, training and region posture is absent. No protected-data provider
+  is enabled by this SPEC.
+- [must-resolve-before-PW1] Tokenization algorithm, scope derivation, collision policy, and separate
+  re-identification-vault owner if reversible tokens are admitted.
+- [must-resolve-before-PW2] Permit issuer, purpose registry, field grammar, emergency process, and
+  subject/lifecycle correlation contract.

--- a/specs/SPEC-PII-pii-wall-ingestion-lifecycle.md
+++ b/specs/SPEC-PII-pii-wall-ingestion-lifecycle.md
@@ -1,6 +1,7 @@
 # SPEC-PII: PII Wall — ingestion, knowledge stores, and lifecycle
 
 Status: ready · Depends on: SPEC-ACL, SPEC-SOT, SPEC-EV, SPEC-OPS · signal-only: SPEC-KP, SPEC-MCP
+Readiness: human-approved by @100rd on 2026-07-22 under accepted ADR-0019
 
 ## Governing ADRs
 
@@ -104,23 +105,26 @@ consume only released safe projections and coverage metadata.
 
 ## Verification
 
-- **P-PII-1 pre-propagation:** seed each class and prove disallowed bytes never reach raw documents,
-  chunks, embedding requests, Postgres, Neo4j, Qdrant, cache, outbox, archive, or logs.
-- **P-PII-2 fail-closed matrix:** missing/expired/skewed policy, detector exception, forged workspace,
-  unknown class, permit expiry, field/sink/provider widening, and quarantine outage all reject before
-  ordinary ingestion.
-- **P-PII-3 transformation:** structured and free-text fixtures produce expected field manifests and
-  receipts; partial parsing never claims sanitized.
-- **P-PII-4 pseudonym isolation:** equal inputs in two tenants/purposes do not produce a joinable global
-  identity, and no reveal surface is reachable.
-- **P-PII-5 retrieval:** PW0/PW1/PW2 consumers receive only their admitted fields; MCP/search/export
-  cannot rehydrate or bypass purpose.
-- **P-PII-6 lifecycle:** delete one seeded subject/workspace across every store, restore an older backup,
+- **P-PII-1 scope policy:** forged workspace, caller-supplied scope, missing mapping and invalid policy
+  signature all reject before content decode and emit only a scoped failure receipt.
+- **P-PII-2 pre-propagation:** seed each class and prove disallowed bytes never reach raw documents,
+  chunks, embedding requests, Postgres, Neo4j, Qdrant, cache, outbox, archive, backup seed or logs.
+- **P-PII-3 PW0 default:** personal, sensitive, prohibited and unknown fixtures cannot enter normal
+  stores; unavailable quarantine causes body-free rejection.
+- **P-PII-4 transformation:** structured and free-text fixtures produce deterministic field manifests
+  and non-identifying receipts; partial parsing never claims sanitized.
+- **P-PII-5 pseudonym isolation:** equal inputs in two tenants or purposes do not produce a joinable
+  global identity, and no reveal surface is reachable.
+- **P-PII-6 PW2 permit:** permit expiry and field, sink, provider, purpose or time widening reject before
+  the selected sink without an administrator or model override.
+- **P-PII-7 lineage:** every admitted derivative retains the required envelope, class, transformation,
+  policy, source, purpose and retention metadata; incapable adapters receive no PW1/PW2 data.
+- **P-PII-8 retrieval:** PW0/PW1/PW2 consumers receive only their admitted fields; MCP, search, export,
+  synthesis and provider egress cannot rehydrate or bypass purpose.
+- **P-PII-9 lifecycle:** delete one seeded subject/workspace across every store, restore an older backup,
   reapply deletion, and prove the receipt remains partial until all declared coverage closes.
-- **P-PII-7 telemetry:** scan response/log/trace/metric/evidence/UI corpora for every seeded raw value and
-  reversible token; results are zero.
-- **P-PII-8 severance:** policy or evidence-plane loss blocks new propagation while already sanitized,
-  permitted reads follow explicit freshness/expiry rules.
+- **P-PII-10 telemetry:** scan response, log, trace, metric, receipt, evidence and UI corpora for every
+  seeded raw value and reversible fingerprint; results are zero and unsafe diagnostics are dropped.
 
 ## Invariants honored
 


### PR DESCRIPTION
Publishes the reviewed Synchronized Platform development handoff on main.

Included:
- accepted and component-owned ADRs
- capability specs and independently executable task specs
- platform entrypoints, indexes, dependency order, and evidence contracts
- central registry alignment across all five components
- portable construction evidence where referenced by the central specs

Verification:
- synchronized-platform hermetic and workspace checks
- portfolio drift check
- 67 contract tests
- 34 ready handoff YAML contracts
- staged Markdown links and diff checks
- full genai SRE harness pytest suite on Python 3.11