### PR TITLE
docs: define SP-95 local runtime handoff

### DIFF
--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -40,6 +40,7 @@ accepted genai-enablement ADR
 | `SP-61` knowledge-plane PII boundary | `SPEC-PII` + `task-sp-61-pii-wall-pw0` | ready for fail-closed non-live development; no profile or data path is active |
 | `SP-81` management-context producer | `SPEC-MCTX` + `task-sp-81-management-context-v1` | ready for bounded non-live producer development; no consumer/live authority |
 | `SP-86` management-readonly release | `SPEC-MCP`, `SPEC-PII`, `SPEC-MCTX` + `task-sp-86-management-readonly-release` | ready to publish one language-neutral immutable release candidate; independent of concurrent Barbarossa SP-90, while SP-87/SP-88 consumer receipts and activation remain external |
+| `SP-95` local owner runtime | complete selected capability closure + `task-sp-95-management-readonly-local-runtime` | ready after exact SP-86 to publish a namespaced image/source Compose fragment and `OmniscienceLocalRuntimeReceipt`; local functional smoke only |
 | issue-350 HA | `gh-issue-350-production-ha` | portable profile merged; live fault-domain proof and stateful topology entitlements remain unverified |
 | issue-350 recovery | `gh-issue-350-backup-restore` | safety harness merged; every destructive drill still needs separate exact human approval |
 | issue-350 scaling | `gh-issue-350-read-scaling-priority` | controller/qualification logic merged; shared-backend selection, dispatch wiring and multi-replica proof remain |
@@ -73,6 +74,18 @@ operation and typed severance; Portal releases owner panels independently and di
 Central ADR-0022 selects Go for the Barbarossa production runtime. That decision does not change the
 Omniscience implementation or producer schema: SP-86 publishes language-neutral contracts and may run
 in parallel with SP-90. SP-87 is responsible for binding both immutable receipts.
+
+## Local launch profile
+
+Accepted local ADR-0023 adopts `management-readonly-local-v1` as a disposable realization of the same
+runtime membership. SP-95 packages the exact SP-86 release as independently runnable, owner-prefixed
+API/admin/PostgreSQL/NATS/Neo4j/Qdrant Compose fragments with local embeddings, dependency-aware
+readiness and no provider call. `genai-enablement` may include those fragments in SP-98 but cannot copy
+Omniscience migrations, policy or health semantics.
+
+The fragment publishes only a read network to exact consumers; its stores and broker remain private.
+Normal stop/restart preserves named volumes, selected-owner mocks and Omnius are absent, and every
+receipt declares `development-single-host`, `ha_qualified=false` and `activation_authority=none`.
 
 ## PII Wall boundary
 

