### PR TITLE
docs: make management release language neutral

### DIFF
--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -39,6 +39,7 @@ accepted genai-enablement ADR
 | `SP-12` consumer severance | `gh-issue-350-consumer-severance` | producer fixtures/verifier merged; Omnius/SRE receipts and live drill remain external |
 | `SP-61` knowledge-plane PII boundary | `SPEC-PII` + `task-sp-61-pii-wall-pw0` | ready for fail-closed non-live development; no profile or data path is active |
 | `SP-81` management-context producer | `SPEC-MCTX` + `task-sp-81-management-context-v1` | ready for bounded non-live producer development; no consumer/live authority |
+| `SP-86` management-readonly release | `SPEC-MCP`, `SPEC-PII`, `SPEC-MCTX` + `task-sp-86-management-readonly-release` | ready to publish one language-neutral immutable release candidate; independent of concurrent Barbarossa SP-90, while SP-87/SP-88 consumer receipts and activation remain external |
 | issue-350 HA | `gh-issue-350-production-ha` | portable profile merged; live fault-domain proof and stateful topology entitlements remain unverified |
 | issue-350 recovery | `gh-issue-350-backup-restore` | safety harness merged; every destructive drill still needs separate exact human approval |
 | issue-350 scaling | `gh-issue-350-read-scaling-priority` | controller/qualification logic merged; shared-backend selection, dispatch wiring and multi-replica proof remain |
@@ -57,6 +58,21 @@ park safely.
 
 Portfolio state and accepted cross-repository decisions cannot promote an Omniscience task to
 `implemented` or `verified`; only component-owned execution evidence can do that.
+
+## Initial runtime profile
+
+Accepted local ADR-0022 adopts `management-readonly-v1`. Omniscience publishes read-only evidence,
+management context, knowledge-quality and non-identifying PW0 projections to exact Barbarossa and
+Platform Portal consumers. Omnius remains part of the target architecture but is not deployed, not a
+consumer gate, and not represented by a live mock in this profile.
+
+The profile does not make Omniscience authoritative for Reliability. Barbarossa retains direct-source
+operation and typed severance; Portal releases owner panels independently and displays Omnius as
+`not_deployed`.
+
+Central ADR-0022 selects Go for the Barbarossa production runtime. That decision does not change the
+Omniscience implementation or producer schema: SP-86 publishes language-neutral contracts and may run
+in parallel with SP-90. SP-87 is responsible for binding both immutable receipts.
 
 ## PII Wall boundary
 