--- a/docs/decisions/0023-management-readonly-local-runtime.md
+++ b/docs/decisions/0023-management-readonly-local-runtime.md
@@ -1,0 +1,78 @@
+# ADR-0023: Publish an owner-contained local runtime for the Management Read-Only profile
+
+Status: accepted
+- **Date:** 2026-07-29
+- **Deciders:** platform owner and Omniscience owner
+- **Governing decisions:** `genai-enablement` ADR-0018, ADR-0021, ADR-0022, ADR-0024
+- **Related local decisions:** ADR-0020, ADR-0021 and ADR-0022
+
+## Context
+
+Omniscience already has full, lite and image-based Compose variants. They use generic resource names
+and host ports and represent an independently operated Omniscience installation, not an includable
+synchronized-platform owner fragment. The integrated local profile also needs exact readiness,
+namespaced resources, a language-neutral service contract, deterministic safe fixtures and an
+immutable handoff receipt for Portal and `genai-enablement`.
+
+The owner fragment must retain Omniscience authority. A parent Compose file may connect an approved
+read consumer, but cannot copy migrations, change dependency semantics, bypass PW0 or turn local
+fixtures into production truth.
+
+## Decision
+
+Omniscience publishes `deploy/compose/management-readonly-local/compose.yaml` plus an optional
+`compose.source.yaml` override and `contracts/releases/management-readonly-local-v1/service-contract.json`.
+The fragment is independently runnable and may be included by the exact `genai-enablement` SP-98
+composition.
+
+The selected local closure is the lite functional runtime:
+
+```text
+omniscience-api -> omniscience-postgres
+                 omniscience-nats
+                 omniscience-neo4j
+                 omniscience-qdrant
+omniscience-admin -> omniscience-api
+```
+
+Embeddings run in-process from a pinned local model/cache. Discovery, reconcile, scheduler and retention
+workers are disabled unless explicitly selected by a later owner profile. Ollama, Caddy, backup sidecar,
+external model/provider and cloud connector are absent from the steady local closure.
+
+Every service/network/volume/config key is `omniscience-*`. Only the admin UI is published by default on
+a configurable loopback port. The API joins one owner-read network for approved consumers and one
+Omniscience-private network for stores. No store or broker is host-published by default.
+
+Readiness covers every load-bearing selected dependency, migrations and PW0 policy initialization. A
+process that is live while PostgreSQL, NATS, Neo4j or Qdrant is unavailable remains unready. Disabled
+workers are reported `not_selected`, never healthy. Health output is non-identifying and carries the
+service-contract/profile revision.
+
+One-shot bootstrap may ingest only deterministic synthetic non-PII fixtures through the same public
+admission/PW0 path used by ordinary owner ingestion. A negative fixture job proves that seeded PII,
+reversible tokens and active content reach no durable/derived/provider/export sink. Bootstrap has no
+steady-state route or Portal credential.
+
+The fragment supports exact image-digest mode and a source-build override. Source mode records the Git
+commit and dirty flag and cannot claim reproducibility when dirty. Both modes produce an
+`OmniscienceLocalRuntimeReceipt` for SP-97/SP-98; neither receipt activates SP-86 or a deployment.
+
+## Runtime invariants
+
+- **OML-1:** the fragment runs independently and remains wholly owned by Omniscience.
+- **OML-2:** namespaced resources introduce no collision with Portal or Barbarossa.
+- **OML-3:** selected readiness is dependency-aware across PostgreSQL, NATS, Neo4j and Qdrant.
+- **OML-4:** local embeddings make no provider/model API call and use a pinned model identity.
+- **OML-5:** PW0 precedes bootstrap, persistence, parsing, chunking, embedding, graph/vector, telemetry,
+  archive and response boundaries.
+- **OML-6:** consumer access is tenant/workspace/purpose-bound and read-only.
+- **OML-7:** Omnius, selected-owner mocks, generic query, action/effect and owner mutation routes are absent.
+- **OML-8:** normal stop/restart preserves owner volumes; reset is separate and explicit.
+- **OML-9:** the receipt declares `availability_class=development-single-host`, `ha_qualified=false`
+  and `activation_authority=none`.
+
+## Development authority
+
+This decision authorizes the bounded SP-95 local packaging and disposable qualification. It does not
+authorize production data, raw PII, external providers, production credentials, infrastructure
+mutation, Portal/Barbarossa writes, Omnius, managed effects, HA evidence or deployment activation.

--- a/docs/decisions/0023-management-readonly-local-runtime.md
+++ b/docs/decisions/0023-management-readonly-local-runtime.md
@@ -3,7 +3,7 @@
 Status: accepted
 - **Date:** 2026-07-29
 - **Deciders:** platform owner and Omniscience owner
-- **Governing decisions:** `genai-enablement` ADR-0018, ADR-0021, ADR-0022, ADR-0024
+- **Governing decisions:** `genai-enablement` ADR-0018, ADR-0021, ADR-0022, ADR-0024 <!-- stale-arch-allow: external ADR namespace -->
 - **Related local decisions:** ADR-0020, ADR-0021 and ADR-0022
 
 ## Context

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -30,6 +30,7 @@ Statuses: `Proposed`, `Accepted`, `Implemented`, `Superseded`, `Deprecated`.
 | [ADR-0020](0020-adopt-distributed-pii-wall.md) | Adopt the distributed PII Wall at every knowledge propagation boundary | Accepted |
 | [ADR-0021](0021-management-context-producer.md) | Publish severable management context without management authority | Accepted |
 | [ADR-0022](0022-management-readonly-runtime-release.md) | Adopt the language-neutral Management Read-Only runtime release boundary, independent of Barbarossa SP-90 | Accepted |
+| [ADR-0023](0023-management-readonly-local-runtime.md) | Publish a namespaced, owner-contained local Management Read-Only runtime fragment | Accepted |
 
 `ADR-0018` was originally committed with the duplicate id `ADR-0015`. The rename is a
 registry repair, not a change to its accepted decision.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -51,8 +51,9 @@ or reinterpret readiness as production/cloud/destructive authority.
 | [task-sp-61-pii-wall-pw0](task-sp-61-pii-wall-pw0.md) | `ready` | fail-closed repository-local PW0 propagation boundary and fixtures |
 | [task-sp-81-management-context-v1](task-sp-81-management-context-v1.md) | `ready` | cited management context and knowledge-quality producer v1 |
 | [task-sp-86-management-readonly-release](task-sp-86-management-readonly-release.md) | `ready` | immutable language-neutral MCP/context/PW0 runtime release and selected-consumer severance qualification; independent of Barbarossa SP-90 |
+| [task-sp-95-management-readonly-local-runtime](task-sp-95-management-readonly-local-runtime.md) | `ready` | independently runnable namespaced Omniscience local fragment, real read contract, dependency-aware health, PW0/provider severance and local receipt |
 
-All three tasks are human-ready for their exact repository-local scopes. SP-86 may run concurrently
+All four tasks are human-ready for their exact repository-local scopes. SP-86 may run concurrently
 with Barbarossa SP-90 and produce a release candidate plus disposable qualification evidence, but none authorizes a production policy/profile, live
 personal data, credential, provider, deployment activation or external effect.
 