--- a/docs/decisions/0022-management-readonly-runtime-release.md
+++ b/docs/decisions/0022-management-readonly-runtime-release.md
@@ -1,0 +1,73 @@
+# ADR-0022: Adopt the Management Read-Only runtime release boundary
+
+Status: accepted
+- **Date:** 2026-07-25
+- **Deciders:** platform owner and Omniscience owner
+- **Governing decisions:** `genai-enablement` ADR-0012, ADR-0017, ADR-0018, ADR-0020, ADR-0021 and ADR-0022
+- **Related local decisions:** ADR-0019, ADR-0020 and ADR-0021
+
+## Context
+
+The first synchronized-platform deployment profile selects Omniscience, Barbarossa and Platform Portal
+while deferring the Omnius Dark Factory. Omniscience already has repository-local MCP v1, PW0 and
+management-context implementations, plus container and Helm packaging. Those facts do not yet form one
+immutable runtime release or prove that the selected consumers can use and sever it safely.
+
+The release must not make Omniscience a Reliability dependency or management authority. It must also
+avoid requiring an Omnius consumer receipt for a profile in which Omnius is deliberately not deployed.
+The newly explicit Barbarossa Go decision must not leak a consumer implementation language into the
+Omniscience producer contract or serialize SP-86 behind the independent SP-90 migration.
+
+## Decision
+
+Omniscience adopts `management-readonly-v1` through one owner-produced release contract:
+`OmniscienceManagementReadOnlyRelease`.
+
+The release binds the exact Git commit, image digest, Helm chart/config digest, MCP and management-context
+contract manifests, schema digests, token/auth profile, SP-60 policy revision, SP-61 PW0 evidence,
+dependency/readiness profile, supported consumer class, evidence references, and rollback target.
+Mutable tags, branches, `latest`, dirty trees and unpinned policy/configuration cannot enter the release.
+
+Producer schemas, fixtures and verification material are language-neutral. A Go consumer can validate
+and consume the release without executing Node.js or depending on a TypeScript-only generated binding.
+SP-86 has no dependency on the Barbarossa SP-90 migration and may execute concurrently with it. The
+later SP-87 consumer task, not Omniscience, joins exact SP-86 and SP-90 receipts.
+
+The selected runtime surface is read-only for consumers. It exposes MCP v1 evidence/context reads,
+management context and knowledge-quality projections, non-identifying privacy coverage/receipts, and
+owner-local health/readiness/metrics. It exposes no management verdict, action recommendation,
+authorization, owner mutation, raw-PII permit or generic query surface.
+
+PW0 remains fail closed before raw persistence, parsing, chunking, embedding, graph/vector projection,
+provider egress, retrieval response, telemetry, archive and backup. A seeded-PII failure cannot be
+masked by sanitizing only the response.
+
+Barbarossa and Platform Portal consume the release under their own tasks and return their own exact
+contract/severance receipts. Omniscience may validate supplied receipts read-only but cannot create,
+repair or sign on behalf of a consumer. Omnius is not a selected consumer and its absence is not a
+producer error for this profile. The existing full SP-12 Omnius/SRE conformance task remains valid and
+separate.
+
+Omniscience loss removes optional Barbarossa context and its Portal panels. Barbarossa continues from
+direct authoritative observations or parks only when those sources also fail. No cache, summary or
+prior success is promoted to current truth after freshness or contract expiry.
+
+## Release invariants
+
+- **OMR-1:** every executable, schema, policy and configuration input is content addressed.
+- **OMR-2:** consumer reads are tenant/workspace and purpose bound with a closed field set.
+- **OMR-3:** PW0 failure precedes every durable, derived, provider and export boundary.
+- **OMR-4:** context never contains a domain outcome, incident decision, priority, approval or effect.
+- **OMR-5:** readiness reports the selected dependency closure and cannot call a disabled worker healthy.
+- **OMR-6:** consumer severance is typed and retains no stale-current success.
+- **OMR-7:** Omnius endpoint, credential, mock and receipt are absent from the release configuration.
+- **OMR-8:** the release receipt grants no deployment activation or management authority.
+- **OMR-9:** the producer kit has no TypeScript/Node-only consumer requirement and SP-86 remains
+  independent of SP-90.
+
+## Development authority
+
+This decision authorizes the bounded SP-86 implementation and disposable qualification in
+`task-sp-86-management-readonly-release`. It does not authorize production data, raw PII, a model or
+external provider, a production credential, an infrastructure mutation, deployment activation,
+Barbarossa truth, Portal truth, Omnius work, or a production-readiness claim.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -29,6 +29,7 @@ Statuses: `Proposed`, `Accepted`, `Implemented`, `Superseded`, `Deprecated`.
 | [ADR-0019](0019-dark-factory-sdd-and-knowledge-plane-boundary.md) | Dark Factory SDD and knowledge-plane boundary | Accepted |
 | [ADR-0020](0020-adopt-distributed-pii-wall.md) | Adopt the distributed PII Wall at every knowledge propagation boundary | Accepted |
 | [ADR-0021](0021-management-context-producer.md) | Publish severable management context without management authority | Accepted |
+| [ADR-0022](0022-management-readonly-runtime-release.md) | Adopt the language-neutral Management Read-Only runtime release boundary, independent of Barbarossa SP-90 | Accepted |
 
 `ADR-0018` was originally committed with the duplicate id `ADR-0015`. The rename is a
 registry repair, not a change to its accepted decision.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -50,9 +50,11 @@ or reinterpret readiness as production/cloud/destructive authority.
 |---|---|---|
 | [task-sp-61-pii-wall-pw0](task-sp-61-pii-wall-pw0.md) | `ready` | fail-closed repository-local PW0 propagation boundary and fixtures |
 | [task-sp-81-management-context-v1](task-sp-81-management-context-v1.md) | `ready` | cited management context and knowledge-quality producer v1 |
+| [task-sp-86-management-readonly-release](task-sp-86-management-readonly-release.md) | `ready` | immutable language-neutral MCP/context/PW0 runtime release and selected-consumer severance qualification; independent of Barbarossa SP-90 |
 
-Both tasks are human-ready for their exact non-live repository scopes. They authorize no production
-policy/profile, live personal data, credential, provider, consumer pin, deployment or external effect.
+All three tasks are human-ready for their exact repository-local scopes. SP-86 may run concurrently
+with Barbarossa SP-90 and produce a release candidate plus disposable qualification evidence, but none authorizes a production policy/profile, live
+personal data, credential, provider, deployment activation or external effect.
 
 ## Terminal execution evidence
 

--- a/docs/specs/task-sp-86-management-readonly-release.md
+++ b/docs/specs/task-sp-86-management-readonly-release.md
@@ -1,0 +1,102 @@
+---
+id: task-sp-86-management-readonly-release
+title: Publish the Omniscience management-readonly-v1 release candidate
+status: ready
+readiness:
+  approvedBy: "@100rd"
+  approvedAt: 2026-07-25
+source: { kind: human, ref: "SP-86" }
+governingAdrs: [genai-enablement/ADR-0012, genai-enablement/ADR-0017, genai-enablement/ADR-0018, genai-enablement/ADR-0020, genai-enablement/ADR-0021, genai-enablement/ADR-0022, Omniscience/ADR-0022]
+capabilitySpecs: [SPEC-MCP, SPEC-PII, SPEC-MCTX, SPEC-ACL, SPEC-EV, SPEC-KP, SPEC-OPS, SPEC-SOT]
+sddMode: full
+repo: 100rd/Omniscience
+executionProfile: management-readonly-v1-release-candidate
+evidenceDestination: ci-artifact://synchronized-platform/task-sp-86-management-readonly-release/
+scope:
+  include:
+    - Dockerfile
+    - helm/omniscience/**
+    - apps/server/src/omniscience_server/app.py
+    - apps/server/src/omniscience_server/routes/health.py
+    - apps/server/src/omniscience_server/management/**
+    - apps/server/src/omniscience_server/privacy/**
+    - packages/core/src/omniscience_core/management/**
+    - packages/core/src/omniscience_core/privacy/**
+    - contracts/mcp/**
+    - contracts/management/**
+    - contracts/pii/**
+    - contracts/releases/management-readonly-v1/**
+    - scripts/qualify_management_readonly_release.py
+    - tests/release/management_readonly/**
+    - tests/test_management_readonly_release*.py
+    - docs/runbooks/management-readonly-release.md
+    - .github/workflows/management-readonly-release.yml
+  exclude: [docs/decisions/**, docs/specs/**, specs/**, graphify-out/**, infra/terraform/**]
+acceptanceCriteria:
+  - id: AC-SP86-1
+    requirement: One immutable release binds the complete selected executable contract policy and configuration closure
+    probe: omniscience-management-readonly-release-lock
+    expected: Git image chart MCP context schema PW0 policy dependency and rollback digests re-derive exactly and mutable or dirty inputs are RED
+    groundTruth: clean protected Git revision OCI registry digest chart package digest and separately published SP-60 policy artifact
+  - id: AC-SP86-2
+    requirement: Selected read and readiness surfaces enforce exact tenant workspace purpose contract freshness and dependency health
+    probe: omniscience-management-readonly-runtime-conformance
+    expected: positive reads pass while foreign stale future skewed incomplete and disabled-dependency states fail closed without field donation
+    groundTruth: independently minted tenant/workspace identities pinned SP-10/SP-81 manifests and direct dependency observations
+  - id: AC-SP86-3
+    requirement: PW0 rejects unsafe data before every durable derived provider telemetry archive and backup boundary
+    probe: omniscience-management-readonly-pw0-seeded-leak
+    expected: seeded PII unknown class reversible token and active content never reach a protected sink response log trace metric archive or backup
+    groundTruth: independent seeded corpus sink captures SP-60 policy revision and per-store SP-61 lifecycle inventory
+  - id: AC-SP86-4
+    requirement: The producer release includes a complete selected-consumer severance fixture kit and read-only verifier
+    probe: omniscience-management-readonly-severance-kit
+    expected: loss token expiry freshness expiry and contract skew fixtures require typed fallback and cannot validate false healthy empty or cached-current decisions
+    groundTruth: immutable SP-10/SP-81 manifests producer fixtures and expected decisions independently reviewed before consumer execution
+  - id: AC-SP86-5
+    requirement: The release is observable restart-safe and reversible without Omnius or a model/provider
+    probe: omniscience-management-readonly-operations-rollback
+    expected: health readiness metrics restart projection convergence and exact-digest rollback pass while Omnius/provider/config scans remain empty
+    groundTruth: disposable environment workload/store observations OCI/chart inventory and post-rollback conformance capture
+  - id: AC-SP86-6
+    requirement: The released consumer contract and severance kit remain implementation-language neutral
+    probe: omniscience-management-readonly-language-neutral-consumer-kit
+    expected: a clean Go consumer validates schemas fixtures auth freshness and severance decisions without executing Node.js or relying on a TypeScript-only generated binding
+    groundTruth: exact released schema and fixture digests independently built minimal Go consumer and captured dependency and process inventories
+rollback: { kind: revert-pr, probe: restore-prior-omniscience-release-digests-and-reject-unqualified-candidate }
+---
+
+## Intent
+
+Turn the already implemented SP-10, SP-61 and SP-81 repository-local slices into one immutable release
+candidate for `management-readonly-v1`. The task may harden packaging, runtime wiring, readiness and
+qualification code only in the listed paths. It must not reinterpret earlier fixture completion as a
+release receipt.
+
+## Required inputs and dependency return
+
+The execution identity requires exact SP-10, SP-60, SP-61, SP-70 and SP-81 artifacts plus a clean source
+revision and disposable qualification target. SP-87/SP-88 consume the completed SP-86 release and
+produce their own later receipts; they are not inputs to this producer task.
+
+SP-86 is also independent of Barbarossa SP-90 and may execute concurrently with it. Omniscience does not
+inspect, approve or mint the Go baseline; SP-87 later binds the two owner receipts.
+
+Missing inputs produce a content-addressed RED/decision-required report. The task cannot edit
+Barbarossa, Platform Portal, Omnius, `genai-enablement`, a production environment, or this ready task
+revision.
+
+## Required output
+
+`OmniscienceManagementReadOnlyRelease` contains at least:
+
+```text
+profile_id/revision; git_commit; image_digest; chart_digest; configuration_digest;
+mcp_manifest_digest; management_context_manifest_digest; schema_set_digest;
+pii_policy_revision/digest; pw0_receipt_refs; auth/token_profile; dependency_profile;
+health/readiness contract; severance_fixture_digest; language_neutral_consumer_kit_digest;
+evidence_refs; rollback_release_digest
+```
+
+The output is producer evidence only. It is not a Barbarossa/Portal receipt, deployment activation,
+privacy verdict or production-readiness claim.


### PR DESCRIPTION
## Summary
- adopt the management-readonly-v1 owner release boundary
- keep SP-86 independent of concurrent Barbarossa SP-90
- require a language-neutral consumer/severance kit usable by Go without Node-only bindings
- preserve PW0, read-only, severance, and owner-authority boundaries

## Verification
- python3 scripts/validate_governance.py: PASS
- central workspace registry check: PASS
- task frontmatter and 6/6 AC structure: PASS
- independent review: PASS, no P0/P1/P2

No graphify-out files are included.