--- a/docs/specs/task-sp-95-management-readonly-local-runtime.md
+++ b/docs/specs/task-sp-95-management-readonly-local-runtime.md
@@ -1,0 +1,103 @@
+---
+id: task-sp-95-management-readonly-local-runtime
+title: Publish the Omniscience local owner fragment for Management Read-Only
+status: ready
+readiness:
+  approvedBy: "@100rd"
+  approvedAt: 2026-07-29
+source: { kind: human, ref: "SP-95" }
+governingAdrs: [genai-enablement/ADR-0018, genai-enablement/ADR-0021, genai-enablement/ADR-0024, Omniscience/ADR-0020, Omniscience/ADR-0021, Omniscience/ADR-0022, Omniscience/ADR-0023]
+capabilitySpecs: [SPEC-IN, SPEC-SOT, SPEC-ACL, SPEC-EV, SPEC-OPS, SPEC-KP, SPEC-MCP, SPEC-PII, SPEC-MCTX]
+sddMode: full
+repo: 100rd/Omniscience
+executionProfile: management-readonly-local-v1-omniscience-owner
+evidenceDestination: ci-artifact://synchronized-platform/task-sp-95-management-readonly-local-runtime/
+scope:
+  include:
+    - Dockerfile
+    - .dockerignore
+    - deploy/compose/management-readonly-local/**
+    - apps/server/src/omniscience_server/app.py
+    - apps/server/src/omniscience_server/routes/health.py
+    - apps/server/src/omniscience_server/management/**
+    - apps/server/src/omniscience_server/privacy/**
+    - packages/core/src/omniscience_core/management/**
+    - packages/core/src/omniscience_core/privacy/**
+    - contracts/releases/management-readonly-local-v1/**
+    - scripts/qualify_management_readonly_local.py
+    - tests/release/management_readonly_local/**
+    - tests/test_management_readonly_local*.py
+    - docs/runbooks/management-readonly-local.md
+    - .github/workflows/management-readonly-local.yml
+  exclude: [docs/decisions/**, docs/specs/**, specs/**, graphify-out/**, infra/terraform/**]
+acceptanceCriteria:
+  - id: AC-SP95-1
+    requirement: One owner-contained namespaced Compose fragment runs independently in image and source modes
+    probe: omniscience-local-fragment-render
+    expected: exact api admin postgres nats neo4j qdrant services plus owner networks volumes health and source override render without generic resource names host-port collisions mutable image tags or parent-owned migrations
+    groundTruth: Docker Compose canonical model exact SP-86 image/source identities and independently enumerated resources
+  - id: AC-SP95-2
+    requirement: Startup and readiness cover the complete selected dependency and migration closure
+    probe: omniscience-local-startup-readiness
+    expected: bounded health-gated start succeeds and each induced PostgreSQL NATS Neo4j Qdrant migration or policy-init failure keeps the API unready with a typed non-identifying reason
+    groundTruth: direct dependency probes migration records service health timeline and API readiness responses
+  - id: AC-SP95-3
+    requirement: The local service contract exposes only exact tenant workspace purpose and read-only Management Read-Only surfaces
+    probe: omniscience-local-consumer-contract
+    expected: exact MCP context knowledge-quality privacy and health reads pass while foreign stale skewed generic-query owner-write action effect and unregistered consumer requests fail closed
+    groundTruth: exact SP-86 contract release local service-contract schema independently minted identities and positive/negative API captures
+  - id: AC-SP95-4
+    requirement: PW0 and local embeddings protect every bootstrap and runtime sink without an external provider
+    probe: omniscience-local-pw0-provider-severance
+    expected: safe synthetic fixtures become retrievable while seeded PII reversible tokens and active content reach no store graph vector embedding response log trace metric archive or backup and no provider network call occurs
+    groundTruth: independent fixture corpus store and egress captures pinned local model identity SP-60 policy and SP-61 lifecycle evidence
+  - id: AC-SP95-5
+    requirement: Normal restart preserves admitted owner state and severance remains explicit
+    probe: omniscience-local-persistence-severance
+    expected: stop start and API restart preserve safe fixture lineage and converge projections while dependency or owner loss becomes typed unavailable and never cached-current healthy or empty
+    groundTruth: named-volume identities before-after owner reads dependency lifecycle timeline and consumer captures
+  - id: AC-SP95-6
+    requirement: The fragment remains laptop-bounded and exposes only approved loopback UI diagnostics
+    probe: omniscience-local-resource-exposure
+    expected: amd64 and arm64 measurements fit the assigned share of the platform reference envelope and socket inventory contains no public API datastore broker graph or vector-store binding
+    groundTruth: named host Docker version resource trace image sizes and host/container socket inventory
+  - id: AC-SP95-7
+    requirement: One immutable local owner receipt binds artifacts configuration behavior and non-authority fields
+    probe: omniscience-local-runtime-receipt
+    expected: Git or image service-contract rendered-fragment model policy fixture health PW0 persistence resource and rollback digests re-derive while dirty source forces reproducible false and availability_class ha_qualified activation_authority remain development-single-host false none
+    groundTruth: clean or explicitly dirty source identity OCI registry where applicable evidence manifest and post-rollback capture
+rollback: { kind: disposable, probe: stop-omniscience-local-fragment-preserve-volumes-and-restore-exact-prior-sp86-artifacts }
+---
+
+## Intent
+
+Package the exact SP-86 Omniscience release as an independently runnable owner fragment for
+`management-readonly-local-v1`. The task may harden local packaging, readiness and fixtures only inside
+the listed paths. It cannot modify the parent composition or a consumer.
+
+## Required inputs
+
+- exact SP-86 `OmniscienceManagementReadOnlyRelease` and SP-60/SP-61 policy evidence;
+- pinned local embedding model/cache identity for both supported architectures;
+- exact tenant/workspace/purpose and read-token profiles;
+- deterministic safe and seeded negative PII/active-content fixtures;
+- declared owner share of the 4-vCPU/8-GB/25-GB minimum image-mode platform reference host; and
+- prior known-good owner fragment/service-contract/receipt digests.
+
+Missing or incompatible input returns RED/decision-required. It cannot be replaced with a Portal mock,
+external model/provider, unpinned tag, sibling edit or favorable readiness fallback.
+
+## Required output
+
+`OmniscienceLocalRuntimeReceipt` contains at least:
+
+```text
+profile/revision; sp86_release_digest; mode/reproducible; git/image/configuration digests;
+service_contract/rendered_fragment/service/network/volume/host_binding inventory digests;
+local_model/dependency/readiness digests; tenant/pw0/provider-severance evidence refs;
+persistence/resource/rollback evidence refs; availability_class=development-single-host;
+ha_qualified=false; activation_authority=none
+```
+
+This is an Omniscience owner-local development receipt. It is not Portal evidence, platform
+qualification, production activation or HA proof.


### PR DESCRIPTION
## What changed

- accepts Omniscience ADR-0023
- adds the independently assignable SP-95 local owner-runtime SPEC
- updates the local platform and ADR/SPEC discovery indexes

## Why

Omniscience must publish its own namespaced, independently runnable Compose fragment and immutable local receipt instead of letting the integration repository copy owner configuration or migrations.

## Impact

SP-95 can be implemented independently after exact SP-86. It requires real read contracts, dependency-aware health, local embeddings, PW0/provider severance, preserved volumes, and explicit non-HA authority fields.

## Validation

- synchronized-platform workspace checker: PASS
- document/YAML/link checks: PASS
- staged diff check: PASS
